### PR TITLE
Fix HID Interface

### DIFF
--- a/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
@@ -2007,11 +2007,11 @@ void suspend_wakeup_init_kb(void) {
 void via_custom_value_command_kb(uint8_t *data, uint8_t length) {
     const char * name = "P0.PolyKybd Split72";
 
-    if(debug_enable && length <= RAW_EPSIZE)
+    if(debug_enable && length < 33)
     {
-        char cmdstring[RAW_EPSIZE+1];
+        char cmdstring[33];
         memcpy(cmdstring, data, length);
-        cmdstring[length]=0; // Make sure string ends with 0
+        cmdstring[length] = 0; // Make sure string ends with 0
         dprintf("DEBUG: custom hid or via command, length=%d cmd=%s\n", length, cmdstring);
     }
 

--- a/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
@@ -2005,8 +2005,15 @@ void suspend_wakeup_init_kb(void) {
 }
 
 void via_custom_value_command_kb(uint8_t *data, uint8_t length) {
-    memset(data, 0, length);
     const char * name = "P0.PolyKybd Split72";
+
+    if(debug_enable && length <= RAW_EPSIZE)
+    {
+        char cmdstring[RAW_EPSIZE+1];
+        memcpy(cmdstring, data, length);
+        cmdstring[length]=0; // Make sure string ends with 0
+        dprintf("DEBUG: custom hid or via command, length=%d cmd=%s\n", length, cmdstring);
+    }
 
     if(length>1 && (data[0] == /*via_command_id::*/id_custom_save || data[0] == 'P')) {
         switch(data[1]) {

--- a/keyboards/handwired/polykybd/split72/keymaps/via/keymap.c
+++ b/keyboards/handwired/polykybd/split72/keymaps/via/keymap.c
@@ -2005,8 +2005,15 @@ void suspend_wakeup_init_kb(void) {
 }
 
 void via_custom_value_command_kb(uint8_t *data, uint8_t length) {
-    memset(data, 0, length);
     const char * name = "P0.PolyKybd Split72";
+
+    if(debug_enable && length < 33)
+    {
+        char cmdstring[33];
+        memcpy(cmdstring, data, length);
+        cmdstring[length] = 0; // Make sure string ends with 0
+        dprintf("DEBUG: custom hid or via command, length=%d cmd=%s\n", length, cmdstring);
+    }
 
     if(length>1 && (data[0] == /*via_command_id::*/id_custom_save || data[0] == 'P')) {
         switch(data[1]) {


### PR DESCRIPTION
## Description

The memset in the beginning of via_custom_value_command_kb broke the HID interface since it overwrites the request before handling it. The memset is done inside the switch statement then anyway. I also added some debug output.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation
