### PR TITLE
polykybd: fix split sync give-up mis-classified as success (slave stuck in idle pulse)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,6 +347,52 @@ local_state->flags &= ~((uint8_t)STATUS_DISP_ON) & ~((uint8_t)DISP_IDLE) & ~((ui
 
 ---
 
+### Bug: slave half stuck in the idle pulsing frame — keypress/shift won't wake it, only a brightness key does
+
+**Symptom (field, 2026-06-18)**: After the displays went into the idle *pulsing*
+animation, the **slave** half froze on one pulse frame ("some keycaps off, others
+very dim") and **did not update at all** — neither a keypress nor Shift brought it
+back. The master woke normally and kept logging key events. Pressing a manual
+brightness key restored the slave.
+
+**Root cause**: `send_to_bridge()` returns the slave's reply ack **byte**, or
+`SYNC_CRC32_ERR` once it exhausts its retries. **All three returns are non-zero**
+(`SYNC_ACK 0xCA`, `SYNC_ACK_SIG 0x4D`, `SYNC_CRC32_ERR 0x35`), but three callers in
+`poly_keymap.c` `sync_and_refresh_displays()` tested it as a bool —
+`if(!send_to_bridge(...))`. `!0x35 == false`, so the failure branch
+(`state_diff/layer_diff = false`, "failed to send") was **dead code**: on a
+give-up the master fell through, ran `copy_global_state()`/`copy_global_layer()`,
+**advanced `global` to `local`**, and so produced no diff next pass → the lost
+sync was **never re-fired**. (The accompanying comment block — "the diff IS the
+retry queue; global only advances on a successful sync" — described the *intended*
+behaviour that the `!` test silently defeated.)
+
+Why it only bit the *pulsing→awake* transition: the pulsing contrast changes every
+housekeeping pass, so a dropped frame is replaced by the next fresh diff and is
+invisible. **Wake-from-idle is single-shot** (`display_wakeup()` clears
+`DISP_IDLE` + restores `contrast` once). If that lone sync's give-up was
+mis-classified as success, the master stopped re-sending and the slave — which
+only pulses because the master *tells* it to, the idle math is `is_usb_host_side()`
+only — stayed on its last received pulse frame indefinitely. A brightness key
+mutates `contrast` again → a brand-new diff → fresh send → recovery (matching "the
+manual brightness control brought it back"). Also explains why no
+`USER_SYNC_POLY_DATA failed to send` line ever appeared in the logs.
+
+**Fix (2026-06-18)**: added `static inline bool sync_succeeded(uint8_t ack)`
+(`split_sync.h`, by the `SYNC_*` defines) returning `ack == SYNC_ACK || ack ==
+SYNC_ACK_SIG`, and routed all `sync_and_refresh_displays()` send sites through it
+(POLY / LAYER / LASTKEY, plus the already-correct MRU send for uniformity). A
+genuine give-up now keeps the diff so the send re-fires next pass, as the comments
+always claimed. ⚠️ Never bool-test `send_to_bridge()` directly — every return value
+is non-zero; classify it with `sync_succeeded()`.
+
+**Relevant files**:
+- `keyboards/handwired/polykybd/poly_keymap.c` — `sync_and_refresh_displays()` send sites; `display_wakeup()`, `housekeeping_task_user()` (the single-shot wake)
+- `keyboards/handwired/polykybd/split_sync.h` — `sync_succeeded()` helper + `SYNC_*` values
+- `keyboards/handwired/polykybd/bridge_helper.c` — `send_to_bridge()` (returns the ack byte / `SYNC_CRC32_ERR`)
+
+---
+
 ### Split-link integrity: wire noise, the app-level CRC32, retries, and the health counter
 
 > **RESOLVED (2026-06-16): migrated the split UART to full-duplex two-wire — the

--- a/keyboards/handwired/polykybd/poly_keymap.c
+++ b/keyboards/handwired/polykybd/poly_keymap.c
@@ -277,7 +277,7 @@ void sync_and_refresh_displays(void) {
             // stall is bounded to ~PERIODIC_SYNC_RETRIES × 40 ms (and the active
             // fw-update path skips this code entirely). No effect on the normal
             // path, where the slave ACKs on the first attempt.
-            if(!send_to_bridge(USER_SYNC_POLY_DATA, (void *)access_local_state(), sizeof(poly_sync_t), PERIODIC_SYNC_RETRIES)) {
+            if(!sync_succeeded(send_to_bridge(USER_SYNC_POLY_DATA, (void *)access_local_state(), sizeof(poly_sync_t), PERIODIC_SYNC_RETRIES))) {
                 // Failed: clear state_diff so the copy_global_state() below is
                 // SKIPPED — global stays != local, so next pass differ() is still
                 // true and re-fires the send. The diff IS the retry queue; global
@@ -297,7 +297,7 @@ void sync_and_refresh_displays(void) {
             // size) to stay within QMK's 32-transaction limit. Only the packed
             // bytes are sent (MRU_SYNC_BYTES), not the struct's crc tail padding.
             uint8_t mru_ack = send_to_bridge(USER_SYNC_OVERLAY_MAP_DATA, &mru_msg, MRU_SYNC_BYTES, PERIODIC_SYNC_RETRIES);
-            if (mru_ack == SYNC_ACK || mru_ack == SYNC_ACK_SIG) {
+            if (sync_succeeded(mru_ack)) {
                 mru_clear_sync_pending();
             } else {
                 uprint("USER_SYNC_MRU_DATA failed to send\n");
@@ -308,18 +308,18 @@ void sync_and_refresh_displays(void) {
         access_local_layer()->mods = get_mods();
         layer_diff = differ(get_local_layer(), get_global_layer(), sizeof(poly_layer_t));
         if ( layer_diff ) {
-            if(!send_to_bridge(USER_SYNC_LAYER_DATA, (void *)access_local_layer(), sizeof(poly_layer_t), PERIODIC_SYNC_RETRIES)) {
+            if(!sync_succeeded(send_to_bridge(USER_SYNC_LAYER_DATA, (void *)access_local_layer(), sizeof(poly_layer_t), PERIODIC_SYNC_RETRIES))) {
                 layer_diff = false; // failed: skip copy_global_layer() below so the diff
                                     // persists and the send re-fires next pass (see state above)
                 uprint("USER_SYNC_LAYER_DATA failed to send\n");
             }
         }
         if ( differ(get_local_last_latin(), get_global_last_latin(), sizeof(poly_last_t)) ) {
-            if(!send_to_bridge(USER_SYNC_LASTKEY_DATA, access_local_last_latin(), sizeof(poly_last_t), PERIODIC_SYNC_RETRIES)) {
+            if(sync_succeeded(send_to_bridge(USER_SYNC_LASTKEY_DATA, access_local_last_latin(), sizeof(poly_last_t), PERIODIC_SYNC_RETRIES))) {
+                copy_global_last_latin(get_local_last_latin());
+            } else {
                 // if failed to sync, do not consider it a diff and try again later
                 uprint("USER_SYNC_LASTKEY_DATA failed to send\n");
-            } else {
-                copy_global_last_latin(get_local_last_latin());
             }
         }
     } else {

--- a/keyboards/handwired/polykybd/split_sync.h
+++ b/keyboards/handwired/polykybd/split_sync.h
@@ -8,6 +8,7 @@
 #include "mru.h"     // MRU_EMOJI_PACKED / MRU_CAP used by mru_sync_t below
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #define SYNC_ACK_SIG    0b01001101
 #define SYNC_ACK        0b11001010
@@ -16,6 +17,16 @@
 typedef struct _poly_sync_reply_t {
     uint8_t ack;
 } poly_sync_reply_t;
+
+// send_to_bridge() returns the slave's reply ack byte, or SYNC_CRC32_ERR after
+// exhausting its retries. ALL of SYNC_ACK / SYNC_ACK_SIG / SYNC_CRC32_ERR are
+// non-zero, so a bare truthiness test — `if(!send_to_bridge(...))` — is NOT a
+// failure check: it is false for the failure value too, so the caller would
+// treat a give-up as success and advance its global snapshot, never re-firing
+// the lost sync. Always classify the return through this helper.
+static inline bool sync_succeeded(uint8_t ack) {
+    return ack == SYNC_ACK || ack == SYNC_ACK_SIG;
+}
 
 
 typedef struct _overlay_sync_t {


### PR DESCRIPTION
## Symptom (field, 2026-06-18)

After the displays went into the idle **pulsing** animation, the **slave** half froze on a single pulse frame ("some keycaps off, others very dim") and did not update at all — neither a keypress nor Shift woke it. The master woke normally and kept logging key events. A manual **brightness key** restored the slave.

## Root cause

`send_to_bridge()` returns the slave's reply ack **byte**, or `SYNC_CRC32_ERR` once it exhausts its retries. **All three returns are non-zero:** `SYNC_ACK` (0xCA), `SYNC_ACK_SIG` (0x4D), `SYNC_CRC32_ERR` (0x35).

Three callers in `poly_keymap.c`'s `sync_and_refresh_displays()` classified the result with a bare bool test — `if(!send_to_bridge(...))`. Since the failure value is non-zero, `!0x35 == false`, so the failure branch (`state_diff/layer_diff = false`, "failed to send") was **dead code**. On a give-up the master fell through, ran `copy_global_state()` / `copy_global_layer()`, **advanced `global` to `local`**, produced no diff next pass, and **never re-fired the lost sync**. The existing comment block ("the diff IS the retry queue; global only advances on a successful sync") described the intended behaviour the `!` test silently defeated.

Why it only bit the *pulsing → awake* transition:
- The pulsing contrast changes every housekeeping pass, so a dropped frame is replaced by the next fresh diff — invisible.
- **Wake-from-idle is single-shot** (`display_wakeup()` clears `DISP_IDLE` + restores `contrast` once). If that lone sync's give-up was mis-classified as success, the master stopped re-sending and the slave — which only pulses because the master tells it to (the idle math is `is_usb_host_side()` only) — stayed on its last received pulse frame indefinitely.
- A brightness key mutates `contrast` again → a brand-new diff → fresh send → recovery (matching "the manual brightness control brought it back").

This also explains why no `USER_SYNC_POLY_DATA failed to send` line ever appeared in the logs.

## Fix

- `split_sync.h`: add `static inline bool sync_succeeded(uint8_t ack)` (next to the `SYNC_*` defines) returning `ack == SYNC_ACK || ack == SYNC_ACK_SIG`, with a comment about the non-zero-return trap.
- `poly_keymap.c`: route all four `sync_and_refresh_displays()` send sites (POLY / LAYER / LASTKEY, plus the already-correct MRU send for uniformity) through `sync_succeeded()`. A genuine give-up now keeps the diff so the send re-fires next pass.
- `CLAUDE.md`: record the bug under "Investigations in progress".

⚠️ Never bool-test `send_to_bridge()` directly — every return value is non-zero; classify it with `sync_succeeded()`.

## Verification

- `handwired/polykybd/split72:default` compiles and links cleanly (ARM toolchain + qmk + submodules set up in the build container). The change is in shared code, so `split42` gets it too.
- Diagnosis is read-and-reason + clean build; the intermittent wake-loss was **not** reproduced on hardware here. Suggested confirmation: let the keyboard idle into pulsing, then verify a keypress reliably wakes the **slave** half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XQ1kfG2WuuYJo5vr1pYRM

---
_Generated by [Claude Code](https://claude.ai/code/session_014XQ1kfG2WuuYJo5vr1pYRM)_

## Summary by Sourcery

Ensure split display sync failures are correctly detected so the master keeps retrying instead of treating a give-up as success, preventing the slave half from getting stuck on a stale idle pulse frame.

Bug Fixes:
- Correctly classify send_to_bridge() return codes as success or failure in display sync paths so failed sync attempts do not advance global state or suppress retries, avoiding the slave display freezing in the idle pulsing frame.

Enhancements:
- Introduce a shared sync_succeeded() helper around split sync ACK values to standardize result handling across polykybd sync call sites and reduce future misclassification bugs.

Documentation:
- Document the idle-pulse slave-freeze bug, its root cause, and the new sync_succeeded() convention in CLAUDE.md for future reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a split keyboard display freeze where one half becomes unresponsive to key presses or Shift input. Improper handling of synchronization error responses from the keyboard slave was preventing proper recovery mechanisms, which are now correctly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->