### PR TITLE
ci(release): build on published releases (bypass [skip ci] on bump commit)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,16 @@ on:
   push:
     tags:
       - 'PolyKybd-fw-v*'
+  # `release` events ignore [skip ci]. Release tags here land on the auto-bump
+  # "[skip ci]" commit (bump-version.yml), which suppresses the tag-push trigger
+  # above — so publishing the release is what reliably starts the build.
+  release:
+    types: [published]
   workflow_dispatch: {}
+
+concurrency:
+  group: release-${{ github.event.release.tag_name || github.ref_name }}
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -37,16 +46,17 @@ jobs:
             .build/${TARGET}.elf \
             ${TARGET}.bin
 
-      # Idempotent: a tag push creates the release; re-running for an existing
-      # release (e.g. a manual workflow_dispatch from the tag, or a re-pushed
-      # tag) just (re-)uploads the assets with --clobber. If two runs race for
-      # the same tag, the create that loses falls back to upload. Guarded to tag
-      # refs so a dispatch from a branch builds as a smoke test, not a release.
+      # Runs on a tag push, on publishing a release, or on a manual dispatch.
+      # Idempotent: creates the release if missing, otherwise (re-)uploads the
+      # assets with --clobber; a create that loses a race falls back to upload.
+      # The `release` trigger matters because release tags land on the auto-bump
+      # "[skip ci]" commit, which suppresses the tag-push trigger. Guarded so a
+      # workflow_dispatch from a branch builds as a smoke test, not a release.
       - name: Create or update GitHub Release
-        if: github.ref_type == 'tag'
+        if: github.event_name == 'release' || github.ref_type == 'tag'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ github.event.release.tag_name || github.ref_name }}
         run: |
           TARGET=$(echo "${{ env.KB }}" | tr '/' '_')_${{ env.KM }}
           if gh release view "$TAG" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Cutting `PolyKybd-fw-v0.8.4` built nothing and shipped no `.uf2`/`.bin`. Root cause: the release tag is created on the auto-bump commit from `bump-version.yml`, whose message ends with **`[skip ci]`** — and `[skip ci]` suppresses **push**-triggered workflows, including the tag-push `release` build. So every release cut this way skips the build.

Fix: add a **`release: [published]`** trigger. `release` events are *not* subject to `[skip ci]`, so publishing a release reliably builds `split72` and attaches the binaries — no manual dispatch needed.

- `on:` gains `release: { types: [published] }` (keeps `push` tags + `workflow_dispatch`).
- `TAG` resolves from `github.event.release.tag_name` (falling back to `github.ref_name`) so it's correct for release events as well as tag pushes/dispatch.
- The release-step guard now allows `release` events: `github.event_name == 'release' || github.ref_type == 'tag'` (still skips a `workflow_dispatch` from a branch).
- Added a per-tag `concurrency` group so the extra trigger can't double-build the same tag; the existing create→upload `--clobber` fallback keeps it idempotent if it ever does.

Note: the existing `v0.8.4` release was already given its binaries via a manual `workflow_dispatch` on the tag; this PR makes future releases work automatically.

## Version bump label

Patch — no label. (CI-only change; merging auto-bumps `FW_VERSION` via `bump-version.yml` as usual.)

## Testing

- [ ] Compiled successfully (`qmk compile -kb handwired/polykybd/split72 -km default`) — **N/A, no firmware code changed**
- [ ] Flashed and tested on hardware — **N/A**
- [x] `release.yml` validated as YAML; triggers (`push`/`release`/`workflow_dispatch`), guard, `TAG`, and concurrency group confirmed
- [x] End-to-end sanity: a manual dispatch on the `v0.8.4` tag (same workflow file) is building and attaching `.uf2`/`.bin`

---
_Generated by [Claude Code](https://claude.ai/code/session_017HHu9G18rzzMuHSCrJtGzE)_

## Summary by Sourcery

Trigger firmware release builds on GitHub release publication instead of relying solely on tag-push events that can be skipped by [skip ci].

CI:
- Add GitHub Actions release workflow trigger on published releases alongside existing tag push and manual dispatch triggers.
- Use per-tag concurrency groups and updated TAG resolution to handle both release and tag events without duplicate builds.