### PR TITLE
polykybd: fix brightness persisting as 0 — save user-chosen brightness, not live contrast

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,25 @@ local_state->flags &= ~((uint8_t)STATUS_DISP_ON) & ~((uint8_t)DISP_IDLE) & ~((ui
 
 ---
 
+### Bug: key display brightness drops to 0 on boot / wake (post-PR-#63 regression)
+
+**Symptom**: Keycap OLED brightness intermittently comes up as 0 on keyboard start and after wake from suspend, without the user having set it to 0.
+
+**Root cause (2026-06-10 — FIXED)**: PR #63's suspend-only persistence flushes `save_user_settings()` at exactly the moments `l_state.contrast` holds a *transient* value, persisting it as the user brightness:
+- `suspend_power_down_kb()` calls `poly_suspend()` (sets `contrast = DISP_OFF`) **before** `save_all_dirty()` — a dirty flag set any time since boot persisted brightness 0.
+- The slave was hit on *every* suspend: the master syncs `contrast = 0` before the flush, and `user_sync_poly_data_handler()` marked settings dirty on any contrast diff — including the suspend sync itself — then copied 0 into local state.
+- The idle paths (`TURN_OFF_TIME` → `poly_suspend()`, fade transition, 0–49 pulsing) also leave transients in `contrast` that a later flush persisted.
+
+**Fix**: `state.c` keeps a `g_user_brightness` snapshot that is updated **only** at deliberate set-points — `inc/dec_brightness()`, the new `set_user_brightness()` (used by the `KC_D*` preset keys and HID cmd 13), `note_user_brightness()` at boot-time EEPROM load, and on the slave when adopting an *awake* master's synced contrast (`contrast > DISP_OFF` and `DISP_IDLE|IDLE_TRANSITION` clear). `save_user_settings()` persists `~g_user_brightness` instead of `~l_state.contrast`. All idle/suspend *restore* paths (`back_from_idle_transition`, fade target, `display_wakeup()`, `suspend_wakeup_init_kb()`, HID stop-idle) now read `get_user_brightness()` instead of re-loading EEPROM — which also means an unflushed brightness change survives an idle/wake cycle (EEPROM was stale there under the suspend-only flush model). The suspend-only flush model itself is unchanged.
+
+**Relevant files**:
+- `keyboards/handwired/polykybd/state.c` / `state.h` — `g_user_brightness`, `set/note/get_user_brightness()`
+- `keyboards/handwired/polykybd/split_sync.c` — `user_sync_poly_data_handler` awake-guard
+- `keyboards/handwired/polykybd/hid_com.c` — cmd 13 (set brightness), cmd 15 (stop idle)
+- `keyboards/handwired/polykybd/split72/keymaps/default/keymap.c`, `corne42/keymaps/default/keymap.c` — preset keys, idle/wake restore paths, boot seeding
+
+---
+
 ### Bug: slave does not show overlay icons after MRU program switch until modifier change
 
 **Symptom**: After the host switches to a new program using the MRU overlay path, the slave half's keycap OLEDs do not display overlay icons. Keys on the master half show correctly. A layer or modifier change (which triggers a full display refresh) makes them appear.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
 - **qmk CLI**: `pip install qmk` (use a venv if system pip errors building `halo` — a Debian setuptools quirk), then `qmk config user.qmk_home=<repo>` (or `export QMK_HOME=<repo>`) so it discovers `compile`/`flash` from the repo's `lib/python`, plus `pip install -r requirements.txt`.
 - **Submodules** (empty in a fresh clone): `make git-submodule`. The minimum for split72 is `lib/chibios lib/chibios-contrib lib/pico-sdk lib/printf lib/lufa` (printf and lufa are needed even on RP2040 — `quantum/logging` and the ChibiOS USB stack pull them in).
 - **Build**: `qmk compile -kb handwired/polykybd/split72 -km default` (or `make handwired/polykybd/split72:default`). Output `.uf2` lands in the repo root and `.build/`.
+- **Deliverable for testing is the `.bin`, NOT the `.uf2`** — the user flashes over HID via PolyKybdHost's firmware updater (`polyhost/device/hid_fw_up.py`), which takes the raw RP2040 image: `arm-none-eabi-objcopy -O binary .build/<target>.elf .build/<target>.bin`. The `.uf2` is only for manual bootloader-drive recovery.
 - **Docker is NOT usable** in the remote container (no daemon) — use the native toolchain above, not the qmk docker image.
 - The `firmware-size-diff` skill builds HEAD vs working tree and diffs sizes / `.text`.
 

--- a/keyboards/handwired/polykybd/corne42/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/corne42/keymaps/default/keymap.c
@@ -176,8 +176,7 @@ void sync_and_refresh_displays(void) {
 
         const bool back_from_idle_transition = flag_turned_on(local_flags, global_flags, IDLE_TRANSITION);
         if (back_from_idle_transition) {
-            poly_eeconf_t ee   = load_user_eeconf();
-            access_local_state()->contrast = ee.brightness;
+            access_local_state()->contrast = get_user_brightness();
         }
 
         if(flags!=local_flags) {
@@ -336,9 +335,8 @@ void housekeeping_task_user(void) {
             flags &= ~((uint8_t)IDLE_TRANSITION);
 
             if(elapsed_time_since_update > FADE_OUT_TIME && contrast >= MIN_BRIGHT && (flags & DISP_IDLE)==0) {
-                poly_eeconf_t ee = load_user_eeconf();
                 int32_t time_after = elapsed_time_since_update - FADE_OUT_TIME;
-                int16_t brightness = ((FADE_TRANSITION_TIME - time_after) * ee.brightness) / FADE_TRANSITION_TIME;
+                int16_t brightness = ((FADE_TRANSITION_TIME - time_after) * get_user_brightness()) / FADE_TRANSITION_TIME;
 
                 if(brightness<=MIN_BRIGHT) {
                     contrast = DISP_OFF;
@@ -1321,24 +1319,19 @@ void post_process_record_user(uint16_t keycode, keyrecord_t* record) {
             request_disp_refresh();
             break;
         case KC_D1Q:
-            local_state->contrast = FULL_BRIGHT/4;
-            mark_settings_dirty();
+            set_user_brightness(FULL_BRIGHT/4);
             break;
         case KC_D3Q:
-            local_state->contrast = (FULL_BRIGHT/4)*3;
-            mark_settings_dirty();
+            set_user_brightness((FULL_BRIGHT/4)*3);
             break;
         case KC_DHLF:
-            local_state->contrast = FULL_BRIGHT/2;
-            mark_settings_dirty();
+            set_user_brightness(FULL_BRIGHT/2);
             break;
         case KC_DMAX:
-            local_state->contrast = FULL_BRIGHT;
-            mark_settings_dirty();
+            set_user_brightness(FULL_BRIGHT);
             break;
         case KC_DMIN:
-            local_state->contrast = 2;
-            mark_settings_dirty();
+            set_user_brightness(2);
             break;
         case KC_DDIM:
             dec_brightness();
@@ -1453,8 +1446,7 @@ bool display_wakeup(keyrecord_t* record) {
         if(local_state->contrast==DISP_OFF && (local_state->flags&DEAD_KEY_ON_WAKEUP)!=0) {
             accept_keypress = get_time_since_last_update()<= TURN_OFF_TIME;
         }
-        poly_eeconf_t ee = load_user_eeconf();
-        local_state->contrast = ee.brightness;
+        local_state->contrast = get_user_brightness();
         local_state->flags &= ~((uint8_t)DISP_IDLE);
         local_state->flags |= STATUS_DISP_ON;
         update_performed();
@@ -1518,6 +1510,7 @@ void keyboard_post_init_user(void) {
     poly_sync_t* local_state = access_local_state();
     local_state->lang = ee.lang;
     local_state->contrast = ee.brightness;
+    note_user_brightness(ee.brightness);
     local_state->flags = STATUS_DISP_ON;  /* no RGB on corne42 */
 
     memcpy(access_global_latin_table()->ex, ee.latin_ex, sizeof(ee.latin_ex));
@@ -1631,8 +1624,7 @@ void suspend_wakeup_init_kb(void) {
     poly_sync_t* local_state = access_local_state();
     local_state->flags |= STATUS_DISP_ON;
     local_state->flags &= ~((uint8_t)DISP_IDLE);
-    poly_eeconf_t ee = load_user_eeconf();
-    local_state->contrast = ee.brightness;
+    local_state->contrast = get_user_brightness();
     set_last_update(0);
 
     update_performed();

--- a/keyboards/handwired/polykybd/hid_com.c
+++ b/keyboards/handwired/polykybd/hid_com.c
@@ -319,8 +319,7 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                 break;
             case 13: //set brightness
                 if ( data[HID_DATA_IDX] <= FULL_BRIGHT) {
-                    local_state->contrast = data[HID_DATA_IDX];
-                    mark_settings_dirty();
+                    set_user_brightness(data[HID_DATA_IDX]);
                     memset(data, 0, length);
                     memcpy(data, "P\x0d.", 3);
                     uprintf("Set brightness to: %u.\n", local_state->contrast);
@@ -364,10 +363,10 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                         suspend_wakeup_init_kb();
                     } else {
                         if (local_state->flags & DISP_IDLE) {
-                            // Contrast is cycling 0-49 during pulsing; restore saved brightness
-                            // so display_wakeup() conditions don't leave the display dark.
-                            poly_eeconf_t ee = load_user_eeconf();
-                            local_state->contrast = ee.brightness;
+                            // Contrast is cycling 0-49 during pulsing; restore the user
+                            // brightness so display_wakeup() conditions don't leave the
+                            // display dark.
+                            local_state->contrast = get_user_brightness();
                         }
                         local_state->flags &= ~((uint8_t)DISP_IDLE);
                         local_state->flags |= STATUS_DISP_ON;

--- a/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
@@ -219,8 +219,7 @@ void sync_and_refresh_displays(void) {
 
         const bool back_from_idle_transition = flag_turned_on(local_flags, global_flags, IDLE_TRANSITION);
         if (back_from_idle_transition) {
-            poly_eeconf_t ee   = load_user_eeconf();
-            access_local_state()->contrast = ee.brightness;
+            access_local_state()->contrast = get_user_brightness();
         }
 
         if(flags!=local_flags) {
@@ -394,9 +393,8 @@ void housekeeping_task_user(void) {
             flags &= ~((uint8_t)IDLE_TRANSITION);
 
             if(elapsed_time_since_update > FADE_OUT_TIME && contrast >= MIN_BRIGHT && (flags & DISP_IDLE)==0) {
-                poly_eeconf_t ee = load_user_eeconf();
                 int32_t time_after = elapsed_time_since_update - FADE_OUT_TIME;
-                int16_t brightness = ((FADE_TRANSITION_TIME - time_after) * ee.brightness) / FADE_TRANSITION_TIME;
+                int16_t brightness = ((FADE_TRANSITION_TIME - time_after) * get_user_brightness()) / FADE_TRANSITION_TIME;
 
                 //transition to pulsing mode
                 if(brightness<=MIN_BRIGHT) {
@@ -1593,24 +1591,19 @@ void post_process_record_user(uint16_t keycode, keyrecord_t* record) {
             request_disp_refresh();
             break;
         case KC_D1Q:
-            local_state->contrast = FULL_BRIGHT/4;
-            mark_settings_dirty();
+            set_user_brightness(FULL_BRIGHT/4);
             break;
         case KC_D3Q:
-            local_state->contrast = (FULL_BRIGHT/4)*3;
-            mark_settings_dirty();
+            set_user_brightness((FULL_BRIGHT/4)*3);
             break;
         case KC_DHLF:
-            local_state->contrast = FULL_BRIGHT/2;
-            mark_settings_dirty();
+            set_user_brightness(FULL_BRIGHT/2);
             break;
         case KC_DMAX:
-            local_state->contrast = FULL_BRIGHT;
-            mark_settings_dirty();
+            set_user_brightness(FULL_BRIGHT);
             break;
         case KC_DMIN:
-            local_state->contrast = 2;
-            mark_settings_dirty();
+            set_user_brightness(2);
             break;
         case KC_DDIM:
             dec_brightness();
@@ -1800,8 +1793,7 @@ bool display_wakeup(keyrecord_t* record) {
         if(local_state->contrast==DISP_OFF && (local_state->flags&DEAD_KEY_ON_WAKEUP)!=0) {
             accept_keypress = get_time_since_last_update()<= TURN_OFF_TIME;
         }
-        poly_eeconf_t ee = load_user_eeconf();
-        local_state->contrast = ee.brightness;
+        local_state->contrast = get_user_brightness();
         local_state->flags &= ~((uint8_t)DISP_IDLE);
         local_state->flags |= STATUS_DISP_ON;
         update_performed();
@@ -1901,6 +1893,7 @@ void keyboard_post_init_user(void) {
     poly_sync_t* local_state = access_local_state();
     local_state->lang = ee.lang;
     local_state->contrast = ee.brightness;
+    note_user_brightness(ee.brightness);
     local_state->flags = set_flag(STATUS_DISP_ON, RGB_ON, rgb_matrix_is_enabled());
 
     memcpy(access_global_latin_table()->ex, ee.latin_ex, sizeof(ee.latin_ex));
@@ -2039,8 +2032,7 @@ void suspend_wakeup_init_kb(void) {
     poly_sync_t* local_state = access_local_state();
     local_state->flags |= STATUS_DISP_ON;
     local_state->flags &= ~((uint8_t)DISP_IDLE);
-    poly_eeconf_t ee = load_user_eeconf();
-    local_state->contrast = ee.brightness;
+    local_state->contrast = get_user_brightness();
     set_last_update(0);
 
     //rgb_matrix_reload_from_eeprom();

--- a/keyboards/handwired/polykybd/split_sync.c
+++ b/keyboards/handwired/polykybd/split_sync.c
@@ -41,7 +41,17 @@ void user_sync_poly_data_handler(uint8_t in_len, const void* in_data, uint8_t ou
         if(crc32 == ((const poly_sync_t *)in_data)->crc32) {
             const poly_sync_t* incoming = (const poly_sync_t *)in_data;
             const poly_sync_t* current  = get_local_state();
-            if (incoming->contrast != current->contrast || incoming->lang != current->lang) {
+            if (incoming->lang != current->lang) {
+                mark_settings_dirty();
+            }
+            // Adopt the synced contrast as the intended user brightness only while
+            // the master is awake: suspend/idle/fade syncs carry transient values
+            // (DISP_OFF, faded or pulsing levels) that must never be persisted as
+            // the brightness — that would make the displays come up dark/wrong on
+            // the next boot or wake.
+            if (incoming->contrast != current->contrast && incoming->contrast > DISP_OFF &&
+                (incoming->flags & ((uint8_t)DISP_IDLE | (uint8_t)IDLE_TRANSITION)) == 0) {
+                note_user_brightness(incoming->contrast);
                 mark_settings_dirty();
             }
             // Detect action flags newly set in this sync and run them immediately,

--- a/keyboards/handwired/polykybd/state.c
+++ b/keyboards/handwired/polykybd/state.c
@@ -14,6 +14,13 @@ static poly_sync_t g_state;
 
 static bool g_brightness_dirty = false;   // lang + brightness need a flush
 
+// The brightness the user actually chose — the value that gets persisted.
+// l_state.contrast also carries transient values (DISP_OFF during suspend,
+// faded/pulsing levels during idle), and the flush points (suspend/shutdown)
+// run exactly when such a transient is live, so the save path must read this
+// snapshot instead of the live contrast.
+static uint8_t g_user_brightness = FULL_BRIGHT;
+
 static bool          g_def_layer_dirty = false;
 static layer_state_t g_def_layer_pending = 0;
 
@@ -160,7 +167,7 @@ void copy_global_latin_table(const latin_sync_t* value) {
 
 // Writes only lang+brightness+unused (4 bytes) to EEPROM.
 void save_user_settings(void) {
-    const poly_eeconf_t ee = { .lang = l_state.lang, .brightness = (uint8_t)(~l_state.contrast), .unused = 0 };
+    const poly_eeconf_t ee = { .lang = l_state.lang, .brightness = (uint8_t)(~g_user_brightness), .unused = 0 };
     eeconfig_update_user_datablock(&ee, 0, offsetof(poly_eeconf_t, latin_ex));
 }
 
@@ -221,6 +228,7 @@ void inc_brightness(void) {
     if (l_state.contrast > FULL_BRIGHT) {
         l_state.contrast = FULL_BRIGHT;
     }
+    g_user_brightness  = l_state.contrast;
     g_brightness_dirty = true;
 }
 
@@ -233,7 +241,30 @@ void dec_brightness(void) {
     } else {
         l_state.contrast = MIN_BRIGHT;
     }
+    g_user_brightness  = l_state.contrast;
     g_brightness_dirty = true;
+}
+
+// Sets the display contrast to a deliberate user-chosen level and records it as
+// the brightness to persist at the next flush. Use for the preset keys and the
+// host's set-brightness command; transient contrast changes (suspend, idle fade)
+// must write l_state.contrast directly so they are never persisted.
+void set_user_brightness(uint8_t value) {
+    l_state.contrast   = value;
+    g_user_brightness  = value;
+    g_brightness_dirty = true;
+}
+
+// Records the intended user brightness without marking settings dirty (boot-time
+// load, slave adopting an awake master's synced contrast).
+void note_user_brightness(uint8_t value) {
+    g_user_brightness = value;
+}
+
+// The brightness to restore after idle/suspend. Unlike a load_user_eeconf()
+// round-trip this tracks changes that have not been flushed to EEPROM yet.
+uint8_t get_user_brightness(void) {
+    return g_user_brightness;
 }
 
 // Marks settings (lang + brightness) as needing an EEPROM write at the next flush.

--- a/keyboards/handwired/polykybd/state.h
+++ b/keyboards/handwired/polykybd/state.h
@@ -122,6 +122,18 @@ void inc_brightness(void);
 // Decrements brightness by BRIGHT_STEP with clamping to MIN_BRIGHT (deferred EEPROM write).
 void dec_brightness(void);
 
+// Sets contrast to a deliberate user-chosen level and records it as the brightness
+// to persist (deferred EEPROM write). Transient contrast changes (suspend, idle
+// fade) must NOT use this — they write l_state.contrast directly.
+void set_user_brightness(uint8_t value);
+
+// Records the intended user brightness without marking settings dirty (boot-time
+// load, slave adopting an awake master's synced contrast).
+void note_user_brightness(uint8_t value);
+
+// The brightness to restore after idle/suspend (tracks unflushed changes).
+uint8_t get_user_brightness(void);
+
 // Marks settings (lang + brightness) as needing an EEPROM write at the next flush.
 void mark_settings_dirty(void);
 


### PR DESCRIPTION
## Symptom

Since PR #63, keycap OLED brightness intermittently comes up as **0 on boot and after wake from suspend**, without the user setting it to 0.

## Root cause

PR #63's suspend-only EEPROM flush persists the **live** `l_state.contrast` — but the flush points run exactly when contrast holds a transient value:

- `suspend_power_down_kb()` calls `save_all_dirty()` **after** `poly_suspend()` has already set `contrast = DISP_OFF` (0). Any dirty settings flag set since boot (brightness key, language change, host HID brightness/lang) persisted 0 as the user brightness.
- The **slave was hit on every suspend**: the master syncs `contrast = 0` before the flush, and `user_sync_poly_data_handler()` marked settings dirty on any contrast diff — including the suspend sync itself — then copied 0 into local state and flushed it.
- The idle paths (`TURN_OFF_TIME` → `poly_suspend()`, fade transition, 0–49 pulsing) also leave transients in `contrast` that a later flush (shutdown, store key, fw-update) persisted.

Every boot / wake / wake-on-keypress path then restored the bad EEPROM value.

## Fix

`state.c` keeps a `g_user_brightness` snapshot updated **only** at deliberate set-points:

- `inc_brightness()` / `dec_brightness()`
- new `set_user_brightness()` — used by the `KC_D*` preset keys and HID set-brightness (cmd 13)
- `note_user_brightness()` at boot-time EEPROM load
- on the slave, when adopting a synced contrast **only while the master is awake** (`contrast > DISP_OFF`, `DISP_IDLE|IDLE_TRANSITION` clear)

`save_user_settings()` persists `~g_user_brightness` instead of `~l_state.contrast`, so suspend/idle transients can never reach EEPROM. All idle/wake restore paths (`back_from_idle_transition`, fade target, `display_wakeup()`, `suspend_wakeup_init_kb()`, HID stop-idle) now read `get_user_brightness()` instead of re-loading EEPROM — fixing a second subtle regression where an unflushed brightness change was silently reverted by an idle/wake cycle.

The suspend-only flush model itself (the slave-UART-blocking fix) is unchanged.

## Verification

- `split72:default` and `corne42:default` compile clean (`revision2` includes the default keymap).
- Documented in CLAUDE.md "Investigations in progress" per convention.

Note after flashing: EEPROM may already hold 0 from the old firmware, so the first boot can still come up dark once — set the brightness once and it persists correctly from then on.

https://claude.ai/code/session_015YYubYJy7bXUP2SpAyHjSZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015YYubYJy7bXUP2SpAyHjSZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed OLED brightness regression that caused intermittent drops to 0 on boot or wake from sleep. Display brightness now correctly persists and restores across power transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->