### PR TITLE
Brightness: host-auto vs manual mode (volatile daylight + KC_DAUTO toggle / protocol v5)

### DIFF
--- a/keyboards/handwired/polykybd/base/com.h
+++ b/keyboards/handwired/polykybd/base/com.h
@@ -3,6 +3,13 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+// Flags for HID SET_BRIGHTNESS (cmd 13), in data[HID_DATA_IDX+1]. 0 (the value
+// a pre-flag host leaves there) == a plain persisted set, preserving the old
+// behaviour. See hid_com.c case 13 and state.c brightness helpers.
+#define BR_FLAG_VOLATILE  (1 << 0)  // daylight/auto value: applied only in auto mode, never persisted
+#define BR_FLAG_AUTO_ON   (1 << 1)  // engage host-driven (auto) brightness mode
+#define BR_FLAG_AUTO_OFF  (1 << 2)  // leave auto mode, revert to persisted manual brightness
+
 enum poly_flag {
     STATUS_DISP_ON      = 1 << 0,
     IDLE_TRANSITION     = 1 << 1,

--- a/keyboards/handwired/polykybd/config.h
+++ b/keyboards/handwired/polykybd/config.h
@@ -103,7 +103,12 @@
 //     that poisoned later commands' reads on the host.
 // v4: adds GET/SET_IDLE_STYLE (cmd 28) — selects the idle (anti-burn-in) display
 //     style (0 = legacy pulse, 1 = jitter). Persisted in EEPROM; host toggle.
-#define PROTOCOL_VERSION 4
+// v5: SET_BRIGHTNESS (cmd 13) gains a flags byte (data[HID_DATA_IDX+1]):
+//     VOLATILE (daylight/auto value, applied only in auto mode, never persisted)
+//     + AUTO_ON / AUTO_OFF to engage/leave host-driven brightness. flags==0 is
+//     the legacy persisted set, so older hosts keep working. The keyboard's
+//     KC_DAUTO key toggles auto mode locally.
+#define PROTOCOL_VERSION 5
 
 #define FULL_BRIGHT 50
 #define MIN_BRIGHT 1

--- a/keyboards/handwired/polykybd/hid_com.c
+++ b/keyboards/handwired/polykybd/hid_com.c
@@ -410,10 +410,32 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                 break;
             case 13: //set brightness
                 if ( data[HID_DATA_IDX] <= FULL_BRIGHT) {
-                    set_user_brightness(data[HID_DATA_IDX]);
+                    // data[HID_DATA_IDX]   = brightness level (0..FULL_BRIGHT)
+                    // data[HID_DATA_IDX+1] = flags (0 from pre-flag hosts ->
+                    //                        plain persisted set, as before).
+                    uint8_t br_flags = data[HID_DATA_IDX + 1];
+                    if (br_flags & BR_FLAG_AUTO_OFF) {
+                        // Leave host-auto; revert to the persisted manual value.
+                        // The level byte is ignored on an AUTO_OFF message.
+                        set_brightness_auto_mode(false);
+                    } else {
+                        if (br_flags & BR_FLAG_AUTO_ON) {
+                            set_brightness_auto_mode(true);
+                        }
+                        if (br_flags & BR_FLAG_VOLATILE) {
+                            // Daylight/auto update: applied only while auto mode
+                            // is engaged, never persisted.
+                            set_auto_brightness_value(data[HID_DATA_IDX]);
+                        } else {
+                            // Explicit set (host slider / polyctl): persists and
+                            // leaves auto mode, exactly like a keyboard key.
+                            set_user_brightness(data[HID_DATA_IDX]);
+                        }
+                    }
                     memset(data, 0, length);
                     memcpy(data, "P\x0d.", 3);
-                    uprintf("Set brightness to: %u.\n", local_state->contrast);
+                    uprintf("Set brightness to: %u (flags 0x%x, auto %u).\n",
+                            local_state->contrast, br_flags, get_brightness_auto_mode());
                 } else {
                     uprintf("Refused to set brightness to: %u.\n", data[HID_DATA_IDX]);
                     memset(data, 0, length);
@@ -454,10 +476,10 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                         suspend_wakeup_init_kb();
                     } else {
                         if (local_state->flags & DISP_IDLE) {
-                            // Contrast is cycling 0-49 during pulsing; restore the user
-                            // brightness so display_wakeup() conditions don't leave the
-                            // display dark.
-                            local_state->contrast = get_user_brightness();
+                            // Contrast is cycling 0-49 during pulsing; restore the active
+                            // brightness (host-auto value or user brightness) so
+                            // display_wakeup() conditions don't leave the display dark.
+                            local_state->contrast = get_active_brightness();
                         }
                         local_state->flags &= ~((uint8_t)DISP_IDLE);
                         local_state->flags |= STATUS_DISP_ON;

--- a/keyboards/handwired/polykybd/hid_com.c
+++ b/keyboards/handwired/polykybd/hid_com.c
@@ -418,19 +418,21 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                         // Leave host-auto; revert to the persisted manual value.
                         // The level byte is ignored on an AUTO_OFF message.
                         set_brightness_auto_mode(false);
-                    } else {
+                    } else if (br_flags & BR_FLAG_VOLATILE) {
                         if (br_flags & BR_FLAG_AUTO_ON) {
                             set_brightness_auto_mode(true);
                         }
-                        if (br_flags & BR_FLAG_VOLATILE) {
-                            // Daylight/auto update: applied only while auto mode
-                            // is engaged, never persisted.
-                            set_auto_brightness_value(data[HID_DATA_IDX]);
-                        } else {
-                            // Explicit set (host slider / polyctl): persists and
-                            // leaves auto mode, exactly like a keyboard key.
-                            set_user_brightness(data[HID_DATA_IDX]);
-                        }
+                        // Daylight/auto update: applied only while auto mode
+                        // is engaged, never persisted.
+                        set_auto_brightness_value(data[HID_DATA_IDX]);
+                    } else if (br_flags & BR_FLAG_AUTO_ON) {
+                        // Engage auto mode without turning this packet into a
+                        // persisted manual write (which would clear auto again).
+                        set_brightness_auto_mode(true);
+                    } else {
+                        // Explicit set (host slider / polyctl): persists and
+                        // leaves auto mode, exactly like a keyboard key.
+                        set_user_brightness(data[HID_DATA_IDX]);
                     }
                     memset(data, 0, length);
                     memcpy(data, "P\x0d.", 3);

--- a/keyboards/handwired/polykybd/keycode_helper.c
+++ b/keyboards/handwired/polykybd/keycode_helper.c
@@ -137,6 +137,7 @@ const uint32_t* keycode_to_static_text(uint16_t keycode, led_t state, uint8_t st
         case KC_DHLF:                       return U"  " PRIVATE_DISP_HALF;
         case KC_DMIN:                       return U"  " PRIVATE_DISP_DARK;
         case KC_DMAX:                       return U"  " PRIVATE_DISP_BRIGHT;
+        case KC_DAUTO:                      return U" Auto";
         case KC_LANG:                       return (state_flags & MORE_TEXT) != 0 ? U"Lang" : PRIVATE_WORLD;
         case SH_TOGG:                       return U"SwpH";
         case QK_MAKE:                       return U"Make";

--- a/keyboards/handwired/polykybd/keycode_helper.h
+++ b/keyboards/handwired/polykybd/keycode_helper.h
@@ -59,8 +59,12 @@ enum my_keycodes {
       for idx in range(10):
           cog.out(f"KC_LAT{idx}, ")
     ]]]*/
