### PR TITLE
Bump firmware version to 0.8.1

### DIFF
--- a/keyboards/handwired/polykybd/config.h
+++ b/keyboards/handwired/polykybd/config.h
@@ -90,7 +90,7 @@
 //######################################
 //#          PolyKybd specific         #
 //######################################
-#define FW_VERSION "0.8.0"
+#define FW_VERSION "0.8.1"
 
 #define FULL_BRIGHT 50
 #define MIN_BRIGHT 1


### PR DESCRIPTION
Bumps `FW_VERSION` `0.8.0` → `0.8.1` (single line in `config.h`).

This is the version that carries the EE_HANDS splash-wipe fix and the always-on FW_UP apply (**#39**), and keeps the firmware in sync with **PolyKybdHost 0.8.1** (companion host PR). It's a version-only change as requested — the actual fixes are in #39.

**Ordering note:** since this is independent of #39, ideally merge it together with / after #39 so `0.8.1` reflects firmware that actually contains those fixes. The two touch different regions of `config.h` (this = `FW_VERSION` line; #39 = the FW_UP_ENABLE_INAPP_APPLY block), so they merge without conflict in either order.

https://claude.ai/code/session_01Ei4DVL1GtqmgBeHrLFeApM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ei4DVL1GtqmgBeHrLFeApM)_

## Summary by Sourcery

Chores:
- Update the firmware version constant from 0.8.0 to 0.8.1 in the PolyKybd configuration.