### PR TITLE
polykybd: fix HIL HID timeouts (split-sync retry cap) + .bin update-path test

### DIFF
--- a/.github/workflows/qmk-test.yml
+++ b/.github/workflows/qmk-test.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       split72: ${{ steps.names.outputs.split72 }}
+      split72_bin: ${{ steps.names.outputs.split72_bin }}
       split72_hil_left: ${{ steps.names.outputs.split72_hil_left }}
       split72_hil_right: ${{ steps.names.outputs.split72_hil_right }}
       corne42: ${{ steps.names.outputs.corne42 }}
@@ -23,6 +24,14 @@ jobs:
         uses: docker://qmkfm/qmk_cli
         with:
           args: qmk compile -kb handwired/polykybd/split72 -km default
+
+      # The HID firmware-update path takes the raw RP2040 .bin (not the .uf2),
+      # which the host streams over HID. objcopy the just-built .elf so the rig
+      # can drive the keyboard's own update path (stage+verify) as a HIL test.
+      - name: Objcopy split72 .bin (for HID firmware-update test)
+        uses: docker://qmkfm/qmk_cli
+        with:
+          args: arm-none-eabi-objcopy -O binary .build/handwired_polykybd_split72_default.elf handwired_polykybd_split72_default.bin
 
       # HIL builds: same firmware but with POLYKYBD_HIL, which fixes the split
       # role at compile time per side instead of using VBUS detection. On the rig
@@ -48,6 +57,7 @@ jobs:
       - id: names
         run: |
           echo "split72=$(ls handwired_polykybd_split72_default*.uf2 2>/dev/null | head -1)" >> "$GITHUB_OUTPUT"
+          echo "split72_bin=$(ls handwired_polykybd_split72_default*.bin 2>/dev/null | head -1)" >> "$GITHUB_OUTPUT"
           echo "split72_hil_left=$(ls handwired_polykybd_split72_hil_left*.uf2 2>/dev/null | head -1)" >> "$GITHUB_OUTPUT"
           echo "split72_hil_right=$(ls handwired_polykybd_split72_hil_right*.uf2 2>/dev/null | head -1)" >> "$GITHUB_OUTPUT"
           echo "corne42=$(ls handwired_polykybd_corne42_default*.uf2 2>/dev/null | head -1)" >> "$GITHUB_OUTPUT"
@@ -55,7 +65,9 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: firmware
-          path: "*.uf2"
+          path: |
+            *.uf2
+            *.bin
           retention-days: 7
 
   hil-test:
@@ -105,6 +117,7 @@ jobs:
           venv/bin/python -u -m station.test_runner \
             --left  "firmware/${{ needs.build.outputs.split72_hil_left }}" \
             --right "firmware/${{ needs.build.outputs.split72_hil_right }}" \
+            --bin   "firmware/${{ needs.build.outputs.split72_bin }}" \
             2>&1 | tee /tmp/hil-test.log
 
       # On failure, collect a deliberately SANITIZED snapshot for triage. This goes

