### PR TITLE
Add host-triggered bootloader HID command (0x17)

### DIFF
--- a/keyboards/handwired/polykybd/corne42/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/corne42/keymaps/default/keymap.c
@@ -1017,12 +1017,8 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
     if (record->event.pressed) {
         switch (keycode) {
             case QK_BOOTLOADER: {
-                uprintf("Bootloader entered. Please copy new Firmware.\n");
-                // Sync slave before returning true — QMK resets before housekeeping runs.
-                access_local_state()->overlay_flags |= BOOTLOADER_DISPLAY;
-                uint8_t ack = send_to_bridge(USER_SYNC_POLY_DATA, (void *)access_local_state(), sizeof(poly_sync_t), 10);
-                uprintf("Master: BOOTLOADER_DISPLAY sync ack=%d\n", ack);
-                display_bootloader_message();
+                // Shared with the host-triggered bootloader HID command (hid_com.c case 23).
+                poly_announce_bootloader();
                 return true;
             }
             case KC_A ... KC_Z:

--- a/keyboards/handwired/polykybd/hid_com.c
+++ b/keyboards/handwired/polykybd/hid_com.c
@@ -16,6 +16,7 @@
 #include "base/com.h"
 #include "base/overlay.h"
 #include "base/update.h"
+#include "poly_util.h"
 
 #include <print.h>
 #include <transactions.h>
@@ -449,6 +450,16 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                 memcpy(data, "P\x16.", 3);
                 data[3] = (uint8_t)local_layer->def_layer;
                 raw_hid_send(data, length);
+                break;
+            case 23: // enter bootloader (host-triggered; mirrors a QK_BOOTLOADER press)
+                uprint("Host requested bootloader.\n");
+                poly_announce_bootloader();
+                memset(data, 0, length);
+                memcpy(data, "P\x17.", 3);
+                raw_hid_send(data, length);
+                // The host does not wait for this reply — jump straight to the
+                // bootloader, exactly as QMK does for the QK_BOOTLOADER keycode.
+                reset_keyboard();
                 break;
             default:
                 printf("Unknown command: %u.\n", data[HID_CMD_IDX]);

--- a/keyboards/handwired/polykybd/poly_util.c
+++ b/keyboards/handwired/polykybd/poly_util.c
@@ -2,10 +2,16 @@
 
 #include "quantum.h"
 
+#include "state.h"
+#include "bridge_helper.h"
+#include "base/com.h"
 #include "base/disp_array.h"
 #include "base/shift_reg.h"
 #include "base/helpers.h"
 #include "base/fonts/FreeSansBold24pt7b.h"
+
+#include <print.h>
+#include <transactions.h>
 
 const uint8_t* get_key_disp_bitmask(uint8_t index);
 uint8_t get_disp_bitmask_size(void);
@@ -35,6 +41,19 @@ void display_bootloader_message(void) {
     set_displays(20, false);
     display_message(1, 1, u"BOOT-",   &FreeSansBold24pt7b);
     display_message(3, 0, u"LOADER!", &FreeSansBold24pt7b);
+}
+
+// Announce an imminent bootloader jump: flag it, sync the slave half so it
+// shows the bootloader message too, then show the message locally. The caller
+// resets afterwards — via QMK for the QK_BOOTLOADER keymap path, or via
+// reset_keyboard() for the host-triggered HID command (hid_com.c case 23).
+void poly_announce_bootloader(void) {
+    uprintf("Bootloader entered. Please copy new Firmware.\n");
+    // Sync slave before the reset — QMK resets before housekeeping runs.
+    access_local_state()->overlay_flags |= BOOTLOADER_DISPLAY;
+    uint8_t ack = send_to_bridge(USER_SYNC_POLY_DATA, (void *)access_local_state(), sizeof(poly_sync_t), 10);
+    uprintf("Master: BOOTLOADER_DISPLAY sync ack=%d\n", ack);
+    display_bootloader_message();
 }
 
 void display_message(uint8_t row, uint8_t col, const uint16_t* message, const GFXfont* font) {

--- a/keyboards/handwired/polykybd/poly_util.h
+++ b/keyboards/handwired/polykybd/poly_util.h
@@ -12,3 +12,5 @@ void clear_all_displays(void);
 void display_message(uint8_t row, uint8_t col, const uint16_t* message, const GFXfont* font);
 
 void display_bootloader_message(void);
+
+void poly_announce_bootloader(void);

--- a/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
@@ -1250,12 +1250,8 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
     if (record->event.pressed) {
         switch (keycode) {
             case QK_BOOTLOADER: {
-                uprintf("Bootloader entered. Please copy new Firmware.\n");
-                // Sync slave before returning true — QMK resets before housekeeping runs.
-                access_local_state()->overlay_flags |= BOOTLOADER_DISPLAY;
-                uint8_t ack = send_to_bridge(USER_SYNC_POLY_DATA, (void *)access_local_state(), sizeof(poly_sync_t), 10);
-                uprintf("Master: BOOTLOADER_DISPLAY sync ack=%d\n", ack);
-                display_bootloader_message();
+                // Shared with the host-triggered bootloader HID command (hid_com.c case 23).
+                poly_announce_bootloader();
                 return true;
             }
             case KC_A ... KC_Z:


### PR DESCRIPTION
## What

Adds a new PolyKybd HID command (`0x17`) that puts the keyboard into the bootloader on request from the host — so it can be brought into flashing mode without physically pressing the bootloader key.

## Why

The host ([PolyKybdHost](https://github.com/thpoll83/PolyKybdHost)) wanted a one-click *Activate Bootloader* menu entry. The obvious routes don't work in this firmware:

- **VIA bootloader-jump (id 11)** isn't handled — `legacy_command_kb()` returns `false` for it, and our custom `raw_hid_receive()` overrides QMK's VIA handler, so the standard path is a no-op.
- **The existing `KEYPRESS` command (`0x0E`)** replays a keycode's *matrix position*, so sending `QK_BOOT` only works if it happens to sit on the active/default layer — but it lives on the settings layer, so from the base layer it would press matrix (0,0) instead.

A dedicated command is the reliable path.

## How

- **`hid_com.c`** — new `case 23`: announces the jump, ACKs (`P\x17.`), then calls `reset_keyboard()`, exactly as QMK core does for the `QK_BOOTLOADER` keycode.
- **`poly_util.c/.h`** — extracted the bootloader-entry logic (set `BOOTLOADER_DISPLAY`, sync the slave half so it shows the message, then display it locally) into a shared `poly_announce_bootloader()`.
- **`corne42` + `split72` keymaps** — their `QK_BOOTLOADER` handlers now call the shared helper, so there's no duplicated logic and the physical-key path behaves exactly as before.

## Testing

Compiled both variants from scratch with the QMK toolchain (`arm-none-eabi-gcc` 13.2.1):

| Variant | Result |
|---|---|
| `handwired/polykybd/split72:default` | Linking **[OK]** · UF2 **[OK]** |
| `handwired/polykybd/corne42:default` | Linking **[OK]** · UF2 **[OK]** |

No errors or warnings in the touched files. Not yet flashed to hardware.

## Pairs with

PolyKybdHost change adding the *Activate Bootloader* menu entry and `ENTER_BOOTLOADER = 23` (sends `0x50 0x17`).

https://claude.ai/code/session_01QqoqURAMwAfhczWSc4VLtX

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqoqURAMwAfhczWSc4VLtX)_

## Summary by Sourcery

Add a host-triggered HID command to enter the bootloader and reuse shared bootloader-announcement logic across keymaps and host commands.

New Features:
- Introduce a new raw HID command (id 23 / 0x17) that lets the host request a jump to the keyboard bootloader.

Enhancements:
- Extract shared bootloader announcement and display logic into poly_announce_bootloader() for reuse by both keymaps and the new HID command.
- Update corne42 and split72 keymaps to call the shared bootloader announcement helper when QK_BOOTLOADER is pressed, keeping behavior consistent while removing duplicated code.