### PR TITLE
ci(release): build & attach firmware on PolyKybd-fw-v* tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'PolyKybd-fw-v*'
+  workflow_dispatch: {}
 
 permissions:
   contents: write
@@ -36,13 +37,25 @@ jobs:
             .build/${TARGET}.elf \
             ${TARGET}.bin
 
-      - name: Create GitHub Release
+      # Idempotent: a tag push creates the release; re-running for an existing
+      # release (e.g. a manual workflow_dispatch from the tag, or a re-pushed
+      # tag) just (re-)uploads the assets with --clobber. Guarded to tag refs so
+      # a dispatch from a branch builds as a smoke test without cutting a release.
+      - name: Create or update GitHub Release
+        if: github.ref_type == 'tag'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
         run: |
           TARGET=$(echo "${{ env.KB }}" | tr '/' '_')_${{ env.KM }}
-          gh release create "${{ github.ref_name }}" \
-            --generate-notes \
-            --title "PolyKybd Firmware ${{ github.ref_name }}" \
-            ${TARGET}.uf2 \
-            ${TARGET}.bin
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — uploading assets (clobbering duplicates)."
+            gh release upload "$TAG" "${TARGET}.uf2" "${TARGET}.bin" --clobber
+          else
+            echo "Creating release $TAG."
+            gh release create "$TAG" \
+              --generate-notes \
+              --title "PolyKybd Firmware $TAG" \
+              "${TARGET}.uf2" \
+              "${TARGET}.bin"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,9 @@ jobs:
 
       # Idempotent: a tag push creates the release; re-running for an existing
       # release (e.g. a manual workflow_dispatch from the tag, or a re-pushed
-      # tag) just (re-)uploads the assets with --clobber. Guarded to tag refs so
-      # a dispatch from a branch builds as a smoke test without cutting a release.
+      # tag) just (re-)uploads the assets with --clobber. If two runs race for
+      # the same tag, the create that loses falls back to upload. Guarded to tag
+      # refs so a dispatch from a branch builds as a smoke test, not a release.
       - name: Create or update GitHub Release
         if: github.ref_type == 'tag'
         env:
@@ -52,10 +53,11 @@ jobs:
             echo "Release $TAG already exists — uploading assets (clobbering duplicates)."
             gh release upload "$TAG" "${TARGET}.uf2" "${TARGET}.bin" --clobber
           else
-            echo "Creating release $TAG."
+            echo "Creating release $TAG (falls back to upload if a concurrent run won the create)."
             gh release create "$TAG" \
               --generate-notes \
               --title "PolyKybd Firmware $TAG" \
               "${TARGET}.uf2" \
-              "${TARGET}.bin"
+              "${TARGET}.bin" \
+            || gh release upload "$TAG" "${TARGET}.uf2" "${TARGET}.bin" --clobber
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - 'PolyKybd-fw-v*'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

The firmware **Release** workflow never ran for PolyKybd releases, so they shipped without the `.uf2`/`.bin` assets the host's in-app updater needs to detect and flash an update.

- **Trigger:** the workflow listened for `v*` tags, but PolyKybd firmware is tagged `PolyKybd-fw-vX.Y.Z` — that glob never matched (0 historical runs of this workflow). Match the real scheme so a `PolyKybd-fw-v*` tag push builds `split72` and attaches `.uf2` + `.bin`.
- **Idempotent release step:** create the release if missing, otherwise `gh release upload --clobber` the assets — so an already-published release (e.g. `PolyKybd-fw-v0.8.3`, created without binaries) can get its assets without being deleted first.
- **Manual run:** add a `workflow_dispatch` trigger, guarded with `if: github.ref_type == 'tag'`, so you can attach assets to an existing tag from the Actions tab (**Run workflow → pick the tag**), while a dispatch from a branch just builds as a smoke test without cutting a release.

**Companion host PR** (parses these tags in the auto-update check): thpoll83/PolyKybdHost#27. Both are needed end-to-end: this PR makes releases *carry binaries*; #27 makes the host *see* `PolyKybd-fw-v*` releases.

## Version bump label

Patch — no label. Note: merging to `PolyKybd` auto-bumps `FW_VERSION` to the next patch via `bump-version.yml`, even though this is a CI-only change. That's harmless — and convenient: bump to `0.8.4`, push `PolyKybd-fw-v0.8.4`, and the fixed workflow attaches the binaries.

## Testing

- [ ] Compiled successfully (`qmk compile -kb handwired/polykybd/split72 -km default`) — **N/A, no firmware code changed**
- [ ] Flashed and tested on hardware — **N/A**
- [x] `release.yml` validated as YAML; both triggers (`push` tag-filter + `workflow_dispatch`) and the `github.ref_type == 'tag'` guard confirmed

> Note: the build step uses `docker://qmkfm/qmk_cli` on GitHub's runners (fine there, unlike the local dev container where Docker isn't available).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved firmware release automation to detect and handle existing releases gracefully, reducing conflicts during concurrent deployments and supporting expanded version tag patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->