### PR TITLE
polykybd: courtyard clear via glyph-mask dilation

### DIFF
--- a/keyboards/handwired/polykybd/base/disp_array.c
+++ b/keyboards/handwired/polykybd/base/disp_array.c
@@ -434,14 +434,22 @@ void kdisp_clear_bitmap_courtyard(int8_t x, int8_t y, const uint8_t pgm_bmp[], i
         }
         if(first!=127) {
             if(num_empty==0) {
-                // Content row. Taper the cleared span over the glyph's own first 3
-                // rows (insets 8/4/2: narrowest at the very top line, widening down
-                // to the full first..last span), mirroring the exponential 2/4/8 fade
-                // the outer/bottom edge gets as it moves away from the glyph below.
-                // This avoids blindly clearing the full span between two lonely far-
-                // apart pixels on the top line — the courtyard fades in toward the
-                // glyph body instead. top_count restarts at every new content block.
+                // Content row. Taper the cleared span as it approaches the glyph's
+                // top edge so we don't blindly clear the full first..last span
+                // between two lonely far-apart pixels on the first lines. The taper
+                // is continuous (monotonic insets 16/12/8/4/2/0): a thin margin fades
+                // in two rows ABOVE the top edge (insets 16/12 — kept like before),
+                // the top content line is narrowest (inset 8), then it widens over
+                // the next two rows (4/2) to the full span and stays full for the
+                // body. mirrors the exponential fade the outer/bottom edge gets as it
+                // moves away from the glyph below. top_count restarts at every new
+                // content block (prev_empty) so multi-part glyphs (e.g. umlaut dots
+                // above a body) each fade in at their own top.
                 top_count = prev_empty ? 0 : (top_count < 3 ? top_count + 1 : 3);
+                if(top_count==0) {
+                    clear_line(x+first+16, x+last-16, bmp_y + y-2);  // thin margin above,
+                    clear_line(x+first+12, x+last-12, bmp_y + y-1);  // fading to a point
+                }
                 int8_t inset = (top_count==0) ? 8 : (top_count==1) ? 4 : (top_count==2) ? 2 : 0;
                 clear_line(x+first+inset, x+last-inset, bmp_y + y);
                 prev_empty = false;

--- a/keyboards/handwired/polykybd/base/disp_array.c
+++ b/keyboards/handwired/polykybd/base/disp_array.c
@@ -416,6 +416,8 @@ void kdisp_clear_bitmap_courtyard(int8_t x, int8_t y, const uint8_t pgm_bmp[], i
     int8_t last=0;
     int8_t num_empty = 0;
     int8_t bits = 0, bit = 0;
+    bool   prev_empty = true;   // was the previous row empty? — detects a glyph block's top edge
+    int8_t top_count = 0;       // content rows since the current block's top edge (0 = topmost)
     for (int8_t bmp_y = 0; bmp_y < bmp_height; ++bmp_y) {
         num_empty++;
         for (int8_t bmp_x = 0; bmp_x < bmp_width; ++bmp_x) {
@@ -432,17 +434,22 @@ void kdisp_clear_bitmap_courtyard(int8_t x, int8_t y, const uint8_t pgm_bmp[], i
         }
         if(first!=127) {
             if(num_empty==0) {
-                // Top edge: taper the cleared span over 3 rows (insets 8/4/2),
-                // mirroring the exponential 2/4/8 fade the outer/bottom edge gets
-                // below — so the courtyard "lazily" narrows toward the glyph top
-                // instead of clearing the full first..last span abruptly.
-                clear_line(x+first+8, x+last-8, bmp_y + y-3);
-                clear_line(x+first+4, x+last-4, bmp_y + y-2);
-                clear_line(x+first+2, x+last-2, bmp_y + y-1);
+                // Content row. Taper the cleared span over the glyph's own first 3
+                // rows (insets 8/4/2: narrowest at the very top line, widening down
+                // to the full first..last span), mirroring the exponential 2/4/8 fade
+                // the outer/bottom edge gets as it moves away from the glyph below.
+                // This avoids blindly clearing the full span between two lonely far-
+                // apart pixels on the top line — the courtyard fades in toward the
+                // glyph body instead. top_count restarts at every new content block.
+                top_count = prev_empty ? 0 : (top_count < 3 ? top_count + 1 : 3);
+                int8_t inset = (top_count==0) ? 8 : (top_count==1) ? 4 : (top_count==2) ? 2 : 0;
+                clear_line(x+first+inset, x+last-inset, bmp_y + y);
+                prev_empty = false;
             } else {
                 num_empty = PK_MIN(num_empty, 6);
+                clear_line(x+first, x+last, bmp_y + y);
+                prev_empty = true;
             }
-            clear_line(x+first, x+last, bmp_y + y);
             uint8_t dist;
             PK_POW(dist, 2, (num_empty+1));
             first+=dist;

--- a/keyboards/handwired/polykybd/base/disp_array.c
+++ b/keyboards/handwired/polykybd/base/disp_array.c
@@ -411,61 +411,41 @@ void clear_line(int8_t from_x, int8_t to_x, int8_t y) {
 }
 
 void kdisp_clear_bitmap_courtyard(int8_t x, int8_t y, const uint8_t pgm_bmp[], int8_t bmp_width, int8_t bmp_height) {
+    // Clear a "courtyard" behind the glyph: every buffer pixel within Chebyshev
+    // distance CY_RADIUS of any glyph-on pixel — i.e. a square-kernel morphological
+    // dilation of the glyph mask. This traces the glyph contour with an even margin:
+    // unlike a per-row [first,last] span it never bridges horizontally-separated
+    // strokes (e.g. the two marks of " or the legs of M), and unlike per-column
+    // extents it does not fill interior vertical gaps (= , ü , " keep their holes).
+    // Implemented per horizontal run of on-pixels (so a solid row is a few clears,
+    // not one-per-pixel): each run [run_start, run_end] is cleared, widened by
+    // CY_RADIUS on each side, across the rows [bmp_y-CY_RADIUS, bmp_y+CY_RADIUS].
+    // clear_line / CLEAR_PIXEL_CLIPPED clip to the buffer, so the margin spilling
+    // past the glyph edges (the intended courtyard) is fine. The glyph itself is
+    // drawn right after this call, so clearing its own pixels here is harmless.
+    enum { CY_RADIUS = 3 };
     uint16_t offset = 0;
-    int8_t first = 127;
-    int8_t last=0;
-    int8_t num_empty = 0;
     int8_t bits = 0, bit = 0;
-    bool   prev_empty = true;   // was the previous row empty? — detects a glyph block's top edge
-    int8_t top_count = 0;       // content rows since the current block's top edge (0 = topmost)
     for (int8_t bmp_y = 0; bmp_y < bmp_height; ++bmp_y) {
-        num_empty++;
+        int8_t run_start = -1;
         for (int8_t bmp_x = 0; bmp_x < bmp_width; ++bmp_x) {
             if (!(bit++ & 7)) {
                 bits = pgm_read_byte(&pgm_bmp[offset++]);
             }
-            if (bits & 0x80) {
-                first = PK_MIN(bmp_x-3, first);
-                last = PK_MAX(bmp_x+3, last);
-                num_empty = 0;
-            }
+            bool on = (bits & 0x80) != 0;
             bits <<= 1;
-
-        }
-        if(first!=127) {
-            if(num_empty==0) {
-                // Content row. Taper the cleared span as it approaches the glyph's
-                // top edge so we don't blindly clear the full first..last span
-                // between two lonely far-apart pixels on the first lines. The taper
-                // is continuous (monotonic insets 16/12/8/4/2/0): a thin margin fades
-                // in two rows ABOVE the top edge (insets 16/12 — kept like before),
-                // the top content line is narrowest (inset 8), then it widens over
-                // the next two rows (4/2) to the full span and stays full for the
-                // body. mirrors the exponential fade the outer/bottom edge gets as it
-                // moves away from the glyph below. top_count restarts at every new
-                // content block (prev_empty) so multi-part glyphs (e.g. umlaut dots
-                // above a body) each fade in at their own top.
-                top_count = prev_empty ? 0 : (top_count < 3 ? top_count + 1 : 3);
-                if(top_count==0) {
-                    clear_line(x+first+16, x+last-16, bmp_y + y-2);  // thin margin above,
-                    clear_line(x+first+12, x+last-12, bmp_y + y-1);  // fading to a point
+            if (on) {
+                if (run_start < 0) run_start = bmp_x;     // run begins
+            } else if (run_start >= 0) {                   // run [run_start, bmp_x-1] ends
+                for (int8_t dy = -CY_RADIUS; dy <= CY_RADIUS; ++dy) {
+                    clear_line(x + run_start - CY_RADIUS, x + bmp_x + CY_RADIUS, bmp_y + y + dy);
                 }
-                int8_t inset = (top_count==0) ? 8 : (top_count==1) ? 4 : (top_count==2) ? 2 : 0;
-                clear_line(x+first+inset, x+last-inset, bmp_y + y);
-                prev_empty = false;
-            } else {
-                num_empty = PK_MIN(num_empty, 6);
-                clear_line(x+first, x+last, bmp_y + y);
-                prev_empty = true;
+                run_start = -1;
             }
-            uint8_t dist;
-            PK_POW(dist, 2, (num_empty+1));
-            first+=dist;
-            last -=dist;
-            if(first>=last) {
-                first = 127;
-                last=0;
-                num_empty = 0;
+        }
+        if (run_start >= 0) {                              // run runs to the row's end
+            for (int8_t dy = -CY_RADIUS; dy <= CY_RADIUS; ++dy) {
+                clear_line(x + run_start - CY_RADIUS, x + bmp_width + CY_RADIUS, bmp_y + y + dy);
             }
         }
     }

--- a/keyboards/handwired/polykybd/base/disp_array.c
+++ b/keyboards/handwired/polykybd/base/disp_array.c
@@ -127,7 +127,7 @@ void kdisp_clear_rect(int8_t x_start, int8_t y_start, int8_t width, int8_t heigh
     @param    ch  The 32-bit Unicode codepoint (SMP codepoints > 0xFFFF allowed)
 */
 /**************************************************************************/
-int8_t kdisp_write_gfx_char(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, uint32_t ch, bool clear_cy) {
+int8_t kdisp_write_gfx_char(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, uint32_t ch, int8_t cy_radius) {
     const GFXfont * currentFont = 0;
     uint32_t first = 0;
     uint32_t last = 0;
@@ -215,8 +215,8 @@ int8_t kdisp_write_gfx_char(const GFXfont *const *fonts, uint8_t num_fonts, int8
     int8_t   xo = pgm_read_byte(&glyph->xOffset), yo = pgm_read_byte(&glyph->yOffset);
     int8_t  xx, yy, bits = 0, bit = 0;
 
-    if(clear_cy) {
-        kdisp_clear_bitmap_courtyard(x+xo, y+yo, &bitmap[bo], w, h);
+    if(cy_radius > 0) {
+        kdisp_clear_bitmap_courtyard(x+xo, y+yo, &bitmap[bo], w, h, cy_radius);
     }
 
     for (yy = 0; yy < h; yy++) {
@@ -235,10 +235,10 @@ int8_t kdisp_write_gfx_char(const GFXfont *const *fonts, uint8_t num_fonts, int8
 }
 
 void kdisp_write_gfx_text(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, const uint32_t *text) {
-    kdisp_write_gfx_text_cy(fonts, num_fonts, x, y, text, false);
+    kdisp_write_gfx_text_cy(fonts, num_fonts, x, y, text, 0);
 }
 
-void kdisp_write_gfx_text_cy(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, const uint32_t *text, bool clear_cy) {
+void kdisp_write_gfx_text_cy(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, const uint32_t *text, int8_t cy_radius) {
     int8_t x_cursor = x;
     int8_t y_cursor = y;
     while (*text != 0) {
@@ -270,7 +270,7 @@ void kdisp_write_gfx_text_cy(const GFXfont *const *fonts, uint8_t num_fonts, int
                 x_cursor = x;
                 break;
             default:
-                x_cursor += kdisp_write_gfx_char(fonts, num_fonts, x_cursor, y_cursor, *text, clear_cy);
+                x_cursor += kdisp_write_gfx_char(fonts, num_fonts, x_cursor, y_cursor, *text, cy_radius);
                 break;
         }
         text++;
@@ -410,20 +410,22 @@ void clear_line(int8_t from_x, int8_t to_x, int8_t y) {
     }
 }
 
-void kdisp_clear_bitmap_courtyard(int8_t x, int8_t y, const uint8_t pgm_bmp[], int8_t bmp_width, int8_t bmp_height) {
+void kdisp_clear_bitmap_courtyard(int8_t x, int8_t y, const uint8_t pgm_bmp[], int8_t bmp_width, int8_t bmp_height, int8_t radius) {
     // Clear a "courtyard" behind the glyph: every buffer pixel within Chebyshev
-    // distance CY_RADIUS of any glyph-on pixel — i.e. a square-kernel morphological
+    // distance `radius` of any glyph-on pixel — i.e. a square-kernel morphological
     // dilation of the glyph mask. This traces the glyph contour with an even margin:
     // unlike a per-row [first,last] span it never bridges horizontally-separated
     // strokes (e.g. the two marks of " or the legs of M), and unlike per-column
     // extents it does not fill interior vertical gaps (= , ü , " keep their holes).
     // Implemented per horizontal run of on-pixels (so a solid row is a few clears,
     // not one-per-pixel): each run [run_start, run_end] is cleared, widened by
-    // CY_RADIUS on each side, across the rows [bmp_y-CY_RADIUS, bmp_y+CY_RADIUS].
+    // `radius` on each side, across the rows [bmp_y-radius, bmp_y+radius].
     // clear_line / CLEAR_PIXEL_CLIPPED clip to the buffer, so the margin spilling
     // past the glyph edges (the intended courtyard) is fine. The glyph itself is
     // drawn right after this call, so clearing its own pixels here is harmless.
-    enum { CY_RADIUS = 3 };
+    // `radius` is the courtyard width (KDISP_CY_DEFAULT for overlays; the lang-layer
+    // flags pass a smaller value so their borders stay tight).
+    if (radius <= 0) return;
     uint16_t offset = 0;
     int8_t bits = 0, bit = 0;
     for (int8_t bmp_y = 0; bmp_y < bmp_height; ++bmp_y) {
@@ -437,15 +439,15 @@ void kdisp_clear_bitmap_courtyard(int8_t x, int8_t y, const uint8_t pgm_bmp[], i
             if (on) {
                 if (run_start < 0) run_start = bmp_x;     // run begins
             } else if (run_start >= 0) {                   // run [run_start, bmp_x-1] ends
-                for (int8_t dy = -CY_RADIUS; dy <= CY_RADIUS; ++dy) {
-                    clear_line(x + run_start - CY_RADIUS, x + bmp_x + CY_RADIUS, bmp_y + y + dy);
+                for (int8_t dy = -radius; dy <= radius; ++dy) {
+                    clear_line(x + run_start - radius, x + bmp_x + radius, bmp_y + y + dy);
                 }
                 run_start = -1;
             }
         }
         if (run_start >= 0) {                              // run runs to the row's end
-            for (int8_t dy = -CY_RADIUS; dy <= CY_RADIUS; ++dy) {
-                clear_line(x + run_start - CY_RADIUS, x + bmp_width + CY_RADIUS, bmp_y + y + dy);
+            for (int8_t dy = -radius; dy <= radius; ++dy) {
+                clear_line(x + run_start - radius, x + bmp_width + radius, bmp_y + y + dy);
             }
         }
     }

--- a/keyboards/handwired/polykybd/base/disp_array.h
+++ b/keyboards/handwired/polykybd/base/disp_array.h
@@ -12,11 +12,16 @@
 #define SCREEN_HEIGHT 40
 #define BUFFER_X 28
 
-int8_t kdisp_write_gfx_char(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, uint32_t c, bool clear_cy);
+// Courtyard radius (Chebyshev) for the glyph-mask dilation behind a glyph.
+// `cy_radius` 0 disables the courtyard clear; KDISP_CY_DEFAULT is the standard
+// margin used behind overlay glyphs. The lang-layer flags use a smaller radius.
+#define KDISP_CY_DEFAULT 3
+
+int8_t kdisp_write_gfx_char(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, uint32_t c, int8_t cy_radius);
 
 void kdisp_write_gfx_text(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, const uint32_t *text);
 
-void kdisp_write_gfx_text_cy(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, const uint32_t *text, bool clear_cy);
+void kdisp_write_gfx_text_cy(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, const uint32_t *text, int8_t cy_radius);
 
 // Measure the horizontal pixel bounding box of `text` (relative to the draw
 // origin x) without drawing — mirrors the cursor advance of kdisp_write_gfx_text.
@@ -34,7 +39,7 @@ void kdisp_write_base_char(int8_t x, int8_t y, char c);
 
 void kdisp_draw_bitmap(int8_t x, int8_t y, const uint8_t pgm_bmp[], int8_t bmp_width, int8_t bmp_height);
 
-void kdisp_clear_bitmap_courtyard(int8_t x, int8_t y, const uint8_t pgm_bmp[], int8_t bmp_width, int8_t bmp_height);
+void kdisp_clear_bitmap_courtyard(int8_t x, int8_t y, const uint8_t pgm_bmp[], int8_t bmp_width, int8_t bmp_height, int8_t radius);
 
 void kdisp_set_buffer(uint8_t vertical_pixel_row_of_8_pixels);
 

--- a/keyboards/handwired/polykybd/corne42/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/corne42/keymaps/default/keymap.c
@@ -892,7 +892,7 @@ bool copy_overlay_to_buffer(uint16_t keycode, uint8_t mods) {
     }
     idx = get_overlay_mapping(idx);
 
-    kdisp_clear_bitmap_courtyard(28, 0, get_overlay(idx), 72, 40);
+    kdisp_clear_bitmap_courtyard(28, 0, get_overlay(idx), 72, 40, KDISP_CY_DEFAULT);
     kdisp_draw_bitmap(28, 0, get_overlay(idx), 72, 40);
     return true;
 }
@@ -976,7 +976,7 @@ static void render_lang_flag_key(uint8_t idx, const uint32_t* label, uint8_t cur
     const int8_t fyo = (int8_t)pgm_read_byte(&ff->glyph[idx].yOffset);
     kdisp_write_gfx_char(lang_flag_fonts, 1, FLAG_LEFT_X,
                          (int8_t)((SCREEN_HEIGHT - fh) / 2 - fyo),
-                         FLAG_CP_BASE + idx, true);
+                         FLAG_CP_BASE + idx, 1);   // flags: tight 1px courtyard
 
     // Language code: vertical, up the right side; inverted bar when selected.
     kdisp_write_gfx_vtext(&NotoSans_Regular_Tiny_6pt7b, LABEL_COL_X, label,
@@ -1054,10 +1054,10 @@ void update_displays(enum refresh_mode mode) {
                         if(text==NULL) {
                             if(!render_key(keycode, state, mods) && (keycode&QK_UNICODEMAP_PAIR)==QK_UNICODEMAP_PAIR){
                                 uint16_t chr = capital_case ? QK_UNICODEMAP_PAIR_GET_SHIFTED_INDEX(keycode) : QK_UNICODEMAP_PAIR_GET_UNSHIFTED_INDEX(keycode);
-                                kdisp_write_gfx_char(ALL_FONTS, ALL_FONT_SIZE, BUFFER_X, 23, unicode_map[chr], false);
+                                kdisp_write_gfx_char(ALL_FONTS, ALL_FONT_SIZE, BUFFER_X, 23, unicode_map[chr], 0);
                             }
                         } else {
-                            kdisp_write_gfx_text_cy(ALL_FONTS, ALL_FONT_SIZE, BUFFER_X, 23, text, true);
+                            kdisp_write_gfx_text_cy(ALL_FONTS, ALL_FONT_SIZE, BUFFER_X, 23, text, KDISP_CY_DEFAULT);
                         }
                         text = NULL;
                         if(display_overlays) {
@@ -1068,7 +1068,7 @@ void update_displays(enum refresh_mode mode) {
                             text = keycode_to_disp_overlay(keycode, state);
                         }
                         if(text) {
-                            kdisp_write_gfx_text_cy(ALL_FONTS, ALL_FONT_SIZE, BUFFER_X, 23, text, true);
+                            kdisp_write_gfx_text_cy(ALL_FONTS, ALL_FONT_SIZE, BUFFER_X, 23, text, KDISP_CY_DEFAULT);
                         }
                         kdisp_send_buffer();
                         }

--- a/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
@@ -1163,7 +1163,7 @@ bool copy_overlay_to_buffer(uint16_t keycode, uint8_t mods) {
     }
     idx = get_overlay_mapping(idx);
 
-    kdisp_clear_bitmap_courtyard(28, 0, get_overlay(idx), 72, 40);
+    kdisp_clear_bitmap_courtyard(28, 0, get_overlay(idx), 72, 40, KDISP_CY_DEFAULT);
     kdisp_draw_bitmap(28, 0, get_overlay(idx), 72, 40); //don't understnad why we start at offset 28... need to think about it
     return true;
 }
@@ -1196,7 +1196,7 @@ static void render_lang_flag_key(uint8_t idx, const uint32_t* label, uint8_t cur
     const int8_t fyo = (int8_t)pgm_read_byte(&ff->glyph[idx].yOffset);
     kdisp_write_gfx_char(lang_flag_fonts, 1, FLAG_LEFT_X,
                          (int8_t)((SCREEN_HEIGHT - fh) / 2 - fyo),
-                         FLAG_CP_BASE + idx, true);
+                         FLAG_CP_BASE + idx, 1);   // flags: tight 1px courtyard
 
     // Language code: vertical, up the right side; inverted bar when selected.
     kdisp_write_gfx_vtext(&NotoSans_Regular_Tiny_6pt7b, LABEL_COL_X, label,
@@ -1336,10 +1336,10 @@ void update_displays(enum refresh_mode mode) {
                         if(text==NULL) {
                             if(!render_key(keycode, state, mods) && (keycode&QK_UNICODEMAP_PAIR)==QK_UNICODEMAP_PAIR){
                                 uint16_t chr = capital_case ? QK_UNICODEMAP_PAIR_GET_SHIFTED_INDEX(keycode) : QK_UNICODEMAP_PAIR_GET_UNSHIFTED_INDEX(keycode);
-                                kdisp_write_gfx_char(ALL_FONTS, ALL_FONT_SIZE, BUFFER_X, 23, unicode_map[chr], false);
+                                kdisp_write_gfx_char(ALL_FONTS, ALL_FONT_SIZE, BUFFER_X, 23, unicode_map[chr], 0);
                             }
                         } else {
-                            kdisp_write_gfx_text_cy(ALL_FONTS, ALL_FONT_SIZE, BUFFER_X, 23, text, true);
+                            kdisp_write_gfx_text_cy(ALL_FONTS, ALL_FONT_SIZE, BUFFER_X, 23, text, KDISP_CY_DEFAULT);
                         }
                         text = NULL;
                         if(display_overlays) {
@@ -1350,7 +1350,7 @@ void update_displays(enum refresh_mode mode) {
                             text = keycode_to_disp_overlay(keycode, state); //this should maybe go away - or setting?
                         }
                         if(text) {
-                            kdisp_write_gfx_text_cy(ALL_FONTS, ALL_FONT_SIZE, BUFFER_X, 23, text, true);
+                            kdisp_write_gfx_text_cy(ALL_FONTS, ALL_FONT_SIZE, BUFFER_X, 23, text, KDISP_CY_DEFAULT);
                         }
                         kdisp_send_buffer();
                         }


### PR DESCRIPTION
## What

Reworks the per-keycap "courtyard" clear behind glyphs (`base/disp_array.c kdisp_clear_bitmap_courtyard`) from a per-row `[first,last]` horizontal span to a **square-kernel morphological dilation** of the glyph mask: every buffer pixel within Chebyshev distance 3 of any glyph-on pixel is cleared.

## Why

The original span approach (and the interim top-edge taper) had visible artifacts because a single horizontal span per row can't follow the glyph shape:

- **Horizontal bridging** — two separated strokes on a row (the two marks of `"`, the legs of `M`/`W`, the parts of `%`) got the whole gap between them cleared.
- **Downward "drip"** — once the glyph ended, the exponential outer-edge fade kept clearing a narrowing span downward (very visible under `"`).
- Asymmetric / uneven margins around most glyphs.

Dilation traces the actual contour with an **even margin**, so none of the above happen. It also beats a per-column-extents alternative, which would fill interior vertical gaps — with dilation `=`, `ü`, `"` keep their holes.

## How

Implemented per **horizontal run** of on-pixels (a solid row is a handful of `clear_line` calls, not one-per-pixel): each run `[run_start, run_end]` is widened by the radius on both sides and cleared across the `±radius` rows. `clear_line` / `CLEAR_PIXEL_CLIPPED` clip to the buffer, so the margin spilling past the glyph edges (the intended courtyard) is free. The glyph is drawn right after this call, so clearing its own pixels is harmless.

The evaluation was done with a new comparison harness in PolyKybdHost (`tools/courtyard_preview.py`, separate branch) that renders each strategy over a hatched overlay stand-in; the dilation (`r=3`) column was selected.

## Testing

- Builds clean: `qmk compile -kb handwired/polykybd/split72 -km default` (exit 0).
- `.bin` handed to the maintainer for on-hardware visual verification over HID.

https://claude.ai/code/session_0174WTrdidu6CwUQ2PmXbfbF

---
_Generated by [Claude Code](https://claude.ai/code/session_0174WTrdidu6CwUQ2PmXbfbF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced display character and text rendering with configurable spacing control, replacing previous on/off mode with adjustable radius parameters for more precise glyph positioning and clearing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->