### PR TITLE
ci: re-trigger HIL test on the expanded station suite

### DIFF
--- a/keyboards/handwired/polykybd/.hil-smoke-test
+++ b/keyboards/handwired/polykybd/.hil-smoke-test
@@ -1,0 +1,14 @@
+HIL workflow trigger — no-op marker (safe to delete).
+
+This file exists only to give a pull request a diff so that
+.github/workflows/qmk-test.yml (Build and HIL Test) runs:
+
+  1. build (ubuntu-latest): split72 default, split72 POLYKYBD_HIL force-master
+     uf2 (flashed to both halves on the rig), corne42 default.
+  2. hil-test (self-hosted polykybd-ctnd): downloads the artifact and runs
+     station.test_runner — now the expanded HID suite in polykybd-ctnd
+     (station/hil_tests.py, 15 tests). Each test reports as its own
+     pass/fail bullet in the job Step Summary.
+
+No firmware/source changes. Delete this file and close the PR once the run
+is confirmed green.

--- a/keyboards/handwired/polykybd/.hil-smoke-test
+++ b/keyboards/handwired/polykybd/.hil-smoke-test
@@ -1,14 +1,15 @@
 HIL workflow trigger — no-op marker (safe to delete).
 
-This file exists only to give a pull request a diff so that
-.github/workflows/qmk-test.yml (Build and HIL Test) runs:
+Gives a pull request a diff so .github/workflows/qmk-test.yml (Build and HIL
+Test) runs:
 
-  1. build (ubuntu-latest): split72 default, split72 POLYKYBD_HIL force-master
-     uf2 (flashed to both halves on the rig), corne42 default.
-  2. hil-test (self-hosted polykybd-ctnd): downloads the artifact and runs
-     station.test_runner — now the expanded HID suite in polykybd-ctnd
-     (station/hil_tests.py, 15 tests). Each test reports as its own
-     pass/fail bullet in the job Step Summary.
+  1. build (ubuntu-latest): split72 default, split72 POLYKYBD_HIL=left (master)
+     and POLYKYBD_HIL=right (slave/usb_disconnect) per-side images, corne42.
+  2. hil-test (self-hosted polykybd-ctnd): flashes the LEFT image to the left
+     half and the RIGHT image to the right half, then runs station.test_runner
+     — the expanded HID suite (station/hil_tests.py, 15 tests). Each test is its
+     own pass/fail bullet in the job Step Summary; a failing run additionally
+     dumps rig diagnostics (lsusb / hidraw / lsblk / picotool / dmesg).
 
-No firmware/source changes. Delete this file and close the PR once the run
-is confirmed green.
+Re-trigger #2 — validating the redeployed station against the per-side firmware.
+No firmware/source changes. Delete this file and close the PR once green.


### PR DESCRIPTION
## What

A throwaway, no-op PR that adds a single marker file under `keyboards/handwired/polykybd/` (`.hil-smoke-test`) purely to exercise the **Build and HIL Test** workflow (`.github/workflows/qmk-test.yml`). Replaces the earlier smoke-test PR (`claude/firmware-hil-test-pr-Z5scR`), which was deleted.

## Why

The HIL station (`thpoll83/polykybd-ctnd`) was just redeployed with an expanded test suite — `station/hil_tests.py` now runs **15 tests** instead of 2, covering every Raw HID command that can be asserted side-effect-free on the rig:

- identity / fresh-boot marker, GET_ID
- read-only state: GET_LANG, GET_LANG_LIST, GET_DEFAULT_LAYER
- error / bounds paths: unknown-command NACK, out-of-range brightness NACK, invalid unicode-mode NACK (+ valid ACKs)
- idle wake ACK
- mutate + restore: overlay-flags round-trip, language round-trip
- upload / soak guards: plain-overlay liveness, **compressed-overlay liveness driving the core1 decompress path** (guards the `multicore_exec.c` `cpsid i` hang), GET_ID stress

This PR confirms the workflow runs end to end against the new suite:

1. **build** (ubuntu-latest) — `split72` default, `split72` `POLYKYBD_HIL=yes` force-master uf2, `corne42` default; uploads the `firmware` artifact.
2. **hil-test** (self-hosted `polykybd-ctnd`) — downloads the artifact and runs `station.test_runner`, flashing the force-master uf2 to both halves and executing the 15 tests. Each test now renders as its own ✅/❌ bullet in the job **Step Summary**, with a `::error::` annotation per failure.

## Notes

- No firmware/source changes — only adds `keyboards/handwired/polykybd/.hil-smoke-test`.
- The `hil-test` job needs the self-hosted rig online to pass. Safe to close/delete once the run is confirmed green.


---
_Generated by [Claude Code](https://claude.ai/code/session_013Z2jFVKJPaxXPWicj6D1us)_

## Summary by Sourcery

Chores:
- Add a no-op smoke-test marker file under the polykybd keyboard to exercise the HIL test workflow.