--- a/keyboards/handwired/polykybd/corne42/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/corne42/keymaps/default/keymap.c
@@ -191,7 +191,13 @@ void sync_and_refresh_displays(void) {
         access_local_state()->lang_page    = lang_pack_state();
         state_diff = differ(get_local_state(), get_global_state(), sizeof(poly_sync_t));
         if ( state_diff ) {
-            if(!send_to_bridge(USER_SYNC_POLY_DATA, (void *)access_local_state(), sizeof(poly_sync_t), 10)) {
+            // Single attempt (was 10): these periodic syncs re-fire every
+            // housekeeping pass while a diff persists, so in-call retries only
+            // pile up full ~40 ms UART timeouts and stall the main loop (and
+            // USB/HID) when the slave is transiently unreachable — e.g. the
+            // post-cold-flash settling window, kept "connected" for ~4 s by the
+            // raised SPLIT_MAX_CONNECTION_ERRORS. See split72 keymap for detail.
+            if(!send_to_bridge(USER_SYNC_POLY_DATA, (void *)access_local_state(), sizeof(poly_sync_t), 1)) {
                 state_diff = false;
                 uprint("USER_SYNC_POLY_DATA failed to send\n");
             }
@@ -204,7 +210,7 @@ void sync_and_refresh_displays(void) {
             mru_sync_t mru_msg;
             mru_emoji_pack(mru_msg.emoji);
             mru_lang_pack(mru_msg.lang);
-            uint8_t mru_ack = send_to_bridge(USER_SYNC_OVERLAY_MAP_DATA, &mru_msg, MRU_SYNC_BYTES, 10);
+            uint8_t mru_ack = send_to_bridge(USER_SYNC_OVERLAY_MAP_DATA, &mru_msg, MRU_SYNC_BYTES, 1);
             if (mru_ack == SYNC_ACK || mru_ack == SYNC_ACK_SIG) {
                 mru_clear_sync_pending();
             } else {
@@ -216,13 +222,13 @@ void sync_and_refresh_displays(void) {
         access_local_layer()->mods = get_mods();
         layer_diff = differ(get_local_layer(), get_global_layer(), sizeof(poly_layer_t));
         if ( layer_diff ) {
-            if(!send_to_bridge(USER_SYNC_LAYER_DATA, (void *)access_local_layer(), sizeof(poly_layer_t), 10)) {
+            if(!send_to_bridge(USER_SYNC_LAYER_DATA, (void *)access_local_layer(), sizeof(poly_layer_t), 1)) {
                 layer_diff = false;
                 uprint("USER_SYNC_LAYER_DATA failed to send\n");
             }
         }
         if ( differ(get_local_last_latin(), get_global_last_latin(), sizeof(poly_last_t)) ) {
-            if(!send_to_bridge(USER_SYNC_LASTKEY_DATA, access_local_last_latin(), sizeof(poly_last_t), 5)) {
+            if(!send_to_bridge(USER_SYNC_LASTKEY_DATA, access_local_last_latin(), sizeof(poly_last_t), 1)) {
                 uprint("USER_SYNC_LASTKEY_DATA failed to send\n");
             } else {
                 copy_global_last_latin(get_local_last_latin());

--- a/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
@@ -236,7 +236,17 @@ void sync_and_refresh_displays(void) {
         access_local_state()->lang_page    = lang_pack_state();
         state_diff = differ(get_local_state(), get_global_state(), sizeof(poly_sync_t));
         if ( state_diff ) {
-            if(!send_to_bridge(USER_SYNC_POLY_DATA, (void *)access_local_state(), sizeof(poly_sync_t), 10)) {
+            // Periodic syncs use a SINGLE attempt (was 10). They re-fire every
+            // housekeeping pass while a diff persists, so in-call retries are
+            // redundant. With SPLIT_MAX_CONNECTION_ERRORS raised to 200 (for the
+            // fw-update erase), transaction_rpc_exec() keeps reporting "connected"
+            // for ~4 s while the slave is transiently unreachable (e.g. the
+            // post-cold-flash settling window) instead of fast-failing — so each
+            // retry pays a full ~40 ms UART timeout and 10× of them blocks the
+            // main loop (and USB/HID servicing) ~400 ms PER sync. One attempt
+            // bounds the stall to ~tens of ms and the next loop retries. No effect
+            // on the normal path, where the slave ACKs on the first attempt.
+            if(!send_to_bridge(USER_SYNC_POLY_DATA, (void *)access_local_state(), sizeof(poly_sync_t), 1)) {
                 state_diff = false; // if failed to sync, do not consider it a diff and try again later
                 uprint("USER_SYNC_POLY_DATA failed to send\n");
             }
@@ -251,7 +261,7 @@ void sync_and_refresh_displays(void) {
             // Multiplexed onto the overlay-map transaction id (distinct payload
             // size) to stay within QMK's 32-transaction limit. Only the packed
             // bytes are sent (MRU_SYNC_BYTES), not the struct's crc tail padding.
-            uint8_t mru_ack = send_to_bridge(USER_SYNC_OVERLAY_MAP_DATA, &mru_msg, MRU_SYNC_BYTES, 10);
+            uint8_t mru_ack = send_to_bridge(USER_SYNC_OVERLAY_MAP_DATA, &mru_msg, MRU_SYNC_BYTES, 1);
             if (mru_ack == SYNC_ACK || mru_ack == SYNC_ACK_SIG) {
                 mru_clear_sync_pending();
             } else {
@@ -263,13 +273,13 @@ void sync_and_refresh_displays(void) {
         access_local_layer()->mods = get_mods();
         layer_diff = differ(get_local_layer(), get_global_layer(), sizeof(poly_layer_t));
         if ( layer_diff ) {
-            if(!send_to_bridge(USER_SYNC_LAYER_DATA, (void *)access_local_layer(), sizeof(poly_layer_t), 10)) {
+            if(!send_to_bridge(USER_SYNC_LAYER_DATA, (void *)access_local_layer(), sizeof(poly_layer_t), 1)) {
                 layer_diff = false; // if failed to sync, do not consider it a diff and try again later
                 uprint("USER_SYNC_LAYER_DATA failed to send\n");
             }
         }
         if ( differ(get_local_last_latin(), get_global_last_latin(), sizeof(poly_last_t)) ) {
-            if(!send_to_bridge(USER_SYNC_LASTKEY_DATA, access_local_last_latin(), sizeof(poly_last_t), 5)) {
+            if(!send_to_bridge(USER_SYNC_LASTKEY_DATA, access_local_last_latin(), sizeof(poly_last_t), 1)) {
                 // if failed to sync, do not consider it a diff and try again later
                 uprint("USER_SYNC_LASTKEY_DATA failed to send\n");
             } else {


### PR DESCRIPTION
Two related changes, both verified green on the rig.

## 1. Fix the HIL split-sync timeouts (firmware)
The recent HIL flakiness (`set unicode mode` / `idle wake` timing out) traces to the master stalling its main loop — and thus USB/HID servicing — in master→slave split-sync retries while the slave is transiently unreachable (the post-cold-flash settling window).

`transaction_rpc_exec()` fast-fails instantly when `is_transport_connected()` is false, but `SPLIT_MAX_CONNECTION_ERRORS` is raised to 200 (for the fw-update erase), so the transport keeps reporting "connected" for ~4 s before fast-fail engages. During that window every periodic sync in `housekeeping_task_user()` retried up to 10× — each a full ~40 ms UART timeout — ~1.5 s of stall per pass, so whatever HID command landed there blew past the host's 3 s budget.

**Fix:** cap the periodic state/MRU/layer/lastkey syncs at **1 attempt** (they re-fire every pass while a diff persists, so in-call retries were redundant). Bounds the stall to tens of ms; no effect on the normal path (slave ACKs first try). Applied to split72 + corne42.

Result on the rig: `set unicode mode` / `idle wake` now reply in ~80 ms (were timeouts); the `Bridge sync retry … Failed to sync` storm is gone.

## 2. Cover the HID firmware-update path (CI)
The rig flashes via UF2/BOOTSEL and never exercises the keyboard's own HID update path. This objcopies the split72 `.elf` to a raw `.bin`, uploads it, and passes it to the rig (`--bin`), which drives **BEGIN → CHUNK → COMMIT** stage+verify (non-destructive — no APPLY). Verified on the rig: 11,951 chunks streamed with 0 resync rewinds, CRC verified — exercising the just-merged PR #67 fw_up code on hardware.

Paired with polykybd-ctnd PR (runner side). The `SPLIT_MAX_CONNECTION_ERRORS` threshold is intentionally left at 200 — lowering it would regress the fw-update erase tolerance, and #1 already removes the stall.

https://claude.ai/code/session_011FdjGMWeMWqpFJYcaj7PHF