### PR TITLE
PolyKybd: HID firmware-apply safety lockout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,14 @@ Seven custom QMK transaction IDs (`USER_SYNC_POLY_DATA`, `USER_SYNC_OVERLAY_DATA
 ### Notable QMK features enabled
 RGB matrix (72 LEDs, 35 effects), dynamic keymap (9 layers, VIA-compatible), unicode input (Linux/macOS/Windows/BSD), Cirque trackpad (split72 variant), `USE_CORE1` multicore.
 
+### HID firmware-apply safety mode (`FW_APPLY_DISPLAY`)
+The HID firmware update has two phases. The **transfer/staging** phase (`FW_UP_BEGIN`/`CHUNK`/`COMMIT`, host code in `PolyKybdHost/polyhost/device/hid_fw_up.py`) writes to a staging region while the keyboard keeps running its current firmware; it is CRC32-verified end-to-end, so typing during it is harmless and a corrupt/interrupted transfer is simply rejected — **no lockout**. The **apply** phase (`FW_UP_APPLY`, cmd `0x44`) is the only irreversible step (copy staging → flash + reboot, both halves), so it engages a lockout that mirrors the existing `BOOTLOADER_DISPLAY` mechanism:
+
+- `FW_APPLY_DISPLAY` (`base/com.h`, bit 4, was `RESERVED_3`) is set by the master in `hid_com.c`'s `0x44` case and **force-synced to the slave** via `USER_SYNC_POLY_DATA` before any reset.
+- While set: `process_record_user` drops every key event (matrix lockout, both halves — slave events relay to master), `rgb_matrix_indicators_kb` + `sync_and_refresh_displays` hold a solid **blue-green** and freeze the display, `suspend_power_down_kb` skips blanking, and `display_fw_apply_message()` (`poly_util.c`) shows **"APPLY/WAIT"** on both halves. The slave renders via `user_sync_poly_data_handler` (`split_sync.c`).
+- The actual copy+reset is a **weak hook** `polykybd_apply_staged_image()` (default no-op — there is no in-app apply backend in-tree yet; the real implementation overrides it and never returns). A housekeeping watchdog `fw_apply_safety_tick()` force-clears the lockout after `FW_APPLY_HOLD_MS` (10 s) as a recovery net.
+- **Scope note:** only the **split72** keymap is wired for the matrix lockout/freeze/watchdog. The shared files (`com.h`, `hid_com.c`, `poly_util.c`, `split_sync.c`) compile for `corne42` too, but `corne42/keymaps/default/keymap.c` was not given the keymap-level hooks.
+
 ## Font generation
 
 Fonts for the per-keycap OLEDs are generated using the `fontconvert` tool from the [`AdafruitGFX/`](../AdafruitGFX/CLAUDE.md) repo.

--- a/keyboards/handwired/polykybd/base/com.h
+++ b/keyboards/handwired/polykybd/base/com.h
@@ -29,7 +29,15 @@ enum overlay_flag {
     // "BOOT-LOADER!" message + solid red RGB so the slave half stays lit
     // while the master is in the RP2040 ROM bootloader.
     BOOTLOADER_DISPLAY  = 1 << 3,
-    RESERVED_3          = 1 << 4,
+    // Set by master when the host requests FW_UP_APPLY (cmd 0x44, the
+    // irreversible "copy staged image to flash + reboot" step) and force-synced
+    // via USER_SYNC_POLY_DATA before the apply runs. While set, both halves lock
+    // the key matrix (no keystrokes reach the host so a stray key can't interrupt
+    // the apply), force the RGB matrix to a solid blue-green, and show an
+    // "APPLY/WAIT" message — mirroring BOOTLOADER_DISPLAY. The transfer/staging
+    // phase (BEGIN/CHUNK/COMMIT) is CRC32-verified and deliberately NOT locked:
+    // typing during it is harmless and a corrupt transfer is simply rejected.
+    FW_APPLY_DISPLAY    = 1 << 4,
     RESET_BUFFERS       = 1 << 5,
     USAGE_RESET         = 1 << 6,
     MAPPING_RESET       = 1 << 7

--- a/keyboards/handwired/polykybd/hid_com.c
+++ b/keyboards/handwired/polykybd/hid_com.c
@@ -16,6 +16,7 @@
 #include "base/com.h"
 #include "base/overlay.h"
 #include "base/update.h"
+#include "poly_util.h"
 
 #include <print.h>
 #include <transactions.h>
@@ -50,6 +51,85 @@ void invert_display(uint8_t r, uint8_t c, bool state);
 // Set on boot; cleared after the first GET_ID exchange so the host can detect
 // a firmware restart even when it never lost the USB connection.
 static bool s_fresh_boot = true;
+
+// ---------------------------------------------------------------------------
+// HID firmware-apply safety mode
+//
+// FW_UP_APPLY (cmd 0x44) is the only irreversible step of the HID firmware
+// update: the staged image is copied over the running flash and both halves
+// reboot. The transfer/staging phase (BEGIN/CHUNK/COMMIT) is CRC32-verified and
+// harmless to interrupt, so it is deliberately NOT locked. APPLY, by contrast,
+// must not be interrupted by a keystroke or other HID traffic — so we enter a
+// bootloader-style lockout (matrix frozen, solid blue-green RGB, "APPLY/WAIT"
+// on both halves) before handing off to the apply backend.
+//
+// The actual "copy staging -> 0x0 and reset" backend is provided as a weak
+// symbol (polykybd_apply_staged_image): a firmware that implements in-app apply
+// overrides it; its implementation never returns (it resets). Builds without an
+// apply backend keep the safe default, which leaves the lockout screen up until
+// the housekeeping watchdog (fw_apply_safety_tick) clears it.
+// ---------------------------------------------------------------------------
+#define CMD_FW_UP_APPLY   0x44
+
+// Max time the apply lockout may stay engaged before the watchdog force-clears
+// it. A real apply resets well within this window; the timeout only matters as
+// a recovery net (e.g. no apply backend, or a backend that failed to reset).
+#define FW_APPLY_HOLD_MS  10000
+
+static uint32_t s_fw_apply_started = 0;
+
+bool is_fw_apply_active(void) {
+    return (get_local_state()->overlay_flags & FW_APPLY_DISPLAY) != 0;
+}
+
+void fw_apply_safety_enter(void) {
+    poly_sync_t* local_state = access_local_state();
+    if (local_state->overlay_flags & FW_APPLY_DISPLAY) {
+        return; // already engaged
+    }
+    // Sync the flag to the slave before anything that could reset — same
+    // ordering the QK_BOOTLOADER path uses. The slave renders its own
+    // apply screen in user_sync_poly_data_handler().
+    local_state->overlay_flags |= FW_APPLY_DISPLAY;
+    uint8_t ack = send_to_bridge(USER_SYNC_POLY_DATA, (void *)local_state, sizeof(poly_sync_t), 10);
+    uprintf("Master: FW_APPLY_DISPLAY sync ack=%d\n", ack);
+    s_fw_apply_started = timer_read32();
+    display_fw_apply_message();
+}
+
+void fw_apply_safety_exit(void) {
+    poly_sync_t* local_state = access_local_state();
+    if ((local_state->overlay_flags & FW_APPLY_DISPLAY) == 0) {
+        return;
+    }
+    local_state->overlay_flags &= ~((uint8_t)FW_APPLY_DISPLAY);
+    send_to_bridge(USER_SYNC_POLY_DATA, (void *)local_state, sizeof(poly_sync_t), 10);
+#if defined(RGB_MATRIX_ENABLE)
+    rgb_matrix_disable_noeeprom();
+#endif
+    request_disp_refresh();
+}
+
+void fw_apply_safety_tick(void) {
+    if ((get_local_state()->overlay_flags & FW_APPLY_DISPLAY) == 0) {
+        return;
+    }
+    // Only the master arms the watchdog (it owns the timer); the slave follows
+    // the flag and is cleared by the next sync from the master.
+    if (is_usb_host_side() && timer_elapsed32(s_fw_apply_started) > FW_APPLY_HOLD_MS) {
+        uprint("FW_APPLY watchdog: clearing apply lockout (no reset occurred).\n");
+        fw_apply_safety_exit();
+    }
+}
+
+// Weak default: this build has no in-app apply backend. A firmware that
+// implements staged-image apply overrides this symbol; that implementation
+// copies the verified staging image to offset 0 on both halves and resets, so
+// it never returns. The default no-op leaves the lockout screen up for the
+// watchdog to clear and lets the host's apply call time out waiting for a
+// reconnect that will not come (it then reports "apply unavailable").
+__attribute__((weak)) void polykybd_apply_staged_image(void) {
+}
 
 
 // Notifies RGB/LED matrix of key event for animation effects based on key press state.
@@ -449,6 +529,21 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                 memcpy(data, "P\x16.", 3);
                 data[3] = (uint8_t)local_layer->def_layer;
                 raw_hid_send(data, length);
+                break;
+            case CMD_FW_UP_APPLY: // 0x44 — apply staged firmware (irreversible)
+                // Engage the bootloader-style safety lockout on BOTH halves
+                // before anything can reset: matrix frozen, blue-green RGB,
+                // "APPLY/WAIT" message. ACK so the host enters its "applying —
+                // wait for reconnect" state, then hand off to the apply backend.
+                fw_apply_safety_enter();
+                memset(data, 0, length);
+                memcpy(data, "P\x44.", 3);
+                raw_hid_send(data, length);
+                // Real backend copies staging -> flash on both halves and
+                // resets (never returns). The weak default is a no-op; the
+                // housekeeping watchdog then clears the lockout and the host's
+                // apply call times out reporting "apply unavailable".
+                polykybd_apply_staged_image();
                 break;
             default:
                 printf("Unknown command: %u.\n", data[HID_CMD_IDX]);

--- a/keyboards/handwired/polykybd/hid_com.h
+++ b/keyboards/handwired/polykybd/hid_com.h
@@ -29,3 +29,27 @@ enum legacy_command_id {
     id_dynamic_keymap_set_encoder           = 0x15,
     id_unhandled                            = 0xFF,
 };
+
+#include <stdbool.h>
+
+// --- HID firmware-apply safety mode (see hid_com.c for the full rationale) ---
+
+// True while the irreversible FW_UP_APPLY lockout is engaged on this half.
+// Used by process_record to drop all key events so a keystroke can't interrupt
+// the apply.
+bool is_fw_apply_active(void);
+
+// Engage / release the apply lockout (matrix freeze + blue-green RGB +
+// "APPLY/WAIT" on both halves). enter() force-syncs the flag to the slave.
+void fw_apply_safety_enter(void);
+void fw_apply_safety_exit(void);
+
+// Watchdog: call from housekeeping_task_user() on both sides. Force-clears the
+// lockout if it has been engaged longer than the apply could legitimately take
+// (recovery net for builds with no apply backend / a backend that failed).
+void fw_apply_safety_tick(void);
+
+// Weak hook: the staged-image apply backend. Default is a no-op; a firmware
+// with in-app apply overrides it (copies staging -> flash on both halves and
+// resets — never returns).
+void polykybd_apply_staged_image(void);

--- a/keyboards/handwired/polykybd/poly_util.c
+++ b/keyboards/handwired/polykybd/poly_util.c
@@ -37,6 +37,22 @@ void display_bootloader_message(void) {
     display_message(3, 0, u"LOADER!", &FreeSansBold24pt7b);
 }
 
+void display_fw_apply_message(void) {
+    #ifdef RGB_MATRIX_ENABLE
+        rgb_matrix_enable_noeeprom();
+        rgb_matrix_mode_noeeprom(RGB_MATRIX_SOLID_COLOR);
+        // Solid blue-green so the apply screen is clearly distinct from the
+        // bootloader's red. Brightness matches the bootloader/slave convention.
+        rgb_matrix_set_color_all(0, 24, 24);
+        rgb_matrix_update_pwm_buffers();
+    #endif
+
+    clear_all_displays();
+    set_displays(20, false);
+    display_message(1, 1, u"APPLY", &FreeSansBold24pt7b);
+    display_message(3, 1, u"WAIT!", &FreeSansBold24pt7b);
+}
+
 void display_message(uint8_t row, uint8_t col, const uint16_t* message, const GFXfont* font) {
 
     const GFXfont* displayFont[] = { font };

--- a/keyboards/handwired/polykybd/poly_util.h
+++ b/keyboards/handwired/polykybd/poly_util.h
@@ -12,3 +12,8 @@ void clear_all_displays(void);
 void display_message(uint8_t row, uint8_t col, const uint16_t* message, const GFXfont* font);
 
 void display_bootloader_message(void);
+
+// Renders the firmware-apply lockout screen (solid blue-green RGB + "APPLY/WAIT")
+// on this half. Called on the master when FW_UP_APPLY arrives and on the slave
+// when it receives the FW_APPLY_DISPLAY flag over the split bridge.
+void display_fw_apply_message(void);

--- a/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
@@ -24,6 +24,7 @@
 #include "side.h"
 #include "fill_overlay.h"
 #include "poly_util.h"
+#include "hid_com.h"
 
 #include "base/com.h"
 #include "polymod_rle.h"
@@ -138,6 +139,12 @@ static uint8_t overlay_flags = 0;
 // ensuring LEDs stay dark regardless of what the transport wrote to enable.
 #ifdef RGB_MATRIX_ENABLE
 bool rgb_matrix_indicators_kb(void) {
+    // Apply-lockout backstop on BOTH halves: hold blue-green every render cycle
+    // so nothing can wash it out while the staged image is being applied.
+    if (get_local_state()->overlay_flags & FW_APPLY_DISPLAY) {
+        rgb_matrix_set_color_all(0, 24, 24);
+        return false;
+    }
     if (!is_keyboard_master()) {
         if (get_local_state()->overlay_flags & BOOTLOADER_DISPLAY) {
             // Backstop: force red even if rgb_matrix_config.enable gets cleared.
@@ -182,6 +189,24 @@ static uint32_t rgb_repeat_callback(uint32_t trigger_time, void* cb_arg) {
 // Synchronizes local and global display state, handling idle transitions, contrast changes, and display updates.
 // Global variables: flags, overlay_flags
 void sync_and_refresh_displays(void) {
+    // Freeze BOTH halves while a firmware apply is in progress: keep the
+    // "APPLY/WAIT" message static and re-assert blue-green every cycle so a
+    // normal refresh can't overwrite it before the apply resets the device.
+    if (get_local_state()->overlay_flags & FW_APPLY_DISPLAY) {
+#ifdef RGB_MATRIX_ENABLE
+        if (!rgb_matrix_is_enabled()) {
+            rgb_matrix_enable_noeeprom();
+        }
+        if (rgb_matrix_get_mode() != RGB_MATRIX_SOLID_COLOR) {
+            rgb_matrix_mode_noeeprom(RGB_MATRIX_SOLID_COLOR);
+        }
+        // Hue 128 = cyan/blue-green, full saturation, val 24.
+        if (rgb_matrix_get_hue() != 128 || rgb_matrix_get_val() != 24) {
+            rgb_matrix_sethsv_noeeprom(128, 255, 24);
+        }
+#endif
+        return;
+    }
     // Freeze slave display while bootloader is active; re-assert RGB each cycle.
     if (!is_usb_host_side() && (get_local_state()->overlay_flags & BOOTLOADER_DISPLAY)) {
 #ifdef RGB_MATRIX_ENABLE
@@ -329,6 +354,7 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 
 // Continuously monitors for idle timeout and dims/pulsates display accordingly.
 void housekeeping_task_user(void) {
+    fw_apply_safety_tick();
     brightness_save_if_pending();
     default_layer_save_if_pending();
     sync_and_refresh_displays();
@@ -1180,6 +1206,13 @@ void kdisp_idle(uint8_t contrast) {
 // Handles keypress events including unicode input, language modifications, and special commands.
 bool process_record_user(uint16_t keycode, keyrecord_t* record) {
 
+    // While a firmware apply is in progress, drop every key event so a
+    // keystroke can't reach the host or interrupt the apply. Slave key events
+    // are relayed here too, so this locks the whole keyboard.
+    if (is_fw_apply_active()) {
+        return false;
+    }
+
     uint32_t t = get_time_since_last_update();
     if(record->event.pressed) {
         uprintf("wait %ld.%03ld\n", t/1000, t%1000);
@@ -1657,7 +1690,8 @@ void poly_suspend(void) {
 // Suspends keyboard: suspends power down, disables RGB, calls housekeeping, resets update timer.
 void suspend_power_down_kb(void) {
     // USB suspend fires on slave when master enters bootloader; skip to keep displays lit.
-    if (get_local_state()->overlay_flags & BOOTLOADER_DISPLAY) {
+    // Same for a firmware apply: keep the lockout screen up rather than blanking.
+    if (get_local_state()->overlay_flags & (BOOTLOADER_DISPLAY | FW_APPLY_DISPLAY)) {
         return;
     }
     poly_suspend();

--- a/keyboards/handwired/polykybd/split_sync.c
+++ b/keyboards/handwired/polykybd/split_sync.c
@@ -59,10 +59,19 @@ void user_sync_poly_data_handler(uint8_t in_len, const void* in_data, uint8_t ou
                 uprint("Slave: BOOTLOADER_DISPLAY received\n");
                 display_bootloader_message();
             }
+            if(newly_set & FW_APPLY_DISPLAY) {
+                uprint("Slave: FW_APPLY_DISPLAY received\n");
+                display_fw_apply_message();
+            }
 #ifdef RGB_MATRIX_ENABLE
             // Disable RGB so the normal split transport restores master's config cleanly.
-            if(newly_cleared & BOOTLOADER_DISPLAY) {
+            if(newly_cleared & (BOOTLOADER_DISPLAY | FW_APPLY_DISPLAY)) {
                 rgb_matrix_disable_noeeprom();
+            }
+            if(newly_cleared & FW_APPLY_DISPLAY) {
+                // Master released the apply lockout (e.g. watchdog timeout) without
+                // resetting — restore the normal display on this half.
+                request_disp_refresh();
             }
 #endif
             ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK;


### PR DESCRIPTION
## What & why

Preventive measures around the **apply** step of the HID firmware update, so a stray keystroke (or other input) can't interrupt the only irreversible part of the flow.

The update has two phases, and only one is dangerous:

| Phase | Commands | Dangerous to interrupt? |
|---|---|---|
| **Transfer / staging** | `FW_UP_BEGIN` / `CHUNK` / `COMMIT` | **No.** Writes to a staging region while the keyboard keeps running its current firmware. CRC32-verified end-to-end — a corrupt/interrupted transfer is simply rejected and you re-flash. Typing during it is harmless. |
| **Apply** | `FW_UP_APPLY` (cmd `0x44`) | **Yes.** Copies staging → flash and reboots, both halves. |

So the lockout engages **only on apply** — exactly the case that matters. It mirrors the existing `BOOTLOADER_DISPLAY` mechanism (the "BOOT-LOADER!" red screen), just in blue-green.

## Behaviour while applying (`FW_APPLY_DISPLAY` set)

- **Matrix locked** — `process_record_user` drops every key event on both halves (slave events relay to the master, so the whole keyboard is locked).
- **RGB held solid blue-green** — indicators backstop + display freeze, re-asserted every render cycle.
- **"APPLY / WAIT" across both per-key OLED halves** — `display_fw_apply_message()`.
- **Suspend skipped** — the lockout screen stays lit.
- The flag is **force-synced master → slave** via `USER_SYNC_POLY_DATA` before anything resets (same ordering as the bootloader path); the slave renders its own screen in `user_sync_poly_data_handler`.

## Apply backend is a weak hook

There is **no in-app apply backend in-tree** (the firmware never had a `FW_UP_*` receiver — the host drives the protocol but `raw_hid_receive` stopped at command 22). The actual "copy staging → 0x0 + reset" is left as a weak symbol `polykybd_apply_staged_image()`:

- **Default (this PR):** no-op. The `0x44` case still engages the full safety screen + lockout, ACKs the host, and a housekeeping watchdog (`fw_apply_safety_tick`, 10 s) clears the lockout as a recovery net. This makes the screen **observable/testable on hardware today** (trigger via the host's *Flash + Apply* / *Apply Staged*), and the host's apply call simply times out reporting "apply unavailable".
- **Future:** the real apply implementation overrides the weak symbol (copies the image on both halves and resets — never returns), and the safety mode wraps it automatically with no further changes here.

## Files

- `base/com.h` — `RESERVED_3` (bit 4) → `FW_APPLY_DISPLAY`
- `poly_util.c/.h` — `display_fw_apply_message()` (blue-green + "APPLY/WAIT")
- `hid_com.c/.h` — `0x44` case + `fw_apply_safety_enter/exit/tick`, `is_fw_apply_active`, weak `polykybd_apply_staged_image`
- `split_sync.c` — slave-side flag detection
- `split72/.../keymap.c` — matrix lockout, RGB backstop/freeze, suspend skip, watchdog call
- `CLAUDE.md` — feature notes

## Notes / open points

- Only the **split72** keymap is wired for the matrix lockout/freeze/watchdog. Shared files compile for **corne42** too, but its keymap-level hooks were not added — happy to add them if wanted.
- **Host side:** no change needed — `apply_staged_firmware_action` already pauses the polling loop during apply, so the host isn't sending other HID traffic. (The earlier idea of locking during *transfer* is intentionally dropped per the CRC reasoning above.)
- Not compile-tested here (no ARM toolchain in this environment); reviewed against the existing `BOOTLOADER_DISPLAY` code paths it mirrors.
- Message text `"APPLY"` / `"WAIT!"` and the blue-green shade (`0,24,24`) are easy to tweak.

https://claude.ai/code/session_01TfXJPBQ4En7XwG8fM7x6Ep

---
_Generated by [Claude Code](https://claude.ai/code/session_01TfXJPBQ4En7XwG8fM7x6Ep)_

## Summary by Sourcery

Add a HID firmware-apply safety lockout around the irreversible apply step, mirroring the existing bootloader display behavior.

New Features:
- Introduce a firmware-apply lockout mode that blocks key input, shows an "APPLY/WAIT" screen, and forces blue-green RGB during FW_UP_APPLY.
- Add a weak hook for in-app staged-image apply so future firmware can implement the actual flash-and-reboot behavior without changing the protocol.

Enhancements:
- Synchronize a new FW_APPLY_DISPLAY overlay flag across halves so both sides present consistent apply status and visuals.
- Extend split72 keymap logic to respect the apply lockout for RGB indicators, display refresh, suspend handling, and housekeeping watchdog behavior.

Documentation:
- Document the HID firmware-apply safety mode and its behavior in CLAUDE.md.