### PR TITLE
docs: add future language candidates section (Oceania + Africa)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,33 @@ See [`AdafruitGFX/CLAUDE.md`](../AdafruitGFX/CLAUDE.md) for `fontconvert` build 
 
 ---
 
+## Future language candidates
+
+Adding a language requires: (1) a new `LANG_*` entry in `lang/lang_lut.c` (code-generated from `lang_lut.xlsx` via cog), (2) re-running `fonts/gen-lang-fonts.sh` to generate the flag glyph and update `flag_fonts.h`, (3) updating the host's `_LANG_REGION` map in `PolyKybdHost/polyhost/host.py` if the country code isn't already there (all ISO 3166-1 codes are covered as of 2026-06).
+
+### Oceania
+| Code | Language / Country | Notes |
+|------|--------------------|-------|
+| `en-AU` | English / Australia | Largest tech market in Oceania; distinct locale (date format, spelling) |
+| `en-NZ` | English / New Zealand | High tech adoption; ~5 M users |
+| `tl-PH` | Filipino / Philippines | Largest Pacific-adjacent user base; geographically SE Asia — host places it in **Asia** submenu via `PH` |
+| `mi-NZ` | Māori / New Zealand | Official NZ language; Latin + macrons (ā ē ī ō ū) + okina; active digital revitalisation |
+| `haw-US` | Hawaiian / United States | Polynesian; Latin + okina (ʻ) + kahakō macrons; note: `US` country code puts it in **Americas** — would need a custom code (e.g. `haw-HI`) to land in Oceania |
+| `sm-WS` | Samoan / Samoa | Most widely spoken Polynesian language; large diaspora in NZ/AU; Latin with macrons |
+| `fj-FJ` | Fijian / Fiji | Most developed Pacific island nation outside AU/NZ; Latin-based |
+
+### Africa
+| Code | Language / Country | Notes |
+|------|--------------------|-------|
+| `en-ZA` | English / South Africa | Largest tech ecosystem on the continent |
+| `ar-EG` | Arabic / Egypt | ~90 M internet users; complements existing `ar-SA` with Egyptian locale |
+| `sw-KE` | Swahili / Kenya | ~200 M speakers across East Africa; Kenya is the continent's leading tech hub; genuinely distinct from existing entries |
+| `am-ET` | Amharic / Ethiopia | Unique Ge'ez (Ethiopic) script; ~120 M people; fast-growing tech sector |
+| `yo-NG` | Yoruba / Nigeria | ~50 M speakers; Nigeria has Africa's largest developer community; Latin with tone diacritics |
+| `af-ZA` | Afrikaans / South Africa | Germanic/Latin; well-established digital presence; distinct from `en-ZA` |
+
+---
+
 ## Investigations in progress
 
 ### Bug: second half of keyboard becomes unresponsive (slave stops sending key events)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ See [`AdafruitGFX/CLAUDE.md`](../AdafruitGFX/CLAUDE.md) for `fontconvert` build 
 
 ## Future language candidates
 
-Adding a language requires: (1) a new `LANG_*` entry in `lang/lang_lut.c` (code-generated from `lang_lut.xlsx` via cog), (2) re-running `fonts/gen-lang-fonts.sh` to generate the flag glyph and update `flag_fonts.h`, (3) updating the host's `_LANG_REGION` map in `PolyKybdHost/polyhost/host.py` if the country code isn't already there (all ISO 3166-1 codes are covered as of 2026-06).
+Adding a language requires: (1) a new `LANG_*` entry in `lang/lang_lut.c` (code-generated from `lang_lut.xlsx` via cog), (2) re-running `fonts/gen-lang-fonts.sh` to generate the flag glyph and update `flag_fonts.h`, (3) updating the host's `_LANG_REGION` map in `PolyKybdHost/polyhost/host.py` if the country code isn't already there. The host map covers all standard ISO 3166-1 alpha-2 country codes; only non-standard or private-use codes need a new entry added manually.
 
 ### Oceania
 | Code | Language / Country | Notes |
@@ -79,7 +79,7 @@ Adding a language requires: (1) a new `LANG_*` entry in `lang/lang_lut.c` (code-
 | `en-NZ` | English / New Zealand | High tech adoption; ~5 M users |
 | `tl-PH` | Filipino / Philippines | Largest Pacific-adjacent user base; geographically SE Asia — host places it in **Asia** submenu via `PH` |
 | `mi-NZ` | Māori / New Zealand | Official NZ language; Latin + macrons (ā ē ī ō ū) + okina; active digital revitalisation |
-| `haw-US` | Hawaiian / United States | Polynesian; Latin + okina (ʻ) + kahakō macrons; note: `US` country code puts it in **Americas** — would need a custom code (e.g. `haw-HI`) to land in Oceania |
+| `haw-US` | Hawaiian / United States | Polynesian; Latin + okina (ʻ) + kahakō macrons; `US` country code puts it in **Americas**. To land in Oceania a pseudo-locale like `haw-HI` could be used, but `HI` is not an ISO 3166-1 code — it would need a manual `"HI": "Oceania"` entry in the host's `_LANG_REGION` map, and `lang_lut.c` would store the non-standard code verbatim. |
 | `sm-WS` | Samoan / Samoa | Most widely spoken Polynesian language; large diaspora in NZ/AU; Latin with macrons |
 | `fj-FJ` | Fijian / Fiji | Most developed Pacific island nation outside AU/NZ; Latin-based |
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a **Future language candidates** section to `CLAUDE.md` between Font generation and Investigations in progress
- 13 shortlisted entries across two regions, with codes, rationale, and implementation notes
- Includes a brief "how to add a language" preamble pointing at the three things that need touching: `lang_lut.c`/`lang_lut.xlsx`, `gen-lang-fonts.sh`, and the host's `_LANG_REGION` map

## Test plan

- [ ] `CLAUDE.md` renders correctly on GitHub
- [ ] All table entries have valid ISO codes and accurate notes

https://claude.ai/code/session_01KpVo3yHuYWjznt3cMu8uBA
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KpVo3yHuYWjznt3cMu8uBA)_

## Summary by Sourcery

Document future language candidates for Oceania and Africa and outline the steps required to add new languages.

Documentation:
- Add a Future language candidates section describing shortlisted Oceania and Africa locales with codes and rationale for potential support.
- Document the three-step process for adding a new language, covering language lookup, font generation, and host region mapping.