### PR TITLE
hid: signal fresh boot via GET_ID response

### DIFF
--- a/keyboards/handwired/polykybd/hid_com.c
+++ b/keyboards/handwired/polykybd/hid_com.c
@@ -47,6 +47,10 @@ while lang_key:
 
 void invert_display(uint8_t r, uint8_t c, bool state);
 
+// Set on boot; cleared after the first GET_ID exchange so the host can detect
+// a firmware restart even when it never lost the USB connection.
+static bool s_fresh_boot = true;
+
 
 // Notifies RGB/LED matrix of key event for animation effects based on key press state.
 void switch_events_poly(uint8_t row, uint8_t col, bool pressed) {
@@ -122,6 +126,10 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
             case 6: //id
                 memset(data, 0, length);
                 memcpy(data, name, strlen(name));
+                if (s_fresh_boot) {
+                    data[2] = '*'; // host sees '*' instead of '.' → firmware just booted
+                    s_fresh_boot = false;
+                }
                 raw_hid_send(data, length);
                 break;
             case 7: //lang


### PR DESCRIPTION
## Summary

- Replaces the unsolicited `FIRMWARE_READY` HID notification with a flag embedded in the existing `GET_ID` response
- On the first `GET_ID` query after boot the handler returns `'*'` as the ACK character (instead of `'.'`); subsequent queries return `'.'` as normal
- The host already polls `GET_ID` every second as a connection health-check, so the fresh-boot signal is detected within ~1 s of a firmware restart

## Why

The unsolicited-notification approach required the host to run a non-blocking HID peek every 250 ms in parallel with the normal request/response protocol, creating a race condition where a `FIRMWARE_READY` packet could arrive mid-command and be misinterpreted. Piggybacking the signal on the solicited `GET_ID` poll eliminates that race and removes all the notification-specific infrastructure from both sides.

## Test plan

- [ ] Flash firmware and confirm host logs "Firmware restart detected" within 1 s of boot
- [ ] Confirm subsequent `GET_ID` queries return `'.'` (flag cleared after first exchange)
- [ ] Reflash while host is running; confirm overlay MRU cache is reset and overlays re-populate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Embed a one-shot fresh-boot flag in the GET_ID HID response so the host can detect firmware restarts without separate notifications.