### PR TITLE
Retire legacy ASCII GET_LANG_LIST (cmd 8); packed list (cmd 27) only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,11 +42,14 @@ The host software (`PolyKybdHost/`) communicates with this firmware over a custo
 - **`PROTOCOL_VERSION`** (`config.h`, reported in the GET_ID string) gates host
   features. **v2** added `GET_LANG_LIST_PACKED` (cmd `27` / `0x1b`): the language
   list as a count byte + one `(ISO 639-1 idx, ISO 3166-1 alpha-2 idx)` **2-byte
-  pair per language** instead of the 4 ASCII chars of cmd `0x08` — 81 langs go
-  from 6 reports to 3, and the firmware `.rodata` shrinks (2 emitted bytes/lang vs
-  4). cmd `0x08` (ASCII) stays for old hosts; the host prefers cmd `27` only when
-  it reads protocol ≥ 2, else falls back. The index↔code tables are the **frozen,
-  append-only** `lang/iso_lang_country.py` (see "Language list encoding" below).
+  pair per language** instead of the 4 ASCII chars of cmd `0x08` — it halves the
+  emitted bytes/lang and the report count. As of the **P2-only cleanup**, cmd `27`
+  is the **only** language-list command: the legacy ASCII cmd `0x08` has been
+  **retired and now NACKs** (`P\x08!`), dropping its ~570 B `.rodata` table. The
+  host (protocol ≥ 2) uses cmd `27` exclusively with **no ASCII fallback**, and
+  firmware older than v2 is unsupported; the rig asserts cmd `0x08` NACKs. The
+  index↔code tables are the **frozen, append-only** `lang/iso_lang_country.py`
+  (see "Language list encoding" below).
 - Overlay transmission: each keycap overlay (360 bytes) is split into 6 × 60-byte segments (cmd `0x0A`), or sent RLE-compressed in 1–2 packets (cmds `0x10`/`0x11`)
 - ROI updates (cmds `0x12`/`0x13`) allow partial refresh of a keycap's display area
 - Overlay index = `keycode_slot + 90 * modifier_variant` (9 variants: bare, Ctrl, Shift, Ctrl+Shift, Alt, Ctrl+Alt, Alt+Shift, Ctrl+Alt+Shift, GUI)

--- a/keyboards/handwired/polykybd/hid_com.c
+++ b/keyboards/handwired/polykybd/hid_com.c
@@ -299,49 +299,15 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                 }
                 raw_hid_send(data, length);
                 break;
-            case 8: //lang list
+            case 8: // GET_LANG_LIST (legacy ASCII list) — RETIRED in protocol v2.
+                // Superseded by GET_LANG_LIST_PACKED (cmd 27), which sends the
+                // same list as compact 2-byte ISO index pairs. Protocol-v2 hosts
+                // use cmd 27 exclusively; NACK the old command so any stale host
+                // that still asks for the ASCII list fails loudly instead of
+                // parsing a missing/partial reply. (Dropping the table here also
+                // frees the ~570 bytes of .rodata the ASCII list occupied.)
                 memset(data, 0, length);
-                /*[[[cog
-                RAW_EPSIZE = 64
-                lang_list = "P\\x08."
-                for lang in languages:
-                    lang_list += lang
-                    if len(lang_list)>=RAW_EPSIZE:
-                        cog.outl(f'memcpy(data, "{lang_list}", {len(lang_list)-3});')
-                        cog.outl(f'raw_hid_send(data, length);')
-                        cog.outl(f'memset(data, 0, length);')
-                        lang_list = "P\\x08."
-                cog.outl(f'memcpy(data, "{lang_list}", {len(lang_list)-3});')
-                ]]]*/
-                memcpy(data, "P\x08.enUSdeDEfrFResESptPTitITtrTRkoKRjaJParSAelGRukUAruRUbeBYkkKZ", 63);
-                raw_hid_send(data, length);
-                memset(data, 0, length);
-                memcpy(data, "P\x08.bgBGplPLroROzhCNnlNLheILsvSEfiFInnNOdaDKhuHUcsCZhrHRskSKltLT", 63);
-                raw_hid_send(data, length);
-                memset(data, 0, length);
-                memcpy(data, "P\x08.lvLVetEEptBRsrRSmkMKfaIRhiINmrINneNPmnMNurPKenGBesMXdeCHfrBE", 63);
-                raw_hid_send(data, length);
-                memset(data, 0, length);
-                memcpy(data, "P\x08.frCAthTHbnINteINtaINzhTWkaGEhyAMidIDazAZisISviVNzhHKenAUenNZ", 63);
-                raw_hid_send(data, length);
-                memset(data, 0, length);
-                memcpy(data, "P\x08.miNZsmWSfjFJtlPHhwUSenZAafZAarEGswKEamETyoNGenNGarMAarIQkuIQ", 63);
-                raw_hid_send(data, length);
-                memset(data, 0, length);
-                memcpy(data, "P\x08.msMYuzUZenCAesARenPGtyPFesCOesPEesVEesCLesECesGTesDOesBOesPY", 63);
-                raw_hid_send(data, length);
-                memset(data, 0, length);
-                memcpy(data, "P\x08.esCResSVesHNesPAesUYesNIdeATnlBEcaESenIEbsBAfrCHslSIfoFOarAE", 63);
-                raw_hid_send(data, length);
-                memset(data, 0, length);
-                memcpy(data, "P\x08.arSYarJOarLBarYEarKWarOMarPSarQAarBHarDZarSDarTNarLYfrCDfrCI", 63);
-                raw_hid_send(data, length);
-                memset(data, 0, length);
-                memcpy(data, "P\x08.frCMfrSNfrMGenGHenUGenZMswTZptAOptMZbnBDenINenPKenPHenSGenLK", 63);
-                raw_hid_send(data, length);
-                memset(data, 0, length);
-                memcpy(data, "P\x08.kyKGtgTJenGUenSBenVUenFMfrNCtoTO", 35);
-                //[[[end]]]
+                memcpy(data, "P\x08!", 3);
                 raw_hid_send(data, length);
                 break;
             case 9: //change language
