### PR TITLE
Fix Debug Toggle

### DIFF
--- a/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
@@ -1456,6 +1456,36 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
     return display_wakeup(record);
 }
 
+bool pre_process_record_user(uint16_t keycode, keyrecord_t* record) {
+    if (record->event.pressed) {
+        switch (keycode)
+        {
+        case QK_DEBUG_TOGGLE:
+            // Quantum usually intercepts the debug key (QK_DEBUG_TOGGLE) in process_record_quantum and handles it internally
+            // By using the pre_process handler we can intercept it earlier and implement the toggle cycle as below
+            if (!debug_enable) {
+                debug_enable = 1;
+            } else if (!debug_keyboard) {
+                debug_keyboard = 1;
+            } else if (!debug_matrix) {
+                debug_matrix = 1;
+            } else {
+                debug_enable   = 0;
+                debug_keyboard = 0;
+                debug_matrix   = 0;
+            }
+            dprintf("DEBUG: enable=%u, keyboard=%u, matrix=%u\n", debug_enable, debug_keyboard, debug_matrix);
+            dprint(QMK_KEYBOARD "/" QMK_KEYMAP " @ " QMK_VERSION ", Built on: " QMK_BUILDDATE "\n");
+            eeconfig_update_debug(debug_config.raw);
+            request_disp_refresh();
+            return false;
+        default:
+            break;
+        }
+    }
+    return true;
+}
+
 void post_process_record_user(uint16_t keycode, keyrecord_t* record) {
     if (keycode == KC_CAPS_LOCK) {
         request_disp_refresh();
@@ -1574,22 +1604,6 @@ void post_process_record_user(uint16_t keycode, keyrecord_t* record) {
         case RGB_MOD:
         case RGB_RMOD:
             request_disp_refresh();
-            break;
-        case QK_DEBUG_TOGGLE:
-            if (!debug_enable) {
-                debug_enable = 1;
-            } else if (!debug_keyboard) {
-                debug_keyboard = 1;
-            } else if (!debug_matrix) {
-                debug_matrix = 1;
-            } else {
-                debug_enable   = 0;
-                debug_keyboard = 0;
-                debug_matrix   = 0;
-            }
-            dprintf("DEBUG: enable=%u, keyboard=%u, matrix=%u\n", debug_enable, debug_keyboard, debug_matrix);
-            dprint(QMK_KEYBOARD "/" QMK_KEYMAP " @ " QMK_VERSION ", Built on: " QMK_BUILDDATE "\n");
-            eeconfig_update_debug(debug_config.raw);
             break;
         default:
             break;


### PR DESCRIPTION
The debug toggle in the settings menu was not working as intended since the debug key press was intercepted by the Qantum code already. This PR moves the key press handling to the pre handler to intercept it before Qantum handles it. Furthermore the request_disp_refresh() call was added at the end to update the debug icon according to the status.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

