### PR TITLE
Add GET_LANG_LIST_PACKED (cmd 27): compact ISO-index language list, protocol v2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,9 +39,35 @@ The host software (`PolyKybdHost/`) communicates with this firmware over a custo
 ### HID protocol (host → firmware)
 - 64-byte raw HID reports; byte 0 = Report ID, byte 1 = Command ID, byte 2+ = payload
 - All responses are prefixed `"P\xNN."` (ACK) or `"P\xNN!"` (NACK)
+- **`PROTOCOL_VERSION`** (`config.h`, reported in the GET_ID string) gates host
+  features. **v2** added `GET_LANG_LIST_PACKED` (cmd `27` / `0x1b`): the language
+  list as a count byte + one `(ISO 639-1 idx, ISO 3166-1 alpha-2 idx)` **2-byte
+  pair per language** instead of the 4 ASCII chars of cmd `0x08` — 81 langs go
+  from 6 reports to 3, and the firmware `.rodata` shrinks (2 emitted bytes/lang vs
+  4). cmd `0x08` (ASCII) stays for old hosts; the host prefers cmd `27` only when
+  it reads protocol ≥ 2, else falls back. The index↔code tables are the **frozen,
+  append-only** `lang/iso_lang_country.py` (see "Language list encoding" below).
 - Overlay transmission: each keycap overlay (360 bytes) is split into 6 × 60-byte segments (cmd `0x0A`), or sent RLE-compressed in 1–2 packets (cmds `0x10`/`0x11`)
 - ROI updates (cmds `0x12`/`0x13`) allow partial refresh of a keycap's display area
 - Overlay index = `keycode_slot + 90 * modifier_variant` (9 variants: bare, Ctrl, Shift, Ctrl+Shift, Alt, Ctrl+Alt, Alt+Shift, Ctrl+Alt+Shift, GUI)
+
+### Language list encoding (`lang/iso_lang_country.py`)
+The packed list (cmd `27`) maps each 4-char code to two 1-byte indices: the
+language's position in the ISO 639-1 table and the country's in ISO 3166-1
+alpha-2. `lang/iso_lang_country.py` is the **frozen, append-only** index table —
+generated once from the `iso-codes` package then frozen (indices never reorder;
+new ISO codes append at the next free slot; private pseudo-codes with no ISO
+639-1 entry, e.g. `hw`, live in a reserved block above the standard codes). The
+`hid_com.c` case-27 cog imports it and emits the index bytes, so the table is a
+**build-time artifact only** — it is *not* compiled into the firmware.
+- ⚠️ **Single source of truth across three repos**: this file is byte-identical
+  to `PolyKybdHost/polyhost/services/iso_lang_country.py` and
+  `polykybd-ctnd/station/iso_lang_country.py`. When it changes, copy it to all
+  three (verify with `cmp`); a mismatch silently decodes wrong languages on the
+  host/rig. Adding a standard ISO language needs no table change (the code is
+  already present); only a new private pseudo-code requires appending an entry.
+- Re-run `cog -r hid_com.c` after any change to the list or the table (needs
+  `cogapp` + `openpyxl`).
 
 ### Display rendering pipeline
 1. Host sends compressed bitmap → `fill_overlay.c` decompresses (optionally on core1) → `overlays[idx][360]`

--- a/keyboards/handwired/polykybd/config.h
+++ b/keyboards/handwired/polykybd/config.h
@@ -84,7 +84,8 @@
 //#          PolyKybd specific         #
 //######################################
 #define FW_VERSION "0.8.15"
-#define PROTOCOL_VERSION 1
+// v2: adds GET_LANG_LIST_PACKED (cmd 27) — language list as 2-byte ISO index pairs.
+#define PROTOCOL_VERSION 2
 
 #define FULL_BRIGHT 50
 #define MIN_BRIGHT 1

--- a/keyboards/handwired/polykybd/hid_com.c
+++ b/keyboards/handwired/polykybd/hid_com.c
@@ -538,6 +538,37 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                 memcpy(data, "P\x1A.", 3);
                 raw_hid_send(data, length);
                 break;
