### PR TITLE
PolyKybd: EE_HANDS splash-wipe fix + unconditional FW_UP apply

### DIFF
--- a/keyboards/handwired/polykybd/config.h
+++ b/keyboards/handwired/polykybd/config.h
@@ -77,16 +77,6 @@
 // for regression reference. See FW_UP_BASELINE.md (run 5).
 // #define FW_UP_CHUNK_NOOP_PROBE
 
-// 2026-05-30: in-application self-apply (FW_UP_APPLY, master-only).  DISABLED by
-// default — the first attempt bricked the master (do_apply erased flash sector 1,
-// which holds the toolchain memcpy it then called → HardFault through the also-
-// erased vector table).  fw_staging.c do_apply has since been HARDENED: RAM-only
-// word copy (no flash memcpy), app body copied first / sector-0 vectors last, and
-// IRQs toggled per sector.  Verified via .elf audit that do_apply makes zero
-// flash-resident calls.  Enable ONLY to test the hardened path; failure is still
-// master-only and BOOTSEL/UF2-recoverable.  See FW_UP_BASELINE.md "Phase 2 run 3".
-// #define FW_UP_ENABLE_INAPP_APPLY
-
 //######################################
 //#          PolyKybd specific         #
 //######################################

--- a/keyboards/handwired/polykybd/hid_fw_up.c
+++ b/keyboards/handwired/polykybd/hid_fw_up.c
@@ -221,16 +221,13 @@ bool hid_fw_up_receive(uint8_t *data, uint8_t length) {
         }
 
         case CMD_FW_UP_APPLY: { // PHASE 2: install the staged image on the MASTER only
-            // DISABLED BY DEFAULT (2026-05-30): the RAM-resident self-flash bricked
-            // the master — do_apply erases flash offset 0 (the live vector table +
-            // HardFault/NMI handlers) and runs ~4 s with IRQs off; an unmaskable
-            // exception (ChibiOS NMI context-switch / HardFault) then vectors through
-            // the erased table → lockup mid-copy → invalid boot2 → BOOTSEL.  See
-            // FW_UP_BASELINE.md "Phase 2 — run 2 (master bricked)".  The redesign
-            // (copy app body with IRQs toggled + vectors intact, then sector 0 last
-            // with VTOR relocated to RAM) is gated behind FW_UP_ENABLE_INAPP_APPLY.
+            // Hardware-verified self-flash (always built in): do_apply copies the
+            // staged image to flash offset 0 while keeping the live vector table
+            // intact until last — app body first with IRQs toggled per sector, then
+            // sector 0 with VTOR relocated to RAM — so the brick the naive
+            // erase-from-zero caused (FW_UP_BASELINE.md "Phase 2 — run 2") can't
+            // recur.  Failure is still master-only and BOOTSEL/UF2-recoverable.
             bool ok = fw_staging_has_valid_staged_image();
-#ifdef FW_UP_ENABLE_INAPP_APPLY
             memset(data, 0, length);
             memcpy(data, ok ? "P\x44." : "P\x44!", 3);
             raw_hid_send(data, length);
@@ -250,15 +247,6 @@ bool hid_fw_up_receive(uint8_t *data, uint8_t length) {
                 uprintf("FW_UP_APPLY: slave apply+reboot ack=0x%02x\n", slave_ack);
                 fw_staging_arm_apply();   // housekeeping → fw_staging_apply_and_reboot()
             }
-#else
-            // Safe default: never arm the brick-prone self-flash.  Report '!' so the
-            // host shows "apply not available" rather than silently doing nothing.
-            (void)ok;
-            memset(data, 0, length);
-            memcpy(data, "P\x44!", 3);
-            raw_hid_send(data, length);
-            uprintf("FW_UP_APPLY: in-app apply DISABLED (FW_UP_ENABLE_INAPP_APPLY off) — staged image left untouched\n");
-#endif
             return true;
         }
 

--- a/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
@@ -1645,11 +1645,6 @@ void keyboard_post_init_user(void) {
 #endif
 }
 
