### PR TITLE
Sync PolyKybd with development branch + record CodeRabbit docstring-coverage policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working in this
 
 For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGFX/`), see [`../CLAUDE.md`](../CLAUDE.md).
 
+## Code review conventions (all PolyKybd repos)
+
+- **Docstring coverage: ignore CodeRabbit's "Docstring Coverage … threshold 80%" pre-merge check.** That 80% target is a CodeRabbit default, **not** a project policy — the check is non-blocking and we deliberately do not chase it. Do **not** add docstrings to existing functions just to satisfy it (out-of-scope churn). Document new code where a docstring genuinely helps a reader, and no more.
+
 ## Building & flashing
 
 **The ARM toolchain is installable in the dev / remote container — do not claim it is unavailable.** Verified end-to-end (`split72:default` → `.uf2`, exit 0) on 2026-05-29.


### PR DESCRIPTION
Brings the `PolyKybd` integration branch up to date with the `claude/busy-bardeen-101sim` development branch (fast-forwardable, linear).

The branch is **71 commits** ahead of `PolyKybd` — accumulated firmware session work plus version bumps. The newest commit is a docs-only policy note:

- **`docs:` record that we ignore CodeRabbit's 80% docstring-coverage check** — it's a CodeRabbit default, not a project policy; the pre-merge check is non-blocking and we deliberately don't chase it (added to all three PolyKybd repos' `CLAUDE.md`).

Most of the diff predates the current session; review accordingly.

https://claude.ai/code/session_01Ny6TVkPnCTkg94dxA8bZzD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ny6TVkPnCTkg94dxA8bZzD)_