### PR TITLE
ci: post HIL failure diagnostics as a PR comment

### DIFF
--- a/.github/workflows/qmk-test.yml
+++ b/.github/workflows/qmk-test.yml
@@ -62,6 +62,13 @@ jobs:
     name: HIL test (split72)
     needs: build
     runs-on: [self-hosted, polykybd-ctnd]
+    # download-artifact needs actions:read; the diagnostics comment needs
+    # pull-requests:write. Setting permissions explicitly replaces the default
+    # set, so both are listed here.
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
     steps:
       - name: Locate station directory
         id: ctnd
@@ -101,8 +108,9 @@ jobs:
             2>&1 | tee /tmp/hil-test.log
 
       # When the flash/test step fails, surface the test_runner output plus a
-      # snapshot of the rig's USB / HID / block-device / picotool state in the
-      # job summary, so failures are self-explanatory without SSHing into the rig.
+      # snapshot of the rig's USB / HID / block-device / picotool state. The block
+      # goes to the job Step Summary AND to /tmp/hil-diagnostics.md, which the next
+      # step posts as a PR comment so the cause is visible via the API too.
       - name: Diagnostics on failure
         if: failure()
         run: |
@@ -141,4 +149,26 @@ jobs:
             echo '```'
             dmesg 2>/dev/null | tail -n 40 || echo "(dmesg unavailable without privileges)"
             echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+          } | tee -a "$GITHUB_STEP_SUMMARY" > /tmp/hil-diagnostics.md
+
+      # Mirror the diagnostics into a PR comment so the failure cause is readable
+      # via the API (and by anything watching the PR), not only on the run page.
+      # pull_request events only — a push has no PR to comment on. The marker
+      # comment lets consumers find the latest diagnostics programmatically.
+      - name: Post diagnostics as PR comment
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let diag = '(diagnostics file not found — the test step failed before producing output)';
+            try { diag = fs.readFileSync('/tmp/hil-diagnostics.md', 'utf8'); } catch (e) {}
+            let body = '<!-- hil-diagnostics -->\n' + diag;
+            const MAX = 65000;
+            if (body.length > MAX) body = body.slice(0, MAX) + '\n\n…(truncated)';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });


### PR DESCRIPTION
## What

When the **HIL test (split72)** job fails, mirror the existing "rig diagnostics" block (test_runner output + `lsusb` / `hidraw` / `lsblk` / `picotool` / `dmesg`) into a **PR comment**, in addition to the job Step Summary.

- The `Diagnostics on failure` step now tees its block to both `$GITHUB_STEP_SUMMARY` and `/tmp/hil-diagnostics.md`.
- A new `Post diagnostics as PR comment` step (`actions/github-script`) reads that file and posts it as a comment, tagged with a `<!-- hil-diagnostics -->` marker. Runs on `failure()` and only for `pull_request` events (a push has no PR).
- The `hil-test` job gets `permissions: { contents: read, actions: read, pull-requests: write }` (explicit, because setting permissions replaces the default set — `actions: read` keeps `download-artifact` working, `pull-requests: write` allows the comment).

## Why

The Step Summary is only visible on the run page — it can't be read through the GitHub API. Mirroring the diagnostics into a PR comment makes a HIL failure's root cause (e.g. how many halves enumerated) visible programmatically to anyone — or any bot — watching the PR, so failures can be triaged/auto-fixed without opening the Actions run or SSHing into the rig.

## Note on activation

`pull_request` runs use the workflow from the **base** branch, so this only takes effect once merged into `PolyKeyboard`. After merge, re-triggering the HIL smoke-test PR (#41) will post the diagnostics as a comment on the next failure. No firmware/source changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_013Z2jFVKJPaxXPWicj6D1us)_

## Summary by Sourcery

Post HIL test failure diagnostics as a pull request comment for easier programmatic consumption.

CI:
- Update the HIL test workflow to grant explicit permissions needed for posting PR comments and downloading artifacts.
- Add a step that saves diagnostics output to a temporary file and posts it as a PR comment on failing pull_request runs.