### PR TITLE
PolyKybd: split-link reliability — full-duplex UART, sync retries, link health counter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,7 +387,8 @@ CRC32 in `split_sync.c` is the only thing that catches a bit flipped by wire
 noise in flight.** This is the single most important fact about the link, and
 the reason the CRC32 was added (intermittent sync corruption that looked random).
 
-**The link (verified 2026-06-16)**: `SERIAL_DRIVER = vendor` → the RP2040 **PIO
+**The link, pre-migration (HISTORICAL — the half-duplex setup in use until the
+2026-06-16 full-duplex switch in the RESOLVED note above)**: `SERIAL_DRIVER = vendor` → the RP2040 **PIO
 half-duplex, single-wire** driver (`serial_vendor.c`) on **`SERIAL_USART_TX_PIN
 GP5`** (no RX pin, no `SERIAL_USART_FULL_DUPLEX` → one shared wire). Baud is
 **230400** (`SELECT_SOFT_SERIAL_SPEED 1` in both variants' `halconf.h` →
@@ -443,7 +444,7 @@ miss) / `transport_fail` (timeout/handshake) / `giveup` (retries exhausted).
 `debug_enable`, ≤ once per `LINK_STATS_LOG_INTERVAL` = 60 s, quiet when idle)
 prints:
 
-```
+```text
 Split link: 12345 tx (+312) crc_err=4 transport_fail=1 giveup=0 err=0.0%
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -440,12 +440,12 @@ fw-update path skips this code).
 master-side, added 2026-06-16). Every `send_to_bridge` frame is counted and
 classified: `ok` / `crc_err` (slave NACK or corrupted reply — payload integrity
 miss) / `transport_fail` (timeout/handshake) / `giveup` (retries exhausted).
-`link_stats_tick()` (called from the master's housekeeping, gated on
-`debug_enable`, ≤ once per `LINK_STATS_LOG_INTERVAL` = 60 s, quiet when idle)
-prints:
+`send_to_bridge` emits a compact summary every `LINK_STATS_LOG_EVERY` = 200
+frames (count-based, no timer — the cadence follows real traffic, so it's dense
+during overlay bursts and silent when idle; gated on `debug_enable`):
 
 ```text
-Split link: 12345 tx (+312) crc_err=4 transport_fail=1 giveup=0 err=0.0%
+Split link: 12345 tx crc_err=4 transport_fail=1 giveup=0 err=0.0%
 ```
 
 `err%` is the all-time detected-error rate over all frames — a direct read on the
@@ -471,8 +471,8 @@ retries=3; if it climbs, attack `p` at the source.
 
 **Relevant files**:
 - `keyboards/handwired/polykybd/split_sync.c` — per-transaction CRC32 (the only payload check)
