### PR TITLE
Add jitter idle style to reduce OLED burn-in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,12 @@ extraction fixed: `corne42` had silently fallen ~98 languages behind split72).
   the host had to drain. The host (protocol 3) no longer drains after mapping
   sends; ordering for `enable_overlays` (case 11) is preserved because HID
   reports dispatch sequentially and the bridge completes before case 21 returns.
+  **v4** added `GET/SET_IDLE_STYLE` (cmd `28` / `0x1c`): selects the idle
+  (anti-burn-in) display style — payload `0xFF` queries (reply byte = current
+  style), else sets it (`0` = legacy pulse, `1` = jitter); out-of-range NACKs.
+  Persisted in `poly_eeconf_t.idle_style` (flushed at the next suspend/store) so
+  it survives reboots. The host (PolyKybdHost) toggles it over this command; the
+  rig has a v4-gated round-trip HIL test. See "Idle anti-burn-in styles" below.
 - Overlay transmission: each keycap overlay (360 bytes) is split into 6 × 60-byte segments (cmd `0x0A`), or sent RLE-compressed in 1–2 packets (cmds `0x10`/`0x11`)
 - ROI updates (cmds `0x12`/`0x13`) allow partial refresh of a keycap's display area
 - Overlay index = `keycode_slot + 90 * modifier_variant` (9 variants: bare, Ctrl, Shift, Ctrl+Shift, Alt, Ctrl+Alt, Alt+Shift, Ctrl+Alt+Shift, GUI)
@@ -115,6 +121,36 @@ new ISO codes append at the next free slot; private pseudo-codes with no ISO
 
 ### Split synchronisation
 Seven custom QMK transaction IDs (`USER_SYNC_POLY_DATA`, `USER_SYNC_OVERLAY_DATA`, `USER_SYNC_COMPRESSED_DATA`, `USER_SYNC_ROI_DATA`, etc.) carry state and overlay data to the slave half over UART with CRC32 validation and up to 10 retries.
