### PR TITLE
polykybd: document the diff-as-retry-queue invariant in the sync loop

### DIFF
--- a/keyboards/handwired/polykybd/corne42/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/corne42/keymaps/default/keymap.c
@@ -198,6 +198,11 @@ void sync_and_refresh_displays(void) {
             // post-cold-flash settling window, kept "connected" for ~4 s by the
             // raised SPLIT_MAX_CONNECTION_ERRORS. See split72 keymap for detail.
             if(!send_to_bridge(USER_SYNC_POLY_DATA, (void *)access_local_state(), sizeof(poly_sync_t), 1)) {
+                // Failed: clearing state_diff skips the copy_global_state() below,
+                // so global stays != local and differ() re-fires the send next
+                // pass. The diff IS the retry queue; global only advances to local
+                // on a successful sync — so 1 vs 10 attempts changes only where
+                // retries happen, never whether the update is delivered.
                 state_diff = false;
                 uprint("USER_SYNC_POLY_DATA failed to send\n");
             }
@@ -223,7 +228,7 @@ void sync_and_refresh_displays(void) {
         layer_diff = differ(get_local_layer(), get_global_layer(), sizeof(poly_layer_t));
         if ( layer_diff ) {
             if(!send_to_bridge(USER_SYNC_LAYER_DATA, (void *)access_local_layer(), sizeof(poly_layer_t), 1)) {
-                layer_diff = false;
+                layer_diff = false; // skip copy_global_layer() below; diff persists, re-fires next pass
                 uprint("USER_SYNC_LAYER_DATA failed to send\n");
             }
         }
@@ -291,12 +296,12 @@ void sync_and_refresh_displays(void) {
         if (contrast_changed || idle_changed) {
             set_displays(get_local_state()->contrast, in_idle_mode);
         }
-        copy_global_state(get_local_state());
+        copy_global_state(get_local_state());   // advance global only on a synced change (see send site)
         request_disp_refresh();
     }
 
     if(layer_diff) {
-        copy_global_layer(get_local_layer());
+        copy_global_layer(get_local_layer());   // advance global only on a synced change (see send site)
         request_disp_refresh();
     }
 

--- a/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
@@ -247,7 +247,13 @@ void sync_and_refresh_displays(void) {
             // bounds the stall to ~tens of ms and the next loop retries. No effect
             // on the normal path, where the slave ACKs on the first attempt.
             if(!send_to_bridge(USER_SYNC_POLY_DATA, (void *)access_local_state(), sizeof(poly_sync_t), 1)) {
-                state_diff = false; // if failed to sync, do not consider it a diff and try again later
+                // Failed: clear state_diff so the copy_global_state() below is
+                // SKIPPED — global stays != local, so next pass differ() is still
+                // true and re-fires the send. The diff IS the retry queue; global
+                // only advances to local on a successful sync, so 1 vs 10 attempts
+                // changes only WHERE retries happen, never whether the update is
+                // eventually delivered.
+                state_diff = false;
                 uprint("USER_SYNC_POLY_DATA failed to send\n");
             }
         }
@@ -274,7 +280,8 @@ void sync_and_refresh_displays(void) {
         layer_diff = differ(get_local_layer(), get_global_layer(), sizeof(poly_layer_t));
         if ( layer_diff ) {
             if(!send_to_bridge(USER_SYNC_LAYER_DATA, (void *)access_local_layer(), sizeof(poly_layer_t), 1)) {
-                layer_diff = false; // if failed to sync, do not consider it a diff and try again later
+                layer_diff = false; // failed: skip copy_global_layer() below so the diff
+                                    // persists and the send re-fires next pass (see state above)
                 uprint("USER_SYNC_LAYER_DATA failed to send\n");
             }
         }
@@ -337,12 +344,12 @@ void sync_and_refresh_displays(void) {
         if (contrast_changed || idle_changed) {
             set_displays(get_local_state()->contrast, in_idle_mode);
         }
-        copy_global_state(get_local_state());
+        copy_global_state(get_local_state());   // advance global only on a synced change (see send site)
         request_disp_refresh();
     }
 
     if(layer_diff) {
-        copy_global_layer(get_local_layer());
+        copy_global_layer(get_local_layer());   // advance global only on a synced change (see send site)
         request_disp_refresh();
     }
 


### PR DESCRIPTION
Follow-up to #68 (merged). Comment-only — no functional change (split72 compiles clean).

Makes explicit the invariant that makes the 1-attempt periodic split syncs safe, which came up in review: the master→slave update isn't delivered by in-call retries but by the `differ()` check across housekeeping passes. `global_state`/`global_layer` only advance to `local` via `copy_global_state()`/`copy_global_layer()`, which sit **inside** the `if(state_diff)`/`if(layer_diff)` blocks — so a *failed* send clears the diff flag, skips that copy, leaves `global != local`, and re-fires the send on the next pass.

The diff is the durable retry queue; **1 vs 10 attempts changes only *where* retries happen (next pass vs blocking the main loop), never whether the update is eventually delivered.** The send site and the resolve (`copy_global_*`) site are now cross-referenced in both split72 and corne42 keymaps.

https://claude.ai/code/session_011FdjGMWeMWqpFJYcaj7PHF

---
_Generated by [Claude Code](https://claude.ai/code/session_011FdjGMWeMWqpFJYcaj7PHF)_

## Summary by Sourcery

Clarify the invariant and retry behavior of the split sync loop for polykybd split72 and corne42 keymaps without changing runtime behavior.

Enhancements:
- Document the diff-as-retry-queue invariant in the split sync loop for state and layer synchronization.
- Add cross-references between send and resolve sites to explain when global state and layer copies occur.

Documentation:
- Improve inline comments describing failure handling, retry semantics, and sync safety in split72 and corne42 keymaps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced synchronization reliability for split keyboard displays; failed sync attempts now properly retry without losing state data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->