### PR TITLE
hid: signal fresh boot via GET_ID response instead of unsolicited notification

### DIFF
--- a/keyboards/handwired/polykybd/hid_com.c
+++ b/keyboards/handwired/polykybd/hid_com.c
@@ -47,6 +47,10 @@ while lang_key:
 
 void invert_display(uint8_t r, uint8_t c, bool state);
 
+// Set on boot; cleared after the first GET_ID exchange so the host can detect
+// a firmware restart even when it never lost the USB connection.
+static bool s_fresh_boot = true;
+
 
 // Notifies RGB/LED matrix of key event for animation effects based on key press state.
 void switch_events_poly(uint8_t row, uint8_t col, bool pressed) {
@@ -122,6 +126,10 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
             case 6: //id
                 memset(data, 0, length);
                 memcpy(data, name, strlen(name));
+                if (s_fresh_boot) {
+                    data[2] = '*'; // host sees '*' instead of '.' → firmware just booted
+                    s_fresh_boot = false;
+                }
                 raw_hid_send(data, length);
                 break;
             case 7: //lang


### PR DESCRIPTION
## Summary

- Replaces the unsolicited `FIRMWARE_READY` HID packet approach with a flag on the `GET_ID` handler
- On the first `GET_ID` query after boot, the ACK byte returns `'*'` instead of `'.'`; subsequent queries return `'.'` as before
- The host already polls `GET_ID` every second as a connection health-check, so it detects a firmware restart within ~1 s with no separate notification path

## Motivation

The previous unsolicited-packet design had a race condition between the notification and in-flight commands, and required a non-blocking peek loop on the host side. This approach reuses the existing polling path with no new notification mechanism.

## Test plan

- [ ] Flash firmware and observe host detects boot flag on first `GET_ID` response (`'*'` ACK)
- [ ] Confirm subsequent `GET_ID` responses return `'.'`
- [ ] Verify host correctly re-initialises state after detecting fresh boot
- [ ] Check no regression in normal HID command handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

New Features:
- Expose a one-time fresh-boot indicator by returning a special ACK marker in the first HID GET_ID response after startup.