### PR TITLE
Add HID command to set split handedness (left/right side)

### DIFF
--- a/keyboards/handwired/polykybd/corne42/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/corne42/keymaps/default/keymap.c
@@ -42,6 +42,7 @@
 #include "state.h"
 #include "multicore_exec.h"
 #include "split_sync.h"
+#include "split_fw_up.h"
 #include "poly_util.h"
 
 #include "lang/lang_lut.h"
@@ -291,6 +292,12 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 }
 
 void housekeeping_task_user(void) {
+    // Slave path for the handedness-change command (USER_SYNC_REBOOT): the
+    // reboot is armed in the transaction handler and fired here, so both halves
+    // restart together onto the new left/right assignment.
+    if (fw_staging_reboot_pending()) {
+        mcu_reset();   // clean full-chip reset; never returns
+    }
     brightness_save_if_pending();
     default_layer_save_if_pending();
     sync_and_refresh_displays();
@@ -1304,6 +1311,10 @@ void keyboard_post_init_user(void) {
     transaction_register_rpc(USER_SYNC_ROI_DATA,            user_sync_roi_data_handler);
     transaction_register_rpc(USER_SYNC_DYNAMIC_KEYMAP_DATA, user_sync_dynamic_keymap_data_handler);
     transaction_register_rpc(USER_SYNC_OVERLAY_MAP_DATA,    user_sync_overlay_map_data_handler);
+    // Reboot coordination — also the carrier for the host's handedness-change
+    // command (hid_com.c case 25), so the slave persists its new EE_HANDS marker
+    // and reboots together with the master.
+    transaction_register_rpc(USER_SYNC_REBOOT,              user_sync_reboot_handler);
 
     poly_eeconf_t ee = load_user_eeconf();
     poly_sync_t* local_state = access_local_state();

--- a/keyboards/handwired/polykybd/hid_com.c
+++ b/keyboards/handwired/polykybd/hid_com.c
@@ -1,5 +1,6 @@
 #include "hid_com.h"
 #include "hid_fw_up.h"
+#include "split_fw_up.h"
 
 #include QMK_KEYBOARD_H
 #include "quantum.h"
@@ -482,6 +483,38 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                 memset(data, 0, length);
                 memcpy(data, "P\x18.", 3);
                 raw_hid_send(data, length);
+                break;
+            case 25: //set handedness (which half is left / which is right)
+                // The host can only address the master (USB) half, so the payload
+                // is expressed relative to it:
+                //   data byte == 0 → this (master/USB) half = LEFT,  slave = RIGHT
+                //   data byte != 0 → this (master/USB) half = RIGHT, slave = LEFT
+                // Master/slave is decided by VBUS (which half holds the USB cable),
+                // independent of handedness — so this fixes a half whose EE_HANDS
+                // marker is wrong without reflashing.  We persist the master's
+                // handedness, push the opposite to the slave over the split link,
+                // ACK the host, then reboot the master.  The slave reboots itself
+                // via the armed handler, so both halves come up on the corrected
+                // assignment (set_side() and the split matrix offset are only
+                // resolved at boot, hence the reboot).
+                {
+                    bool master_is_left = (data[HID_DATA_IDX] == 0);
+                    eeconfig_update_handedness(master_is_left);
+                    // Reuse the USER_SYNC_REBOOT transaction (the split table is full
+                    // at QMK's 32-transaction cap): the slave persists the opposite
+                    // handedness, then reboots.  set_handedness=1 distinguishes this
+                    // from a plain QK_REBOOT.
+                    fw_up_apply_sync_t msg = { .crc32 = 0, .magic = FW_UP_SYNC_MAGIC,
+                                               .set_handedness = 1, .is_left = master_is_left ? 0 : 1 };
+                    uint8_t ack = send_to_bridge(USER_SYNC_REBOOT, &msg, sizeof(msg), 5);
+                    uprintf("Set handedness: master=%s, slave ack=%d.\n", master_is_left ? "LEFT" : "RIGHT", ack);
+                    memset(data, 0, length);
+                    memcpy(data, "P\x19.", 3);
+                    raw_hid_send(data, length);
+                    // Reboot the master last — like QK_REBOOT, so both halves
+                    // restart together and re-read their new handedness at boot.
+                    soft_reset_keyboard();
+                }
                 break;
             default:
                 // Try the fw_up command range (0x40..0x43) before failing.

--- a/keyboards/handwired/polykybd/split_fw_up.c
+++ b/keyboards/handwired/polykybd/split_fw_up.c
@@ -175,6 +175,12 @@ void user_sync_reboot_handler(uint8_t in_len, const void* in_data, uint8_t out_l
         ((poly_sync_reply_t *)out_data)->ack = SYNC_CRC32_ERR;
         return;
     }
+    // Handedness-change carrier (see fw_up_apply_sync_t): when requested, persist
+    // this (slave) half's new EE_HANDS marker before the reboot so it comes up on
+    // the corrected left/right assignment.  Plain QK_REBOOT leaves this zero.
+    if (msg->set_handedness) {
+        eeconfig_update_handedness(msg->is_left != 0);
+    }
     fw_staging_arm_reboot();   // housekeeping_task_user() → mcu_reset()
     ((poly_sync_reply_t *)out_data)->ack = SYNC_ACK;
 }

--- a/keyboards/handwired/polykybd/split_fw_up.h
+++ b/keyboards/handwired/polykybd/split_fw_up.h
@@ -56,11 +56,21 @@ typedef struct _fw_up_status_reply_t {
 // stray transaction triggers an unexpected reboot.  Shared by the FW_UP
 // apply-and-reboot and the plain QK_REBOOT paths; the transaction ID
 // (USER_SYNC_FW_UP_APPLY vs USER_SYNC_REBOOT) selects the slave's action.
+//
+// The USER_SYNC_REBOOT path also doubles as the handedness-change carrier: QMK
+// caps split transactions at 32 and the table is already full, so rather than
+// add a dedicated transaction the reboot message gains two optional fields.
+// When set_handedness != 0 the slave persists `is_left` to its EE_HANDS marker
+// before rebooting, so both halves come up on the corrected left/right
+// assignment (see hid_com.c case 25).  The plain reboot/apply senders leave
+// these zero via designated initialisers, so their behaviour is unchanged.
 #define FW_UP_SYNC_MAGIC 0xB007B007u
 
 typedef struct _fw_up_apply_sync_t {
-    uint32_t crc32;   // [0..3] CRC over the magic, filled in by send_to_bridge()
-    uint32_t magic;   // [4..7] must equal FW_UP_SYNC_MAGIC
+    uint32_t crc32;          // [0..3] CRC over the bytes below, filled in by send_to_bridge()
+    uint32_t magic;          // [4..7] must equal FW_UP_SYNC_MAGIC
+    uint8_t  set_handedness; // [8]    reboot path only: 1 = persist `is_left` before reboot
+    uint8_t  is_left;        // [9]    slave's new handedness when set_handedness != 0 (1 = left)
 } fw_up_apply_sync_t;
 
 void user_sync_fw_up_query_handler  (uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data);


### PR DESCRIPTION
## What

Adds a HID command (PolyKybd cmd `25`) so the left/right assignment can be corrected over USB — no reflashing an `EE_HANDS` `.eep` required. This fixes the case where a half's handedness marker is wrong (e.g. the right half reads as "left").

## Why it's expressed as two options

Master/slave is decided by which half holds the USB cable (VBUS), **independent** of left/right (handedness lives in each half's EEPROM via `EE_HANDS`). A HID command only ever reaches the **master** half, so the payload is relative to it:

- byte `0` → connected (master) half = **LEFT**, other = RIGHT
- byte `1` → connected (master) half = **RIGHT**, other = LEFT

## How

The master persists its own handedness, pushes the opposite to the slave over the split link, ACKs the host, then both halves reboot so `set_side()` and the split-matrix offset are re-resolved at boot.

QMK caps split transactions at 32 and the table was already full, so rather than add a dedicated transaction the existing `USER_SYNC_REBOOT` transaction carries the change: its message gains two optional fields (`set_handedness` / `is_left`) and the slave persists its `EE_HANDS` marker before the armed reboot. Plain `QK_REBOOT` / `FW_UP_APPLY` senders leave these zero via designated initialisers, so their behaviour is unchanged.

`corne42` now registers `USER_SYNC_REBOOT` and services the deferred reboot in housekeeping, so the feature works on both boards.

## Files

- `hid_com.c` — new HID command `25`
- `split_fw_up.h` / `split_fw_up.c` — extended reboot message + slave-side handedness write
- `corne42/keymaps/default/keymap.c` — register reboot handler + service deferred reboot

## Verification

- ✅ `split72:default` and `corne42:default` both compile to `.uf2`
- ✅ Flashed via HID and confirmed working on hardware

Host-side support (the `set_handedness` API + "Fix Left/Right Side" tray menu) is in the matching `PolyKybdHost` branch.

https://claude.ai/code/session_01CYgiHDaukQN8RWpcsM3BqZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYgiHDaukQN8RWpcsM3BqZ)_