### PR TITLE
feat: tag-triggered release workflow producing .uf2 and .bin assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+env:
+  KB: handwired/polykybd/split72
+  KM: default
+
 jobs:
   release:
     name: Build and release firmware
@@ -20,23 +24,25 @@ jobs:
       - name: Build split72
         uses: docker://qmkfm/qmk_cli
         with:
-          args: qmk compile -kb handwired/polykybd/split72 -km default
+          args: qmk compile -kb ${{ env.KB }} -km ${{ env.KM }}
 
       - name: Install ARM binutils
-        run: sudo apt-get install -y --no-install-recommends binutils-arm-none-eabi
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends binutils-arm-none-eabi
 
       - name: Extract .bin from ELF
         run: |
+          TARGET=$(echo "${{ env.KB }}" | tr '/' '_')_${{ env.KM }}
           arm-none-eabi-objcopy -O binary \
-            .build/handwired_polykybd_split72_default.elf \
-            handwired_polykybd_split72_default.bin
+            .build/${TARGET}.elf \
+            ${TARGET}.bin
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          TARGET=$(echo "${{ env.KB }}" | tr '/' '_')_${{ env.KM }}
           gh release create "${{ github.ref_name }}" \
             --generate-notes \
             --title "PolyKybd Firmware ${{ github.ref_name }}" \
-            handwired_polykybd_split72_default.uf2 \
-            handwired_polykybd_split72_default.bin
+            ${TARGET}.uf2 \
+            ${TARGET}.bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and release firmware
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Build split72
+        uses: docker://qmkfm/qmk_cli
+        with:
+          args: qmk compile -kb handwired/polykybd/split72 -km default
+
+      - name: Install ARM binutils
+        run: sudo apt-get install -y --no-install-recommends binutils-arm-none-eabi
+
+      - name: Extract .bin from ELF
+        run: |
+          arm-none-eabi-objcopy -O binary \
+            .build/handwired_polykybd_split72_default.elf \
+            handwired_polykybd_split72_default.bin
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --generate-notes \
+            --title "PolyKybd Firmware ${{ github.ref_name }}" \
+            handwired_polykybd_split72_default.uf2 \
+            handwired_polykybd_split72_default.bin


### PR DESCRIPTION
## Summary

- **`.github/workflows/release.yml`**: triggers on `push: tags: v*`; builds `handwired/polykybd/split72:default` via `docker://qmkfm/qmk_cli`, installs `binutils-arm-none-eabi`, extracts a raw ARM binary via `arm-none-eabi-objcopy -O binary`, then publishes a GitHub Release with both files attached

## Why both formats?

| File | Used by |
|---|---|
| `.uf2` | Manual BOOTSEL flashing (drag-and-drop to RP2040 mass storage) |
| `.bin` | PolyKybdHost HID FW_UP path (`hid_fw_up.py` — validates boot2 CRC32 + ARM vector table, streams over HID 0x40–0x44) |

## How to release

```bash
git tag v0.8.0
git push origin v0.8.0
```

The workflow runs, builds the firmware, and creates a GitHub Release with release notes auto-generated from commits since the previous tag.

## Test plan

- [ ] Push a `v*` tag and confirm the workflow completes successfully
- [ ] Verify the release has both `handwired_polykybd_split72_default.uf2` and `.bin` attached
- [ ] Confirm the `.bin` flashes correctly via PolyKybdHost's firmware update flow

https://claude.ai/code/session_01KdiiJunbnUYKP84NDuix6j

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdiiJunbnUYKP84NDuix6j)_

## Summary by Sourcery

Add an automated tag-triggered workflow to build and publish firmware releases with attached artifacts.

New Features:
- Introduce a GitHub Actions workflow that builds the handwired/polykybd/split72:default firmware on version tag pushes and creates a GitHub Release with artifacts.

Build:
- Configure the release workflow to produce both .uf2 and raw .bin firmware artifacts from the compiled ELF using ARM binutils.

CI:
- Add a GitHub Actions release job that runs on v* tags, compiles firmware via the qmk_cli Docker image, and publishes a GitHub Release with generated notes and title.