### PR TITLE
Protocol v3: make SEND_OVERLAY_MAPPING (cmd 21) silent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,14 @@ The host software (`PolyKybdHost/`) communicates with this firmware over a custo
   host (protocol ≥ 2) uses cmd `27` exclusively with **no ASCII fallback**, and
   firmware older than v2 is unsupported; the rig asserts cmd `0x08` NACKs. The
   index↔code tables are the **frozen, append-only** `lang/iso_lang_country.py`
-  (see "Language list encoding" below).
+  (see "Language list encoding" below). **v3** made `SEND_OVERLAY_MAPPING`
+  (cmd `21`) **silent** — no per-chunk ACK, matching the other bulk overlay
+  commands (`0x0A`, `0x10`/`0x11`, `0x12`/`0x13`). The old ACK was informationless
+  (always `.`), discarded unread by the host, and arrived only after the blocking
+  UART bridge to the slave — escaped ACKs were the main source of stale replies
+  the host had to drain. The host (protocol 3) no longer drains after mapping
+  sends; ordering for `enable_overlays` (case 11) is preserved because HID
+  reports dispatch sequentially and the bridge completes before case 21 returns.
 - Overlay transmission: each keycap overlay (360 bytes) is split into 6 × 60-byte segments (cmd `0x0A`), or sent RLE-compressed in 1–2 packets (cmds `0x10`/`0x11`)
 - ROI updates (cmds `0x12`/`0x13`) allow partial refresh of a keycap's display area
 - Overlay index = `keycode_slot + 90 * modifier_variant` (9 variants: bare, Ctrl, Shift, Ctrl+Shift, Alt, Ctrl+Alt, Alt+Shift, Ctrl+Alt+Shift, GUI)

--- a/keyboards/handwired/polykybd/config.h
+++ b/keyboards/handwired/polykybd/config.h
@@ -85,7 +85,12 @@
 //######################################
 #define FW_VERSION "0.8.21"
 // v2: adds GET_LANG_LIST_PACKED (cmd 27) — language list as 2-byte ISO index pairs.
-#define PROTOCOL_VERSION 2
+// v3: SEND_OVERLAY_MAPPING (cmd 21) no longer ACKs per chunk — like every other
+//     bulk overlay command (10, 16/17, 18/19) it is silent. The per-chunk ACK
+//     carried no information (always ".", never read by the host) and arrived
+//     only after the blocking UART bridge to the slave, leaving stale replies
+//     that poisoned later commands' reads on the host.
+#define PROTOCOL_VERSION 3
 
 #define FULL_BRIGHT 50
 #define MIN_BRIGHT 1

--- a/keyboards/handwired/polykybd/hid_com.c
+++ b/keyboards/handwired/polykybd/hid_com.c
@@ -538,17 +538,22 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                 }
                 raw_hid_send(data, length);
                 break;
-            case 21:
+            case 21: //receive overlay mapping
                 {
+                    // Deliberately no ACK (protocol v3+): like the other bulk
+                    // overlay commands (10, 16/17, 18/19) this is fire-and-forget.
+                    // The old per-chunk ACK was sent only after the blocking UART
+                    // bridge below, so it arrived hundreds of ms late and the host
+                    // discarded it unread — leftover ACKs poisoned the reply
+                    // stream of later commands. Ordering for enable_overlays
+                    // (case 11) still holds: reports are dispatched sequentially
+                    // and the bridge completes before this case returns.
                     overlay_map_sync_t map_sync;
                     memcpy(map_sync.mapping, &data[HID_DATA_IDX], HID_DATA_MAX);
                     send_to_bridge(USER_SYNC_OVERLAY_MAP_DATA, (void*)&map_sync, sizeof(overlay_map_sync_t), 10);
                     set_10bit_overlay_mapping(&data[HID_DATA_IDX]);
                     request_disp_refresh();
-                    memset(data, 0, length);
-                    memcpy(data, "P\x15.", 3);
                     uprintf("Overlay mapping data received.\n");
-                    raw_hid_send(data, length);
                 }
                 break;
             case 22: // get default layer


### PR DESCRIPTION
## Summary

Removes the per-chunk ACK from `SEND_OVERLAY_MAPPING` (cmd 21) to match the protocol behavior of other bulk overlay commands (10, 16/17, 18/19). The old ACK was informationless (always `"P\x15."`), arrived only after the blocking UART bridge to the slave, and was discarded unread by the host — escaped ACKs were a major source of stale replies that poisoned later command reads.

This is a **protocol change** (v2 → v3): the host no longer expects or drains an ACK after mapping sends. Ordering for `enable_overlays` (case 11) is preserved because HID reports dispatch sequentially and the bridge completes before case 21 returns.

## Changes

- **`hid_com.c`**: Removed ACK generation (`memset` + `memcpy` + `raw_hid_send`) from case 21; added detailed comment explaining the rationale and ordering guarantees.
- **`config.h`**: Bumped `PROTOCOL_VERSION` from 2 → 3 with documentation of the change.
- **`CLAUDE.md`**: Updated protocol documentation to reflect v3 behavior.

## Version bump label

`bump:protocol`

> ⚠️ **Requires matching PR in [PolyKybdHost](https://github.com/thpoll83/PolyKybdHost)** to update the host's `__protocol__` and remove the ACK drain after mapping sends.

## Testing

- [x] Compiled successfully (`qmk compile -kb handwired/polykybd/split72 -km default`)
- [ ] Flashed and tested on hardware (pending host-side protocol v3 implementation)
- [ ] If protocol changed: host updated and tested together (blocked on PolyKybdHost PR)

https://claude.ai/code/session_01Lz99SUyH77gyGN3ooAPk3X