### PR TITLE
Show bootloader message on slave half before reset

### DIFF
--- a/keyboards/handwired/polykybd/base/com.h
+++ b/keyboards/handwired/polykybd/base/com.h
@@ -23,7 +23,12 @@ enum overlay_flag {
     // mapping that crosses the split can find the bitmap on the side that
     // actually has to render it. Off = legacy side-conditional storage.
     MIRROR_OVERLAYS     = 1 << 2,
-    RESERVED_2          = 1 << 3,
+    // Set by master in the QK_BOOTLOADER case and force-synced via
+    // USER_SYNC_POLY_DATA before reset_keyboard() runs. Slave detects the
+    // 0->1 transition in user_sync_poly_data_handler() and renders the
+    // "BOOT-LOADER!" message + solid red RGB so the slave half stays lit
+    // while the master is in the RP2040 ROM bootloader.
+    BOOTLOADER_DISPLAY  = 1 << 3,
     RESERVED_3          = 1 << 4,
     RESET_BUFFERS       = 1 << 5,
     USAGE_RESET         = 1 << 6,

--- a/keyboards/handwired/polykybd/corne42/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/corne42/keymaps/default/keymap.c
@@ -133,7 +133,7 @@ bool rgb_matrix_indicators_kb(void) {
         if (get_local_state()->overlay_flags & BOOTLOADER_DISPLAY) {
             // Backstop in case the SOLID_COLOR mode change in the sync
             // handler didn't take effect — value matched to the sethsv val.
-            rgb_matrix_set_color_all(8, 0, 0);
+            rgb_matrix_set_color_all(64, 0, 0);
             return false;
         }
         if ((get_local_state()->flags & STATUS_DISP_ON) == 0) {
@@ -1041,24 +1041,26 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
     const poly_layer_t* global_layer = get_global_layer();
     if (record->event.pressed) {
         switch (keycode) {
-            case QK_BOOTLOADER:
+            case QK_BOOTLOADER: {
                 uprintf("Bootloader entered. Please copy new Firmware.\n");
                 // Tell the slave first — once we return true, QMK calls
                 // reset_keyboard() and the master goes dark before housekeeping
                 // could push a deferred state diff over UART.
                 access_local_state()->overlay_flags |= BOOTLOADER_DISPLAY;
-                send_to_bridge(USER_SYNC_POLY_DATA, (void *)access_local_state(), sizeof(poly_sync_t), 10);
+                uint8_t ack = send_to_bridge(USER_SYNC_POLY_DATA, (void *)access_local_state(), sizeof(poly_sync_t), 10);
+                uprintf("Master: BOOTLOADER_DISPLAY sync ack=%d\n", ack);
                 display_bootloader_message();
 #ifdef RGB_MATRIX_ENABLE
                 // corne42 has no RGB matrix hardware, so this block is a
                 // no-op there — kept for parity with split72.
                 rgb_matrix_enable_noeeprom();
                 rgb_matrix_mode_noeeprom(RGB_MATRIX_SOLID_COLOR);
-                rgb_matrix_sethsv_noeeprom(0, 255, 8);
-                rgb_matrix_set_color_all(8, 0, 0);
+                rgb_matrix_sethsv_noeeprom(0, 255, 64);
+                rgb_matrix_set_color_all(64, 0, 0);
                 rgb_matrix_update_pwm_buffers();
 #endif
                 return true;
+            }
             case KC_A ... KC_Z:
                 set_local_last_latin_keycode(keycode);
                 if((get_mods() & MOD_MASK_ALT) == 0 && addlang) {

--- a/keyboards/handwired/polykybd/corne42/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/corne42/keymaps/default/keymap.c
@@ -91,6 +91,10 @@ void clear_all_displays(void) {
 
 void display_bootloader_message(void) {
     clear_all_displays();
+    // Drive the OLEDs at minimum contrast — once the master is in ROM
+    // bootloader nothing else will restore brightness, so use as little
+    // current as possible while keeping the message readable.
+    set_displays(MIN_BRIGHT, false);
     display_message(1, 1, u"BOOT-",   &FreeSansBold24pt7b);
     display_message(3, 0, u"LOADER!", &FreeSansBold24pt7b);
 }
@@ -127,7 +131,9 @@ static uint8_t overlay_flags = 0;
 bool rgb_matrix_indicators_kb(void) {
     if (!is_keyboard_master()) {
         if (get_local_state()->overlay_flags & BOOTLOADER_DISPLAY) {
-            rgb_matrix_set_color_all(255, 0, 0);
+            // Backstop in case the SOLID_COLOR mode change in the sync
+            // handler didn't take effect — value matched to the sethsv val.
+            rgb_matrix_set_color_all(8, 0, 0);
             return false;
         }
         if ((get_local_state()->flags & STATUS_DISP_ON) == 0) {
@@ -166,6 +172,15 @@ static uint32_t rgb_repeat_callback(uint32_t trigger_time, void* cb_arg) {
 #endif
 
 void sync_and_refresh_displays(void) {
+    // On the slave, once the bootloader screen is up nothing else may touch
+    // the keycap OLEDs — otherwise update_displays() redraws every keycap
+    // from the overlay buffers and wipes "BOOT-LOADER!". Master is in ROM
+    // bootloader and cannot recover, so freezing slave state until
+    // power-cycle is fine.
+    if (!is_usb_host_side() && (get_local_state()->overlay_flags & BOOTLOADER_DISPLAY)) {
+        return;
+    }
+
     bool layer_diff = false;
     bool state_diff = false;
 
@@ -1035,8 +1050,12 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
                 send_to_bridge(USER_SYNC_POLY_DATA, (void *)access_local_state(), sizeof(poly_sync_t), 10);
                 display_bootloader_message();
 #ifdef RGB_MATRIX_ENABLE
+                // corne42 has no RGB matrix hardware, so this block is a
+                // no-op there — kept for parity with split72.
                 rgb_matrix_enable_noeeprom();
-                rgb_matrix_set_color_all(255, 0, 0);
+                rgb_matrix_mode_noeeprom(RGB_MATRIX_SOLID_COLOR);
+                rgb_matrix_sethsv_noeeprom(0, 255, 8);
+                rgb_matrix_set_color_all(8, 0, 0);
                 rgb_matrix_update_pwm_buffers();
 #endif
                 return true;

--- a/keyboards/handwired/polykybd/corne42/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/corne42/keymaps/default/keymap.c
@@ -89,6 +89,12 @@ void clear_all_displays(void) {
     kdisp_send_buffer();
 }
 
+void display_bootloader_message(void) {
+    clear_all_displays();
+    display_message(1, 1, u"BOOT-",   &FreeSansBold24pt7b);
+    display_message(3, 0, u"LOADER!", &FreeSansBold24pt7b);
+}
+
 void early_hardware_init_post(void) {
     spi_hw_setup();
 }
@@ -119,9 +125,15 @@ static uint8_t overlay_flags = 0;
 
 #ifdef RGB_MATRIX_ENABLE
 bool rgb_matrix_indicators_kb(void) {
-    if (!is_keyboard_master() && (get_local_state()->flags & STATUS_DISP_ON) == 0) {
-        rgb_matrix_set_color_all(0, 0, 0);
-        return false;
+    if (!is_keyboard_master()) {
+        if (get_local_state()->overlay_flags & BOOTLOADER_DISPLAY) {
+            rgb_matrix_set_color_all(255, 0, 0);
+            return false;
+        }
+        if ((get_local_state()->flags & STATUS_DISP_ON) == 0) {
+            rgb_matrix_set_color_all(0, 0, 0);
+            return false;
+        }
     }
     return rgb_matrix_indicators_user();
 }
@@ -1016,9 +1028,17 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
         switch (keycode) {
             case QK_BOOTLOADER:
                 uprintf("Bootloader entered. Please copy new Firmware.\n");
-                clear_all_displays();
-                display_message(1, 1, u"BOOT-", &FreeSansBold24pt7b);
-                display_message(3, 0, u"LOADER!", &FreeSansBold24pt7b);
+                // Tell the slave first — once we return true, QMK calls
+                // reset_keyboard() and the master goes dark before housekeeping
+                // could push a deferred state diff over UART.
+                access_local_state()->overlay_flags |= BOOTLOADER_DISPLAY;
+                send_to_bridge(USER_SYNC_POLY_DATA, (void *)access_local_state(), sizeof(poly_sync_t), 10);
+                display_bootloader_message();
+#ifdef RGB_MATRIX_ENABLE
+                rgb_matrix_enable_noeeprom();
+                rgb_matrix_set_color_all(255, 0, 0);
+                rgb_matrix_update_pwm_buffers();
+#endif
                 return true;
             case KC_A ... KC_Z:
                 set_local_last_latin_keycode(keycode);

--- a/keyboards/handwired/polykybd/corne42/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/corne42/keymaps/default/keymap.c
@@ -91,10 +91,10 @@ void clear_all_displays(void) {
 
 void display_bootloader_message(void) {
     clear_all_displays();
-    // Drive the OLEDs at minimum contrast — once the master is in ROM
-    // bootloader nothing else will restore brightness, so use as little
-    // current as possible while keeping the message readable.
-    set_displays(MIN_BRIGHT, false);
+    // Dim OLED contrast. set_displays() sends SETCONTRAST(value - 1), so
+    // value=10 → hardware contrast 9/255 ≈ 18% of max — dim but legible.
+    // MIN_BRIGHT (1 → SETCONTRAST 0) was tested and proved unreadable.
+    set_displays(10, false);
     display_message(1, 1, u"BOOT-",   &FreeSansBold24pt7b);
     display_message(3, 0, u"LOADER!", &FreeSansBold24pt7b);
 }

--- a/keyboards/handwired/polykybd/corne42/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/corne42/keymaps/default/keymap.c
@@ -42,6 +42,7 @@
 #include "state.h"
 #include "multicore_exec.h"
 #include "split_sync.h"
+#include "poly_util.h"
 
 #include "lang/lang_lut.h"
 #include "lang/lang_lut_ext.h"
@@ -78,27 +79,6 @@ void set_selected_displays(int8_t old_value, int8_t new_value);
 void oled_update_buffer(void);
 void poly_suspend(void);
 
-
-void select_all_displays(void) {
-    sr_shift_out_0_latch(NUM_SHIFT_REGISTERS);
-}
-
-void clear_all_displays(void) {
-    select_all_displays();
-    kdisp_set_buffer(0x00);
-    kdisp_send_buffer();
-}
-
-void display_bootloader_message(void) {
-    clear_all_displays();
-    // Dim OLED contrast. set_displays() sends SETCONTRAST(value - 1), so
-    // value=10 → hardware contrast 9/255 ≈ 18% of max — dim but legible.
-    // MIN_BRIGHT (1 → SETCONTRAST 0) was tested and proved unreadable.
-    set_displays(10, false);
-    display_message(1, 1, u"BOOT-",   &FreeSansBold24pt7b);
-    display_message(3, 0, u"LOADER!", &FreeSansBold24pt7b);
-}
-
 void early_hardware_init_post(void) {
     spi_hw_setup();
 }
@@ -131,8 +111,7 @@ static uint8_t overlay_flags = 0;
 bool rgb_matrix_indicators_kb(void) {
     if (!is_keyboard_master()) {
         if (get_local_state()->overlay_flags & BOOTLOADER_DISPLAY) {
-            // Backstop on top of SOLID_COLOR mode + re-assert. corne42 has
-            // no RGB hardware so this is dead code in practice.
+            // Backstop: force red even if rgb_matrix_config.enable gets cleared.
             rgb_matrix_set_color_all(24, 0, 0);
             return false;
         }
@@ -172,11 +151,7 @@ static uint32_t rgb_repeat_callback(uint32_t trigger_time, void* cb_arg) {
 #endif
 
 void sync_and_refresh_displays(void) {
-    // On the slave, once the bootloader screen is up nothing else may touch
-    // the keycap OLEDs — otherwise update_displays() redraws every keycap
-    // from the overlay buffers and wipes "BOOT-LOADER!". Master is in ROM
-    // bootloader and cannot recover, so freezing slave state until
-    // power-cycle is fine. corne42 has no RGB hardware so no RGB re-assert.
+    // Freeze slave display while bootloader is active.
     if (!is_usb_host_side() && (get_local_state()->overlay_flags & BOOTLOADER_DISPLAY)) {
         return;
     }
@@ -1043,22 +1018,11 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
         switch (keycode) {
             case QK_BOOTLOADER: {
                 uprintf("Bootloader entered. Please copy new Firmware.\n");
-                // Tell the slave first — once we return true, QMK calls
-                // reset_keyboard() and the master goes dark before housekeeping
-                // could push a deferred state diff over UART.
+                // Sync slave before returning true — QMK resets before housekeeping runs.
                 access_local_state()->overlay_flags |= BOOTLOADER_DISPLAY;
                 uint8_t ack = send_to_bridge(USER_SYNC_POLY_DATA, (void *)access_local_state(), sizeof(poly_sync_t), 10);
                 uprintf("Master: BOOTLOADER_DISPLAY sync ack=%d\n", ack);
                 display_bootloader_message();
-#ifdef RGB_MATRIX_ENABLE
-                // corne42 has no RGB matrix hardware, so this block is a
-                // no-op there — kept for parity with split72.
-                rgb_matrix_enable_noeeprom();
-                rgb_matrix_mode_noeeprom(RGB_MATRIX_SOLID_COLOR);
-                rgb_matrix_sethsv_noeeprom(0, 255, 24);
-                rgb_matrix_set_color_all(24, 0, 0);
-                rgb_matrix_update_pwm_buffers();
-#endif
                 return true;
             }
             case KC_A ... KC_Z:
@@ -1425,11 +1389,7 @@ void poly_suspend(void) {
 }
 
 void suspend_power_down_kb(void) {
-    // Master entering the RP2040 ROM bootloader trips USB suspend on the
-    // slave a few ms after the sync handler painted the bootloader screen.
-    // Without this guard, poly_suspend() queues contrast=0 and the next
-    // sync_and_refresh_displays would turn the OLEDs off. Once
-    // BOOTLOADER_DISPLAY is set the only way out is power-cycle.
+    // USB suspend fires on slave when master enters bootloader; skip to keep displays lit.
     if (get_local_state()->overlay_flags & BOOTLOADER_DISPLAY) {
         return;
     }

--- a/keyboards/handwired/polykybd/corne42/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/corne42/keymaps/default/keymap.c
@@ -131,9 +131,9 @@ static uint8_t overlay_flags = 0;
 bool rgb_matrix_indicators_kb(void) {
     if (!is_keyboard_master()) {
         if (get_local_state()->overlay_flags & BOOTLOADER_DISPLAY) {
-            // Backstop in case the SOLID_COLOR mode change in the sync
-            // handler didn't take effect — value matched to the sethsv val.
-            rgb_matrix_set_color_all(64, 0, 0);
+            // Backstop on top of SOLID_COLOR mode + re-assert. corne42 has
+            // no RGB hardware so this is dead code in practice.
+            rgb_matrix_set_color_all(24, 0, 0);
             return false;
         }
         if ((get_local_state()->flags & STATUS_DISP_ON) == 0) {
@@ -176,7 +176,7 @@ void sync_and_refresh_displays(void) {
     // the keycap OLEDs — otherwise update_displays() redraws every keycap
     // from the overlay buffers and wipes "BOOT-LOADER!". Master is in ROM
     // bootloader and cannot recover, so freezing slave state until
-    // power-cycle is fine.
+    // power-cycle is fine. corne42 has no RGB hardware so no RGB re-assert.
     if (!is_usb_host_side() && (get_local_state()->overlay_flags & BOOTLOADER_DISPLAY)) {
         return;
     }
@@ -1055,8 +1055,8 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
                 // no-op there — kept for parity with split72.
                 rgb_matrix_enable_noeeprom();
                 rgb_matrix_mode_noeeprom(RGB_MATRIX_SOLID_COLOR);
-                rgb_matrix_sethsv_noeeprom(0, 255, 64);
-                rgb_matrix_set_color_all(64, 0, 0);
+                rgb_matrix_sethsv_noeeprom(0, 255, 24);
+                rgb_matrix_set_color_all(24, 0, 0);
                 rgb_matrix_update_pwm_buffers();
 #endif
                 return true;

--- a/keyboards/handwired/polykybd/corne42/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/corne42/keymaps/default/keymap.c
@@ -1423,6 +1423,14 @@ void poly_suspend(void) {
 }
 
 void suspend_power_down_kb(void) {
+    // Master entering the RP2040 ROM bootloader trips USB suspend on the
+    // slave a few ms after the sync handler painted the bootloader screen.
+    // Without this guard, poly_suspend() queues contrast=0 and the next
+    // sync_and_refresh_displays would turn the OLEDs off. Once
+    // BOOTLOADER_DISPLAY is set the only way out is power-cycle.
+    if (get_local_state()->overlay_flags & BOOTLOADER_DISPLAY) {
+        return;
+    }
     poly_suspend();
     sync_and_refresh_displays();
     suspend_power_down_user();

--- a/keyboards/handwired/polykybd/poly_util.c
+++ b/keyboards/handwired/polykybd/poly_util.c
@@ -5,10 +5,37 @@
 #include "base/disp_array.h"
 #include "base/shift_reg.h"
 #include "base/helpers.h"
+#include "base/fonts/FreeSansBold24pt7b.h"
 
 const uint8_t* get_key_disp_bitmask(uint8_t index);
-
 uint8_t get_disp_bitmask_size(void);
+
+extern void set_displays(uint8_t contrast, bool idle);
+
+void select_all_displays(void) {
+    sr_shift_out_0_latch(NUM_SHIFT_REGISTERS);
+}
+
+void clear_all_displays(void) {
+    select_all_displays();
+    kdisp_set_buffer(0x00);
+    kdisp_send_buffer();
+}
+
+void display_bootloader_message(void) {
+    #ifdef RGB_MATRIX_ENABLE
+        rgb_matrix_enable_noeeprom();
+        rgb_matrix_mode_noeeprom(RGB_MATRIX_SOLID_COLOR);
+        rgb_matrix_set_color_all(0, 5, 3);
+        rgb_matrix_update_pwm_buffers();
+    #endif
+
+    clear_all_displays();
+    // Contrast 10 → SETCONTRAST 9/255; contrast 1 tested unreadable.
+    set_displays(20, false);
+    display_message(1, 1, u"BOOT-",   &FreeSansBold24pt7b);
+    display_message(3, 0, u"LOADER!", &FreeSansBold24pt7b);
+}
 
 void display_message(uint8_t row, uint8_t col, const uint16_t* message, const GFXfont* font) {
 

--- a/keyboards/handwired/polykybd/poly_util.h
+++ b/keyboards/handwired/polykybd/poly_util.h
@@ -5,3 +5,8 @@
 #include <stdint.h>
 
 void display_message(uint8_t row, uint8_t col, const uint16_t* message, const GFXfont* font);
+
+// Clears all keycap displays then renders the "BOOT-LOADER!" message.
+// Called on master before reset_keyboard() and on slave from the
+// USER_SYNC_POLY_DATA handler when BOOTLOADER_DISPLAY is newly set.
+void display_bootloader_message(void);

--- a/keyboards/handwired/polykybd/poly_util.h
+++ b/keyboards/handwired/polykybd/poly_util.h
@@ -4,9 +4,11 @@
 
 #include <stdint.h>
 
+
+void select_all_displays(void);
+
+void clear_all_displays(void);
+
 void display_message(uint8_t row, uint8_t col, const uint16_t* message, const GFXfont* font);
 
-// Clears all keycap displays then renders the "BOOT-LOADER!" message.
-// Called on master before reset_keyboard() and on slave from the
-// USER_SYNC_POLY_DATA handler when BOOTLOADER_DISPLAY is newly set.
 void display_bootloader_message(void);

--- a/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
@@ -169,7 +169,7 @@ bool rgb_matrix_indicators_kb(void) {
         if (get_local_state()->overlay_flags & BOOTLOADER_DISPLAY) {
             // Backstop in case the SOLID_COLOR mode change in the sync
             // handler didn't take effect — value matched to the sethsv val.
-            rgb_matrix_set_color_all(8, 0, 0);
+            rgb_matrix_set_color_all(64, 0, 0);
             return false;
         }
         if ((get_local_state()->flags & STATUS_DISP_ON) == 0) {
@@ -1266,25 +1266,29 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
     const poly_layer_t* global_layer = get_global_layer();
     if (record->event.pressed) {
         switch (keycode) {
-            case QK_BOOTLOADER:
+            case QK_BOOTLOADER: {
                 uprintf("Bootloader entered. Please copy new Firmware.\n");
                 // Tell the slave first — once we return true, QMK calls
                 // reset_keyboard() and the master goes dark before housekeeping
                 // could push a deferred state diff over UART.
                 access_local_state()->overlay_flags |= BOOTLOADER_DISPLAY;
-                send_to_bridge(USER_SYNC_POLY_DATA, (void *)access_local_state(), sizeof(poly_sync_t), 10);
+                uint8_t ack = send_to_bridge(USER_SYNC_POLY_DATA, (void *)access_local_state(), sizeof(poly_sync_t), 10);
+                uprintf("Master: BOOTLOADER_DISPLAY sync ack=%d\n", ack);
                 display_bootloader_message();
 #ifdef RGB_MATRIX_ENABLE
-                // Mode-switch latches the slave into solid red; set_color_all
+                // Mode-switch + sethsv keeps slave in dim solid red; set_color_all
                 // + update_pwm_buffers immediately flushes red to the master's
                 // LED driver (no further frames will render before reset).
+                // Value is scaled by RGB_MATRIX_MAXIMUM_BRIGHTNESS (100);
+                // val=64 → ~25 PWM, dim but reliably visible.
                 rgb_matrix_enable_noeeprom();
                 rgb_matrix_mode_noeeprom(RGB_MATRIX_SOLID_COLOR);
-                rgb_matrix_sethsv_noeeprom(0, 255, 8);
-                rgb_matrix_set_color_all(8, 0, 0);
+                rgb_matrix_sethsv_noeeprom(0, 255, 64);
+                rgb_matrix_set_color_all(64, 0, 0);
                 rgb_matrix_update_pwm_buffers();
 #endif
                 return true;
+            }
             case KC_A ... KC_Z:
                 set_local_last_latin_keycode(keycode);
                 if((get_mods() & MOD_MASK_ALT) == 0 && addlang) {

--- a/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
@@ -1683,6 +1683,15 @@ void poly_suspend(void) {
 
 // Suspends keyboard: suspends power down, disables RGB, calls housekeeping, resets update timer.
 void suspend_power_down_kb(void) {
+    // Master entering the RP2040 ROM bootloader trips USB suspend on the
+    // slave a few ms after the sync handler painted the bootloader screen.
+    // Without this guard, poly_suspend() + rgb_matrix_disable_noeeprom()
+    // immediately wipe the red and queue contrast=0 → the slave goes black.
+    // Once BOOTLOADER_DISPLAY is set the only way out is power-cycle, so
+    // freezing the suspend path is correct.
+    if (get_local_state()->overlay_flags & BOOTLOADER_DISPLAY) {
+        return;
+    }
     poly_suspend();
     rgb_matrix_disable_noeeprom();
     sync_and_refresh_displays();

--- a/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
@@ -117,6 +117,11 @@ void clear_all_displays(void) {
 
 void display_bootloader_message(void) {
     clear_all_displays();
+    // Drive the OLEDs at minimum contrast so the bootloader screen is as dim
+    // as possible — once the master is in ROM bootloader nothing else will
+    // restore the brightness, so we want to consume as little current as
+    // possible while keeping the message readable.
+    set_displays(MIN_BRIGHT, false);
     display_message(1, 1, u"BOOT-",   &FreeSansBold24pt7b);
     display_message(3, 0, u"LOADER!", &FreeSansBold24pt7b);
 }
@@ -162,7 +167,9 @@ static uint8_t overlay_flags = 0;
 bool rgb_matrix_indicators_kb(void) {
     if (!is_keyboard_master()) {
         if (get_local_state()->overlay_flags & BOOTLOADER_DISPLAY) {
-            rgb_matrix_set_color_all(255, 0, 0);
+            // Backstop in case the SOLID_COLOR mode change in the sync
+            // handler didn't take effect — value matched to the sethsv val.
+            rgb_matrix_set_color_all(8, 0, 0);
             return false;
         }
         if ((get_local_state()->flags & STATUS_DISP_ON) == 0) {
@@ -203,6 +210,15 @@ static uint32_t rgb_repeat_callback(uint32_t trigger_time, void* cb_arg) {
 // Synchronizes local and global display state, handling idle transitions, contrast changes, and display updates.
 // Global variables: flags, overlay_flags
 void sync_and_refresh_displays(void) {
+    // On the slave, once the bootloader screen is up we want nothing else to
+    // touch the keycap OLEDs — otherwise the next state_diff branch redraws
+    // every keycap from the overlay buffers and wipes "BOOT-LOADER!".
+    // The master will never recover from this (it's in the ROM bootloader),
+    // so freezing the slave display state until power-cycle is fine.
+    if (!is_usb_host_side() && (get_local_state()->overlay_flags & BOOTLOADER_DISPLAY)) {
+        return;
+    }
+
     bool layer_diff = false;
     bool state_diff = false;
 
@@ -1259,8 +1275,13 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
                 send_to_bridge(USER_SYNC_POLY_DATA, (void *)access_local_state(), sizeof(poly_sync_t), 10);
                 display_bootloader_message();
 #ifdef RGB_MATRIX_ENABLE
+                // Mode-switch latches the slave into solid red; set_color_all
+                // + update_pwm_buffers immediately flushes red to the master's
+                // LED driver (no further frames will render before reset).
                 rgb_matrix_enable_noeeprom();
-                rgb_matrix_set_color_all(255, 0, 0);
+                rgb_matrix_mode_noeeprom(RGB_MATRIX_SOLID_COLOR);
+                rgb_matrix_sethsv_noeeprom(0, 255, 8);
+                rgb_matrix_set_color_all(8, 0, 0);
                 rgb_matrix_update_pwm_buffers();
 #endif
                 return true;

--- a/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
@@ -117,11 +117,10 @@ void clear_all_displays(void) {
 
 void display_bootloader_message(void) {
     clear_all_displays();
-    // Drive the OLEDs at minimum contrast so the bootloader screen is as dim
-    // as possible — once the master is in ROM bootloader nothing else will
-    // restore the brightness, so we want to consume as little current as
-    // possible while keeping the message readable.
-    set_displays(MIN_BRIGHT, false);
+    // Dim OLED contrast. set_displays() sends SETCONTRAST(value - 1), so
+    // value=10 → hardware contrast 9/255 ≈ 18% of max — dim but legible.
+    // MIN_BRIGHT (1 → SETCONTRAST 0) was tested and proved unreadable.
+    set_displays(10, false);
     display_message(1, 1, u"BOOT-",   &FreeSansBold24pt7b);
     display_message(3, 0, u"LOADER!", &FreeSansBold24pt7b);
 }

--- a/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
@@ -42,6 +42,7 @@
 #include "state.h"
 #include "multicore_exec.h"
 #include "split_sync.h"
+#include "poly_util.h"
 
 #include "lang/lang_lut.h"
 #include "lang/lang_lut_ext.h"
@@ -99,34 +100,7 @@ void oled_update_buffer(void);
 void poly_suspend(void);
 
 
-// Selects all shift registers to communicate with all displays.
-// Global variables: (none - uses SPI functions only)
-void select_all_displays(void) {
-    // make sure we are talking to all shift registers
-    sr_shift_out_0_latch(NUM_SHIFT_REGISTERS);
-}
-
-// Clears all displays by setting buffer to zero and sending to all shift registers.
-// Global variables: (none - delegates to display functions)
-void clear_all_displays(void) {
-    select_all_displays();
-
-    kdisp_set_buffer(0x00);
-    kdisp_send_buffer();
-}
-
-void display_bootloader_message(void) {
-    clear_all_displays();
-    // Dim OLED contrast. set_displays() sends SETCONTRAST(value - 1), so
-    // value=10 → hardware contrast 9/255 ≈ 18% of max — dim but legible.
-    // MIN_BRIGHT (1 → SETCONTRAST 0) was tested and proved unreadable.
-    set_displays(10, false);
-    display_message(1, 1, u"BOOT-",   &FreeSansBold24pt7b);
-    display_message(3, 0, u"LOADER!", &FreeSansBold24pt7b);
-}
-
 // Initializes SPI hardware for display communication after hardware reset.
-// Global variables: (none - initializes hardware only)
 void early_hardware_init_post(void) {
     spi_hw_setup();
 }
@@ -166,9 +140,7 @@ static uint8_t overlay_flags = 0;
 bool rgb_matrix_indicators_kb(void) {
     if (!is_keyboard_master()) {
         if (get_local_state()->overlay_flags & BOOTLOADER_DISPLAY) {
-            // Backstop on top of the SOLID_COLOR mode + re-assert in
-            // sync_and_refresh_displays. Only runs when effect != 0, so this
-            // only helps if rgb_matrix_config.enable is true.
+            // Backstop: force red even if rgb_matrix_config.enable gets cleared.
             rgb_matrix_set_color_all(24, 0, 0);
             return false;
         }
@@ -210,19 +182,9 @@ static uint32_t rgb_repeat_callback(uint32_t trigger_time, void* cb_arg) {
 // Synchronizes local and global display state, handling idle transitions, contrast changes, and display updates.
 // Global variables: flags, overlay_flags
 void sync_and_refresh_displays(void) {
-    // On the slave, once the bootloader screen is up we want nothing else to
-    // touch the keycap OLEDs — otherwise the next state_diff branch redraws
-    // every keycap from the overlay buffers and wipes "BOOT-LOADER!".
-    // The master will never recover from this (it's in the ROM bootloader),
-    // so freezing the slave display state until power-cycle is fine.
+    // Freeze slave display while bootloader is active; re-assert RGB each cycle.
     if (!is_usb_host_side() && (get_local_state()->overlay_flags & BOOTLOADER_DISPLAY)) {
 #ifdef RGB_MATRIX_ENABLE
-        // Re-assert solid red every cycle. Standard QMK split RGB sync or
-        // some transient state could flip rgb_matrix_config.enable to 0
-        // after our one-shot setup in user_sync_poly_data_handler; once
-        // enable=0 the matrix renders RGB_MATRIX_NONE and indicators_kb is
-        // skipped (rgb_matrix.c rgb_task_render: `if (effect)` gate), so
-        // the backstop is dead too. Idempotent calls fix the race.
         if (!rgb_matrix_is_enabled()) {
             rgb_matrix_enable_noeeprom();
         }
@@ -1285,25 +1247,11 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
         switch (keycode) {
             case QK_BOOTLOADER: {
                 uprintf("Bootloader entered. Please copy new Firmware.\n");
-                // Tell the slave first — once we return true, QMK calls
-                // reset_keyboard() and the master goes dark before housekeeping
-                // could push a deferred state diff over UART.
+                // Sync slave before returning true — QMK resets before housekeeping runs.
                 access_local_state()->overlay_flags |= BOOTLOADER_DISPLAY;
                 uint8_t ack = send_to_bridge(USER_SYNC_POLY_DATA, (void *)access_local_state(), sizeof(poly_sync_t), 10);
                 uprintf("Master: BOOTLOADER_DISPLAY sync ack=%d\n", ack);
                 display_bootloader_message();
-#ifdef RGB_MATRIX_ENABLE
-                // Mode-switch + sethsv keeps slave in dim solid red; set_color_all
-                // + update_pwm_buffers immediately flushes red to the master's
-                // LED driver (no further frames will render before reset).
-                // Value is scaled by RGB_MATRIX_MAXIMUM_BRIGHTNESS (100);
-                // val=24 → ~9 PWM, clearly visible but dim.
-                rgb_matrix_enable_noeeprom();
-                rgb_matrix_mode_noeeprom(RGB_MATRIX_SOLID_COLOR);
-                rgb_matrix_sethsv_noeeprom(0, 255, 24);
-                rgb_matrix_set_color_all(24, 0, 0);
-                rgb_matrix_update_pwm_buffers();
-#endif
                 return true;
             }
             case KC_A ... KC_Z:
@@ -1704,12 +1652,7 @@ void poly_suspend(void) {
 
 // Suspends keyboard: suspends power down, disables RGB, calls housekeeping, resets update timer.
 void suspend_power_down_kb(void) {
-    // Master entering the RP2040 ROM bootloader trips USB suspend on the
-    // slave a few ms after the sync handler painted the bootloader screen.
-    // Without this guard, poly_suspend() + rgb_matrix_disable_noeeprom()
-    // immediately wipe the red and queue contrast=0 → the slave goes black.
-    // Once BOOTLOADER_DISPLAY is set the only way out is power-cycle, so
-    // freezing the suspend path is correct.
+    // USB suspend fires on slave when master enters bootloader; skip to keep displays lit.
     if (get_local_state()->overlay_flags & BOOTLOADER_DISPLAY) {
         return;
     }

--- a/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
@@ -166,9 +166,10 @@ static uint8_t overlay_flags = 0;
 bool rgb_matrix_indicators_kb(void) {
     if (!is_keyboard_master()) {
         if (get_local_state()->overlay_flags & BOOTLOADER_DISPLAY) {
-            // Backstop in case the SOLID_COLOR mode change in the sync
-            // handler didn't take effect — value matched to the sethsv val.
-            rgb_matrix_set_color_all(64, 0, 0);
+            // Backstop on top of the SOLID_COLOR mode + re-assert in
+            // sync_and_refresh_displays. Only runs when effect != 0, so this
+            // only helps if rgb_matrix_config.enable is true.
+            rgb_matrix_set_color_all(24, 0, 0);
             return false;
         }
         if ((get_local_state()->flags & STATUS_DISP_ON) == 0) {
@@ -215,6 +216,23 @@ void sync_and_refresh_displays(void) {
     // The master will never recover from this (it's in the ROM bootloader),
     // so freezing the slave display state until power-cycle is fine.
     if (!is_usb_host_side() && (get_local_state()->overlay_flags & BOOTLOADER_DISPLAY)) {
+#ifdef RGB_MATRIX_ENABLE
+        // Re-assert solid red every cycle. Standard QMK split RGB sync or
+        // some transient state could flip rgb_matrix_config.enable to 0
+        // after our one-shot setup in user_sync_poly_data_handler; once
+        // enable=0 the matrix renders RGB_MATRIX_NONE and indicators_kb is
+        // skipped (rgb_matrix.c rgb_task_render: `if (effect)` gate), so
+        // the backstop is dead too. Idempotent calls fix the race.
+        if (!rgb_matrix_is_enabled()) {
+            rgb_matrix_enable_noeeprom();
+        }
+        if (rgb_matrix_get_mode() != RGB_MATRIX_SOLID_COLOR) {
+            rgb_matrix_mode_noeeprom(RGB_MATRIX_SOLID_COLOR);
+        }
+        if (rgb_matrix_get_val() != 24) {
+            rgb_matrix_sethsv_noeeprom(0, 255, 24);
+        }
+#endif
         return;
     }
 
@@ -1279,11 +1297,11 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
                 // + update_pwm_buffers immediately flushes red to the master's
                 // LED driver (no further frames will render before reset).
                 // Value is scaled by RGB_MATRIX_MAXIMUM_BRIGHTNESS (100);
-                // val=64 → ~25 PWM, dim but reliably visible.
+                // val=24 → ~9 PWM, clearly visible but dim.
                 rgb_matrix_enable_noeeprom();
                 rgb_matrix_mode_noeeprom(RGB_MATRIX_SOLID_COLOR);
-                rgb_matrix_sethsv_noeeprom(0, 255, 64);
-                rgb_matrix_set_color_all(64, 0, 0);
+                rgb_matrix_sethsv_noeeprom(0, 255, 24);
+                rgb_matrix_set_color_all(24, 0, 0);
                 rgb_matrix_update_pwm_buffers();
 #endif
                 return true;

--- a/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
@@ -115,6 +115,12 @@ void clear_all_displays(void) {
     kdisp_send_buffer();
 }
 
+void display_bootloader_message(void) {
+    clear_all_displays();
+    display_message(1, 1, u"BOOT-",   &FreeSansBold24pt7b);
+    display_message(3, 0, u"LOADER!", &FreeSansBold24pt7b);
+}
+
 // Initializes SPI hardware for display communication after hardware reset.
 // Global variables: (none - initializes hardware only)
 void early_hardware_init_post(void) {
@@ -154,9 +160,15 @@ static uint8_t overlay_flags = 0;
 // ensuring LEDs stay dark regardless of what the transport wrote to enable.
 #ifdef RGB_MATRIX_ENABLE
 bool rgb_matrix_indicators_kb(void) {
-    if (!is_keyboard_master() && (get_local_state()->flags & STATUS_DISP_ON) == 0) {
-        rgb_matrix_set_color_all(0, 0, 0);
-        return false;
+    if (!is_keyboard_master()) {
+        if (get_local_state()->overlay_flags & BOOTLOADER_DISPLAY) {
+            rgb_matrix_set_color_all(255, 0, 0);
+            return false;
+        }
+        if ((get_local_state()->flags & STATUS_DISP_ON) == 0) {
+            rgb_matrix_set_color_all(0, 0, 0);
+            return false;
+        }
     }
     return rgb_matrix_indicators_user();
 }
@@ -1240,9 +1252,17 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
         switch (keycode) {
             case QK_BOOTLOADER:
                 uprintf("Bootloader entered. Please copy new Firmware.\n");
-                clear_all_displays();
-                display_message(1, 1, u"BOOT-", &FreeSansBold24pt7b);
-                display_message(3, 0, u"LOADER!", &FreeSansBold24pt7b);
+                // Tell the slave first — once we return true, QMK calls
+                // reset_keyboard() and the master goes dark before housekeeping
+                // could push a deferred state diff over UART.
+                access_local_state()->overlay_flags |= BOOTLOADER_DISPLAY;
+                send_to_bridge(USER_SYNC_POLY_DATA, (void *)access_local_state(), sizeof(poly_sync_t), 10);
+                display_bootloader_message();
+#ifdef RGB_MATRIX_ENABLE
+                rgb_matrix_enable_noeeprom();
+                rgb_matrix_set_color_all(255, 0, 0);
+                rgb_matrix_update_pwm_buffers();
+#endif
                 return true;
             case KC_A ... KC_Z:
                 set_local_last_latin_keycode(keycode);

--- a/keyboards/handwired/polykybd/split_sync.c
+++ b/keyboards/handwired/polykybd/split_sync.c
@@ -58,15 +58,17 @@ void user_sync_poly_data_handler(uint8_t in_len, const void* in_data, uint8_t ou
             // while master is dark. The flag is left set so rgb_matrix_indicators_kb
             // keeps forcing red until the slave is power-cycled by the reflash.
             if(newly_set & BOOTLOADER_DISPLAY) {
+                uprint("Slave: BOOTLOADER_DISPLAY received\n");
                 display_bootloader_message();
 #ifdef RGB_MATRIX_ENABLE
-                // Switch to a persistent solid-red effect on the slave at the
-                // minimum visible brightness. set_color_all alone gets wiped by
-                // the next frame of whatever effect was running; SOLID_COLOR +
-                // sethsv keeps red latched until power-cycle.
+                // Persistent solid red. Value scales through
+                // RGB_MATRIX_MAXIMUM_BRIGHTNESS (100); val=64 → ~25 PWM,
+                // dim but reliably visible.
                 rgb_matrix_enable_noeeprom();
                 rgb_matrix_mode_noeeprom(RGB_MATRIX_SOLID_COLOR);
-                rgb_matrix_sethsv_noeeprom(0, 255, 8);
+                rgb_matrix_sethsv_noeeprom(0, 255, 64);
+                rgb_matrix_set_color_all(64, 0, 0);
+                rgb_matrix_update_pwm_buffers();
 #endif
             }
             ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK;

--- a/keyboards/handwired/polykybd/split_sync.c
+++ b/keyboards/handwired/polykybd/split_sync.c
@@ -60,9 +60,13 @@ void user_sync_poly_data_handler(uint8_t in_len, const void* in_data, uint8_t ou
             if(newly_set & BOOTLOADER_DISPLAY) {
                 display_bootloader_message();
 #ifdef RGB_MATRIX_ENABLE
+                // Switch to a persistent solid-red effect on the slave at the
+                // minimum visible brightness. set_color_all alone gets wiped by
+                // the next frame of whatever effect was running; SOLID_COLOR +
+                // sethsv keeps red latched until power-cycle.
                 rgb_matrix_enable_noeeprom();
-                rgb_matrix_set_color_all(255, 0, 0);
-                rgb_matrix_update_pwm_buffers();
+                rgb_matrix_mode_noeeprom(RGB_MATRIX_SOLID_COLOR);
+                rgb_matrix_sethsv_noeeprom(0, 255, 8);
 #endif
             }
             ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK;

--- a/keyboards/handwired/polykybd/split_sync.c
+++ b/keyboards/handwired/polykybd/split_sync.c
@@ -42,7 +42,10 @@ void user_sync_poly_data_handler(uint8_t in_len, const void* in_data, uint8_t ou
             // mirroring the master's case-11 handling. Without this, a mapping
             // bridge transaction arriving before housekeeping runs would have its
             // use_overlay bits wiped by a later deferred reset_overlay_usage().
-            uint8_t newly_set = (incoming->overlay_flags & ~current->overlay_flags);
+            uint8_t newly_set     = (incoming->overlay_flags & ~current->overlay_flags);
+#ifdef RGB_MATRIX_ENABLE
+            uint8_t newly_cleared = (current->overlay_flags  & ~incoming->overlay_flags);
+#endif
             copy_local_state(incoming);
             if(newly_set & OVERLAY_ACTION_FLAGS) {
                 apply_overlay_action_flags(newly_set);
@@ -52,27 +55,16 @@ void user_sync_poly_data_handler(uint8_t in_len, const void* in_data, uint8_t ou
                 // won't fire now that local matches global — trigger the refresh ourselves.
                 request_disp_refresh();
             }
-            // Master is about to enter the RP2040 ROM bootloader. Render the
-            // bootloader message on the slave's keycap displays and latch a
-            // solid red on the RGB matrix so the slave half stays visibly lit
-            // while master is dark. The flag is left set so rgb_matrix_indicators_kb
-            // keeps forcing red until the slave is power-cycled by the reflash.
             if(newly_set & BOOTLOADER_DISPLAY) {
                 uprint("Slave: BOOTLOADER_DISPLAY received\n");
                 display_bootloader_message();
-#ifdef RGB_MATRIX_ENABLE
-                // Persistent solid red at low brightness. Value scales
-                // through RGB_MATRIX_MAXIMUM_BRIGHTNESS (100); val=24 →
-                // ~9 PWM, clearly visible but dim. sync_and_refresh_displays
-                // re-asserts this each cycle as a self-heal in case standard
-                // QMK split sync flips rgb_matrix_config.enable back to 0.
-                rgb_matrix_enable_noeeprom();
-                rgb_matrix_mode_noeeprom(RGB_MATRIX_SOLID_COLOR);
-                rgb_matrix_sethsv_noeeprom(0, 255, 24);
-                rgb_matrix_set_color_all(24, 0, 0);
-                rgb_matrix_update_pwm_buffers();
-#endif
             }
+#ifdef RGB_MATRIX_ENABLE
+            // Disable RGB so the normal split transport restores master's config cleanly.
+            if(newly_cleared & BOOTLOADER_DISPLAY) {
+                rgb_matrix_disable_noeeprom();
+            }
+#endif
             ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK;
         } else {
             ((poly_sync_reply_t*)out_data)->ack = SYNC_CRC32_ERR;

--- a/keyboards/handwired/polykybd/split_sync.c
+++ b/keyboards/handwired/polykybd/split_sync.c
@@ -61,13 +61,15 @@ void user_sync_poly_data_handler(uint8_t in_len, const void* in_data, uint8_t ou
                 uprint("Slave: BOOTLOADER_DISPLAY received\n");
                 display_bootloader_message();
 #ifdef RGB_MATRIX_ENABLE
-                // Persistent solid red. Value scales through
-                // RGB_MATRIX_MAXIMUM_BRIGHTNESS (100); val=64 → ~25 PWM,
-                // dim but reliably visible.
+                // Persistent solid red at low brightness. Value scales
+                // through RGB_MATRIX_MAXIMUM_BRIGHTNESS (100); val=24 →
+                // ~9 PWM, clearly visible but dim. sync_and_refresh_displays
+                // re-asserts this each cycle as a self-heal in case standard
+                // QMK split sync flips rgb_matrix_config.enable back to 0.
                 rgb_matrix_enable_noeeprom();
                 rgb_matrix_mode_noeeprom(RGB_MATRIX_SOLID_COLOR);
-                rgb_matrix_sethsv_noeeprom(0, 255, 64);
-                rgb_matrix_set_color_all(64, 0, 0);
+                rgb_matrix_sethsv_noeeprom(0, 255, 24);
+                rgb_matrix_set_color_all(24, 0, 0);
                 rgb_matrix_update_pwm_buffers();
 #endif
             }

--- a/keyboards/handwired/polykybd/split_sync.c
+++ b/keyboards/handwired/polykybd/split_sync.c
@@ -18,6 +18,9 @@
 #include "state.h"
 #include "side.h"
 #include "matrix_helper.h"
+#include "poly_util.h"
+
+void rgb_matrix_update_pwm_buffers(void);
 
 void invert_display(uint8_t r, uint8_t c, bool state);
 
@@ -48,6 +51,19 @@ void user_sync_poly_data_handler(uint8_t in_len, const void* in_data, uint8_t ou
                 // Housekeeping's state_diff branch (which used to call this at the end)
                 // won't fire now that local matches global — trigger the refresh ourselves.
                 request_disp_refresh();
+            }
+            // Master is about to enter the RP2040 ROM bootloader. Render the
+            // bootloader message on the slave's keycap displays and latch a
+            // solid red on the RGB matrix so the slave half stays visibly lit
+            // while master is dark. The flag is left set so rgb_matrix_indicators_kb
+            // keeps forcing red until the slave is power-cycled by the reflash.
+            if(newly_set & BOOTLOADER_DISPLAY) {
+                display_bootloader_message();
+#ifdef RGB_MATRIX_ENABLE
+                rgb_matrix_enable_noeeprom();
+                rgb_matrix_set_color_all(255, 0, 0);
+                rgb_matrix_update_pwm_buffers();
+#endif
             }
             ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK;
         } else {


### PR DESCRIPTION
## Summary
- Adds `BOOTLOADER_DISPLAY` bit (replacing the unused `RESERVED_2` slot in `overlay_flag`) so master can signal the slave half right before `reset_keyboard()` runs.
- Master's `QK_BOOTLOADER` handler now sets the flag, force-syncs `USER_SYNC_POLY_DATA` synchronously (housekeeping wouldn't get a chance to push the diff before reset), draws the message locally, and latches solid red on the RGB matrix (`_noeeprom`).
- Slave's `user_sync_poly_data_handler()` detects the 0->1 transition, renders `BOOT-LOADER!` via a new `display_bootloader_message()` helper (defined in each keymap so the static font data isn't duplicated across translation units), and latches red.
- `rgb_matrix_indicators_kb()` on the slave early-returns red while the flag is set so the existing suspend-mode zero-out doesn't clobber it.
- Both `split72` and `corne42` keymaps updated identically.

Both `handwired/polykybd/split72:default` and `handwired/polykybd/corne42:default` compile clean.

## Test plan
- [ ] Press the `QK_BOOTLOADER` key on master with both halves connected — confirm both halves render `BOOT-LOADER!` and turn solid red.
- [ ] Confirm the slave stays red until power-cycled (i.e. it survives master being in ROM bootloader).
- [ ] Confirm reflashing both halves restores normal RGB / display state — `BOOTLOADER_DISPLAY` bit is not persisted to EEPROM (it lives in `poly_sync_t.overlay_flags`, not `poly_eeconf_t`).
- [ ] Quick check: brightness / language / layer changes still sync correctly (no regression in `user_sync_poly_data_handler`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a synchronized bootloader display and RGB indication across both halves of split polykybd boards when entering the bootloader.

New Features:
- Introduce a BOOTLOADER_DISPLAY overlay flag to signal bootloader entry from master to slave over split sync.
- Display a unified "BOOT-LOADER!" message and solid red RGB state on both master and slave when QK_BOOTLOADER is triggered.

Enhancements:
- Refine rgb_matrix indicator handling on the slave so bootloader red state overrides suspend-driven LED blanking.
- Factor out bootloader display rendering into a shared display_bootloader_message helper used by multiple keymaps.

Tests:
- Ensure both split72 and corne42 default keymaps use the new bootloader signaling and display behavior.