### PR TITLE
polykybd: add HID command 0x18 to turn the OLED displays off

### DIFF
--- a/keyboards/handwired/polykybd/hid_com.c
+++ b/keyboards/handwired/polykybd/hid_com.c
@@ -46,6 +46,10 @@ while lang_key:
 //[[[end]]]
 
 void invert_display(uint8_t r, uint8_t c, bool state);
+// Defined in each board's keymap.c (split72 / corne42); declared here so the
+// shared HID dispatcher can drive the display-off command (case 24).
+void poly_suspend(void);
+void sync_and_refresh_displays(void);
 
 // Set on boot; cleared after the first GET_ID exchange so the host can detect
 // a firmware restart even when it never lost the USB connection.
@@ -448,6 +452,24 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                 memset(data, 0, length);
                 memcpy(data, "P\x16.", 3);
                 data[3] = (uint8_t)local_layer->def_layer;
+                raw_hid_send(data, length);
+                break;
+            // case 23 (0x17) is reserved for the host-triggered bootloader-jump command.
+            case 24: //display off
+                // Turn the status OLED and every keycap OLED off on host request, so the
+                // panels don't sit lit (e.g. after a HIL test/deploy) and age/burn in.
+                // Mirrors the USB-suspend display path (suspend_power_down_kb): poly_suspend()
+                // clears STATUS_DISP_ON/DISP_IDLE/IDLE_TRANSITION and sets contrast = DISP_OFF,
+                // sync_and_refresh_displays() pushes that to the slave half and switches both
+                // halves' panels off, and set_last_update(-1) stops the idle housekeeping block
+                // from re-asserting STATUS_DISP_ON on the next tick. Nothing is written to
+                // EEPROM, so a key press (display_wakeup) or the idle-wake command (case 15,
+                // data byte 0) restores the saved brightness; the keyboard stays USB-enumerated.
+                poly_suspend();
+                sync_and_refresh_displays();
+                set_last_update(-1);
+                memset(data, 0, length);
+                memcpy(data, "P\x18.", 3);
                 raw_hid_send(data, length);
                 break;
             default:


### PR DESCRIPTION
## What

Adds PolyKybd raw-HID command **`0x18`** (case 24) so the host can switch **both** the 128×64 status OLED and all per-key OLEDs off on request — e.g. after a successful HIL test/deploy — so the panels don't sit lit between runs and age / burn in.

## Why

On the HIL rig (and any host integration) the keyboard can sit powered for long stretches showing a static image. The firmware already auto-idles (fade at `FADE_OUT_TIME` = 2 min, power-down at `TURN_OFF_TIME` = 20 min), but nothing let the host turn the displays off **promptly** and **cleanly**:

- `0x0D` (set brightness) `0` switches only the keycap OLEDs off, leaves the status OLED lit, **and** persists `0` to EEPROM (the board then boots dark and won't wake on keypress).
- `0x0F` (idle) just re-arms the screensaver; on a freshly-flashed board it doesn't blank promptly.

A dedicated command is the reliable path.

## How

`case 24` mirrors the well-tested USB-suspend display path (`suspend_power_down_kb`):

```c
poly_suspend();              // clear STATUS_DISP_ON/DISP_IDLE/IDLE_TRANSITION, contrast = DISP_OFF
sync_and_refresh_displays(); // push to the slave half; both halves' panels off (oled_off + kdisp_enable(false))
set_last_update(-1);         // stop the idle housekeeping block re-asserting STATUS_DISP_ON next tick
```

…then it ACKs `P\x18.`. Properties:

- **Both displays, both halves** — the off-state syncs over the split link.
- **Nothing written to EEPROM** — a key press (`display_wakeup`) or the idle-wake command (`0x0F`, data byte `0`) restores the saved brightness.
- **Stays USB-enumerated** — it is not a USB suspend.

`poly_suspend()` / `sync_and_refresh_displays()` are defined in each board's `keymap.c`; they're forward-declared in `hid_com.c` next to the existing `invert_display` declaration. Command id `0x17` (case 23) is intentionally left as a gap, reserved for the in-flight host-triggered bootloader-jump command (#32).

## Testing

Built from scratch with the QMK toolchain (`arm-none-eabi-gcc` 13.2.1):

| Variant | Result |
|---|---|
| `handwired/polykybd/split72:default` | Linking **[OK]** · UF2 **[OK]** |
| `handwired/polykybd/split72` `-e POLYKYBD_HIL=yes` | Linking **[OK]** · UF2 **[OK]** |
| `handwired/polykybd/corne42:default` | Linking **[OK]** · UF2 **[OK]** |

No warnings/errors in the touched file, and it links on both boards that share `hid_com.c`. Not yet flashed to hardware.

## Pairs with

`thpoll83/polykybd-ctnd` change that sends `0x18` from the HIL station after a passing run.

https://claude.ai/code/session_01HzDNcyKXMuJpa6ixkzAKiM

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzDNcyKXMuJpa6ixkzAKiM)_

## Summary by Sourcery

Add a new raw HID command to allow the host to turn off all PolyKybd OLED displays on demand.

New Features:
- Introduce HID command 0x18 to power down both the status OLED and all per-key OLEDs via host request.

Enhancements:
- Declare shared display control helpers so the HID dispatcher can reuse the existing suspend display path for host-driven display-off behavior.