-- `keyboards/handwired/polykybd/bridge_helper.c` / `.h` — `send_to_bridge` retries + `link_stats_tick()` counters
-- `keyboards/handwired/polykybd/poly_keymap.c` — `PERIODIC_SYNC_RETRIES`, `sync_and_refresh_displays()`, the `link_stats_tick()` call
+- `keyboards/handwired/polykybd/bridge_helper.c` / `.h` — `send_to_bridge` retries + the link health counters / `LINK_STATS_LOG_EVERY` summary
+- `keyboards/handwired/polykybd/poly_keymap.c` — `PERIODIC_SYNC_RETRIES`, `sync_and_refresh_displays()`
 - `keyboards/handwired/polykybd/config.h` — `SPLIT_MAX_CONNECTION_ERRORS`; the full-duplex defines (`SERIAL_USART_FULL_DUPLEX`, `SERIAL_USART_TX_PIN GP5`, `SERIAL_USART_RX_PIN GP4`, `SERIAL_USART_PIN_SWAP`)
 - `<variant>/halconf.h` — `SELECT_SOFT_SERIAL_SPEED` (baud)
 - `platforms/chibios/drivers/serial_protocol.c`, `drivers/vendor/RP/RP2040/serial_vendor.c` — QMK transport (no payload integrity)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,6 +349,39 @@ local_state->flags &= ~((uint8_t)STATUS_DISP_ON) & ~((uint8_t)DISP_IDLE) & ~((ui
 
 ### Split-link integrity: wire noise, the app-level CRC32, retries, and the health counter
 
+> **RESOLVED (2026-06-16): migrated the split UART to full-duplex two-wire — the
+> ongoing corruption is gone.** `config.h` now sets `SERIAL_USART_FULL_DUPLEX` +
+> `SERIAL_USART_TX_PIN GP5` / `SERIAL_USART_RX_PIN GP4` + `SERIAL_USART_PIN_SWAP`.
+> GP4 was always wired (a second conductor) but unused — there was no PIO
+> full-duplex when the board was brought up; the vendor PIO driver supports it
+> now. The cable is **straight** (GP5↔GP5, GP4↔GP4); `SERIAL_USART_PIN_SWAP`
+> gives the crossover by swapping TX/RX **only on the master half's init path**
+> (`serial_vendor.c`: `serial_transport_driver_master_init` swaps,
+> `..._slave_init` does not), so **one identical image** produces the logical
+> crossover at runtime by role — no per-side build, no EEPROM handedness. Works
+> for the normal single image (USB half = master) and the HIL rig (roles forced
+> per image via `POLYKYBD_HIL`, same `is_keyboard_master()`).
+>
+> **Measured result** via the health counter below: half-duplex was corrupting the
+> small frequent syncs (`Failed to sync … UserLayer/UserPoly` lines — i.e. exactly
+> the layer-drop + RGB-flash symptoms). On full-duplex, across **858 tx including
+> deliberate heavy overlay/RGB load, `crc_err`/`giveup` stayed frozen at the
+> boot-only burst (39/13) with `transport_fail=0`** — i.e. **zero** steady-state
+> errors; `err%` only decays as the boot burst dilutes (14.3 → 4.5 % and falling).
+> The boot burst is unmonitored (it precedes HID-console attach — the counter
+> caught what the live log couldn't) and harmless (persistent state, re-delivered
+> by the diff re-fire once the link settles). Why it works: full-duplex removes the
+> single-wire **bus-turnaround/line-float** hazard and drives push-pull both ways
+> (no pull-up), and gives the reply direction its own clean line.
+>
+> **Consequently the transport-level CRC patch and the upstream QMK PR are SHELVED**
+> — they would have fixed *ongoing* payload corruption, which no longer occurs. The
+> app-level CRC32 + `PERIODIC_SYNC_RETRIES=3` stay as the cheap backstop that
+> absorbs the boot burst. Reopen only if `crc_err`/`giveup` start climbing in
+> *steady state* (watch the counter). The analysis below is retained as the record
+> of why the link behaves as it does — note the "half-duplex/single-wire/230400/
+> 12 mA" descriptions are now historical (pre-2026-06-16).
+
 **The split UART has no payload integrity check of its own — the per-transaction
 CRC32 in `split_sync.c` is the only thing that catches a bit flipped by wire
 noise in flight.** This is the single most important fact about the link, and
@@ -431,13 +464,14 @@ retries=3; if it climbs, attack `p` at the source.
    culprit: ~100 Ω series resistor near the driver (damp reflections), a ground
    conductor twisted with the data line, shorter/shielded cable, solid common
    ground, good connector contact; rule out RGB/SPI/I²C coupling.
-4. **Full-duplex two-wire** (if a spare conductor exists) removes single-wire
-   bus-turnaround hazards — hardware change.
+4. **Full-duplex two-wire** ✅ **DONE (2026-06-16)** — see the RESOLVED note at the
+   top of this section. Removed the single-wire bus-turnaround hazard and drove the
+   steady-state error rate to zero, so options 1–3 above were never needed.
 
 **Relevant files**:
 - `keyboards/handwired/polykybd/split_sync.c` — per-transaction CRC32 (the only payload check)
 - `keyboards/handwired/polykybd/bridge_helper.c` / `.h` — `send_to_bridge` retries + `link_stats_tick()` counters
 - `keyboards/handwired/polykybd/poly_keymap.c` — `PERIODIC_SYNC_RETRIES`, `sync_and_refresh_displays()`, the `link_stats_tick()` call
-- `keyboards/handwired/polykybd/config.h` — `SPLIT_MAX_CONNECTION_ERRORS`, `SERIAL_USART_TX_PIN`
+- `keyboards/handwired/polykybd/config.h` — `SPLIT_MAX_CONNECTION_ERRORS`; the full-duplex defines (`SERIAL_USART_FULL_DUPLEX`, `SERIAL_USART_TX_PIN GP5`, `SERIAL_USART_RX_PIN GP4`, `SERIAL_USART_PIN_SWAP`)
 - `<variant>/halconf.h` — `SELECT_SOFT_SERIAL_SPEED` (baud)
 - `platforms/chibios/drivers/serial_protocol.c`, `drivers/vendor/RP/RP2040/serial_vendor.c` — QMK transport (no payload integrity)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,3 +344,100 @@ local_state->flags &= ~((uint8_t)STATUS_DISP_ON) & ~((uint8_t)DISP_IDLE) & ~((ui
 - `keyboards/handwired/polykybd/split_sync.c` — `user_sync_overlay_map_data_handler`
 - `keyboards/handwired/polykybd/hid_com.c` — case 21
 - `keyboards/handwired/polykybd/base/com.h` — `OVERLAY_SYNCED_STATE_FLAGS`
+
+---
+
+### Split-link integrity: wire noise, the app-level CRC32, retries, and the health counter
+
+**The split UART has no payload integrity check of its own — the per-transaction
+CRC32 in `split_sync.c` is the only thing that catches a bit flipped by wire
+noise in flight.** This is the single most important fact about the link, and
+the reason the CRC32 was added (intermittent sync corruption that looked random).
+
+**The link (verified 2026-06-16)**: `SERIAL_DRIVER = vendor` → the RP2040 **PIO
+half-duplex, single-wire** driver (`serial_vendor.c`) on **`SERIAL_USART_TX_PIN
+GP5`** (no RX pin, no `SERIAL_USART_FULL_DUPLEX` → one shared wire). Baud is
+**230400** (`SELECT_SOFT_SERIAL_SPEED 1` in both variants' `halconf.h` →
+`serial_usart.h` maps that to 230400; 8× PIO oversampling). TX is driven at
+**12 mA** (`GPIO_DRIVE_STRENGTH_12MA`, `serial_vendor.c`) — fast, strong edges
+that ring/reflect on a longer split cable.
+
+**What QMK's transport guarantees (almost nothing)** — traced in
+`platforms/chibios/drivers/serial_protocol.c`:
+- A **1-byte handshake token**: master sends the transaction id, slave echoes
+  `tid ^ NUM_TOTAL_TRANSACTIONS`. Proves *a* transaction of that id is starting —
+  says nothing about the data bytes.
+- A **20 ms** receive timeout (`SERIAL_USART_TIMEOUT`).
+- The actual `initiator2target` / `target2initiator` **payload buffers travel
+  raw** — no CRC, no checksum, not even parity. A flipped bit inside the 64-byte
+  buffer is delivered to the slave callback and the transaction reports
+  **success**. Without the app-level CRC32 the slave applies garbage state
+  (contrast/flags/layer/overlay bytes) silently. ⚠️ Do **not** remove the CRC32
+  thinking the transport covers it — it does not.
+- Note the **reply** (`poly_sync_reply_t`, 1 ACK byte) has **no CRC** either; a
+  corrupted reply can turn a real `SYNC_ACK` into a non-ACK → master retries (safe,
+  idempotent) or, ~1/256, into a false ACK. Low impact, but it's why a tiny
+  fraction of `crc_err` counts can be reply corruption rather than payload.
+
+**How CRC32 + retries + noise interact** (the model that drives the retry-count
+choice). With `p` = probability a single frame is corrupted (and caught by CRC32),
+`N` independent attempts fail this housekeeping pass with prob ≈ `p^N`:
+- **CRC32 detects** corruption → slave returns `SYNC_CRC32_ERR` (not `SYNC_ACK`).
+- **Retries recover** → `send_to_bridge` re-sends; all handlers are idempotent.
+- Retries trade latency/CPU for resilience; **they do not reduce `p`.** A high
+  `SPLIT_MAX_CONNECTION_ERRORS` (200, raised for the fw-update erase) is itself a
+  tell that `p` is non-trivial.
+
+**Periodic syncs use `PERIODIC_SYNC_RETRIES` (=3)** in `poly_keymap.c`
+`sync_and_refresh_displays()` (poly/MRU/layer/last-key). Was briefly cut to **1**
+(to avoid the ~400 ms main-loop stall that 10 retries × ~40 ms timeout costs once
+`SPLIT_MAX_CONNECTION_ERRORS=200` stops failures fast-failing). **1 was too few**:
+the diff re-fire only guarantees eventual delivery of state that *persists* (it
+re-sends the current snapshot; global advances only on success), so a *transient*
+that reverts to == global before the next successful sync is dropped, and even a
+persistent transition leaves the slave visibly stale for a pass+. Field symptoms
+at retries=1: layer updates occasionally not propagating (briefly-held momentary
+layer lost), and the RGB matrix flashing on the slave for a fraction of a second
+(stale disp/RGB until the deferred sync lands). 3 rides through a single glitch
+within the same pass while bounding the worst-case stall to ~3 × 40 ms (the active
+fw-update path skips this code).
+
+**Measuring `p` — the split-link health counter** (`bridge_helper.c`,
+master-side, added 2026-06-16). Every `send_to_bridge` frame is counted and
+classified: `ok` / `crc_err` (slave NACK or corrupted reply — payload integrity
+miss) / `transport_fail` (timeout/handshake) / `giveup` (retries exhausted).
+`link_stats_tick()` (called from the master's housekeeping, gated on
+`debug_enable`, ≤ once per `LINK_STATS_LOG_INTERVAL` = 60 s, quiet when idle)
+prints:
+
+```
+Split link: 12345 tx (+312) crc_err=4 transport_fail=1 giveup=0 err=0.0%
+```
+
+`err%` is the all-time detected-error rate over all frames — a direct read on the
+wire. **Use it to validate any link change** (baud/cable/drive/termination) by
+watching the number move, instead of by feel. `giveup` should stay ~0 with
+retries=3; if it climbs, attack `p` at the source.
+
+**Reducing `p` at the source (the real root fix), in order of leverage**:
+1. **Lower the baud** — biggest, cheapest software lever. 230400 → 115200
+   (`SELECT_SOFT_SERIAL_SPEED 2`) roughly doubles the per-bit sampling margin.
+   Cost: overlay transfers (the bulk of UART bytes) ~2× slower; tiny state/layer
+   syncs imperceptibly. A/B-test it against the health counter before keeping it.
+2. **Driver edge rate** — the 12 mA TX drive in `serial_vendor.c` is strong; a
+   slower edge helps signal integrity but lives in QMK core (would be a tracked
+   local divergence, not a config knob).
+3. **Hardware** — single-wire half-duplex over a TRRS-style cable is the classic
+   culprit: ~100 Ω series resistor near the driver (damp reflections), a ground
+   conductor twisted with the data line, shorter/shielded cable, solid common
+   ground, good connector contact; rule out RGB/SPI/I²C coupling.
+4. **Full-duplex two-wire** (if a spare conductor exists) removes single-wire
+   bus-turnaround hazards — hardware change.
+
+**Relevant files**:
+- `keyboards/handwired/polykybd/split_sync.c` — per-transaction CRC32 (the only payload check)
+- `keyboards/handwired/polykybd/bridge_helper.c` / `.h` — `send_to_bridge` retries + `link_stats_tick()` counters
+- `keyboards/handwired/polykybd/poly_keymap.c` — `PERIODIC_SYNC_RETRIES`, `sync_and_refresh_displays()`, the `link_stats_tick()` call
+- `keyboards/handwired/polykybd/config.h` — `SPLIT_MAX_CONNECTION_ERRORS`, `SERIAL_USART_TX_PIN`
+- `<variant>/halconf.h` — `SELECT_SOFT_SERIAL_SPEED` (baud)
+- `platforms/chibios/drivers/serial_protocol.c`, `drivers/vendor/RP/RP2040/serial_vendor.c` — QMK transport (no payload integrity)

--- a/keyboards/handwired/polykybd/bridge_helper.c
+++ b/keyboards/handwired/polykybd/bridge_helper.c
@@ -16,6 +16,21 @@
 
 static enum com_state com = NOT_INITIALIZED;
 
+// ── Split-link quality counters (master side) ───────────────────────────────
+// Each transaction_rpc_exec() call is one frame on the single-wire UART. The
+// QMK vendor transport carries the payload with no integrity check of its own
+// (only a 1-byte handshake token + a 20 ms timeout), so the per-transaction
+// CRC32 in split_sync.c is the only thing that detects a bit flipped in flight.
+// Counting the outcomes here lets us measure the link's real error behaviour
+// (the bit-error rate `p`) and quantitatively compare cable / baud / drive
+// changes instead of guessing. Cumulative since boot; link_stats_tick() emits a
+// compact summary line once per interval. Touched only on core0 (the master's
+// main loop) — no ISR access, so plain (non-volatile) is fine.
+static uint32_t ls_attempts       = 0;  // frames sent (transaction_rpc_exec calls)
+static uint32_t ls_crc_err        = 0;  // slave NACK'd / non-ACK reply → payload corrupted in flight
+static uint32_t ls_transport_fail = 0;  // transport returned false (timeout / handshake / no reply)
+static uint32_t ls_call_giveup    = 0;  // send_to_bridge() calls that exhausted every retry
+
 void set_com_state(enum com_state state) {
     com = state;
 }
@@ -55,21 +70,63 @@ uint8_t send_to_bridge(int8_t tid, void* buffer_with4crc_bytes, const uint8_t nu
         // line below would print the previous successful call's ack value.
         reply.ack = SYNC_CRC32_ERR;
         bool sync_success = transaction_rpc_exec(tid, num_bytes, buffer_with4crc_bytes, sizeof(poly_sync_reply_t), &reply);
+        ls_attempts++;
         if(sync_success && (reply.ack == SYNC_ACK || reply.ack == SYNC_ACK_SIG)) {
             if(debug_enable && retry>0) {
                 uprintf("Success on retry %d (tid: %s, success: %d, ack: %d, bytes: %d)\n", retry, tid_to_str(tid), sync_success, reply.ack != SYNC_CRC32_ERR, num_bytes);
             }
             return reply.ack;
         }
+        // Failed attempt. sync_success==true means the transport delivered a
+        // reply but it wasn't an ACK → the slave rejected the frame on CRC (or
+        // the reply itself was corrupted): a payload-integrity miss. false means
+        // the transport gave up (timeout / bad handshake / no reply).
+        if(sync_success) {
+            ls_crc_err++;
+        } else {
+            ls_transport_fail++;
+        }
         if(debug_enable) {
             uprintf("Bridge sync retry %d (tid: %s, success: %d, ack: %d, bytes: %d)\n", retry, tid_to_str(tid), sync_success, reply.ack != SYNC_CRC32_ERR, num_bytes);
         }
     }
+    ls_call_giveup++;
     if(debug_enable) {
         uprintf("Failed to sync %d bytes for transaction %s!\n", num_bytes, tid_to_str(tid));
     }
 
     return SYNC_CRC32_ERR;
+}
+
+// Emit a compact split-link health line at most once per LINK_STATS_LOG_INTERVAL
+// (ms), and only when something has been sent since the last line. Call from the
+// master's housekeeping. Gated on debug_enable to match the retry logs (and to
+// keep it off the console in normal use). The percentage is the all-time
+// detected-error rate (CRC + transport) over all frames — a direct read on the
+// wire's bit-error behaviour `p`.
+#ifndef LINK_STATS_LOG_INTERVAL
+#    define LINK_STATS_LOG_INTERVAL 60000
+#endif
+void link_stats_tick(void) {
+    static uint32_t last_log      = 0;
+    static uint32_t last_attempts = 0;
+
+    if (!debug_enable) return;
+    if (timer_elapsed32(last_log) < LINK_STATS_LOG_INTERVAL) return;
+    last_log = timer_read32();
+
+    uint32_t attempts = ls_attempts;
+    if (attempts == last_attempts) return;   // idle window — stay quiet
+    uint32_t window = attempts - last_attempts;
+    last_attempts = attempts;
+
+    uint32_t errs    = ls_crc_err + ls_transport_fail;
+    uint32_t permille = attempts ? (uint32_t)(((uint64_t)errs * 1000U) / attempts) : 0U;
+    uprintf("Split link: %lu tx (+%lu) crc_err=%lu transport_fail=%lu giveup=%lu err=%lu.%lu%%\n",
+            (unsigned long)attempts, (unsigned long)window,
+            (unsigned long)ls_crc_err, (unsigned long)ls_transport_fail,
+            (unsigned long)ls_call_giveup,
+            (unsigned long)(permille / 10U), (unsigned long)(permille % 10U));
 }
 
 bool differ(const void* b1, const void* b2, uint8_t byte_count) {

--- a/keyboards/handwired/polykybd/bridge_helper.c
+++ b/keyboards/handwired/polykybd/bridge_helper.c
@@ -93,7 +93,7 @@ uint8_t send_to_bridge(int8_t tid, void* buffer_with4crc_bytes, const uint8_t nu
         ls_attempts++;
         if(sync_success && (reply.ack == SYNC_ACK || reply.ack == SYNC_ACK_SIG)) {
             if(debug_enable && retry>0) {
-                uprintf("Success on retry %d (tid: %s, success: %d, ack: %d, bytes: %d)\n", retry, tid_to_str(tid), sync_success, reply.ack != SYNC_CRC32_ERR, num_bytes);
+                uprintf("Success on retry %d (tid: %s, success: %d, ack: %d, bytes: %d)\n", retry, tid_to_str(tid), sync_success, reply.ack, num_bytes);
             }
             return reply.ack;
         }
@@ -107,7 +107,7 @@ uint8_t send_to_bridge(int8_t tid, void* buffer_with4crc_bytes, const uint8_t nu
             ls_transport_fail++;
         }
         if(debug_enable) {
-            uprintf("Bridge sync retry %d (tid: %s, success: %d, ack: %d, bytes: %d)\n", retry, tid_to_str(tid), sync_success, reply.ack != SYNC_CRC32_ERR, num_bytes);
+            uprintf("Bridge sync retry %d (tid: %s, success: %d, ack: %d, bytes: %d)\n", retry, tid_to_str(tid), sync_success, reply.ack, num_bytes);
         }
     }
     ls_call_giveup++;

--- a/keyboards/handwired/polykybd/bridge_helper.c
+++ b/keyboards/handwired/polykybd/bridge_helper.c
@@ -17,7 +17,7 @@
 static enum com_state com = NOT_INITIALIZED;
 
 // ── Split-link quality counters (master side) ───────────────────────────────
-// Each transaction_rpc_exec() call is one frame on the single-wire UART. The
+// Each transaction_rpc_exec() call is one frame on the split UART link. The
 // QMK vendor transport carries the payload with no integrity check of its own
 // (only a 1-byte handshake token + a 20 ms timeout), so the per-transaction
 // CRC32 in split_sync.c is the only thing that detects a bit flipped in flight.

--- a/keyboards/handwired/polykybd/bridge_helper.c
+++ b/keyboards/handwired/polykybd/bridge_helper.c
@@ -23,13 +23,19 @@ static enum com_state com = NOT_INITIALIZED;
 // CRC32 in split_sync.c is the only thing that detects a bit flipped in flight.
 // Counting the outcomes here lets us measure the link's real error behaviour
 // (the bit-error rate `p`) and quantitatively compare cable / baud / drive
-// changes instead of guessing. Cumulative since boot; link_stats_tick() emits a
-// compact summary line once per interval. Touched only on core0 (the master's
-// main loop) — no ISR access, so plain (non-volatile) is fine.
+// changes instead of guessing. Cumulative since boot; a compact summary is
+// emitted from send_to_bridge() every LINK_STATS_LOG_EVERY frames — count-based,
+// so the cadence follows real traffic (dense during overlay bursts, sparse when
+// idle, silent with no traffic) without needing a timer. Touched only on core0
+// (the master's main loop) — no ISR access, so plain (non-volatile) is fine.
+#ifndef LINK_STATS_LOG_EVERY
+#    define LINK_STATS_LOG_EVERY 200   // emit one health line per N frames sent
+#endif
 static uint32_t ls_attempts       = 0;  // frames sent (transaction_rpc_exec calls)
 static uint32_t ls_crc_err        = 0;  // slave NACK'd / non-ACK reply → payload corrupted in flight
 static uint32_t ls_transport_fail = 0;  // transport returned false (timeout / handshake / no reply)
 static uint32_t ls_call_giveup    = 0;  // send_to_bridge() calls that exhausted every retry
+static uint32_t ls_last_log       = 0;  // ls_attempts at the last emitted summary
 
 void set_com_state(enum com_state state) {
     com = state;
@@ -63,6 +69,20 @@ const char* tid_to_str(int8_t tid) {
 uint8_t send_to_bridge(int8_t tid, void* buffer_with4crc_bytes, const uint8_t num_bytes, const uint8_t max_retries) {
     poly_sync_reply_t reply;
     uint8_t retry = 0;
+
+    // Periodic split-link health line, once per LINK_STATS_LOG_EVERY frames sent.
+    // Count-based (no timer): the cadence tracks real traffic. Checked once per
+    // call on fully-settled cumulative counts, so it covers every exit path.
+    if (debug_enable && (ls_attempts - ls_last_log) >= LINK_STATS_LOG_EVERY) {
+        ls_last_log = ls_attempts;
+        uint32_t errs    = ls_crc_err + ls_transport_fail;
+        uint32_t permille = ls_attempts ? (uint32_t)(((uint64_t)errs * 1000U) / ls_attempts) : 0U;
+        uprintf("Split link: %lu tx crc_err=%lu transport_fail=%lu giveup=%lu err=%lu.%lu%%\n",
+                (unsigned long)ls_attempts, (unsigned long)ls_crc_err,
+                (unsigned long)ls_transport_fail, (unsigned long)ls_call_giveup,
+                (unsigned long)(permille / 10U), (unsigned long)(permille % 10U));
+    }
+
     *((uint32_t *)buffer_with4crc_bytes) = crc32_1byte(&((uint8_t *)buffer_with4crc_bytes)[4], num_bytes-4, 0);
     for(; retry<max_retries; ++retry) {
         // Reset the reply each iteration: transaction_rpc_exec() leaves it
@@ -96,37 +116,6 @@ uint8_t send_to_bridge(int8_t tid, void* buffer_with4crc_bytes, const uint8_t nu
     }
 
     return SYNC_CRC32_ERR;
-}
-
-// Emit a compact split-link health line at most once per LINK_STATS_LOG_INTERVAL
-// (ms), and only when something has been sent since the last line. Call from the
-// master's housekeeping. Gated on debug_enable to match the retry logs (and to
-// keep it off the console in normal use). The percentage is the all-time
-// detected-error rate (CRC + transport) over all frames — a direct read on the
-// wire's bit-error behaviour `p`.
-#ifndef LINK_STATS_LOG_INTERVAL
-#    define LINK_STATS_LOG_INTERVAL 60000
-#endif
-void link_stats_tick(void) {
-    static uint32_t last_log      = 0;
-    static uint32_t last_attempts = 0;
-
-    if (!debug_enable) return;
-    if (timer_elapsed32(last_log) < LINK_STATS_LOG_INTERVAL) return;
-    last_log = timer_read32();
-
-    uint32_t attempts = ls_attempts;
-    if (attempts == last_attempts) return;   // idle window — stay quiet
-    uint32_t window = attempts - last_attempts;
-    last_attempts = attempts;
-
-    uint32_t errs    = ls_crc_err + ls_transport_fail;
-    uint32_t permille = attempts ? (uint32_t)(((uint64_t)errs * 1000U) / attempts) : 0U;
-    uprintf("Split link: %lu tx (+%lu) crc_err=%lu transport_fail=%lu giveup=%lu err=%lu.%lu%%\n",
-            (unsigned long)attempts, (unsigned long)window,
-            (unsigned long)ls_crc_err, (unsigned long)ls_transport_fail,
-            (unsigned long)ls_call_giveup,
-            (unsigned long)(permille / 10U), (unsigned long)(permille % 10U));
 }
 
 bool differ(const void* b1, const void* b2, uint8_t byte_count) {

--- a/keyboards/handwired/polykybd/bridge_helper.h
+++ b/keyboards/handwired/polykybd/bridge_helper.h
@@ -16,8 +16,4 @@ const char* tid_to_str(int8_t tid);
 
 uint8_t send_to_bridge(int8_t tid, void* buffer_with4crc_bytes, const uint8_t num_bytes, const uint8_t max_retries);
 
-// Master-side periodic split-link health log (CRC / transport error rate). Call
-// from housekeeping on the USB host side; rate-limited and quiet when idle.
-void link_stats_tick(void);
-
 bool differ(const void* b1, const void* b2, uint8_t byte_count);

--- a/keyboards/handwired/polykybd/bridge_helper.h
+++ b/keyboards/handwired/polykybd/bridge_helper.h
@@ -16,4 +16,8 @@ const char* tid_to_str(int8_t tid);
 
 uint8_t send_to_bridge(int8_t tid, void* buffer_with4crc_bytes, const uint8_t num_bytes, const uint8_t max_retries);
 
+// Master-side periodic split-link health log (CRC / transport error rate). Call
+// from housekeeping on the USB host side; rate-limited and quiet when idle.
+void link_stats_tick(void);
+
 bool differ(const void* b1, const void* b2, uint8_t byte_count);

--- a/keyboards/handwired/polykybd/config.h
+++ b/keyboards/handwired/polykybd/config.h
@@ -18,7 +18,18 @@
 
 // Split keyboard
 // https://docs.qmk.fm/#/feature_split_keyboard?id=split-keyboard
+// Full-duplex two-wire link (GP5 TX, GP4 RX). Replaces the previous single-wire
+// half-duplex: removes the bus-turnaround/line-float hazard and drives push-pull
+// both ways (no pull-up needed) — fewer wire-noise glitches on the split UART.
+// The physical cable is wired STRAIGHT (GP5<->GP5, GP4<->GP4), so we rely on
+// SERIAL_USART_PIN_SWAP, which swaps TX/RX only on the MASTER half's init path
+// (serial_vendor.c: master_init swaps, slave_init does not). One identical image
+// on both halves therefore produces the logical crossover at runtime by role —
+// no per-side build, no EEPROM handedness needed.
 #define SERIAL_USART_TX_PIN GP5
+#define SERIAL_USART_RX_PIN GP4
+#define SERIAL_USART_FULL_DUPLEX
+#define SERIAL_USART_PIN_SWAP
 
 #define SPLIT_TRANSPORT_MIRROR
 // #define SPLIT_LAYER_STATE_ENABLE

--- a/keyboards/handwired/polykybd/poly_keymap.c
+++ b/keyboards/handwired/polykybd/poly_keymap.c
@@ -79,6 +79,15 @@
 void rgb_matrix_update_pwm_buffers(void);
 #endif
 
+// In-call retry count for the periodic master->slave state pushes in
+// sync_and_refresh_displays(). Kept small: each failed attempt pays a full UART
+// timeout (SPLIT_MAX_CONNECTION_ERRORS is raised, so failures don't fast-fail),
+// so this bounds the worst-case main-loop stall while still riding through a
+// single transient UART glitch within the same housekeeping pass — which the
+// diff re-fire alone does NOT cover for transient state (see the comment at the
+// USER_SYNC_POLY_DATA send site).
+#define PERIODIC_SYNC_RETRIES 3
+
 /*[[[cog
 import cog
 import os
@@ -252,23 +261,27 @@ void sync_and_refresh_displays(void) {
         access_local_state()->lang_page    = lang_pack_state();
         state_diff = differ(get_local_state(), get_global_state(), sizeof(poly_sync_t));
         if ( state_diff ) {
-            // Periodic syncs use a SINGLE attempt (was 10). They re-fire every
-            // housekeeping pass while a diff persists, so in-call retries are
-            // redundant. With SPLIT_MAX_CONNECTION_ERRORS raised to 200 (for the
-            // fw-update erase), transaction_rpc_exec() keeps reporting "connected"
-            // for ~4 s while the slave is transiently unreachable (e.g. the
-            // post-cold-flash settling window) instead of fast-failing — so each
-            // retry pays a full ~40 ms UART timeout and 10× of them blocks the
-            // main loop (and USB/HID servicing) ~400 ms PER sync. One attempt
-            // bounds the stall to ~tens of ms and the next loop retries. No effect
-            // on the normal path, where the slave ACKs on the first attempt.
-            if(!send_to_bridge(USER_SYNC_POLY_DATA, (void *)access_local_state(), sizeof(poly_sync_t), 1)) {
+            // Periodic syncs use a SMALL retry count (PERIODIC_SYNC_RETRIES, was
+            // briefly 1, originally 10). The diff re-fires every housekeeping pass
+            // while a diff persists, but that re-fire only guarantees delivery of
+            // state that PERSISTS: the re-fire sends the CURRENT snapshot, and
+            // global advances to local only on a successful sync. A TRANSIENT that
+            // reverts to == global before the next successful sync (a briefly-held
+            // momentary layer, or an RGB/disp transition seen during the
+            // post-flash settling window) is therefore dropped, or leaves the
+            // slave visibly stale for a pass or more. A few in-call retries ride
+            // through a single UART glitch within the same pass so the transient
+            // lands. The stall this guards against: with SPLIT_MAX_CONNECTION_ERRORS
+            // raised to 200 (for the fw-update erase) a failed attempt no longer
+            // fast-fails — it pays a full ~40 ms UART timeout — so the worst-case
+            // stall is bounded to ~PERIODIC_SYNC_RETRIES × 40 ms (and the active
+            // fw-update path skips this code entirely). No effect on the normal
+            // path, where the slave ACKs on the first attempt.
+            if(!send_to_bridge(USER_SYNC_POLY_DATA, (void *)access_local_state(), sizeof(poly_sync_t), PERIODIC_SYNC_RETRIES)) {
                 // Failed: clear state_diff so the copy_global_state() below is
                 // SKIPPED — global stays != local, so next pass differ() is still
                 // true and re-fires the send. The diff IS the retry queue; global
-                // only advances to local on a successful sync, so 1 vs 10 attempts
-                // changes only WHERE retries happen, never whether the update is
-                // eventually delivered.
+                // only advances to local on a successful sync.
                 state_diff = false;
                 uprint("USER_SYNC_POLY_DATA failed to send\n");
             }
@@ -283,7 +296,7 @@ void sync_and_refresh_displays(void) {
             // Multiplexed onto the overlay-map transaction id (distinct payload
             // size) to stay within QMK's 32-transaction limit. Only the packed
             // bytes are sent (MRU_SYNC_BYTES), not the struct's crc tail padding.
-            uint8_t mru_ack = send_to_bridge(USER_SYNC_OVERLAY_MAP_DATA, &mru_msg, MRU_SYNC_BYTES, 1);
+            uint8_t mru_ack = send_to_bridge(USER_SYNC_OVERLAY_MAP_DATA, &mru_msg, MRU_SYNC_BYTES, PERIODIC_SYNC_RETRIES);
             if (mru_ack == SYNC_ACK || mru_ack == SYNC_ACK_SIG) {
                 mru_clear_sync_pending();
             } else {
@@ -295,14 +308,14 @@ void sync_and_refresh_displays(void) {
         access_local_layer()->mods = get_mods();
         layer_diff = differ(get_local_layer(), get_global_layer(), sizeof(poly_layer_t));
         if ( layer_diff ) {
-            if(!send_to_bridge(USER_SYNC_LAYER_DATA, (void *)access_local_layer(), sizeof(poly_layer_t), 1)) {
+            if(!send_to_bridge(USER_SYNC_LAYER_DATA, (void *)access_local_layer(), sizeof(poly_layer_t), PERIODIC_SYNC_RETRIES)) {
                 layer_diff = false; // failed: skip copy_global_layer() below so the diff
                                     // persists and the send re-fires next pass (see state above)
                 uprint("USER_SYNC_LAYER_DATA failed to send\n");
             }
         }
         if ( differ(get_local_last_latin(), get_global_last_latin(), sizeof(poly_last_t)) ) {
-            if(!send_to_bridge(USER_SYNC_LASTKEY_DATA, access_local_last_latin(), sizeof(poly_last_t), 1)) {
+            if(!send_to_bridge(USER_SYNC_LASTKEY_DATA, access_local_last_latin(), sizeof(poly_last_t), PERIODIC_SYNC_RETRIES)) {
                 // if failed to sync, do not consider it a diff and try again later
                 uprint("USER_SYNC_LASTKEY_DATA failed to send\n");
             } else {

--- a/keyboards/handwired/polykybd/poly_keymap.c
+++ b/keyboards/handwired/polykybd/poly_keymap.c
@@ -431,6 +431,9 @@ void housekeeping_task_user(void) {
         // store request (on the master locally, on the slave via SAVE_EEPROM).
         save_all_if_requested();
         sync_and_refresh_displays();
+        if (is_usb_host_side()) {
+            link_stats_tick();   // periodic split-link CRC/transport error-rate line
+        }
     }
     int32_t update = get_last_update();
     if(update>=0) {

--- a/keyboards/handwired/polykybd/poly_keymap.c
+++ b/keyboards/handwired/polykybd/poly_keymap.c
@@ -431,9 +431,6 @@ void housekeeping_task_user(void) {
         // store request (on the master locally, on the slave via SAVE_EEPROM).
         save_all_if_requested();
         sync_and_refresh_displays();
-        if (is_usb_host_side()) {
-            link_stats_tick();   // periodic split-link CRC/transport error-rate line
-        }
     }
     int32_t update = get_last_update();
     if(update>=0) {


### PR DESCRIPTION
## Summary

Fixes the intermittent split-sync corruption that showed up as the **RGB matrix flashing on the slave** and **layer updates occasionally not propagating**. Root cause traced to the single-wire half-duplex UART corrupting payloads (the QMK vendor transport has no payload integrity check — the per-transaction CRC32 in `split_sync.c` is the only thing catching a flipped bit). Resolved by moving to **full-duplex two-wire**, with two supporting robustness/diagnostic changes.

## Commits

1. **`PERIODIC_SYNC_RETRIES` 1 → 3** — the periodic master→slave pushes in `sync_and_refresh_displays()` had been cut to a single attempt, which dropped *transient* state (a briefly-held momentary layer) and left the slave visibly stale through the post-flash settling window. 3 rides through a single UART glitch within the same housekeeping pass while bounding the worst-case stall (~3 × 40 ms); the active fw-update path skips this code.
2. **Split-link health counter** (`bridge_helper.c`) — every `send_to_bridge` frame is classified `ok` / `crc_err` / `transport_fail` / `giveup`; `link_stats_tick()` prints a compact summary from the master's housekeeping, ≤ once/60 s, gated on `debug_enable`:
   ```
   Split link: 858 tx (+88) crc_err=39 transport_fail=0 giveup=13 err=4.5%
   ```
   Turns "feels glitchy" into a measured bit-error rate — and caught the boot-window errors the HID console can't see (they precede console attach).
3. **Full-duplex two-wire** (`config.h`) — `SERIAL_USART_FULL_DUPLEX` + `SERIAL_USART_TX_PIN GP5` / `SERIAL_USART_RX_PIN GP4` + `SERIAL_USART_PIN_SWAP`. GP4 was always wired but unused (no PIO full-duplex when the board was brought up). Cable is **straight**; `PIN_SWAP` swaps TX/RX only on the master half's init path, so **one identical image** gives the logical crossover at runtime by role — no per-side build, no EEPROM handedness. Removes the single-wire bus-turnaround/line-float hazard and drives push-pull both ways (no pull-up).
4. **Docs** — the investigation + measured outcome recorded in `CLAUDE.md` ("Split-link integrity").

## Measured result

Via the health counter. Half-duplex was corrupting the small frequent syncs (`Failed to sync … UserLayer/UserPoly` — exactly the layer-drop + RGB-flash symptoms). On full-duplex, across **858 tx including deliberate heavy overlay/RGB load**, `crc_err`/`giveup` stayed frozen at a **boot-only burst (39/13) with `transport_fail=0`** — i.e. zero steady-state errors; `err%` only decays as the boot burst dilutes (14.3 → 4.5 % and falling). The boot burst is harmless (persistent state, re-delivered by the diff re-fire once the link settles).

App-level CRC32 + retries=3 stay as the cheap backstop. A transport-level CRC patch / upstream PR was considered but **shelved** — it would have fixed *ongoing* corruption, which no longer occurs.

## Build / test

`qmk compile` clean for both **split72** and **split42**. Verified on hardware via the health counter (numbers above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019qMMMJtfrsaW69DxbSs87A)_

## Summary by Sourcery

Improve PolyKybd split-link reliability and observability for master–slave UART communication.

New Features:
- Add a master-side split-link health counter and periodic log summarizing CRC and transport errors on the UART link.

Enhancements:
- Increase periodic split sync retry count to better tolerate transient UART glitches without losing transient state.
- Switch the split UART configuration to full-duplex two-wire operation using dedicated TX/RX pins for more robust communication.
- Document the split-link integrity model, UART configuration, and health counter usage in CLAUDE.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Split keyboard link now includes health monitoring with error tracking and periodic communication quality reporting.
  * Improved retry logic for master-slave state synchronization to enhance reliability.

* **Documentation**
  * Added comprehensive documentation on split-link integrity testing and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->