### PR TITLE
Add FIRMWARE_READY HID notification on boot

### DIFF
--- a/keyboards/handwired/polykybd/hid_com.c
+++ b/keyboards/handwired/polykybd/hid_com.c
@@ -4,6 +4,7 @@
 #include "quantum.h"
 
 #include "raw_hid.h"
+#include "usb_device_state.h"
 
 #include "state.h"
 #include "side.h"
@@ -48,12 +49,17 @@ while lang_key:
 void invert_display(uint8_t r, uint8_t c, bool state);
 
 void hid_notify_firmware_ready(void) {
+    static bool s_sent = false;
+    if (s_sent || usb_device_state != USB_DEVICE_STATE_CONFIGURED) {
+        return;
+    }
     uint8_t data[RAW_EPSIZE];
     memset(data, 0, RAW_EPSIZE);
     data[0] = 'P';
     data[1] = 0x17;
     data[2] = '.';
     raw_hid_send(data, RAW_EPSIZE);
+    s_sent = true;
 }
 
 

--- a/keyboards/handwired/polykybd/hid_com.c
+++ b/keyboards/handwired/polykybd/hid_com.c
@@ -47,6 +47,15 @@ while lang_key:
 
 void invert_display(uint8_t r, uint8_t c, bool state);
 
+void hid_notify_firmware_ready(void) {
+    uint8_t data[RAW_EPSIZE];
+    memset(data, 0, RAW_EPSIZE);
+    data[0] = 'P';
+    data[1] = 0x17;
+    data[2] = '.';
+    raw_hid_send(data, RAW_EPSIZE);
+}
+
 
 // Notifies RGB/LED matrix of key event for animation effects based on key press state.
 void switch_events_poly(uint8_t row, uint8_t col, bool pressed) {

--- a/keyboards/handwired/polykybd/hid_com.h
+++ b/keyboards/handwired/polykybd/hid_com.h
@@ -5,6 +5,8 @@
 #define LANG_TO_UI32(a,b,c,d) (((uint32_t)(a))<<24 | ((uint32_t)(b))<<16 | ((uint32_t)(c))<<8 | (d))
 #define LANG_TO_UI32_ARR(arr) (((uint32_t)(arr[0]))<<24 | ((uint32_t)(arr[1]))<<16 | ((uint32_t)(arr[2]))<<8 | (arr[3]))
 
+void hid_notify_firmware_ready(void);
+
 enum legacy_command_id {
     id_get_protocol_version                 = 0x01, // always 0x01
     id_get_keyboard_value                   = 0x02,

--- a/keyboards/handwired/polykybd/polykybd.c
+++ b/keyboards/handwired/polykybd/polykybd.c
@@ -1,1 +1,9 @@
 #include QMK_KEYBOARD_H
+
+#include "hid_com.h"
+
+void housekeeping_task_kb(void) {
+    if (is_keyboard_master()) {
+        hid_notify_firmware_ready();
+    }
+}

--- a/keyboards/handwired/polykybd/rules.mk
+++ b/keyboards/handwired/polykybd/rules.mk
@@ -3,4 +3,4 @@ DEFAULT_FOLDER = handwired/polykybd/split72
 # pico-sdk host header uses K&R-style empty () prototype; suppress the warning it triggers
 CFLAGS += -Wno-strict-prototypes
 
-SRC += side.c state.c split_sync.c multicore_exec.c hid_com.c fill_overlay.c polykybd.c fill_overlay.c poly_util.c matrix_helper.c bridge_helper.c
+SRC += side.c state.c split_sync.c multicore_exec.c hid_com.c fill_overlay.c fill_overlay.c poly_util.c matrix_helper.c bridge_helper.c

--- a/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
@@ -42,6 +42,7 @@
 #include "state.h"
 #include "multicore_exec.h"
 #include "split_sync.h"
+#include "hid_com.h"
 
 #include "lang/lang_lut.h"
 #include "lang/lang_lut_ext.h"
@@ -322,6 +323,12 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 
 // Continuously monitors for idle timeout and dims/pulsates display accordingly.
 void housekeeping_task_user(void) {
+    static bool s_firmware_ready_sent = false;
+    if (!s_firmware_ready_sent && is_keyboard_master()) {
+        hid_notify_firmware_ready();
+        s_firmware_ready_sent = true;
+    }
+
     brightness_save_if_pending();
     default_layer_save_if_pending();
     sync_and_refresh_displays();

--- a/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
@@ -42,7 +42,6 @@
 #include "state.h"
 #include "multicore_exec.h"
 #include "split_sync.h"
-#include "hid_com.h"
 
 #include "lang/lang_lut.h"
 #include "lang/lang_lut_ext.h"
@@ -323,12 +322,6 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 
 // Continuously monitors for idle timeout and dims/pulsates display accordingly.
 void housekeeping_task_user(void) {
-    static bool s_firmware_ready_sent = false;
-    if (!s_firmware_ready_sent && is_keyboard_master()) {
-        hid_notify_firmware_ready();
-        s_firmware_ready_sent = true;
-    }
-
     brightness_save_if_pending();
     default_layer_save_if_pending();
     sync_and_refresh_displays();


### PR DESCRIPTION
## Summary

- Adds `hid_notify_firmware_ready()` which sends an unsolicited `P\x17.` HID report to the host on the first `housekeeping_task_user()` tick (master half only)
- Signals the host that the firmware has restarted so it can reset its overlay cache
- More reliable than watching for HID connect/disconnect events, which can be missed when the firmware resets without a full USB re-enumeration

## Test plan

- [ ] Flash firmware and confirm host receives `P\x17.` report on boot
- [ ] Verify report is sent only once per boot (static flag guard)
- [ ] Confirm slave half does not send the report (`is_keyboard_master()` guard)
- [ ] Verify no regression in normal HID communication after the notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Send a one-time HID notification to the host when the firmware has finished booting, restricted to the keyboard master half.

New Features:
- Introduce a firmware-ready HID notification report sent to the host on boot.

Enhancements:
- Trigger the firmware-ready HID notification from the housekeeping task, guarded to run only once and only on the master half.