-    KC_LAT0, KC_LAT1, KC_LAT2, KC_LAT3, KC_LAT4, KC_LAT5, KC_LAT6, KC_LAT7, KC_LAT8, KC_LAT9, 
+    KC_LAT0, KC_LAT1, KC_LAT2, KC_LAT3, KC_LAT4, KC_LAT5, KC_LAT6, KC_LAT7, KC_LAT8, KC_LAT9,
     //[[[end]]]
+    // Toggle host-driven (daylight/auto) display brightness vs. manual control.
+    // Appended at the end of the QK_KB_0 range so existing keycode values (incl.
+    // KC_LAT*) and the QK_USER_0-based KCL_* range below are NOT renumbered.
+    KC_DAUTO,
     /*[[[cog
         for lang in languages:
             if lang == "ENUS":

--- a/keyboards/handwired/polykybd/poly_keymap.c
+++ b/keyboards/handwired/polykybd/poly_keymap.c
@@ -244,7 +244,7 @@ void sync_and_refresh_displays(void) {
 
         const bool back_from_idle_transition = flag_turned_on(local_flags, global_flags, IDLE_TRANSITION);
         if (back_from_idle_transition) {
-            access_local_state()->contrast = get_user_brightness();
+            access_local_state()->contrast = get_active_brightness();
         }
 
         if(flags!=local_flags) {
@@ -467,7 +467,7 @@ void housekeeping_task_user(void) {
 
             if(elapsed_time_since_update > FADE_OUT_TIME && contrast >= MIN_BRIGHT && (flags & DISP_IDLE)==0) {
                 int32_t time_after = elapsed_time_since_update - FADE_OUT_TIME;
-                int16_t brightness = ((FADE_TRANSITION_TIME - time_after) * get_user_brightness()) / FADE_TRANSITION_TIME;
+                int16_t brightness = ((FADE_TRANSITION_TIME - time_after) * get_active_brightness()) / FADE_TRANSITION_TIME;
 
                 //transition to pulsing mode
                 if(brightness<=MIN_BRIGHT) {
@@ -1585,6 +1585,15 @@ void post_process_record_user(uint16_t keycode, keyrecord_t* record) {
         case KC_DBRI:
             inc_brightness();
             break;
+        case KC_DAUTO:
+            // Toggle host-driven (daylight/auto) brightness vs. manual control.
+            // Guard on press: the surrounding switch runs on press AND release,
+            // so an unguarded toggle would cancel itself.
+            if (record->event.pressed) {
+                toggle_brightness_auto_mode();
+                request_disp_refresh();
+            }
+            break;
         case KC_STORE_EE:
             // Manual "commit everything to EEPROM" — for users who want to be
             // sure their changes survive a hard power-cut without suspending.
@@ -1869,7 +1878,7 @@ bool display_wakeup(keyrecord_t* record) {
         if(local_state->contrast==DISP_OFF && (local_state->flags&DEAD_KEY_ON_WAKEUP)!=0) {
             accept_keypress = get_time_since_last_update()<= TURN_OFF_TIME;
         }
-        local_state->contrast = get_user_brightness();
+        local_state->contrast = get_active_brightness();
         local_state->flags &= ~((uint8_t)DISP_IDLE);
         local_state->flags |= STATUS_DISP_ON;
         local_state->idle_dx = 0;   // recentre the legend on wake (drop any jitter offset)
@@ -2106,7 +2115,7 @@ void suspend_wakeup_init_kb(void) {
     poly_sync_t* local_state = access_local_state();
     local_state->flags |= STATUS_DISP_ON;
     local_state->flags &= ~((uint8_t)DISP_IDLE);
-    local_state->contrast = get_user_brightness();
+    local_state->contrast = get_active_brightness();
     local_state->idle_dx = 0;
     local_state->idle_dy = 0;
     set_last_update(0);

--- a/keyboards/handwired/polykybd/poly_keymap.c
+++ b/keyboards/handwired/polykybd/poly_keymap.c
@@ -1587,12 +1587,10 @@ void post_process_record_user(uint16_t keycode, keyrecord_t* record) {
             break;
         case KC_DAUTO:
             // Toggle host-driven (daylight/auto) brightness vs. manual control.
-            // Guard on press: the surrounding switch runs on press AND release,
-            // so an unguarded toggle would cancel itself.
-            if (record->event.pressed) {
-                toggle_brightness_auto_mode();
-                request_disp_refresh();
-            }
+            // This switch is inside `if (!record->event.pressed)`, so it already
+            // runs once per keypress (on release) — no extra guard needed.
+            toggle_brightness_auto_mode();
+            request_disp_refresh();
             break;
         case KC_STORE_EE:
             // Manual "commit everything to EEPROM" — for users who want to be

--- a/keyboards/handwired/polykybd/split42/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/split42/keymaps/default/keymap.c
@@ -148,7 +148,7 @@ const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      */
     [_SL] = LAYOUT_crkbd(
         KC_DDIM, KC_DMIN, KC_D1Q,  KC_DHLF, KC_D3Q,  KC_DMAX,
-        KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_DBRI,
+        KC_DAUTO,KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_DBRI,
         KC_NO,   KC_L0,   KC_L1,   KC_L2,   KC_L3,   KC_L4,
         KC_BASE, LBL_TEXT,KC_TOGMODS,
         KC_NO,   KC_NO,   KC_NO,   KC_NO,   QK_MAKE, QK_BOOT,

--- a/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
+++ b/keyboards/handwired/polykybd/split72/keymaps/default/keymap.c
@@ -221,7 +221,7 @@ const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     //Settings Layer
     [_SL] = LAYOUT_left_right_stacked(
         KC_DDIM,    KC_DMIN,    KC_D1Q,     KC_DHLF,    KC_D3Q,     KC_DMAX,    KC_DBRI,
-        KC_NO,      KC_NO,      KC_NO,      KC_NO,      KC_NO,      KC_NO,      KC_NO,
+        KC_DAUTO,   KC_NO,      KC_NO,      KC_NO,      KC_NO,      KC_NO,      KC_NO,
         KC_NO,      KC_L0,      KC_L1,      KC_L2,      KC_L3,      KC_L4,      KC_NO,      _______,
         KC_NO,      KC_NO,      KC_NO,      KC_NO,      KC_NO,      KC_NO,      KC_NO,      QK_RBT,
         KC_BASE,    LBL_TEXT,   KC_TOGMODS, KC_TOGTEXT,             KC_NO,      QK_MAKE,    QK_BOOT,

--- a/keyboards/handwired/polykybd/state.c
+++ b/keyboards/handwired/polykybd/state.c
@@ -24,6 +24,16 @@ static uint8_t g_user_brightness = FULL_BRIGHT;
 // Active idle (anti-burn-in) display style — persisted alongside lang+brightness.
 static uint8_t g_idle_style = IDLE_STYLE_PULSE;
 
+// Host-driven (daylight/auto) brightness mode. While engaged, the keyboard
+// applies the host's VOLATILE brightness updates and restores to the last auto
+// value after idle/wake — but that value is NEVER persisted to EEPROM. Any
+// deliberate set (keyboard brightness keys, or a host explicit/non-volatile
+// set) leaves auto mode so the manual choice wins until auto is re-engaged.
+// RAM-only: defaults off at boot; the host re-asserts it on connect from its
+// daylight setting.
+static bool    g_auto_brightness      = false;
+static uint8_t g_last_auto_brightness = FULL_BRIGHT;
+
 static bool          g_def_layer_dirty = false;
 static layer_state_t g_def_layer_pending = 0;
 
@@ -236,6 +246,7 @@ void inc_brightness(void) {
         l_state.contrast = FULL_BRIGHT;
     }
     g_user_brightness  = l_state.contrast;
+    g_auto_brightness  = false;   // deliberate change — leave host-auto mode
     g_brightness_dirty = true;
 }
 
@@ -249,6 +260,7 @@ void dec_brightness(void) {
         l_state.contrast = MIN_BRIGHT;
     }
     g_user_brightness  = l_state.contrast;
+    g_auto_brightness  = false;   // deliberate change — leave host-auto mode
     g_brightness_dirty = true;
 }
 
