### PR TITLE
fix: trackpad not working when on slave side (split72)

### DIFF
--- a/keyboards/handwired/polykybd/split72/config.h
+++ b/keyboards/handwired/polykybd/split72/config.h
@@ -84,12 +84,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define SPLIT_POINTING_ENABLE
 
 // Pointing device is on the right split.
-#define POINTING_DEVICE_COMBINED
+// Use POINTING_DEVICE_COMBINED instead if a left trackpad is also added.
+#define POINTING_DEVICE_RIGHT
 
 // Limits the frequency that the sensor is polled for motion.
 #define POINTING_DEVICE_TASK_THROTTLE_MS 1
 
-#define POINTING_DEVICE_ROTATION_90_RIGHT
+// POINTING_DEVICE_ROTATION_90_RIGHT only applies in POINTING_DEVICE_COMBINED mode.
+#define POINTING_DEVICE_ROTATION_90
 //#define POINTING_DEVICE_GESTURES_CURSOR_GLIDE_ENABLE
 
 //#define POINTING_DEVICE_DEBUG


### PR DESCRIPTION
## Summary

- `POINTING_DEVICE_COMBINED` sets `POINTING_DEVICE_THIS_SIDE = true` on **both** halves, so the side without the Cirque chip attempts I2C init, fails with `INIT_FAILED`, and bails out of `pointing_device_task()` before ever reading the shared report from the other side via the split transport — meaning the trackpad is dead whenever it is not on the master side.
- Switch to `POINTING_DEVICE_RIGHT`: driver init only runs on the right half; when the left is master it reads from `shared_mouse_report`, which `SPLIT_POINTING_ENABLE` already populates regardless of which side holds USB.
- Replace `POINTING_DEVICE_ROTATION_90_RIGHT` → `POINTING_DEVICE_ROTATION_90`: the `_RIGHT` variant is only applied by `pointing_device_adjust_by_defines_right()`, which is only called in the `COMBINED` code path.

> If a left trackpad is added later: change `POINTING_DEVICE_RIGHT` → `POINTING_DEVICE_COMBINED` and `POINTING_DEVICE_ROTATION_90` → `POINTING_DEVICE_ROTATION_90_RIGHT`.

## Test plan

- [ ] Flash both halves with new firmware
- [ ] Plug USB into the side **without** the trackpad (left = master, right = slave) — verify cursor moves
- [ ] Plug USB into the side **with** the trackpad (right = master) — verify cursor still moves
- [ ] Verify tap-to-click and glide still work in both configurations

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

## Summary by Sourcery

Configure the split72 keyboard so the Cirque trackpad is treated as a right-side-only pointing device instead of a combined device, ensuring it works regardless of which half is the USB master.

Bug Fixes:
- Fix trackpad not working when the USB master is on the half without the Cirque trackpad by only initializing the pointing device on the right side.

Enhancements:
- Clarify configuration comments for switching between right-only and combined pointing device modes and update rotation to match the non-combined configuration.