### PR TITLE
ci: push version bump with BUMP_PAT instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -20,7 +20,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: PolyKybd
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # PAT (Contents: write) whose identity is on the PolyKybd ruleset
+          # bypass list. GITHUB_TOKEN cannot push to PolyKybd because the
+          # ruleset requires changes go through a pull request (GH013).
+          token: ${{ secrets.BUMP_PAT }}
 
       - name: Determine bump type from PR labels
         id: bump_type


### PR DESCRIPTION
## Why

The **Bump Firmware Version on PR Merge** workflow pushes the version-bump commit directly to `PolyKybd`. It authenticated with `GITHUB_TOKEN`, which the branch ruleset rejects:

```
remote: error: GH013: Repository rule violations found for refs/heads/PolyKybd.
remote: - Changes must be made through a pull request.
 ! [remote rejected]   PolyKybd -> PolyKybd (push declined due to repository rule violations)
```

The bump logic itself worked (it computed `0.8.1 → 0.8.2` and committed), but the push was declined, so `config.h` on `PolyKybd` stayed at `0.8.1` after PR #50 ([failed run](https://github.com/thpoll83/qmk_firmware/actions/runs/26972381775)).

## What

Authenticate the `actions/checkout` step (and therefore the subsequent `git push`) with a PAT stored in the `BUMP_PAT` secret. The PAT's identity is on the `PolyKybd` ruleset bypass list, so the direct push is allowed. One-line change plus an explanatory comment.

## Prerequisites (configured in repo settings — not in this diff)

- `BUMP_PAT` repository secret holding a PAT with **Contents: write** on this repo.
- That PAT's identity (Repository admin) added to the `PolyKybd` ruleset **bypass list** with mode **Always**.

## Note on testing

For a `pull_request: [closed]` trigger the workflow YAML is read from the base branch, so the **next** PR merged into `PolyKybd` after this one is the definitive test that the push now succeeds. Merging this PR may still run the pre-change workflow once.

https://claude.ai/code/session_01KkUfcJmVfr93yuCtiMEUzw

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkUfcJmVfr93yuCtiMEUzw)_

## Summary by Sourcery

CI:
- Update the bump-version workflow checkout step to authenticate with the BUMP_PAT secret so version bump commits can be pushed directly to the PolyKybd branch despite PR-only rules.