-// is_keyboard_left_impl() reads handedness directly (uncached) and is valid this
-// early; is_keyboard_left() only returns the right value after split_pre_init(),
-// which runs later (in keyboard_init, after keyboard_pre_init_user).
-bool is_keyboard_left_impl(void);
-
 // Pre-initialization setup: initializes display hardware, loads EEPROM config, shows splash screen.
 void keyboard_pre_init_user(void) {
     kdisp_hw_setup();
@@ -1670,7 +1665,18 @@ void keyboard_pre_init_user(void) {
     // (left = "POLY KYBD", right = "SPLIT 72") instead of both showing the
     // right-side text.  set_side() otherwise runs only in post_init, after the
     // splash, so the splash always saw side == UNDECIDED → both rendered "SPLIT 72".
-    set_side(is_keyboard_left_impl() ? LEFT_SIDE : RIGHT_SIDE);
+    //
+    // Read handedness with the pure eeconfig_read_handedness(), NOT
+    // is_keyboard_left_impl(): the EE_HANDS branch of is_keyboard_left_impl() runs
+    // `if (!eeconfig_is_enabled()) eeconfig_init();`.  Called this early — right
+    // after eeprom_driver_init() in keyboard_setup, before the wear-leveling store
+    // is validated — it can see eeconfig as "not enabled" and run eeconfig_init()
+    // → nvm_eeconfig_erase() → eeprom_driver_format(), which wipes the *entire*
+    // emulated EEPROM including the per-half EE_HANDS marker.  Both halves then
+    // lose their stored side and fall back to a master-derived handedness.
+    // eeprom_driver_init() has already run, so the direct read is valid here and,
+    // being read-only, can never trigger that erase.
+    set_side(eeconfig_read_handedness() ? LEFT_SIDE : RIGHT_SIDE);
     show_splash_screen();
 #ifdef FW_UP_BOOT_TRACE
     boot_trace(u"0");

--- a/keyboards/handwired/polykybd/split72/rules.mk
+++ b/keyboards/handwired/polykybd/split72/rules.mk
@@ -37,11 +37,3 @@ HOLD_ON_OTHER_KEY_PRESS = yes
 PERMISSIVE_HOLD = yes
 
 DYNAMIC_KEYMAP_ENABLE = yes
-
-# In-app firmware apply (FW_UP_APPLY): both halves install the staged image and
-# reboot onto it (no replug). On by default now that it is hardware-verified;
-# build with FW_UP_INAPP_APPLY=no to ship stage-only firmware instead.
-FW_UP_INAPP_APPLY ?= yes
-ifeq ($(strip $(FW_UP_INAPP_APPLY)), yes)
-    OPT_DEFS += -DFW_UP_ENABLE_INAPP_APPLY
-endif


### PR DESCRIPTION
Two firmware fixes that landed **after** PR #37 was merged, so they never made it into `PolyKeyboard` (PR #37 merged at the baseline-merge commit `ea9e9d1f2e`, before these were pushed). This brings them in. Both build + link cleanly (split72 and corne42); the diff over `PolyKeyboard` is exactly these two commits.

### 1. `split72`: fix EE_HANDS wipe from early splash handedness read (`512e47d265`)
The per-side boot-splash change called `is_keyboard_left_impl()` in `keyboard_pre_init_user`. For EE_HANDS that runs `if (!eeconfig_is_enabled()) eeconfig_init();`, and called that early (during `keyboard_setup`, before the wear-leveling store is validated) it can fire `eeconfig_init() → nvm_eeconfig_erase() → eeprom_driver_format()`, **wiping the entire emulated EEPROM including the per-half handedness marker** — both halves then lost their side and followed the master. Fixed by resolving the splash side with the read-only `eeconfig_read_handedness()` instead (no `eeconfig_init()` side effect). Hardware-verified.

### 2. `fw_up`: make in-app apply unconditional (`fa17cfcb57`)
The hardened master self-apply is now hardware-verified end-to-end on both halves (host stage + apply installs the image and both halves reboot onto it, no brick — confirmed via a `0.8.0 → 0.8.1` version bump round-trip). Removed the `FW_UP_ENABLE_INAPP_APPLY` build gate entirely: dropped the `#ifdef/#else` in `hid_fw_up.c`, the `FW_UP_INAPP_APPLY` toggle in `split72/rules.mk`, and the commented define in `config.h`. **Note:** this also enables in-app apply for **corne42** (shares `hid_fw_up.c`, already links `base/fw_staging.c`) — links fine but not yet hardware-tested on corne42.

https://claude.ai/code/session_01Ei4DVL1GtqmgBeHrLFeApM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ei4DVL1GtqmgBeHrLFeApM)_

## Summary by Sourcery

Bring PolyKybd up to date with recent firmware changes by fixing EE_HANDS splash handedness handling and enabling the hardened in-app firmware apply path unconditionally.

Bug Fixes:
- Prevent EE_HANDS configurations on split72 from wiping emulated EEPROM handedness data during early splash initialization by using a read-only handedness lookup for deciding the display side.

Enhancements:
- Always build and enable the hardened in-application firmware apply flow for PolyKybd boards, removing the previous build-time gate and associated configuration toggles.