@@ -259,7 +271,42 @@ void dec_brightness(void) {
 void set_user_brightness(uint8_t value) {
     l_state.contrast   = value;
     g_user_brightness  = value;
+    g_auto_brightness  = false;   // deliberate change — leave host-auto mode
     g_brightness_dirty = true;
+}
+
+// True while host-driven (daylight/auto) brightness is engaged.
+bool get_brightness_auto_mode(void) {
+    return g_auto_brightness;
+}
+
+// Engage/disengage host-driven brightness. RAM-only (never persisted); applies
+// the resulting active brightness to the display via the normal sync/refresh.
+void set_brightness_auto_mode(bool on) {
+    g_auto_brightness = on;
+    l_state.contrast  = get_active_brightness();
+}
+
+// Toggle for the KC_DAUTO key.
+void toggle_brightness_auto_mode(void) {
+    set_brightness_auto_mode(!g_auto_brightness);
+}
+
+// Apply a host auto/daylight brightness update. Remembered as the restore
+// target and applied only while auto mode is engaged. NEVER persisted, and it
+// does not change the deliberate user brightness or the auto mode itself.
+void set_auto_brightness_value(uint8_t value) {
+    g_last_auto_brightness = value;
+    if (g_auto_brightness) {
+        l_state.contrast = value;
+    }
+}
+
+// The brightness currently in effect: the last host auto value while auto mode
+// is engaged, otherwise the deliberate user brightness. Idle/suspend/fade
+// restore paths use this so they restore whatever is actually driving.
+uint8_t get_active_brightness(void) {
+    return g_auto_brightness ? g_last_auto_brightness : g_user_brightness;
 }
 
 // Records the intended user brightness without marking settings dirty (boot-time

--- a/keyboards/handwired/polykybd/state.h
+++ b/keyboards/handwired/polykybd/state.h
@@ -152,8 +152,22 @@ void set_user_brightness(uint8_t value);
 // load, slave adopting an awake master's synced contrast).
 void note_user_brightness(uint8_t value);
 
-// The brightness to restore after idle/suspend (tracks unflushed changes).
+// The deliberate user brightness — the value that gets persisted (tracks
+// unflushed changes). Restore paths should use get_active_brightness() instead.
 uint8_t get_user_brightness(void);
+
+// Host-driven (daylight/auto) brightness mode (RAM-only, never persisted).
+bool get_brightness_auto_mode(void);
+void set_brightness_auto_mode(bool on);
+void toggle_brightness_auto_mode(void);
+
+// Apply a host auto/daylight brightness update: volatile, applied only while
+// auto mode is engaged, never persisted, leaves the deliberate brightness intact.
+void set_auto_brightness_value(uint8_t value);
+
+// The brightness currently in effect: auto ? last host auto value : the user
+// brightness. Idle/suspend/fade restore paths use this.
+uint8_t get_active_brightness(void);
 
 // Marks settings (lang + brightness) as needing an EEPROM write at the next flush.
 void mark_settings_dirty(void);


### PR DESCRIPTION
Separates **deliberate (persisted)** brightness from **host-driven (auto/daylight)** brightness, so the daylight value never lands in EEPROM and a manual choice wins until auto is re-engaged. Pairs with the PolyKybdHost PR on the same branch.

## Behaviour
| Action | Result |
|---|---|
| Keyboard `KC_D*` key | persists, **leaves auto mode** (manual wins) |
| Host explicit set (`flags=0`) | persists, leaves auto mode — identical to a keyboard key |
| Host daylight 10-min tick (`VOLATILE`) | applied only if auto mode on; **ignored if you took manual control**; never persisted |
| Host daylight enabled / on connect (`VOLATILE\|AUTO_ON`) | engages auto + pushes value |
| Host daylight disabled (`AUTO_OFF`) | keyboard reverts to its stored manual brightness |
| **`KC_DAUTO`** (settings layer) | toggles auto mode locally |

## Changes
- **`state.c`/`.h`**: `g_auto_brightness` (RAM, default off) + `g_last_auto_brightness`. `get_active_brightness()` = `auto ? last_auto : g_user_brightness`; idle/wake/fade restore paths now use it (so restore tracks whatever is driving without persisting the auto value). `set_auto_brightness_value()` applies a host auto update only while auto mode is on, never persists. `set_brightness_auto_mode()` / `toggle_brightness_auto_mode()` manage the mode. `set_user_brightness` / `inc_brightness` / `dec_brightness` now also clear auto mode. EEPROM still persists only `g_user_brightness`.
- **`hid_com.c`** cmd 13: new flags byte `data[HID_DATA_IDX+1]` (0 from pre-v5 hosts = legacy persisted set): `VOLATILE`, `AUTO_ON`, `AUTO_OFF`. `base/com.h` defines the bits.
- **`config.h`**: `PROTOCOL_VERSION` 4 → 5.
- **`KC_DAUTO`**: new keycode appended at the end of the `QK_KB_0` range (nothing renumbers), placed on the settings layer of split72 + split42, label "Auto".

## Build
Build-verified with the apt ARM toolchain (gcc 13.2.1): `split72:default` and `split42:default` both link. `.text`/image well within the 2 MB partition (split72 ~832 KB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gvsLwzVDNtVPY7mzmM5T9

---
_Generated by [Claude Code](https://claude.ai/code/session_014gvsLwzVDNtVPY7mzmM5T9)_

## Summary by Sourcery

Separate manual brightness from host-driven auto brightness, ensuring host daylight values remain volatile while manual settings persist and take precedence unless auto mode is re-enabled.

New Features:
- Introduce a RAM-only host auto brightness mode with tracking of the last host-provided brightness and an API to query the active brightness.
- Add KC_DAUTO keycode and bindings on the settings layer to locally toggle host-driven brightness auto mode.
- Extend the HID SET_BRIGHTNESS command with a flags byte to support volatile daylight updates and auto on/off control while maintaining backward compatibility with older hosts.

Enhancements:
- Update all idle, fade, and wake display restore paths to use the effective active brightness, whether driven by host auto or manual settings.
- Log brightness changes with additional context about flags and auto mode state for easier debugging.

Build:
- Bump the PolyKybd protocol version from 4 to 5 to advertise the new brightness flags and KC_DAUTO support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added host-driven automatic brightness mode, allowing the keyboard to respond to brightness commands from the computer.
  * Introduced a new key to toggle between automatic and manual brightness control.
  * Manual brightness adjustments now properly exit automatic mode.

* **Chores**
  * Updated protocol version to support enhanced brightness control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->