### PR TITLE
perf: move g_led_config and ALL_FONTS to flash (.rodata)

### DIFF
--- a/keyboards/handwired/polykybd/base/disp_array.c
+++ b/keyboards/handwired/polykybd/base/disp_array.c
@@ -124,7 +124,7 @@ void kdisp_clear_rect(int8_t x_start, int8_t y_start, int8_t width, int8_t heigh
     @param    ch  The 16-bit font-indexed character
 */
 /**************************************************************************/
-int8_t kdisp_write_gfx_char(const GFXfont **fonts, uint8_t num_fonts, int8_t x, int8_t y, uint16_t ch, bool clear_cy) {
+int8_t kdisp_write_gfx_char(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, uint16_t ch, bool clear_cy) {
     const GFXfont * currentFont = 0;
     uint16_t first = 0;
     uint16_t last = 0;
@@ -176,11 +176,11 @@ int8_t kdisp_write_gfx_char(const GFXfont **fonts, uint8_t num_fonts, int8_t x, 
     return pgm_read_byte(&glyph->xAdvance);
 }
 
-void kdisp_write_gfx_text(const GFXfont **fonts, uint8_t num_fonts, int8_t x, int8_t y, const uint16_t *text) {
+void kdisp_write_gfx_text(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, const uint16_t *text) {
     kdisp_write_gfx_text_cy(fonts, num_fonts, x, y, text, false);
 }
 
-void kdisp_write_gfx_text_cy(const GFXfont **fonts, uint8_t num_fonts, int8_t x, int8_t y, const uint16_t *text, bool clear_cy) {
+void kdisp_write_gfx_text_cy(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, const uint16_t *text, bool clear_cy) {
     int8_t x_cursor = x;
     int8_t y_cursor = y;
     while (*text != 0) {

--- a/keyboards/handwired/polykybd/base/disp_array.h
+++ b/keyboards/handwired/polykybd/base/disp_array.h
@@ -8,11 +8,11 @@
 #define SCREEN_WIDTH 72
 #define SCREEN_HEIGHT 40
 
-int8_t kdisp_write_gfx_char(const GFXfont **fonts, uint8_t num_fonts, int8_t x, int8_t y, uint16_t c, bool clear_cy);
+int8_t kdisp_write_gfx_char(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, uint16_t c, bool clear_cy);
 
-void kdisp_write_gfx_text(const GFXfont **fonts, uint8_t num_fonts, int8_t x, int8_t y, const uint16_t *text);
+void kdisp_write_gfx_text(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, const uint16_t *text);
 
-void kdisp_write_gfx_text_cy(const GFXfont **fonts, uint8_t num_fonts, int8_t x, int8_t y, const uint16_t *text, bool clear_cy);
+void kdisp_write_gfx_text_cy(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, const uint16_t *text, bool clear_cy);
 
 void kdisp_write_base_char(int8_t x, int8_t y, char c);
 

--- a/keyboards/handwired/polykybd/base/fonts/gfx_used_fonts.h
+++ b/keyboards/handwired/polykybd/base/fonts/gfx_used_fonts.h
@@ -46,7 +46,7 @@
 
 #include "FreeSansBold24pt7b.h"
 
-const GFXfont* ALL_FONTS [] = {
+const GFXfont* const ALL_FONTS [] = {
   &IconsFont,
   &NotoSans_Regular_Base_14pt7b,
   &NotoSans_Regular_SupAndExtA_14pt16b,

--- a/keyboards/handwired/polykybd/corne42/status_oled.c
+++ b/keyboards/handwired/polykybd/corne42/status_oled.c
@@ -20,7 +20,7 @@
 #include <stdint.h>
 #include <stdio.h>
 
-extern const GFXfont* ALL_FONTS[];
+extern const GFXfont* const ALL_FONTS[];
 #define ALL_FONT_SIZE_OLED_INT 43
 
 /*

--- a/keyboards/handwired/polykybd/create_fonts.sh
+++ b/keyboards/handwired/polykybd/create_fonts.sh
@@ -93,7 +93,7 @@ echo -e "#pragma once\n" > gfx_used_fonts.h
 ls -1 generated/*pt.h | while read line; do echo '#include "'${line}'"'; done >> gfx_used_fonts.h
 echo -e '#include "gfx_icons.h"\n' >> gfx_used_fonts.h
 echo -e '#include "FreeSansBold24pt7b.h"\n' >> gfx_used_fonts.h
-echo -e 'const GFXfont* ALL_FONTS [] = {' >> gfx_used_fonts.h
+echo -e 'const GFXfont* const ALL_FONTS [] = {' >> gfx_used_fonts.h
 echo -e '  &IconsFont,' >> gfx_used_fonts.h
 cat  generated/*pt.h | grep -oP 'const GFXfont \K\w+' | while read line; do echo "  &"${line}","; done >> gfx_used_fonts.h
 echo -e '};\n' >> gfx_used_fonts.h

--- a/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
@@ -700,7 +700,11 @@ layer_state_t get_function_layer(layer_state_t def_layer) {
 }
 
 #define LX(x,y) ((x)/2),y
-led_config_t g_led_config = { {// Key Matrix to LED Index
+// Placed in .rodata so the 296-byte table sits in flash rather than RAM.
+// QMK only reads g_led_config (verified in quantum/{led,rgb}_matrix/*.c); the
+// type stays non-const to match the upstream extern declaration in
+// quantum/rgb_matrix/rgb_matrix.h, so this is a placement override only.
+__attribute__((section(".rodata"))) led_config_t g_led_config = { {// Key Matrix to LED Index
                               {6, 5, 4, 3, 2, 1, 0, NO_LED},
                               {13, 12, 11, 10, 9, 8, 7, NO_LED},
                               {20, 19, 18, 17, 16, 15, 14, NO_LED},

--- a/keyboards/handwired/polykybd/split72/status_oled.c
+++ b/keyboards/handwired/polykybd/split72/status_oled.c
@@ -21,7 +21,7 @@
 #include <stdio.h>
 
 //this should go away with some font refactoring!
-extern const GFXfont* ALL_FONTS [];
+extern const GFXfont* const ALL_FONTS [];
 #define ALL_FONT_SIZE_OLED_INT 43
 
 // Renders status screen with layer, lock states, RGB settings, display brightness, WPM, and language on OLED.


### PR DESCRIPTION
## Summary

Both `g_led_config` (split72) and `ALL_FONTS` (shared) were ending up in `.data` — i.e., RAM — despite being populated once at startup and only read thereafter. Moving them to `.rodata` frees **468 bytes of RAM** on RP2040, which matters when usage is already at ~92%.

## Changes

**`g_led_config`** — `split72/keymaps/default/keymap.c`
Forced into `.rodata` via `__attribute__((section(".rodata")))`. The type stays non-`const` so it still matches the upstream extern in `quantum/rgb_matrix/rgb_matrix.h` — making it `const` triggers a redeclaration conflict. Verified that QMK's RGB/LED matrix code only reads `g_led_config`, never writes. (One benign assembler warning "setting incorrect section attributes for .rodata" — section attribute on a non-const decl is unusual but the linker places it correctly.)

**`ALL_FONTS`** — `base/fonts/gfx_used_fonts.h`
Added the missing inner `const` so the array of pointers itself is read-only (the *elements* were already `const GFXfont*`, but the array of pointers wasn't). Ripples to:
- `base/disp_array.{h,c}`: `kdisp_write_gfx_{char,text,text_cy}` now take `const GFXfont *const *fonts` (was `const GFXfont **fonts`).
- `split72/status_oled.c`, `corne42/status_oled.c`: `extern` declarations updated to match.
- `create_fonts.sh`: codegen template updated so the next regeneration preserves the inner `const`.

## Verification

Built clean on both `split72` and `corne42`. Symbol table after vs. baseline:

| Symbol | Baseline | After |
|---|---|---|
| `g_led_config` | `.data` 296 B | `.rodata` 296 B |
| `ALL_FONTS` (split72) | `.data` 172 B | `.rodata` 172 B |
| `ALL_FONTS` (corne42) | `.data` 172 B | `.rodata` 172 B |

split72 section deltas:

```
.text:     0    80024 -> 80024 B
.data:  -468     7776 ->  7308 B   (468 B moved to .rodata)
.rodata: +468  157196 -> 157664 B
.bss:      0   241224 -> 241224 B
UF2:       0   491008 -> 491008 B  (.data was already loaded from flash)

RAM:    -468 B
Flash:     0 B net
```

## Test plan

- [ ] Build split72 and flash to master + slave halves
- [ ] Confirm RGB matrix layout still works (key positions / LED indices unchanged)
- [ ] Confirm all per-keycap glyphs still render (fonts walk through `ALL_FONTS`)
- [ ] Confirm status OLED still renders (uses `ALL_FONTS` for icons)
- [ ] Build corne42 and flash; confirm status OLED renders

https://claude.ai/code/session_01BKT5k4FcLTBcdZDQsfoyEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKT5k4FcLTBcdZDQsfoyEA)_

## Summary by Sourcery

Move LED and font configuration tables into flash-backed read-only data to reduce RAM usage on RP2040 builds.

Enhancements:
- Make g_led_config reside in .rodata while preserving compatibility with the upstream non-const extern declaration.
- Mark the ALL_FONTS pointer array as read-only and propagate const-correct function signatures for font rendering utilities.
- Update OLED status modules and font generation script to reflect the const-qualified ALL_FONTS array type.