+
+### Idle anti-burn-in styles (`poly_keymap.c`)
+When the keyboard idles, the keycap legends would otherwise burn the **same**
+pixels in. Two styles (EEPROM `poly_eeconf_t.idle_style`, HID cmd 28, enum
+`poly_idle_style` in `state.h`):
+- **`IDLE_STYLE_PULSE` (0, default, legacy):** `kdisp_idle()` only modulates each
+  keycap's SSD1306 contrast register (a per-key out-of-phase "breathing"). The
+  buffer is never re-rendered, so the lit pixels never move — the burn-in risk.
+- **`IDLE_STYLE_JITTER` (1):** keeps the pulse, but once per ~15 s pulse cycle the
+  master picks a small bounded random offset (`IDLE_JITTER_*` in `config.h`) and
+  **relocates** the legend so the lit pixels migrate. Mechanics:
+  - `housekeeping_task_user()` (master only, `is_usb_host_side()`) computes the
+    per-cycle offset into `poly_sync_t.idle_dx/idle_dy` (synced to the slave like
+    `contrast`, so both halves relocate in lockstep — **no extra UART traffic**:
+    the offset rides the existing per-300 ms poly sync, and the slave just renders
+    whatever offset arrives, so it needs no idle-style of its own).
+  - `update_displays()` normally early-returns while `DISP_IDLE` is set; in jitter
+    it re-renders **only when `idle_dx/idle_dy` changed** (a static last-offset
+    guard), drawing once at the new spot at a low fixed contrast; `kdisp_idle()`
+    resumes the pulse on the next tick. The offset is applied globally via
+    `kdisp_set_draw_offset()` in `disp_array.c` (added to every gfx-char/text
+    draw, reset to 0 after) — so **text legends** jitter; full-bleed **overlay
+    images** (`copy_overlay_to_buffer`) do not (they'd clip), a deliberate limit.
+  - Offsets are reset to 0 on every wake/suspend path (`display_wakeup`,
+    `poly_suspend`, `suspend_wakeup_init_kb`, cmd 15 stop-idle) so a refresh right
+    after waking is centred. Bounds are conservative (single-char legends never
+    clip; `SET_PIXEL_CLIPPED` is the backstop).
+  A "Matrix-style" idle animation was considered but shelved — it defeats the
+  "glance at the dimmed legend and resume typing" hint the pulse preserves; jitter
+  was chosen as the default-preserving, legibility-preserving fix.
 
 ### Notable QMK features enabled
 RGB matrix (72 LEDs, 35 effects), dynamic keymap (9 layers, VIA-compatible), unicode input (Linux/macOS/Windows/BSD), Cirque trackpad (split72 variant), `USE_CORE1` multicore.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,24 +130,39 @@ pixels in. Two styles (EEPROM `poly_eeconf_t.idle_style`, HID cmd 28, enum
   keycap's SSD1306 contrast register (a per-key out-of-phase "breathing"). The
   buffer is never re-rendered, so the lit pixels never move — the burn-in risk.
 - **`IDLE_STYLE_JITTER` (1):** keeps the pulse, but once per ~15 s pulse cycle the
-  master picks a small bounded random offset (`IDLE_JITTER_*` in `config.h`) and
-  **relocates** the legend so the lit pixels migrate. Mechanics:
+  master picks a small random offset and **relocates** the legend so the lit pixels
+  migrate. Mechanics:
   - `housekeeping_task_user()` (master only, `is_usb_host_side()`) computes the
     per-cycle offset into `poly_sync_t.idle_dx/idle_dy` (synced to the slave like
     `contrast`, so both halves relocate in lockstep — **no extra UART traffic**:
     the offset rides the existing per-300 ms poly sync, and the slave just renders
-    whatever offset arrives, so it needs no idle-style of its own).
+    whatever offset arrives, so it needs no idle-style of its own). The
+    `IDLE_JITTER_DX/DY_*` envelope in `config.h` is only the *proposed* range — it
+    no longer has to be clip-safe (the per-key clamp below makes it so), so it's
+    tuned for how far small legends roam.
   - `update_displays()` normally early-returns while `DISP_IDLE` is set; in jitter
     it re-renders **only when `idle_dx/idle_dy` changed** (a static last-offset
-    guard), drawing once at the new spot at a low fixed contrast; `kdisp_idle()`
-    resumes the pulse on the next tick. The offset is applied globally via
-    `kdisp_set_draw_offset()` in `disp_array.c` (added to every gfx-char/text
-    draw, reset to 0 after) — so **text legends** jitter; full-bleed **overlay
-    images** (`copy_overlay_to_buffer`) do not (they'd clip), a deliberate limit.
+    guard). Each drawable key is then routed to **`render_idle_key()`** (the single
+    place all idle rendering lives), which draws **only the resting normal legend**
+    — no shift/AltGr preview, no overlay image, no tab/MRU chrome (those keycodes
+    aren't on the base layer at idle anyway), at the low fixed `IDLE_JITTER_REDRAW_CONTRAST`;
+    `kdisp_idle()` resumes the pulse on the next tick.
+  - **The offset is clamped per key to that glyph's own bounds**, so the legend is
+    *always fully visible* at every jitter position — for any script, not just
+    Latin. `render_idle_key()` measures the legend with `kdisp_gfx_text_bbox()`
+    (full x+y box, mirroring the draw's cursor rules and per-glyph yAdvance shift;
+    `kdisp_gfx_text_bounds()` is now a wrapper over it) and `clamp_idle_offset()`
+    bounds the synced `idle_dx/idle_dy` so the box stays inside the visible window
+    `[BUFFER_X, BUFFER_X+SCREEN_WIDTH-1] × [0, SCREEN_HEIGHT-1]` (= `[28,99]×[0,39]`).
+    A glyph with no slack in an axis (e.g. a full-width CJK legend) simply doesn't
+    move in it — no clipping, no special-casing. This **replaces** the old global
+    `kdisp_set_draw_offset()` + fixed-`±N` approach, whose Latin-sized constants
+    clipped zero-bearing glyphs (`A W X Y T V`, `J`) on the flush-left origin and
+    were wrong for wide scripts. `SET_PIXEL_CLIPPED` in `disp_array.c` remains the
+    memory-safety backstop, but is no longer relied on for visibility.
   - Offsets are reset to 0 on every wake/suspend path (`display_wakeup`,
     `poly_suspend`, `suspend_wakeup_init_kb`, cmd 15 stop-idle) so a refresh right
-    after waking is centred. Bounds are conservative (single-char legends never
-    clip; `SET_PIXEL_CLIPPED` is the backstop).
+    after waking is centred.
   A "Matrix-style" idle animation was considered but shelved — it defeats the
   "glance at the dimmed legend and resume typing" hint the pulse preserves; jitter
   was chosen as the default-preserving, legibility-preserving fix.

--- a/keyboards/handwired/polykybd/base/disp_array.c
+++ b/keyboards/handwired/polykybd/base/disp_array.c
@@ -70,6 +70,17 @@
 
 uint8_t scratch_buffer[BUFFER_BYTE_WIDTH * BUFFER_BYTE_HEIGHT];
 
+// Global pixel offset added to every gfx-char/text draw. Normally 0; the idle
+// "jitter" anti-burn-in path sets it for the duration of a relocation redraw and
+// restores it to 0 afterwards (see update_displays in poly_keymap.c).
+static int8_t s_draw_ox = 0;
+static int8_t s_draw_oy = 0;
+
+void kdisp_set_draw_offset(int8_t ox, int8_t oy) {
+    s_draw_ox = ox;
+    s_draw_oy = oy;
+}
+
 uint8_t* get_scratch_buffer(void) {
     return scratch_buffer;
 }
@@ -128,6 +139,8 @@ void kdisp_clear_rect(int8_t x_start, int8_t y_start, int8_t width, int8_t heigh
 */
 /**************************************************************************/
 int8_t kdisp_write_gfx_char(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, uint32_t ch, int8_t cy_radius) {
+    x += s_draw_ox;   // anti-burn-in jitter offset (0 except during an idle relocation redraw)
+    y += s_draw_oy;
     const GFXfont * currentFont = 0;
     uint32_t first = 0;
     uint32_t last = 0;

--- a/keyboards/handwired/polykybd/base/disp_array.c
+++ b/keyboards/handwired/polykybd/base/disp_array.c
@@ -303,17 +303,25 @@ void kdisp_write_gfx_text_cy(const GFXfont *const *fonts, uint8_t num_fonts, int
     }
 }
 
-void kdisp_gfx_text_bounds(const GFXfont *const *fonts, uint8_t num_fonts, const uint32_t *text, int8_t *out_min, int8_t *out_max) {
-    int16_t x = 0;          // cursor, same advance rules as kdisp_write_gfx_text_cy
-    int16_t mn = 127, mx = -128;
+void kdisp_gfx_text_bbox(const GFXfont *const *fonts, uint8_t num_fonts, const uint32_t *text,
+                         int8_t *out_xmin, int8_t *out_xmax, int8_t *out_ymin, int8_t *out_ymax) {
+    // Cursor relative to the draw origin: x from 0, y from the baseline (0). Mirrors
+    // every cursor rule of kdisp_write_gfx_text_cy, including the vertical controls,
+    // so the measured box matches what would actually be drawn — both axes.
+    int16_t x = 0, y = 0;
+    int16_t xmn = 127, xmx = -128, ymn = 127, ymx = -128;
+    const int16_t base_yadv = pgm_read_byte(&fonts[0]->yAdvance);
     while (*text != 0) {
         switch (*text) {
-            case U'\x05': case U'\f': case U'\v': break;   // vertical-only controls
-            case U'\x18': case U'\r':         x = 0; break; // reset x to origin
+            case U'\x05':                     y += 2; break; // down 2px
+            case U'\f':                       y = y > 1 ? y - 2 : 0; break; // up 2px
+            case U'\v':                       y += ((y) / 15 + 1) * 15; break;
+            case U'\x18':                     x = 0; y = 0; break; // cancel -> origin
+            case U'\r':                       x = 0; break;
             case U'\b':                       x = x > 1 ? x - 2 : 0; break;
             case U'\x06':                     x += 2; break; // nudge right 2px
             case U'\t':                       x += ((x) / 36 + 1) * 36; break;
-            case U'\n':                       x = 0; break;
+            case U'\n':                       y += base_yadv; x = 0; break;
             default: {
                 // Locate the font whose [first,last] contains the codepoint (linear
                 // scan; this is a cold measuring path, no MRU cache needed).
@@ -327,11 +335,20 @@ void kdisp_gfx_text_bounds(const GFXfont *const *fonts, uint8_t num_fonts, const
                 if (!f) { f = fonts[0]; first = pgm_read_dword(&f->first); ch = U'!'; }
                 const GFXglyph *g = pgm_read_glyph_ptr(f, ch - first);
                 int8_t w  = pgm_read_byte(&g->width);
+                int8_t h  = pgm_read_byte(&g->height);
                 int8_t xo = pgm_read_byte(&g->xOffset);
-                if (w > 0) {
+                int8_t yo = pgm_read_byte(&g->yOffset);
+                if (w > 0 && h > 0) {
                     int16_t l = x + xo, r = x + xo + w - 1;
-                    if (l < mn) mn = l;
-                    if (r > mx) mx = r;
+                    if (l < xmn) xmn = l;
+                    if (r > xmx) xmx = r;
+                    // kdisp_write_gfx_char shifts each glyph by (font yAdvance - fonts[0]
+                    // yAdvance) before applying yOffset; mirror it so the vertical box
+                    // matches the rasterised pixels.
+                    int16_t yadj = (int16_t)pgm_read_byte(&f->yAdvance) - base_yadv;
+                    int16_t t = y + yadj + yo, b = t + h - 1;
+                    if (t < ymn) ymn = t;
+                    if (b > ymx) ymx = b;
                 }
                 x += pgm_read_byte(&g->xAdvance);
                 break;
@@ -339,9 +356,16 @@ void kdisp_gfx_text_bounds(const GFXfont *const *fonts, uint8_t num_fonts, const
         }
         text++;
     }
-    if (mx < mn) { mn = 0; mx = 0; }      // empty / whitespace-only
-    *out_min = (int8_t)mn;
-    *out_max = (int8_t)mx;
+    if (xmx < xmn) { xmn = 0; xmx = 0; ymn = 0; ymx = 0; }   // empty / whitespace-only
+    *out_xmin = (int8_t)xmn;
+    *out_xmax = (int8_t)xmx;
+    *out_ymin = (int8_t)ymn;
+    *out_ymax = (int8_t)ymx;
+}
+
+void kdisp_gfx_text_bounds(const GFXfont *const *fonts, uint8_t num_fonts, const uint32_t *text, int8_t *out_min, int8_t *out_max) {
+    int8_t ymin, ymax;
+    kdisp_gfx_text_bbox(fonts, num_fonts, text, out_min, out_max, &ymin, &ymax);
 }
 
 // Draw `text` as a vertical column, each glyph rotated -90° (counter-clockwise),

--- a/keyboards/handwired/polykybd/base/disp_array.h
+++ b/keyboards/handwired/polykybd/base/disp_array.h
@@ -19,6 +19,10 @@
 
 int8_t kdisp_write_gfx_char(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, uint32_t c, int8_t cy_radius);
 
+// Sets a global pixel offset added to every subsequent gfx-char/text draw, used by
+// the idle "jitter" anti-burn-in relocation redraw. Pass 0,0 to disable.
+void kdisp_set_draw_offset(int8_t ox, int8_t oy);
+
 void kdisp_write_gfx_text(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, const uint32_t *text);
 
 void kdisp_write_gfx_text_cy(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, const uint32_t *text, int8_t cy_radius);

--- a/keyboards/handwired/polykybd/base/disp_array.h
+++ b/keyboards/handwired/polykybd/base/disp_array.h
@@ -34,6 +34,13 @@ void kdisp_write_gfx_text_cy(const GFXfont *const *fonts, uint8_t num_fonts, int
 // base glyph).  Both are 0 for empty/blank text.
 void kdisp_gfx_text_bounds(const GFXfont *const *fonts, uint8_t num_fonts, const uint32_t *text, int8_t *out_min, int8_t *out_max);
 
+// Full pixel bounding box of `text` relative to the draw origin (x from the origin
+// x, y from the baseline), mirroring every cursor rule — and the per-glyph vertical
+// shift — of kdisp_write_gfx_text_cy. Lets a caller clamp a draw offset so the
+// glyph stays fully on-screen (idle anti-burn-in jitter). All four are 0 for blank text.
+void kdisp_gfx_text_bbox(const GFXfont *const *fonts, uint8_t num_fonts, const uint32_t *text,
+                         int8_t *out_xmin, int8_t *out_xmax, int8_t *out_ymin, int8_t *out_ymax);
+
 // Vertical (rotated -90°, bottom-to-top) single-font text, centred in the visible
 // height with its baseline along x = col_x.  `selected` draws it as dark text on
 // a filled bar (else lit text on the dark background).  Used by the lang layer.

--- a/keyboards/handwired/polykybd/config.h
+++ b/keyboards/handwired/polykybd/config.h
@@ -94,14 +94,16 @@
 //######################################
 //#          PolyKybd specific         #
 //######################################
-#define FW_VERSION "0.8.25"
+#define FW_VERSION "0.8.26"
 // v2: adds GET_LANG_LIST_PACKED (cmd 27) — language list as 2-byte ISO index pairs.
 // v3: SEND_OVERLAY_MAPPING (cmd 21) no longer ACKs per chunk — like every other
 //     bulk overlay command (10, 16/17, 18/19) it is silent. The per-chunk ACK
 //     carried no information (always ".", never read by the host) and arrived
 //     only after the blocking UART bridge to the slave, leaving stale replies
 //     that poisoned later commands' reads on the host.
-#define PROTOCOL_VERSION 3
+// v4: adds GET/SET_IDLE_STYLE (cmd 28) — selects the idle (anti-burn-in) display
+//     style (0 = legacy pulse, 1 = jitter). Persisted in EEPROM; host toggle.
+#define PROTOCOL_VERSION 4
 
 #define FULL_BRIGHT 50
 #define MIN_BRIGHT 1
@@ -114,6 +116,20 @@
 #define FADE_OUT_TIME 120000
 //10 min
 #define TURN_OFF_TIME 1200000
+
+// Idle "jitter" style: while pulsing, the rendered legend is relocated by a small
+// random offset once per pulse cycle so the lit pixels migrate and don't burn in.
+// Bounds are kept conservative so single-char legends stay on-screen (the renderer
+// clips as a backstop); they bracket the base draw origin (BUFFER_X=28, baseline 23).
+#define IDLE_JITTER_DX_MIN (-6)
+#define IDLE_JITTER_DX_MAX (10)
+#define IDLE_JITTER_DY_MIN (-4)
+#define IDLE_JITTER_DY_MAX (6)
+// One pulse cycle is 50 contrast steps × 300 ms (~15 s); relocate at each boundary.
+#define IDLE_JITTER_CYCLE_STEPS 50
+// Contrast used for the one relocation redraw (the live value is the pulsing 0-49
+// counter at that instant); kdisp_idle() resumes the per-key pulse on the next tick.
+#define IDLE_JITTER_REDRAW_CONTRAST 2
 
 //######################################
 //#          Overlays specific         #

--- a/keyboards/handwired/polykybd/config.h
+++ b/keyboards/handwired/polykybd/config.h
@@ -119,12 +119,15 @@
 
 // Idle "jitter" style: while pulsing, the rendered legend is relocated by a small
 // random offset once per pulse cycle so the lit pixels migrate and don't burn in.
-// Bounds are kept conservative so single-char legends stay on-screen (the renderer
-// clips as a backstop); they bracket the base draw origin (BUFFER_X=28, baseline 23).
-#define IDLE_JITTER_DX_MIN (-6)
-#define IDLE_JITTER_DX_MAX (10)
-#define IDLE_JITTER_DY_MIN (-4)
-#define IDLE_JITTER_DY_MAX (6)
+// These are only the *proposed* offset envelope (a deliberately generous range);
+// render_idle_key() then clamps the offset per key to that glyph's measured bounding
+// box, so the legend is always fully on-screen regardless of these values and of the
+// script (Latin, CJK, Arabic, …). A glyph with no slack in an axis simply does not
+// move in it. So tune these for how far small legends roam, not for clip-safety.
+#define IDLE_JITTER_DX_MIN (-10)
+#define IDLE_JITTER_DX_MAX (18)
+#define IDLE_JITTER_DY_MIN (-6)
+#define IDLE_JITTER_DY_MAX (10)
 // One pulse cycle is 50 contrast steps × 300 ms (~15 s); relocate at each boundary.
 #define IDLE_JITTER_CYCLE_STEPS 50
 // Contrast used for the one relocation redraw (the live value is the pulsing 0-49

--- a/keyboards/handwired/polykybd/hid_com.c
+++ b/keyboards/handwired/polykybd/hid_com.c
@@ -461,6 +461,8 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                         }
                         local_state->flags &= ~((uint8_t)DISP_IDLE);
                         local_state->flags |= STATUS_DISP_ON;
+                        local_state->idle_dx = 0;   // recentre legend (drop jitter offset)
+                        local_state->idle_dy = 0;
                         request_disp_refresh();
                         update_performed();
                     }
@@ -644,6 +646,34 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                 memcpy(data, "\x50\x1b\x2e\x83\xad\x0a\x1c\x77\xe8\xb9\x9c\x81\x02\x49\x25\x1a\x25\xba\xe8", 19);
                 raw_hid_send(data, length);
                 //[[[end]]]
+                break;
+            case 28: //get/set idle (anti-burn-in) display style (protocol v4+)
+                {
+                    // data[HID_DATA_IDX] == 0xFF -> query (reply current style in data[3]).
+                    // Otherwise set the style (0 = pulse, 1 = jitter); persisted at the
+                    // next EEPROM flush (suspend / store key).
+                    uint8_t arg = data[HID_DATA_IDX];
+                    memset(data, 0, length);
+                    if (arg == 0xFF) {
+                        memcpy(data, "P\x1c.", 3);
+                        data[3] = get_idle_style();
+                    } else if (arg < IDLE_STYLE_COUNT) {
+                        set_idle_style(arg);
+                        if (arg == IDLE_STYLE_PULSE) {
+                            // Recentre immediately if we switch away from jitter mid-idle.
+                            local_state->idle_dx = 0;
+                            local_state->idle_dy = 0;
+                            request_disp_refresh();
+                        }
+                        memcpy(data, "P\x1c.", 3);
+                        data[3] = arg;
+                        uprintf("Set idle style to %u.\n", arg);
+                    } else {
+                        memcpy(data, "P\x1c!", 3);
+                        uprintf("Refused idle style %u.\n", arg);
+                    }
+                    raw_hid_send(data, length);
+                }
                 break;
             default:
                 if (hid_fw_up_receive(data, length)) {

--- a/keyboards/handwired/polykybd/poly_keymap.c
+++ b/keyboards/handwired/polykybd/poly_keymap.c
@@ -405,6 +405,25 @@ layer_state_t layer_state_set_user(layer_state_t state) {
     return state;
 }
 
+// Idle "jitter" anti-burn-in state (master-side; the offset is synced to the
+// slave through poly_sync_t). g_jitter_epoch counts pulse cycles so the legend is
+// relocated once per cycle; UINT32_MAX forces a fresh offset on each idle entry.
+static uint32_t g_jitter_epoch = UINT32_MAX;
+static int8_t   g_jitter_dx = 0;
+static int8_t   g_jitter_dy = 0;
+
+// Deterministic small pseudo-random offset for a given pulse cycle (epoch) and
+// axis salt, clamped to [lo, hi]. Deterministic so a glance is reproducible and
+// the value is stable for the whole epoch; only the master evaluates it.
+static int8_t jitter_axis(uint32_t epoch, uint32_t salt, int8_t lo, int8_t hi) {
+    uint32_t h = (epoch + salt) * 2654435761u;
+    h ^= h >> 15;
+    h *= 2246822519u;
+    h ^= h >> 13;
+    uint8_t range = (uint8_t)(hi - lo + 1);
+    return (int8_t)(lo + (int8_t)(h % range));
+}
+
 // Continuously monitors for idle timeout and dims/pulsates display accordingly.
 void housekeeping_task_user(void) {
     // fw_up state machine: apply on success path, advance deferred erase.
@@ -440,6 +459,8 @@ void housekeeping_task_user(void) {
             poly_sync_t* local_state = access_local_state();
             uint8_t  contrast = local_state->contrast;
             uint8_t  flags = local_state->flags;
+            int8_t   idle_dx = 0;   // anti-burn-in jitter offset; 0 unless idle+JITTER
+            int8_t   idle_dy = 0;
 
             flags |= STATUS_DISP_ON;
             flags &= ~((uint8_t)IDLE_TRANSITION);
@@ -452,6 +473,7 @@ void housekeeping_task_user(void) {
                 if(brightness<=MIN_BRIGHT) {
                     contrast = DISP_OFF;
                     flags |= DISP_IDLE;
+                    g_jitter_epoch = UINT32_MAX;   // force a fresh jitter offset for this idle session
                     uprint("Transition to pulsing\n");
                 } else if(brightness>FULL_BRIGHT) {
                     contrast = FULL_BRIGHT;
@@ -469,12 +491,27 @@ void housekeeping_task_user(void) {
             } else if((flags & DISP_IDLE)!=0) {
                 int32_t time_after = PK_MAX(elapsed_time_since_update - FADE_OUT_TIME - FADE_TRANSITION_TIME, 0)/300;
                 contrast = time_after%50;
+                // Jitter style: relocate the legend once per pulse cycle so the lit
+                // pixels migrate. The offset is constant within a cycle and synced to
+                // the slave; update_displays() re-renders only when it changes.
+                if(get_idle_style() == IDLE_STYLE_JITTER) {
+                    uint32_t epoch = (uint32_t)time_after / IDLE_JITTER_CYCLE_STEPS;
+                    if(epoch != g_jitter_epoch) {
+                        g_jitter_epoch = epoch;
+                        g_jitter_dx = jitter_axis(epoch, 0x1u, IDLE_JITTER_DX_MIN, IDLE_JITTER_DX_MAX);
+                        g_jitter_dy = jitter_axis(epoch, 0x2u, IDLE_JITTER_DY_MIN, IDLE_JITTER_DY_MAX);
+                    }
+                    idle_dx = g_jitter_dx;
+                    idle_dy = g_jitter_dy;
+                }
             } else {
                 flags &= ~((uint8_t)DISP_IDLE);
             }
 
             local_state->contrast = contrast;
             local_state->flags = flags;
+            local_state->idle_dx = idle_dx;
+            local_state->idle_dy = idle_dy;
         }
     }
 }
@@ -1088,9 +1125,24 @@ uint16_t keymap_key_to_keycode(uint8_t layer, keypos_t key) {
 
 void update_displays(enum refresh_mode mode) {
     const poly_sync_t* local_state = get_local_state();
-    if(local_state->contrast<=DISP_OFF || (local_state->flags&DISP_IDLE)!=0) {
+    const bool idle = (local_state->flags & DISP_IDLE) != 0;
+    // Anti-burn-in jitter: while idle we normally do NOT re-render — kdisp_idle()
+    // just pulses the existing buffer. Re-render only when the jitter offset
+    // changed, to relocate the legend to its new spot for this pulse cycle.
+    static int8_t s_last_dx = 0, s_last_dy = 0;
+    if(idle) {
+        if(local_state->idle_dx == s_last_dx && local_state->idle_dy == s_last_dy) {
+            return;
+        }
+    } else if(local_state->contrast<=DISP_OFF) {
         return;
     }
+    // The offset is applied only while idle; a normal render is always centred.
+    const int8_t draw_ox = idle ? local_state->idle_dx : 0;
+    const int8_t draw_oy = idle ? local_state->idle_dy : 0;
+    s_last_dx = draw_ox;
+    s_last_dy = draw_oy;
+    kdisp_set_draw_offset(draw_ox, draw_oy);
 
     //uint8_t layer = get_highest_layer(layer_state);
     const poly_layer_t* local_layer = get_local_layer();
@@ -1131,7 +1183,7 @@ void update_displays(enum refresh_mode mode) {
                     uint16_t highest_kc = poly_keycode_at(layer,r + offset,c); //if we encounter a transparent key go down one layer (but only one!)
                     keycode = (highest_kc == KC_TRNS) ? poly_keycode_at(get_highest_layer(local_layer->layer&~(1<<layer)),r + offset,c) : highest_kc;
                     kdisp_enable(true);
-                    kdisp_set_contrast(local_state->contrast-1);
+                    kdisp_set_contrast(idle ? IDLE_JITTER_REDRAW_CONTRAST : (uint8_t)(local_state->contrast-1));
                     if(keycode!=KC_TRNS) {
                         int16_t lang_idx = lang_index_for_keycode(keycode);
                         if (lang_idx >= 0) {
@@ -1193,6 +1245,7 @@ void update_displays(enum refresh_mode mode) {
             sr_shift_once_latch();
         }
     }
+    kdisp_set_draw_offset(0, 0);   // clear the jitter offset so non-idle renders stay centred
 }
 
 // Converts brightness level 0-7 to pulsating contrast value for idle display animation.
@@ -1767,6 +1820,8 @@ bool display_wakeup(keyrecord_t* record) {
         local_state->contrast = get_user_brightness();
         local_state->flags &= ~((uint8_t)DISP_IDLE);
         local_state->flags |= STATUS_DISP_ON;
+        local_state->idle_dx = 0;   // recentre the legend on wake (drop any jitter offset)
+        local_state->idle_dy = 0;
         update_performed();
         request_disp_refresh();
     }
@@ -1867,6 +1922,7 @@ void keyboard_post_init_user(void) {
     local_state->lang = ee.lang;
     local_state->contrast = ee.brightness;
     note_user_brightness(ee.brightness);
+    note_idle_style(ee.idle_style);
 #ifdef RGB_MATRIX_ENABLE
     local_state->flags = set_flag(STATUS_DISP_ON, RGB_ON, rgb_matrix_is_enabled());
 #else
@@ -1957,6 +2013,8 @@ void poly_suspend(void) {
     local_state->overlay_flags = flag_off(local_state->overlay_flags, DISPLAY_OVERLAYS);
     local_state->flags &= ~((uint8_t)STATUS_DISP_ON) & ~((uint8_t)DISP_IDLE) & ~((uint8_t)IDLE_TRANSITION);// & ~((uint8_t)RGB_ON);
     local_state->contrast = DISP_OFF;
+    local_state->idle_dx = 0;
+    local_state->idle_dy = 0;
 }
 
 // Suspends keyboard: suspends power down, disables RGB, calls housekeeping, resets update timer.
@@ -1997,6 +2055,8 @@ void suspend_wakeup_init_kb(void) {
     local_state->flags |= STATUS_DISP_ON;
     local_state->flags &= ~((uint8_t)DISP_IDLE);
     local_state->contrast = get_user_brightness();
+    local_state->idle_dx = 0;
+    local_state->idle_dy = 0;
     set_last_update(0);
 
     //rgb_matrix_reload_from_eeprom();

--- a/keyboards/handwired/polykybd/poly_keymap.c
+++ b/keyboards/handwired/polykybd/poly_keymap.c
@@ -1123,6 +1123,54 @@ uint16_t keymap_key_to_keycode(uint8_t layer, keypos_t key) {
     return poly_keycode_at(layer, key.row, key.col);
 }
 
+// Clamp a desired idle jitter offset so the legend's bounding box (measured at the
+// draw origin ox/oy) stays inside the visible window [BUFFER_X, BUFFER_X+SCREEN_WIDTH-1]
+// x [0, SCREEN_HEIGHT-1]. Glyph-driven, so it is correct for any script: a narrow
+// Latin letter may travel far, a full-width CJK glyph barely or not at all (clamped
+// to 0 in that axis) — the legend is never partially cut off at any offset.
+static void clamp_idle_offset(const uint32_t* text, int8_t ox, int8_t oy, int8_t* dx, int8_t* dy) {
+    int8_t xmin, xmax, ymin, ymax;
+    kdisp_gfx_text_bbox(ALL_FONTS, ALL_FONT_SIZE, text, &xmin, &xmax, &ymin, &ymax);
+    int16_t axmin = ox + xmin, axmax = ox + xmax;   // glyph extent at the un-jittered origin
+    int16_t aymin = oy + ymin, aymax = oy + ymax;
+    int16_t lo, hi;
+    lo = (int16_t)BUFFER_X - axmin;                          // keep left edge >= BUFFER_X
+    hi = (int16_t)(BUFFER_X + SCREEN_WIDTH - 1) - axmax;     // keep right edge <= last visible col
+    *dx = (hi < lo) ? 0 : (int8_t)PK_MIN(PK_MAX((int16_t)*dx, lo), hi);
+    lo = -aymin;                                             // keep top >= 0
+    hi = (int16_t)(SCREEN_HEIGHT - 1) - aymax;               // keep bottom <= last visible row
+    *dy = (hi < lo) ? 0 : (int8_t)PK_MIN(PK_MAX((int16_t)*dy, lo), hi);
+}
+
+// Idle (anti-burn-in) per-key render: draws ONLY the resting normal legend — no
+// shift/AltGr preview, no overlay image, no tab/MRU chrome — relocated by the synced
+// jitter offset, clamped per glyph so it is always fully visible. Keeps all idle-mode
+// rendering in one place instead of threading an "idle" flag through the awake path.
+static void render_idle_key(uint16_t keycode, led_t state) {
+    const poly_sync_t* local_state = get_local_state();
+    uint32_t unimap[2] = {0, 0};
+    const uint32_t* text = to_static_text(keycode, state);
+    if (text == NULL) {
+        // letter / symbol legends come from the language table (unshifted, no AltGr)
+        text = translate_keycode(local_state->lang, keycode, false, state.caps_lock);
+    }
+    if (text == NULL && (keycode & QK_UNICODEMAP_PAIR) == QK_UNICODEMAP_PAIR) {
+        uint16_t chr = state.caps_lock ? QK_UNICODEMAP_PAIR_GET_SHIFTED_INDEX(keycode)
+                                       : QK_UNICODEMAP_PAIR_GET_UNSHIFTED_INDEX(keycode);
+        unimap[0] = unicode_map[chr];
+        text = unimap;
+    }
+    kdisp_set_buffer(0x00);
+    if (text != NULL && text[0] != 0) {
+        int8_t dx = local_state->idle_dx, dy = local_state->idle_dy;
+        clamp_idle_offset(text, BUFFER_X, 23, &dx, &dy);
+        kdisp_set_draw_offset(dx, dy);
+        kdisp_write_gfx_text(ALL_FONTS, ALL_FONT_SIZE, BUFFER_X, 23, text);
+        kdisp_set_draw_offset(0, 0);
+    }
+    kdisp_send_buffer();
+}
+
 void update_displays(enum refresh_mode mode) {
     const poly_sync_t* local_state = get_local_state();
     const bool idle = (local_state->flags & DISP_IDLE) != 0;
@@ -1137,12 +1185,11 @@ void update_displays(enum refresh_mode mode) {
     } else if(local_state->contrast<=DISP_OFF) {
         return;
     }
-    // The offset is applied only while idle; a normal render is always centred.
-    const int8_t draw_ox = idle ? local_state->idle_dx : 0;
-    const int8_t draw_oy = idle ? local_state->idle_dy : 0;
-    s_last_dx = draw_ox;
-    s_last_dy = draw_oy;
-    kdisp_set_draw_offset(draw_ox, draw_oy);
+    // Remember the offset we render this pass so the guard above can skip until it
+    // changes again. The offset itself is applied per key by render_idle_key (clamped
+    // to each glyph's bounds); awake rendering is always centred.
+    s_last_dx = idle ? local_state->idle_dx : 0;
+    s_last_dy = idle ? local_state->idle_dy : 0;
 
     //uint8_t layer = get_highest_layer(layer_state);
     const poly_layer_t* local_layer = get_local_layer();
@@ -1185,6 +1232,10 @@ void update_displays(enum refresh_mode mode) {
                     kdisp_enable(true);
                     kdisp_set_contrast(idle ? IDLE_JITTER_REDRAW_CONTRAST : (uint8_t)(local_state->contrast-1));
                     if(keycode!=KC_TRNS) {
+                        if(idle) {
+                            // Idle shows only the resting legend, jittered + clamped.
+                            render_idle_key(keycode, state);
+                        } else {
                         int16_t lang_idx = lang_index_for_keycode(keycode);
                         if (lang_idx >= 0) {
                             // Language layer: country flag + tiny language code
@@ -1234,6 +1285,7 @@ void update_displays(enum refresh_mode mode) {
                             kdisp_write_gfx_text_cy(ALL_FONTS, ALL_FONT_SIZE, BUFFER_X, 23, text, KDISP_CY_DEFAULT);
                         }
                         kdisp_send_buffer();
+                        }
                         }
                     }
                 }

--- a/keyboards/handwired/polykybd/state.c
+++ b/keyboards/handwired/polykybd/state.c
@@ -21,6 +21,9 @@ static bool g_brightness_dirty = false;   // lang + brightness need a flush
 // snapshot instead of the live contrast.
 static uint8_t g_user_brightness = FULL_BRIGHT;
 
+// Active idle (anti-burn-in) display style — persisted alongside lang+brightness.
+static uint8_t g_idle_style = IDLE_STYLE_PULSE;
+
 static bool          g_def_layer_dirty = false;
 static layer_state_t g_def_layer_pending = 0;
 
@@ -165,9 +168,10 @@ void copy_global_latin_table(const latin_sync_t* value) {
 }
 
 
-// Writes only lang+brightness+unused (4 bytes) to EEPROM.
+// Writes only lang+brightness+idle_style+unused (4 bytes) to EEPROM.
 void save_user_settings(void) {
-    const poly_eeconf_t ee = { .lang = l_state.lang, .brightness = (uint8_t)(~g_user_brightness), .unused = 0 };
+    const poly_eeconf_t ee = { .lang = l_state.lang, .brightness = (uint8_t)(~g_user_brightness),
+                               .idle_style = g_idle_style, .unused = 0 };
     eeconfig_update_user_datablock(&ee, 0, offsetof(poly_eeconf_t, latin_ex));
 }
 
@@ -214,6 +218,9 @@ poly_eeconf_t load_user_eeconf(void) {
     ee.brightness = ~ee.brightness;
     if(ee.brightness>FULL_BRIGHT) {
         ee.brightness = FULL_BRIGHT;
+    }
+    if(ee.idle_style >= IDLE_STYLE_COUNT) {
+        ee.idle_style = IDLE_STYLE_PULSE;   // unwritten/garbage EEPROM -> safe default
     }
     return ee;
 }
@@ -270,6 +277,26 @@ uint8_t get_user_brightness(void) {
 // Marks settings (lang + brightness) as needing an EEPROM write at the next flush.
 void mark_settings_dirty(void) {
     g_brightness_dirty = true;
+}
+
+// The active idle (anti-burn-in) display style.
+uint8_t get_idle_style(void) {
+    return g_idle_style;
+}
+
+// Sets the idle style and marks the settings block dirty (flushed at the next
+// suspend / store). Out-of-range values are ignored.
+void set_idle_style(uint8_t style) {
+    if (style >= IDLE_STYLE_COUNT) {
+        return;
+    }
+    g_idle_style = style;
+    g_brightness_dirty = true;
+}
+
+// Records the idle style without marking settings dirty (boot-time EEPROM load).
+void note_idle_style(uint8_t style) {
+    g_idle_style = (style < IDLE_STYLE_COUNT) ? style : IDLE_STYLE_PULSE;
 }
 
 // Defers a default-layer EEPROM write — safe to call from split sync handlers.

--- a/keyboards/handwired/polykybd/state.h
+++ b/keyboards/handwired/polykybd/state.h
@@ -7,6 +7,15 @@
 #include "quantum.h"
 #include "mru.h"
 
+// Idle (anti-burn-in) display style, persisted in poly_eeconf_t.idle_style and
+// toggled over HID (cmd 28). PULSE is the legacy contrast-only breathing; JITTER
+// adds a per-cycle relocation of the legend so the lit pixels migrate over time.
+enum poly_idle_style {
+    IDLE_STYLE_PULSE  = 0,
+    IDLE_STYLE_JITTER = 1,
+    IDLE_STYLE_COUNT
+};
+
 typedef struct _poly_layer_t {
     uint32_t      crc32;
     layer_state_t layer;
@@ -27,6 +36,12 @@ typedef struct _poly_sync_t {
     uint8_t  emj_page;
     // Language layer page — synced so both halves show the same page of languages.
     uint8_t  lang_page;
+    // Anti-burn-in idle jitter offset for the rendered legend (signed pixels).
+    // 0/0 in the legacy pulse style; the master picks a new small random offset
+    // each pulse cycle in JITTER style and syncs it so both halves relocate in
+    // lockstep. update_displays() re-renders only when these change.
+    int8_t   idle_dx;
+    int8_t   idle_dy;
 } poly_sync_t;
 
 typedef struct _poly_last_t {
@@ -42,13 +57,19 @@ typedef struct _latin_sync_t {
 typedef struct _poly_eeconf_t {
     uint8_t lang;
     uint8_t brightness;
-    uint16_t unused;
+    uint8_t idle_style;   // enum poly_idle_style (carved out of the former uint16_t unused)
+    uint8_t unused;
     uint8_t latin_ex[26];
     // MRU recents for the emoji / language selection layers. Persisted only on a
     // power-suspension event (and the host save command), and only when dirty.
     // Emoji are bit-packed 14-bit category|offset codes; languages are LANG_* bytes.
     uint8_t  mru_emoji[MRU_EMOJI_PACKED];
     uint8_t  mru_lang[MRU_CAP];
+    // Restores the trailing byte the former `uint16_t unused` added via 2-byte
+    // struct alignment, so splitting it into idle_style+unused keeps sizeof at
+    // EECONFIG_USER_DATA_SIZE and leaves latin_ex/mru at their original offsets
+    // (existing EEPROMs stay readable).
+    uint8_t  reserved;
 } poly_eeconf_t;
 
 
@@ -136,6 +157,16 @@ uint8_t get_user_brightness(void);
 
 // Marks settings (lang + brightness) as needing an EEPROM write at the next flush.
 void mark_settings_dirty(void);
+
+// The active idle (anti-burn-in) display style — see enum poly_idle_style.
+uint8_t get_idle_style(void);
+
+// Sets the idle style and marks settings dirty (deferred EEPROM write). Out-of-range
+// values are ignored. Used by the HID toggle (cmd 28).
+void set_idle_style(uint8_t style);
+
+// Records the idle style without marking settings dirty (boot-time EEPROM load).
+void note_idle_style(uint8_t style);
 
 // Queues a default-layer EEPROM write — safe from a sync handler. Written at the next flush.
 void defer_default_layer_save(layer_state_t def_layer);


### PR DESCRIPTION
## Problem

When the keyboard idles, the legacy "pulse" style only modulates each keycap's SSD1306 **contrast register** — the buffer is never re-rendered, so the **same legend pixels stay lit** every cycle. That's an OLED burn-in risk.

## Change

Add a second, EEPROM-selectable idle style. **Pulse stays the default and is byte-for-byte unchanged.**

- **`IDLE_STYLE_PULSE` (0, default):** legacy contrast-only breathing.
- **`IDLE_STYLE_JITTER` (1):** keeps the pulse, but once per ~15 s pulse cycle the master picks a small bounded random offset and **relocates the legend** so the lit pixels migrate. The legend stays readable (preserves the "glance and resume typing" hint); the move lands in the dark part of the cycle.

### Mechanics
- `housekeeping_task_user()` (master only) computes the per-cycle offset into `poly_sync_t.idle_dx/idle_dy`, **synced to the slave on the existing per-300 ms poly sync** — both halves relocate in lockstep with no extra UART traffic.
- `update_displays()` normally early-returns while idle; in jitter it re-renders **only when the offset changed** (static last-offset guard), at a low fixed contrast; `kdisp_idle()` resumes the pulse next tick.
- Offset is applied globally via `kdisp_set_draw_offset()` (added to every gfx text draw, reset to 0 after) — so **text legends** jitter; full-bleed **overlay images** do not (they'd clip) — a deliberate limit.
- Offsets reset on every wake/suspend path so a refresh right after waking is centred. Bounds (`IDLE_JITTER_*` in `config.h`) are conservative so single-char legends never clip; `SET_PIXEL_CLIPPED` is the backstop.

### Protocol / persistence
- HID **cmd 28** `GET/SET_IDLE_STYLE` (`0xFF` queries, else sets; out-of-range NACKs). `PROTOCOL_VERSION` → **4**, `FW_VERSION` → **0.8.26**.
- Persisted in `poly_eeconf_t.idle_style` (carved from the former `uint16_t unused`; a trailing `reserved` byte keeps `sizeof` and field offsets, so existing EEPROMs stay readable).

A "Matrix-style" idle animation was considered but shelved — it defeats the glance-to-resume hint; jitter was chosen as the default-preserving, legibility-preserving fix.

## Testing
- `split72:default` and `split42:default` both build clean (ARM toolchain in the dev container).
- A v4-gated round-trip HIL test is added in `polykybd-ctnd`; the host toggle lands in `PolyKybdHost`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CuPnCAA6syPsWqXx6gPgHj

---
_Generated by [Claude Code](https://claude.ai/code/session_01CuPnCAA6syPsWqXx6gPgHj)_

## Summary by Sourcery

Introduce a configurable idle anti-burn-in display style that jitters legends during idle while preserving the legacy pulse behavior as the default.

New Features:
- Add a selectable idle display style enum with a new JITTER mode that periodically repositions legends to reduce OLED burn-in.
- Expose a HID command to get and set the idle display style, persisted in EEPROM and synchronized across split halves.

Enhancements:
- Update display rendering to support per-cycle jitter offsets with minimal redraws and a global draw offset mechanism for text rendering.
- Extend split sync and power-state handling to carry and reset idle jitter offsets so legends recenter on wake and suspend.
- Document the idle anti-burn-in behavior and new protocol version in the project documentation.

Build:
- Bump firmware and protocol versions to advertise the new idle-style HID command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an idle “jitter” anti-burn-in display mode, letting you choose between legacy pulse and jitter styles.
  * Introduced HID protocol v4 support to query and set the idle style; the selection is saved to the device.
* **Bug Fixes**
  * Improved jitter legend rendering so it stays fully visible, with offsets reset appropriately when idle is stopped and across wake/suspend transitions.
* **Documentation**
  * Updated protocol and anti-burn-in behavior documentation, including the new v4 idle-style command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->