@@ -622,6 +588,7 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                 packed = [len(languages)]
                 for lang in languages:
                     packed += list(encode_pair(lang))
+                RAW_EPSIZE = 64        # raw HID report size; was set by the retired cmd 8 block
                 CHUNK = RAW_EPSIZE - 3  # 61 payload bytes after the 3-byte "P\x1b." header
                 for off in range(0, len(packed), CHUNK):
                     seg = packed[off:off+CHUNK]

--- a/keyboards/handwired/polykybd/hid_com.c
+++ b/keyboards/handwired/polykybd/hid_com.c
@@ -37,6 +37,11 @@ import cog
 import os
 from textwrap import wrap
 from openpyxl import load_workbook
+# Shared cog constant for all language-list report generators below (mirrors the
+# C RAW_EPSIZE macro = raw HID report size). Defined here, in the first cog block,
+# so the per-command blocks chunk payloads against one value instead of each
+# redefining it.
+RAW_EPSIZE = 64
 wb = load_workbook(filename = os.path.join(os.path.abspath(os.path.dirname(cog.inFile)), "lang", "lang_lut.xlsx"))
 sheet = wb['key_lut']
 
@@ -588,8 +593,7 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                 packed = [len(languages)]
                 for lang in languages:
                     packed += list(encode_pair(lang))
-                RAW_EPSIZE = 64        # raw HID report size; was set by the retired cmd 8 block
-                CHUNK = RAW_EPSIZE - 3  # 61 payload bytes after the 3-byte "P\x1b." header
+                CHUNK = RAW_EPSIZE - 3  # 61 payload bytes after the 3-byte "P\x1b." header (RAW_EPSIZE from the top cog block)
                 for off in range(0, len(packed), CHUNK):
                     seg = packed[off:off+CHUNK]
                     # All bytes emitted as \xNN (incl. header) so no literal char ever


### PR DESCRIPTION
## What & why

Protocol v2 added `GET_LANG_LIST_PACKED` (cmd `27`): the language list as compact 2-byte ISO index pairs. The legacy ASCII `GET_LANG_LIST` (cmd `8`) is now redundant — both the host and the HIL rig read the packed list — so this **retires cmd 8**.

- `case 8` in `hid_com.c` now returns a single NACK `P\x08!` instead of streaming the 10-packet ASCII table.
- Frees **~570 bytes of `.rodata`** (the ASCII code table is gone).
- `PROTOCOL_VERSION` stays at **2** — a v2 host already uses cmd 27 exclusively; this only removes the dead legacy path.
- The case-27 cog block now defines its own `RAW_EPSIZE` (previously set by the removed case-8 block); `cog --check` passes with case-27 output **byte-identical**.

## Coordinated change (3 repos, branch `claude/funny-thompson-7851hp`)

This is the firmware half of a P2-only language-list cleanup:
- **PolyKybdHost** — `enumerate_lang()` is packed-only; the ASCII fallback is removed.
- **polykybd-ctnd** (HIL rig) — language tests are packed-only; a new test asserts cmd 8 now NACKs.

## Verification

- `cog --check` clean (generation intact, case-27 bytes unchanged).
- Firmware compile is covered by this repo's **Build firmware** CI job (split72 / corne42 / HIL) — see checks below.

⚠️ **HIL job note:** the `HIL test (split72)` job runs the rig's *installed* `station/hil_tests.py` on the self-hosted runner. For it to pass, the rig at `/opt/polykybd-ctnd` must be updated to the matching polykybd-ctnd branch **and** the runner must be online. Until then that job may stay pending (runner offline) or fail on the old ASCII test — the firmware change itself is verified by the build job.

https://claude.ai/code/session_01K95YjhhA8vuuYD2FYVZBRU

---
_Generated by [Claude Code](https://claude.ai/code/session_01K95YjhhA8vuuYD2FYVZBRU)_

## Summary by Sourcery

Retire the legacy ASCII GET_LANG_LIST (cmd 8) path in the firmware in favor of the packed GET_LANG_LIST_PACKED (cmd 27) protocol v2 command.

Enhancements:
- Replace the old multi-packet ASCII language list response for cmd 8 with a single NACK frame, removing the embedded language string table and reducing firmware .rodata size.
- Adjust the cmd 27 packed language list generator to define its own raw HID report size constant after the cmd 8 block removal.
- Clarify protocol documentation to state that cmd 27 is now the sole language-list command and that cmd 8 is retired and expected to NACK.

Documentation:
- Update CLAUDE.md protocol documentation to describe cmd 8 as retired, document cmd 27 as the only supported language list mechanism, and reflect the removal of ASCII fallback behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Legacy ASCII language list command (0x08) is now retired and returns error responses
  * Hosts must use the packed format command exclusively
  * Minimum firmware version increased to v2

* **Documentation**
  * Updated HID protocol documentation to reflect language list encoding and support changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->