+            case 27: //packed lang list: 1 count byte + (ISO 639-1 idx, ISO 3166-1 idx) per lang
+                memset(data, 0, length);
+                /*[[[cog
+                import sys
+                sys.path.insert(0, os.path.join(os.path.dirname(cog.inFile), "lang"))
+                from iso_lang_country import encode_pair
+                # Payload: count, then 2 index bytes per language (see lang/iso_lang_country.py).
+                packed = [len(languages)]
+                for lang in languages:
+                    packed += list(encode_pair(lang))
+                CHUNK = RAW_EPSIZE - 3  # 61 payload bytes after the 3-byte "P\x1b." header
+                for off in range(0, len(packed), CHUNK):
+                    seg = packed[off:off+CHUNK]
+                    # All bytes emitted as \xNN (incl. header) so no literal char ever
+                    # follows a hex escape -> avoids C's greedy \x escape swallowing it.
+                    lit = "\\x50\\x1b\\x2e" + "".join(f"\\x{b:02x}" for b in seg)
+                    cog.outl(f'memcpy(data, "{lit}", {3 + len(seg)});')
+                    cog.outl('raw_hid_send(data, length);')
+                    if off + CHUNK < len(packed):
+                        cog.outl('memset(data, 0, length);')
+                ]]]*/
+                memcpy(data, "\x50\x1b\x2e\x51\x25\xe8\x20\x38\x2f\x4a\x27\x43\x82\xb7\x48\x6d\xa4\xe0\x54\x79\x4a\x71\x07\xc0\x24\x58\xaa\xe5\x87\xbe\x0d\x23\x50\x7c\x0e\x15\x80\xb2\x86\xbc\xb6\x2f\x73\xa5\x38\x66\x99\xc4\x2c\x45\x74\xa6\x1f\x3a\x3d\x63\x1b\x37\x3b\x61\x8f\xc9\x61\x84", 64);
+                raw_hid_send(data, length);
+                memset(data, 0, length);
+                memcpy(data, "\x50\x1b\x2e\x63\x86\x28\x3f\x82\x1e\x95\xbd\x67\x8f\x2a\x6b\x39\x68\x6a\x68\x71\xa7\x69\x92\xab\xb1\x25\x4c\x27\x9c\x20\x2a\x2f\x13\x2f\x25\x9e\xd9\x12\x68\x9c\x68\x9b\x68\xb6\xe3\x4c\x4e\x3e\x06\x41\x64\x0b\x0f\x47\x6c\xae\xf0\xb6\x5e\x25\x0c\x25\xaa\x66", 64);
+                raw_hid_send(data, length);
+                memset(data, 0, length);
+                memcpy(data, "\x50\x1b\x2e\xaa\x91\xf3\x2d\x46\xa1\xb0\xb8\xe8\x25\xf6\x03\xf6\x07\x40\x9a\x72\x05\x44\xb4\xa3\x25\xa3\x07\x88\x07\x6a\x57\x6a\x6b\x9d\xac\xea\x25\x25\x27\x09\x25\xaf\xa8\xae", 44);
+                raw_hid_send(data, length);
+                //[[[end]]]
+                break;
             default:
                 if (hid_fw_up_receive(data, length)) {
                     break;

--- a/keyboards/handwired/polykybd/lang/iso_lang_country.py
+++ b/keyboards/handwired/polykybd/lang/iso_lang_country.py
@@ -1,0 +1,60 @@
+"""FROZEN single source of truth: ISO 639-1 language + ISO 3166-1 alpha-2
+country code <-> 1-byte index tables for the PolyKybd GET_LANG_LIST payload.
+
+The keyboard's language list is transmitted as one (lang_idx, country_idx) byte
+pair per language instead of the 4 ASCII chars (cmd GET_LANG_LIST_PACKED). Each
+index is the position of the code in the tuples below.
+
+Generated once from the `iso-codes` package (json), then FROZEN. The index of a
+code is APPEND-ONLY: never reorder, never delete; new ISO codes get appended at
+the next free index. The host decoder and the firmware encoder must agree on
+these exact indices, so this file is the shared source both are generated from.
+
+Initial assignment (2026-06-10): alphabetical, for determinism only.
+ISO 639-1: 184 codes (idx 0..183); private langs start at 184.
+ISO 3166-1 alpha-2: 249 codes (idx 0..248).
+"""
+
+_LANG = (
+    "aa ab ae af ak am an ar as av ay az ba be bg bh bi bm bn bo br bs ca ce ch co cr cs cu cv cy da de dv dz ee el en eo es et eu fa ff fi fj fo fr fy ga gd gl gn gu gv ha he hi ho hr ht hu hy hz ia id ie ig ii ik io is it iu ja jv ka kg ki kj kk kl km kn ko kr ks ku kv kw ky la lb lg li ln lo lt lu lv mg mh mi mk ml mn mr ms mt my na nb nd ne ng nl nn no nr nv ny oc oj om or os pa pi pl ps pt qu rm rn ro ru rw sa sc sd se sg si sk sl sm sn so sq sr ss st su sv sw ta te tg th ti tk tl tn to tr ts tt tw ty ug uk ur uz ve vi vo wa wo xh yi yo za zh zu"
+).split()
+
+# Private-use language pseudo-codes with no ISO 639-1 entry, appended above the
+# standard block. hw = Hawaiian (ISO 639-2/3 'haw' cannot fit the 2-char field).
+PRIVATE_LANGS = ["hw"]
+
+_COUNTRY = (
+    "AD AE AF AG AI AL AM AO AQ AR AS AT AU AW AX AZ BA BB BD BE BF BG BH BI BJ BL BM BN BO BQ BR BS BT BV BW BY BZ CA CC CD CF CG CH CI CK CL CM CN CO CR CU CV CW CX CY CZ DE DJ DK DM DO DZ EC EE EG EH ER ES ET FI FJ FK FM FO FR GA GB GD GE GF GG GH GI GL GM GN GP GQ GR GS GT GU GW GY HK HM HN HR HT HU ID IE IL IM IN IO IQ IR IS IT JE JM JO JP KE KG KH KI KM KN KP KR KW KY KZ LA LB LC LI LK LR LS LT LU LV LY MA MC MD ME MF MG MH MK ML MM MN MO MP MQ MR MS MT MU MV MW MX MY MZ NA NC NE NF NG NI NL NO NP NR NU NZ OM PA PE PF PG PH PK PL PM PN PR PS PT PW PY QA RE RO RS RU RW SA SB SC SD SE SG SH SI SJ SK SL SM SN SO SR SS ST SV SX SY SZ TC TD TF TG TH TJ TK TL TM TN TO TR TT TV TW TZ UA UG UM US UY UZ VA VC VE VG VI VN VU WF WS YE YT ZA ZM ZW"
+).split()
+
+LANG_CODES = _LANG + PRIVATE_LANGS
+COUNTRY_CODES = _COUNTRY
+
+_LANG_IDX = {c: i for i, c in enumerate(LANG_CODES)}
+_COUNTRY_IDX = {c: i for i, c in enumerate(COUNTRY_CODES)}
+
+assert len(LANG_CODES) <= 256 and len(COUNTRY_CODES) <= 256, "index must fit one byte"
+
+
+def encode_pair(code: str) -> bytes:
+    """4-char 'llCC' (lang lower + country UPPER) -> 2 bytes (lang_idx, country_idx)."""
+    return bytes((_LANG_IDX[code[:2]], _COUNTRY_IDX[code[2:]]))
+
+
+def decode_pair(lang_idx: int, country_idx: int) -> str:
+    """Inverse of encode_pair: 2 indices -> 4-char 'llCC' code."""
+    return LANG_CODES[lang_idx] + COUNTRY_CODES[country_idx]
+
+
+def encode_packed(codes) -> bytes:
+    """Encode a list of 4-char codes as: 1 count byte + 2 index bytes per code."""
+    out = bytearray([len(codes)])
+    for code in codes:
+        out += encode_pair(code)
+    return bytes(out)
+
+
+def decode_packed(buf) -> list:
+    """Inverse of encode_packed. buf[0] = count, then count*(lang,country) pairs."""
+    count = buf[0]
+    return [decode_pair(buf[1 + 2 * i], buf[2 + 2 * i]) for i in range(count)]


### PR DESCRIPTION
## What

Adds a compact language-list HID command and bumps the protocol version.

- **`hid_com.c` case 27 (`GET_LANG_LIST_PACKED`)**: emits a count byte + one `(ISO 639-1 idx, ISO 3166-1 alpha-2 idx)` **2-byte pair per language** instead of the 4 ASCII chars of cmd `0x08`. The 81-language list drops from **6 HID reports to 3**, and the emitted `.rodata` halves (2 bytes/lang vs 4).
- **`config.h`**: `PROTOCOL_VERSION 1 → 2` so the host knows to prefer cmd 27.
- cmd `0x08` (ASCII) is **kept** for older hosts; unknown-command NACK on v1 firmware is unchanged.
- **`lang/iso_lang_country.py`**: the frozen, append-only index table (generated once from the `iso-codes` package). The case-27 cog imports it and emits the index bytes, so the table is a **build-time artifact only** — not compiled into the firmware.

## Why

The language list is the largest one-time registration query. The existing bit-RLE (built for keycap bitmaps) *inflates* high-entropy ASCII codes ~5×; indexing each part into the ISO tables (184 langs / 249 countries, both <256) is the right tool and halves the payload.

## Verification

- cog output decodes **byte-for-byte** to the ASCII list (81 langs, 3 reports).
- `split72:default` builds clean (`.uf2` produced).

## Single source of truth ⚠️

`lang/iso_lang_country.py` is **byte-identical** (verified with `cmp`) to the copies in:
- `PolyKybdHost/polyhost/services/iso_lang_country.py`
- `polykybd-ctnd/station/iso_lang_country.py`

Keep all three in sync or the host/rig silently decode wrong languages.

## Companion PRs (same branch `claude/keen-mccarthy-pqsclf`)

- **PolyKybdHost** — host-side decode + protocol-≥2 gate + fallback
- **polykybd-ctnd** — HIL test that cross-checks cmd 27 against the ASCII list

This PR is the one that makes cmd 27 exist on hardware; the other two depend on it.

https://claude.ai/code/session_01Lfcket9qE5W6YU5YQfn8tn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lfcket9qE5W6YU5YQfn8tn)_

## Summary by Sourcery

Introduce a packed language list HID command and update the protocol version to support it while keeping the existing ASCII list for backward compatibility.

New Features:
- Add GET_LANG_LIST_PACKED (command 27) HID endpoint that returns the language list as indexed ISO code pairs in a compact binary format.

Enhancements:
- Increase PROTOCOL_VERSION to 2 so hosts can detect and prefer the packed language list command when supported.
- Document the new protocol version, packed language list encoding, and shared ISO index table workflow in CLAUDE.md.
- Add a shared ISO 639-1 / ISO 3166-1 index table module used at build time to generate the packed language list payload without embedding the table in firmware.

Documentation:
- Expand CLAUDE.md with details on protocol version gating, packed language list encoding, and the cross-repo single source of truth for ISO language/country indices.