### PR TITLE
fix(ci): detect station dir by venv presence, not directory existence

### DIFF
--- a/.github/workflows/qmk-test.yml
+++ b/.github/workflows/qmk-test.yml
@@ -46,14 +46,21 @@ jobs:
       - name: Locate station directory
         id: ctnd
         run: |
-          # Use CTND_DIR env var if set; otherwise try /opt then home directory
+          # Use CTND_DIR env var if set; otherwise find the first candidate
+          # that actually has a venv (directory existing is not enough).
           dir="${CTND_DIR:-}"
           if [ -z "$dir" ]; then
-            if [ -d "/opt/polykybd-ctnd" ]; then
-              dir=/opt/polykybd-ctnd
-            else
-              dir="$HOME/polykybd-ctnd"
-            fi
+            for candidate in /opt/polykybd-ctnd "$HOME/polykybd-ctnd"; do
+              if [ -f "$candidate/venv/bin/python" ]; then
+                dir="$candidate"
+                break
+              fi
+            done
+          fi
+          if [ -z "$dir" ]; then
+            echo "ERROR: could not find a polykybd-ctnd install with a venv." >&2
+            echo "Set CTND_DIR in the runner environment or run scripts/setup.sh." >&2
+            exit 1
           fi
           echo "dir=$dir" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
/opt/polykybd-ctnd may exist as an empty directory while the real install is in ~/polykybd-ctnd. Check for venv/bin/python in each candidate so the correct path is always found, and fail with a clear message if neither has a venv.

https://claude.ai/code/session_0125omCkyAof4zXHRzTjCfqB

<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Improve CI workflow detection of the polykybd-ctnd station directory based on presence of a Python virtual environment and fail clearly when no valid installation is found.

Bug Fixes:
- Ensure the CI job selects the correct polykybd-ctnd station directory by requiring a venv-backed installation rather than relying on directory existence.

CI:
- Update qmk-test workflow logic to scan candidate station directories for a venv and exit with an explicit error when none are suitable.