### PR TITLE
Idle jitter: relocate each key independently as it pulses dark

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,12 @@ pixels in. Two styles (EEPROM `poly_eeconf_t.idle_style`, HID cmd 28, enum
     fight `kdisp_idle()` and redraw the awake chrome) — the keycaps already hold the
     last centred awake render when idle begins, and `kdisp_idle()` owns all idle
     visuals from there. `render_idle_key()` draws **only the resting normal legend** —
-    no shift/AltGr preview, no overlay image, no tab/MRU chrome.
+    no shift/AltGr preview, no overlay image, no tab/MRU chrome. The relocated keycode
+    is resolved through **`display_keycode_at()`** — the shared helper (also used by the
+    awake `update_displays`) that honours the active momentary stack **and the default
+    layer** (`def_layer`, folded in so a Colemak/Neo base shows its own legends, not
+    `_BL`) with a one-level transparent fallback — so a jittered key matches what was on
+    screen rather than snapping to the base layer.
   - **The travel range is derived per glyph from its own on-screen slack** — there is
     deliberately **no global `±N` offset envelope**. `render_idle_key()` measures the
     legend with `kdisp_gfx_text_bbox()` (full x+y box, mirroring the draw's cursor

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,12 +136,18 @@ pixels in. Two styles (EEPROM `poly_eeconf_t.idle_style`, HID cmd 28, enum
   - `kdisp_idle()` already computes a **per-key brightness** (`to_brightness((contrast
     + per-key phase) % 50)`) and walks every key on this half with the shift register
     selecting each in turn. On the **lit→dark edge** (`idle_brightness==0` and the
-    `s_idle_was_dark[r][c]` latch was clear) in JITTER style, it rolls a per-key
-    `(dx,dy)` via `jitter_axis(s_idle_roll++, …)` and calls **`render_idle_key(keycode,
-    led_state, dx, dy)`** to redraw *that one key* straight into the currently selected
-    display. The key is dark at that moment, so the move is invisible; it reappears at
-    the new spot on its next bright cycle (~once per ~15 s per key). `s_idle_was_dark`
-    gates it to once per dark episode (a 1-bit-per-key latch, this-half-only).
+    `s_idle_was_dark[r][c]` latch was clear) in JITTER style it **switches that key's
+    panel OFF first, then** calls **`render_idle_key(kc, led_state, seed)`** to redraw
+    *that one key* straight into the currently selected (now-dark) display. Writing the
+    new frame *after* the off-switch is what makes the move invisible — the glyph
+    reappears already at its new spot on the next bright cycle (~once per ~15 s per key);
+    writing before the off-switch flashed it at the old contrast first (a visible jump
+    just before the key dimmed out). `s_idle_was_dark` gates it to once per dark episode
+    (a 1-bit-per-key latch, this-half-only). `render_idle_key()` **returns false without
+    touching the buffer** when the keycode has no plain-text legend (a language flag,
+    emoji, region tab, MRU control — full-bleed images that can't be jittered), so those
+    keys keep their current frame and just pulse instead of being blanked (the
+    language-layer flags no longer disappear on the first idle cycle).
   - **No shared offset, so nothing extra crosses the UART.** Each half runs
     `kdisp_idle()` on its own keys with the synced pulse `contrast`; only the **style
     bit** is synced (`poly_sync_t.idle_style`, set from `housekeeping_task_user()` on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,19 +154,20 @@ pixels in. Two styles (EEPROM `poly_eeconf_t.idle_style`, HID cmd 28, enum
     last centred awake render when idle begins, and `kdisp_idle()` owns all idle
     visuals from there. `render_idle_key()` draws **only the resting normal legend** —
     no shift/AltGr preview, no overlay image, no tab/MRU chrome.
-  - **The offset is clamped per key to that glyph's own bounds**, so the legend is
-    *always fully visible* at every jitter position — for any script, not just
-    Latin. `render_idle_key()` measures the legend with `kdisp_gfx_text_bbox()`
-    (full x+y box, mirroring the draw's cursor rules and per-glyph yAdvance shift;
-    `kdisp_gfx_text_bounds()` is now a wrapper over it) and `clamp_idle_offset()`
-    bounds the rolled `(dx,dy)` so the box stays inside the visible window
-    `[BUFFER_X, BUFFER_X+SCREEN_WIDTH-1] × [0, SCREEN_HEIGHT-1]` (= `[28,99]×[0,39]`).
-    A glyph with no slack in an axis (e.g. a full-width CJK legend) simply doesn't
-    move in it — no clipping, no special-casing. `SET_PIXEL_CLIPPED` in
-    `disp_array.c` remains the memory-safety backstop, but is not relied on for
-    visibility. The `IDLE_JITTER_DX/DY_*` envelope in `config.h` is only the
-    *proposed* range (the per-key clamp makes it clip-safe) — tune it for how far
-    small legends roam.
+  - **The travel range is derived per glyph from its own on-screen slack** — there is
+    deliberately **no global `±N` offset envelope**. `render_idle_key()` measures the
+    legend with `kdisp_gfx_text_bbox()` (full x+y box, mirroring the draw's cursor
+    rules and per-glyph yAdvance shift; `kdisp_gfx_text_bounds()` is now a wrapper over
+    it) and `roll_idle_offset()` rolls a **uniform random position within that glyph's
+    free space** inside the visible window `[BUFFER_X, BUFFER_X+SCREEN_WIDTH-1] × [0,
+    SCREEN_HEIGHT-1]` (= `[28,99]×[0,39]`). So a slim `i` roams its full free width
+    while a wide `w` (or a full-width CJK legend) moves only as far as it can without
+    clipping — each uses all *and only* the room it has, for any script. A fixed cap
+    would be counter-productive: it would throttle the slim glyph and edge-bias the
+    wide one (most rolls clamping to the same boundary). A glyph with no slack in an
+    axis simply doesn't move in it — no clipping, no special-casing. `SET_PIXEL_CLIPPED`
+    in `disp_array.c` remains the memory-safety backstop, but is not relied on for
+    visibility.
   - The per-key latch is cleared by **`reset_idle_jitter()`** on every wake/suspend
     path (`display_wakeup`, `poly_suspend`, `suspend_wakeup_init_kb`, cmd 15
     stop-idle), so a fresh idle session starts from the centred awake legend and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,40 +129,51 @@ pixels in. Two styles (EEPROM `poly_eeconf_t.idle_style`, HID cmd 28, enum
 - **`IDLE_STYLE_PULSE` (0, default, legacy):** `kdisp_idle()` only modulates each
   keycap's SSD1306 contrast register (a per-key out-of-phase "breathing"). The
   buffer is never re-rendered, so the lit pixels never move — the burn-in risk.
-- **`IDLE_STYLE_JITTER` (1):** keeps the pulse, but once per ~15 s pulse cycle the
-  master picks a small random offset and **relocates** the legend so the lit pixels
-  migrate. Mechanics:
-  - `housekeeping_task_user()` (master only, `is_usb_host_side()`) computes the
-    per-cycle offset into `poly_sync_t.idle_dx/idle_dy` (synced to the slave like
-    `contrast`, so both halves relocate in lockstep — **no extra UART traffic**:
-    the offset rides the existing per-300 ms poly sync, and the slave just renders
-    whatever offset arrives, so it needs no idle-style of its own). The
-    `IDLE_JITTER_DX/DY_*` envelope in `config.h` is only the *proposed* range — it
-    no longer has to be clip-safe (the per-key clamp below makes it so), so it's
-    tuned for how far small legends roam.
-  - `update_displays()` normally early-returns while `DISP_IDLE` is set; in jitter
-    it re-renders **only when `idle_dx/idle_dy` changed** (a static last-offset
-    guard). Each drawable key is then routed to **`render_idle_key()`** (the single
-    place all idle rendering lives), which draws **only the resting normal legend**
-    — no shift/AltGr preview, no overlay image, no tab/MRU chrome (those keycodes
-    aren't on the base layer at idle anyway), at the low fixed `IDLE_JITTER_REDRAW_CONTRAST`;
-    `kdisp_idle()` resumes the pulse on the next tick.
+- **`IDLE_STYLE_JITTER` (1):** keeps the pulse, but **each key independently**
+  relocates its own legend to a fresh random spot the instant that key's
+  out-of-phase pulse dims it to black — so the lit pixels migrate per key, not in
+  lockstep. Mechanics (all in `kdisp_idle()`):
+  - `kdisp_idle()` already computes a **per-key brightness** (`to_brightness((contrast
+    + per-key phase) % 50)`) and walks every key on this half with the shift register
+    selecting each in turn. On the **lit→dark edge** (`idle_brightness==0` and the
+    `s_idle_was_dark[r][c]` latch was clear) in JITTER style, it rolls a per-key
+    `(dx,dy)` via `jitter_axis(s_idle_roll++, …)` and calls **`render_idle_key(keycode,
+    led_state, dx, dy)`** to redraw *that one key* straight into the currently selected
+    display. The key is dark at that moment, so the move is invisible; it reappears at
+    the new spot on its next bright cycle (~once per ~15 s per key). `s_idle_was_dark`
+    gates it to once per dark episode (a 1-bit-per-key latch, this-half-only).
+  - **No shared offset, so nothing extra crosses the UART.** Each half runs
+    `kdisp_idle()` on its own keys with the synced pulse `contrast`; only the **style
+    bit** is synced (`poly_sync_t.idle_style`, set from `housekeeping_task_user()` on
+    the master, adopted by the slave's `copy_local_state`) so the slave jitters iff
+    the master's style says so. The legend is **re-derived from the keycode** on every
+    relocation — nothing is stored in the OLED's own memory (the panel only holds the
+    last frame we send).
+  - `update_displays()` **early-returns while `DISP_IDLE` is set** (it would otherwise
+    fight `kdisp_idle()` and redraw the awake chrome) — the keycaps already hold the
+    last centred awake render when idle begins, and `kdisp_idle()` owns all idle
+    visuals from there. `render_idle_key()` draws **only the resting normal legend** —
+    no shift/AltGr preview, no overlay image, no tab/MRU chrome.
   - **The offset is clamped per key to that glyph's own bounds**, so the legend is
     *always fully visible* at every jitter position — for any script, not just
     Latin. `render_idle_key()` measures the legend with `kdisp_gfx_text_bbox()`
     (full x+y box, mirroring the draw's cursor rules and per-glyph yAdvance shift;
     `kdisp_gfx_text_bounds()` is now a wrapper over it) and `clamp_idle_offset()`
-    bounds the synced `idle_dx/idle_dy` so the box stays inside the visible window
+    bounds the rolled `(dx,dy)` so the box stays inside the visible window
     `[BUFFER_X, BUFFER_X+SCREEN_WIDTH-1] × [0, SCREEN_HEIGHT-1]` (= `[28,99]×[0,39]`).
     A glyph with no slack in an axis (e.g. a full-width CJK legend) simply doesn't
-    move in it — no clipping, no special-casing. This **replaces** the old global
-    `kdisp_set_draw_offset()` + fixed-`±N` approach, whose Latin-sized constants
-    clipped zero-bearing glyphs (`A W X Y T V`, `J`) on the flush-left origin and
-    were wrong for wide scripts. `SET_PIXEL_CLIPPED` in `disp_array.c` remains the
-    memory-safety backstop, but is no longer relied on for visibility.
-  - Offsets are reset to 0 on every wake/suspend path (`display_wakeup`,
-    `poly_suspend`, `suspend_wakeup_init_kb`, cmd 15 stop-idle) so a refresh right
-    after waking is centred.
+    move in it — no clipping, no special-casing. `SET_PIXEL_CLIPPED` in
+    `disp_array.c` remains the memory-safety backstop, but is not relied on for
+    visibility. The `IDLE_JITTER_DX/DY_*` envelope in `config.h` is only the
+    *proposed* range (the per-key clamp makes it clip-safe) — tune it for how far
+    small legends roam.
+  - The per-key latch is cleared by **`reset_idle_jitter()`** on every wake/suspend
+    path (`display_wakeup`, `poly_suspend`, `suspend_wakeup_init_kb`, cmd 15
+    stop-idle), so a fresh idle session starts from the centred awake legend and
+    relocates every key cleanly. (This **replaces** the earlier global-offset jitter,
+    where the master picked one `idle_dx/idle_dy` per ~15 s cycle, synced it, and all
+    keys shifted together — the per-key version is the nicer effect *and* drops the
+    synced offset.)
   A "Matrix-style" idle animation was considered but shelved — it defeats the
   "glance at the dimmed legend and resume typing" hint the pulse preserves; jitter
   was chosen as the default-preserving, legibility-preserving fix.

--- a/keyboards/handwired/polykybd/base/update.h
+++ b/keyboards/handwired/polykybd/base/update.h
@@ -21,3 +21,8 @@ void request_disp_refresh(void);
 void set_disp_refresh(enum refresh_mode mode);
 
 enum refresh_mode get_refresh_mode(void) ;
+
+// Clears the per-key idle anti-burn-in "was dark" latch so the next idle session
+// starts from the centred awake legend and relocates every key cleanly. Call on any
+// wake / suspend / stop-idle path. Defined in poly_keymap.c.
+void reset_idle_jitter(void);

--- a/keyboards/handwired/polykybd/config.h
+++ b/keyboards/handwired/polykybd/config.h
@@ -122,19 +122,14 @@
 //10 min
 #define TURN_OFF_TIME 1200000
 
-// Idle "jitter" style: while pulsing, each key independently relocates its own
-// legend to a fresh random offset the moment that key's out-of-phase pulse dims it
-// to black (kdisp_idle), so the lit pixels migrate and don't burn in — keys roam
-// individually rather than in lockstep. These are only the *proposed* offset
-// envelope (a deliberately generous range); render_idle_key() then clamps the
-// offset per key to that glyph's measured bounding box, so the legend is always
-// fully on-screen regardless of these values and of the script (Latin, CJK,
-// Arabic, …). A glyph with no slack in an axis simply does not move in it. So tune
-// these for how far small legends roam, not for clip-safety.
-#define IDLE_JITTER_DX_MIN (-10)
-#define IDLE_JITTER_DX_MAX (18)
-#define IDLE_JITTER_DY_MIN (-6)
-#define IDLE_JITTER_DY_MAX (10)
+// Idle "jitter" style: while pulsing, each key independently relocates its own legend
+// to a fresh random spot the moment that key's out-of-phase pulse dims it to black
+// (kdisp_idle), so the lit pixels migrate and don't burn in — keys roam individually
+// rather than in lockstep. There is deliberately NO global offset envelope: the travel
+// range is derived per glyph from its own on-screen slack (roll_idle_offset), so a slim
+// "i" roams its full free width while a wide "w" or a full-width CJK legend moves only
+// as far as it can without clipping. A fixed ±N cap would be counter-productive here
+// (it would throttle the slim glyph and edge-bias the wide one).
 
 //######################################
 //#          Overlays specific         #

--- a/keyboards/handwired/polykybd/config.h
+++ b/keyboards/handwired/polykybd/config.h
@@ -130,6 +130,10 @@
 // "i" roams its full free width while a wide "w" or a full-width CJK legend moves only
 // as far as it can without clipping. A fixed ±N cap would be counter-productive here
 // (it would throttle the slim glyph and edge-bias the wide one).
+// How often a key relocates: the breathing curve dips dark ~twice per ~15 s pulse
+// cycle, so we'd otherwise move each key ~every 7.5 s. Relocate only every Nth dark
+// episode to slow the drift (3 -> ~every 22 s per key). Raise for a calmer display.
+#define IDLE_JITTER_PERIOD 3
 
 //######################################
 //#          Overlays specific         #

--- a/keyboards/handwired/polykybd/config.h
+++ b/keyboards/handwired/polykybd/config.h
@@ -117,22 +117,19 @@
 //10 min
 #define TURN_OFF_TIME 1200000
 
-// Idle "jitter" style: while pulsing, the rendered legend is relocated by a small
-// random offset once per pulse cycle so the lit pixels migrate and don't burn in.
-// These are only the *proposed* offset envelope (a deliberately generous range);
-// render_idle_key() then clamps the offset per key to that glyph's measured bounding
-// box, so the legend is always fully on-screen regardless of these values and of the
-// script (Latin, CJK, Arabic, …). A glyph with no slack in an axis simply does not
-// move in it. So tune these for how far small legends roam, not for clip-safety.
+// Idle "jitter" style: while pulsing, each key independently relocates its own
+// legend to a fresh random offset the moment that key's out-of-phase pulse dims it
+// to black (kdisp_idle), so the lit pixels migrate and don't burn in — keys roam
+// individually rather than in lockstep. These are only the *proposed* offset
+// envelope (a deliberately generous range); render_idle_key() then clamps the
+// offset per key to that glyph's measured bounding box, so the legend is always
+// fully on-screen regardless of these values and of the script (Latin, CJK,
+// Arabic, …). A glyph with no slack in an axis simply does not move in it. So tune
+// these for how far small legends roam, not for clip-safety.
 #define IDLE_JITTER_DX_MIN (-10)
 #define IDLE_JITTER_DX_MAX (18)
 #define IDLE_JITTER_DY_MIN (-6)
 #define IDLE_JITTER_DY_MAX (10)
-// One pulse cycle is 50 contrast steps × 300 ms (~15 s); relocate at each boundary.
-#define IDLE_JITTER_CYCLE_STEPS 50
-// Contrast used for the one relocation redraw (the live value is the pulsing 0-49
-// counter at that instant); kdisp_idle() resumes the per-key pulse on the next tick.
-#define IDLE_JITTER_REDRAW_CONTRAST 2
 
 //######################################
 //#          Overlays specific         #

--- a/keyboards/handwired/polykybd/hid_com.c
+++ b/keyboards/handwired/polykybd/hid_com.c
@@ -461,8 +461,7 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                         }
                         local_state->flags &= ~((uint8_t)DISP_IDLE);
                         local_state->flags |= STATUS_DISP_ON;
-                        local_state->idle_dx = 0;   // recentre legend (drop jitter offset)
-                        local_state->idle_dy = 0;
+                        reset_idle_jitter();   // fresh, centred idle session next time
                         request_disp_refresh();
                         update_performed();
                     }
@@ -659,12 +658,9 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                         data[3] = get_idle_style();
                     } else if (arg < IDLE_STYLE_COUNT) {
                         set_idle_style(arg);
-                        if (arg == IDLE_STYLE_PULSE) {
-                            // Recentre immediately if we switch away from jitter mid-idle.
-                            local_state->idle_dx = 0;
-                            local_state->idle_dy = 0;
-                            request_disp_refresh();
-                        }
+                        // The style is synced to the slave from housekeeping; both
+                        // halves relocate their own keys, so there is no shared
+                        // offset to reset here.
                         memcpy(data, "P\x1c.", 3);
                         data[3] = arg;
                         uprintf("Set idle style to %u.\n", arg);

--- a/keyboards/handwired/polykybd/poly_keymap.c
+++ b/keyboards/handwired/polykybd/poly_keymap.c
@@ -1144,14 +1144,17 @@ static void roll_idle_offset(const uint32_t* text, int8_t ox, int8_t oy, uint32_
     *dy = (yhi < ylo) ? 0 : jitter_axis(seed, 0x1000u, (int8_t)ylo, (int8_t)yhi);
 }
 
-// Idle (anti-burn-in) per-key render: draws ONLY the resting normal legend — no
-// shift/AltGr preview, no overlay image, no tab/MRU chrome — relocated to a fresh
-// random spot within THIS glyph's own slack (roll_idle_offset, seeded by `seed`), so
-// it is always fully visible. Renders into the currently selected display's buffer, so
-// it works from inside kdisp_idle()'s shift-register walk (the caller selects the
-// key). Keeps all idle-mode rendering in one place instead of threading an "idle" flag
-// through the awake path.
-static void render_idle_key(uint16_t keycode, led_t state, uint32_t seed) {
+// Idle (anti-burn-in) per-key relocation: redraws ONLY the resting normal legend — no
+// shift/AltGr preview, no overlay image, no tab/MRU chrome — at a fresh random spot
+// within THIS glyph's own slack (roll_idle_offset, seeded by `seed`), always fully
+// visible. Renders into the currently selected display's buffer, so it works from
+// inside kdisp_idle()'s shift-register walk (the caller selects the key, with the panel
+// switched OFF, so the move is invisible). Returns false WITHOUT touching the buffer
+// when the keycode has no plain-text legend (a language flag, emoji, region tab, MRU
+// control, …): those can't be jittered (full-bleed images), so we leave their current
+// frame in place instead of blanking it — e.g. the language-layer flags stay put and
+// keep pulsing rather than disappearing on the first idle cycle.
+static bool render_idle_key(uint16_t keycode, led_t state, uint32_t seed) {
     const poly_sync_t* local_state = get_local_state();
     uint32_t unimap[2] = {0, 0};
     const uint32_t* text = to_static_text(keycode, state);
@@ -1165,15 +1168,17 @@ static void render_idle_key(uint16_t keycode, led_t state, uint32_t seed) {
         unimap[0] = unicode_map[chr];
         text = unimap;
     }
-    kdisp_set_buffer(0x00);
-    if (text != NULL && text[0] != 0) {
-        int8_t dx, dy;
-        roll_idle_offset(text, BUFFER_X, 23, seed, &dx, &dy);
-        kdisp_set_draw_offset(dx, dy);
-        kdisp_write_gfx_text(ALL_FONTS, ALL_FONT_SIZE, BUFFER_X, 23, text);
-        kdisp_set_draw_offset(0, 0);
+    if (text == NULL || text[0] == 0) {
+        return false;   // no text legend — keep the key's current frame
     }
+    int8_t dx, dy;
+    roll_idle_offset(text, BUFFER_X, 23, seed, &dx, &dy);
+    kdisp_set_buffer(0x00);
+    kdisp_set_draw_offset(dx, dy);
+    kdisp_write_gfx_text(ALL_FONTS, ALL_FONT_SIZE, BUFFER_X, 23, text);
+    kdisp_set_draw_offset(0, 0);
     kdisp_send_buffer();
+    return true;
 }
 
 // Per-key "was dark on the previous kdisp_idle() pass" latch (this half only), so a
@@ -1354,19 +1359,23 @@ void kdisp_idle(uint8_t contrast) {
                 if (disp_idx != 255) {
                     uint8_t idle_brightness = to_brightness((contrast+(c%3+r)*base_kc+offset+r)%50);
                     if(idle_brightness==0) {
-                        // Lit -> dark edge in JITTER style: relocate this key now,
-                        // while it is invisible. The legend is resolved from the active
-                        // layer (display_keycode_at) so it matches the awake render, not
-                        // the base layer; render_idle_key() rolls a fresh offset within
-                        // this glyph's slack and draws into the currently selected display.
-                        if(jitter && !s_idle_was_dark[r][c]) {
+                        // Lit -> dark edge in JITTER style: relocate this key now. Turn
+                        // the panel OFF *first*, THEN write the new frame while it is
+                        // dark — so the move is never seen; the glyph reappears already
+                        // at its new spot on the next bright cycle (writing before the
+                        // off-switch made it flash at the old contrast — a visible jump
+                        // just before the key dimmed out). The legend is resolved from
+                        // the active layer (display_keycode_at) so it matches the awake
+                        // render, not the base layer.
+                        bool dark_edge = !s_idle_was_dark[r][c];
+                        s_idle_was_dark[r][c] = 1;
+                        kdisp_enable(false);
+                        if(jitter && dark_edge) {
                             uint16_t kc = display_keycode_at(local_layer, r + offset, c);
                             if(kc != KC_TRNS) {
                                 render_idle_key(kc, led_state, s_idle_roll++);
                             }
                         }
-                        s_idle_was_dark[r][c] = 1;
-                        kdisp_enable(false);
                     } else {
                         s_idle_was_dark[r][c] = 0;
                         kdisp_enable(true);

--- a/keyboards/handwired/polykybd/poly_keymap.c
+++ b/keyboards/handwired/polykybd/poly_keymap.c
@@ -405,16 +405,10 @@ layer_state_t layer_state_set_user(layer_state_t state) {
     return state;
 }
 
-// Idle "jitter" anti-burn-in state (master-side; the offset is synced to the
-// slave through poly_sync_t). g_jitter_epoch counts pulse cycles so the legend is
-// relocated once per cycle; UINT32_MAX forces a fresh offset on each idle entry.
-static uint32_t g_jitter_epoch = UINT32_MAX;
-static int8_t   g_jitter_dx = 0;
-static int8_t   g_jitter_dy = 0;
-
-// Deterministic small pseudo-random offset for a given pulse cycle (epoch) and
-// axis salt, clamped to [lo, hi]. Deterministic so a glance is reproducible and
-// the value is stable for the whole epoch; only the master evaluates it.
+// Small deterministic pseudo-random offset for a given seed and axis salt, mapped
+// into [lo, hi]. Used per key, per dark-episode (see kdisp_idle): the seed is a
+// rolling counter so each relocation lands somewhere new, the salt separates the X
+// and Y axes. Cheap integer hash — no PRNG state to carry on either half.
 static int8_t jitter_axis(uint32_t epoch, uint32_t salt, int8_t lo, int8_t hi) {
     uint32_t h = (epoch + salt) * 2654435761u;
     h ^= h >> 15;
@@ -459,8 +453,6 @@ void housekeeping_task_user(void) {
             poly_sync_t* local_state = access_local_state();
             uint8_t  contrast = local_state->contrast;
             uint8_t  flags = local_state->flags;
-            int8_t   idle_dx = 0;   // anti-burn-in jitter offset; 0 unless idle+JITTER
-            int8_t   idle_dy = 0;
 
             flags |= STATUS_DISP_ON;
             flags &= ~((uint8_t)IDLE_TRANSITION);
@@ -473,7 +465,6 @@ void housekeeping_task_user(void) {
                 if(brightness<=MIN_BRIGHT) {
                     contrast = DISP_OFF;
                     flags |= DISP_IDLE;
-                    g_jitter_epoch = UINT32_MAX;   // force a fresh jitter offset for this idle session
                     uprint("Transition to pulsing\n");
                 } else if(brightness>FULL_BRIGHT) {
                     contrast = FULL_BRIGHT;
@@ -491,27 +482,17 @@ void housekeeping_task_user(void) {
             } else if((flags & DISP_IDLE)!=0) {
                 int32_t time_after = PK_MAX(elapsed_time_since_update - FADE_OUT_TIME - FADE_TRANSITION_TIME, 0)/300;
                 contrast = time_after%50;
-                // Jitter style: relocate the legend once per pulse cycle so the lit
-                // pixels migrate. The offset is constant within a cycle and synced to
-                // the slave; update_displays() re-renders only when it changes.
-                if(get_idle_style() == IDLE_STYLE_JITTER) {
-                    uint32_t epoch = (uint32_t)time_after / IDLE_JITTER_CYCLE_STEPS;
-                    if(epoch != g_jitter_epoch) {
-                        g_jitter_epoch = epoch;
-                        g_jitter_dx = jitter_axis(epoch, 0x1u, IDLE_JITTER_DX_MIN, IDLE_JITTER_DX_MAX);
-                        g_jitter_dy = jitter_axis(epoch, 0x2u, IDLE_JITTER_DY_MIN, IDLE_JITTER_DY_MAX);
-                    }
-                    idle_dx = g_jitter_dx;
-                    idle_dy = g_jitter_dy;
-                }
+                // In JITTER style each key relocates its own legend independently as
+                // it pulses dark (kdisp_idle) — there is no shared per-cycle offset
+                // to compute here; only the pulse `contrast` drives both halves.
             } else {
                 flags &= ~((uint8_t)DISP_IDLE);
             }
 
             local_state->contrast = contrast;
             local_state->flags = flags;
-            local_state->idle_dx = idle_dx;
-            local_state->idle_dy = idle_dy;
+            // Sync the active idle style so the slave jitters in lockstep with us.
+            local_state->idle_style = get_idle_style();
         }
     }
 }
@@ -1143,10 +1124,13 @@ static void clamp_idle_offset(const uint32_t* text, int8_t ox, int8_t oy, int8_t
 }
 
 // Idle (anti-burn-in) per-key render: draws ONLY the resting normal legend — no
-// shift/AltGr preview, no overlay image, no tab/MRU chrome — relocated by the synced
-// jitter offset, clamped per glyph so it is always fully visible. Keeps all idle-mode
-// rendering in one place instead of threading an "idle" flag through the awake path.
-static void render_idle_key(uint16_t keycode, led_t state) {
+// shift/AltGr preview, no overlay image, no tab/MRU chrome — relocated by the given
+// (dx,dy) offset, clamped per glyph so it is always fully visible. Renders into the
+// currently selected display's buffer, so it works both from update_displays() and
+// from inside kdisp_idle()'s shift-register walk (the caller selects the key). Keeps
+// all idle-mode rendering in one place instead of threading an "idle" flag through
+// the awake path.
+static void render_idle_key(uint16_t keycode, led_t state, int8_t dx, int8_t dy) {
     const poly_sync_t* local_state = get_local_state();
     uint32_t unimap[2] = {0, 0};
     const uint32_t* text = to_static_text(keycode, state);
@@ -1162,7 +1146,6 @@ static void render_idle_key(uint16_t keycode, led_t state) {
     }
     kdisp_set_buffer(0x00);
     if (text != NULL && text[0] != 0) {
-        int8_t dx = local_state->idle_dx, dy = local_state->idle_dy;
         clamp_idle_offset(text, BUFFER_X, 23, &dx, &dy);
         kdisp_set_draw_offset(dx, dy);
         kdisp_write_gfx_text(ALL_FONTS, ALL_FONT_SIZE, BUFFER_X, 23, text);
@@ -1171,25 +1154,30 @@ static void render_idle_key(uint16_t keycode, led_t state) {
     kdisp_send_buffer();
 }
 
+// Per-key "was dark on the previous kdisp_idle() pass" latch (this half only), so a
+// key relocates exactly once per pulse-dark episode rather than every pass while it
+// is dark. Reset on every wake/suspend/stop-idle path (reset_idle_jitter) so a fresh
+// idle session starts from the centred awake legend and re-relocates cleanly.
+static uint8_t s_idle_was_dark[MATRIX_ROWS_PER_SIDE][MATRIX_COLS];
+// Rolling seed for the per-key offset hash — bumped on every relocation so each lands
+// somewhere new (no per-key PRNG state to keep).
+static uint16_t s_idle_roll = 0;
+
+void reset_idle_jitter(void) {
+    memset(s_idle_was_dark, 0, sizeof(s_idle_was_dark));
+}
+
 void update_displays(enum refresh_mode mode) {
     const poly_sync_t* local_state = get_local_state();
     const bool idle = (local_state->flags & DISP_IDLE) != 0;
-    // Anti-burn-in jitter: while idle we normally do NOT re-render — kdisp_idle()
-    // just pulses the existing buffer. Re-render only when the jitter offset
-    // changed, to relocate the legend to its new spot for this pulse cycle.
-    static int8_t s_last_dx = 0, s_last_dy = 0;
-    if(idle) {
-        if(local_state->idle_dx == s_last_dx && local_state->idle_dy == s_last_dy) {
-            return;
-        }
-    } else if(local_state->contrast<=DISP_OFF) {
+    // While idle we never full-re-render here: kdisp_idle() pulses the existing
+    // buffer and (in JITTER style) relocates each key's legend itself as that key
+    // dims. A full update_displays() pass at idle would fight that and redraw the
+    // awake chrome. The displays already hold the last centred awake render when we
+    // enter idle, so there is nothing to do until we wake.
+    if(idle || local_state->contrast<=DISP_OFF) {
         return;
     }
-    // Remember the offset we render this pass so the guard above can skip until it
-    // changes again. The offset itself is applied per key by render_idle_key (clamped
-    // to each glyph's bounds); awake rendering is always centred.
-    s_last_dx = idle ? local_state->idle_dx : 0;
-    s_last_dy = idle ? local_state->idle_dy : 0;
 
     //uint8_t layer = get_highest_layer(layer_state);
     const poly_layer_t* local_layer = get_local_layer();
@@ -1230,12 +1218,8 @@ void update_displays(enum refresh_mode mode) {
                     uint16_t highest_kc = poly_keycode_at(layer,r + offset,c); //if we encounter a transparent key go down one layer (but only one!)
                     keycode = (highest_kc == KC_TRNS) ? poly_keycode_at(get_highest_layer(local_layer->layer&~(1<<layer)),r + offset,c) : highest_kc;
                     kdisp_enable(true);
-                    kdisp_set_contrast(idle ? IDLE_JITTER_REDRAW_CONTRAST : (uint8_t)(local_state->contrast-1));
+                    kdisp_set_contrast((uint8_t)(local_state->contrast-1));
                     if(keycode!=KC_TRNS) {
-                        if(idle) {
-                            // Idle shows only the resting legend, jittered + clamped.
-                            render_idle_key(keycode, state);
-                        } else {
                         int16_t lang_idx = lang_index_for_keycode(keycode);
                         if (lang_idx >= 0) {
                             // Language layer: country flag + tiny language code
@@ -1286,7 +1270,6 @@ void update_displays(enum refresh_mode mode) {
                         }
                         kdisp_send_buffer();
                         }
-                        }
                     }
                 }
                 sr_shift_once_latch();
@@ -1316,10 +1299,21 @@ uint8_t to_brightness(uint8_t b) {
     }
 }
 
-// Updates all displays to show idle pulsating animation with varying brightness pattern.
+// Updates all displays to show idle pulsating animation with varying brightness
+// pattern. In JITTER style this is also where anti-burn-in relocation happens: the
+// instant a key's out-of-phase pulse dims it to black, we redraw that one key's
+// resting legend at a fresh random offset (clamped to its glyph). The move is
+// invisible because the key is dark at that moment; it reappears at the new spot on
+// its next bright cycle. Each half relocates only its own keys, so there is no
+// cross-half offset to sync — the keys roam individually rather than in lockstep.
+// The glyph is re-derived from the keycode each time, so nothing is stored in the
+// OLED's own memory; only a 1-bit-per-key "was dark" latch (s_idle_was_dark) gates
+// the once-per-episode redraw.
 void kdisp_idle(uint8_t contrast) {
     uint8_t offset = is_left_side() ? 0 : MATRIX_ROWS_PER_SIDE;
     uint8_t skip = 0;
+    const bool jitter = get_local_state()->idle_style == IDLE_STYLE_JITTER;
+    const led_t led_state = get_local_layer()->led_state;
     sr_shift_out_buffer_latch(disp_row_0.bitmask, sizeof(struct display_info));
 
     //uint8_t idx = 0;
@@ -1336,8 +1330,21 @@ void kdisp_idle(uint8_t contrast) {
                 if (disp_idx != 255) {
                     uint8_t idle_brightness = to_brightness((contrast+(c%3+r)*keycode+offset+r)%50);
                     if(idle_brightness==0) {
+                        // Lit -> dark edge in JITTER style: relocate this key now,
+                        // while it is invisible. The currently selected display is
+                        // this key's, so render_idle_key() draws straight into it.
+                        if(jitter && !s_idle_was_dark[r][c] && keycode != KC_TRNS) {
+                            int8_t dx = jitter_axis(s_idle_roll, ((uint32_t)(r*MATRIX_COLS+c)<<1)|0u,
+                                                    IDLE_JITTER_DX_MIN, IDLE_JITTER_DX_MAX);
+                            int8_t dy = jitter_axis(s_idle_roll, ((uint32_t)(r*MATRIX_COLS+c)<<1)|1u,
+                                                    IDLE_JITTER_DY_MIN, IDLE_JITTER_DY_MAX);
+                            s_idle_roll++;
+                            render_idle_key(keycode, led_state, dx, dy);
+                        }
+                        s_idle_was_dark[r][c] = 1;
                         kdisp_enable(false);
                     } else {
+                        s_idle_was_dark[r][c] = 0;
                         kdisp_enable(true);
                         kdisp_set_contrast(idle_brightness-1);
                     }
@@ -1872,8 +1879,7 @@ bool display_wakeup(keyrecord_t* record) {
         local_state->contrast = get_user_brightness();
         local_state->flags &= ~((uint8_t)DISP_IDLE);
         local_state->flags |= STATUS_DISP_ON;
-        local_state->idle_dx = 0;   // recentre the legend on wake (drop any jitter offset)
-        local_state->idle_dy = 0;
+        reset_idle_jitter();   // fresh, centred idle session next time
         update_performed();
         request_disp_refresh();
     }
@@ -2065,8 +2071,7 @@ void poly_suspend(void) {
     local_state->overlay_flags = flag_off(local_state->overlay_flags, DISPLAY_OVERLAYS);
     local_state->flags &= ~((uint8_t)STATUS_DISP_ON) & ~((uint8_t)DISP_IDLE) & ~((uint8_t)IDLE_TRANSITION);// & ~((uint8_t)RGB_ON);
     local_state->contrast = DISP_OFF;
-    local_state->idle_dx = 0;
-    local_state->idle_dy = 0;
+    reset_idle_jitter();
 }
 
 // Suspends keyboard: suspends power down, disables RGB, calls housekeeping, resets update timer.
@@ -2107,8 +2112,7 @@ void suspend_wakeup_init_kb(void) {
     local_state->flags |= STATUS_DISP_ON;
     local_state->flags &= ~((uint8_t)DISP_IDLE);
     local_state->contrast = get_user_brightness();
-    local_state->idle_dx = 0;
-    local_state->idle_dy = 0;
+    reset_idle_jitter();
     set_last_update(0);
 
     //rgb_matrix_reload_from_eeprom();

--- a/keyboards/handwired/polykybd/poly_keymap.c
+++ b/keyboards/handwired/polykybd/poly_keymap.c
@@ -1104,6 +1104,23 @@ uint16_t keymap_key_to_keycode(uint8_t layer, keypos_t key) {
     return poly_keycode_at(layer, key.row, key.col);
 }
 
+// Resolve the keycode whose legend a physical key is currently showing, honouring the
+// active layer stack with a one-level transparent fallback. The single source of truth
+// for both the awake render (update_displays) and the idle relocation (kdisp_idle), so
+// a jittered legend always matches what was last drawn awake instead of snapping to the
+// base layer. The effective state folds in the default layer (`def_layer`, tracked
+// separately from the momentary `layer` stack — e.g. a Colemak/Neo base) so a key with
+// no momentary layer active still shows its default-layer legend, not _BL.
+static uint16_t display_keycode_at(const poly_layer_t* lyr, uint8_t row, uint8_t col) {
+    layer_state_t eff = lyr->layer | ((layer_state_t)1 << lyr->def_layer);
+    uint8_t layer = get_highest_layer(eff);
+    uint16_t kc = poly_keycode_at(layer, row, col);
+    if (kc == KC_TRNS) {
+        kc = poly_keycode_at(get_highest_layer(eff & ~((layer_state_t)1 << layer)), row, col);
+    }
+    return kc;
+}
+
 // Roll a per-glyph idle jitter offset: a uniform random position within the legend's
 // OWN on-screen slack, measured from its bounding box at the draw origin (ox/oy). The
 // range is glyph-derived — never a global cap — so a slim "i" roams its full free
@@ -1219,9 +1236,7 @@ void update_displays(enum refresh_mode mode) {
             }
             else {
                 if (disp_idx != 255) {
-                    uint8_t layer = get_highest_layer(local_layer->layer);
-                    uint16_t highest_kc = poly_keycode_at(layer,r + offset,c); //if we encounter a transparent key go down one layer (but only one!)
-                    keycode = (highest_kc == KC_TRNS) ? poly_keycode_at(get_highest_layer(local_layer->layer&~(1<<layer)),r + offset,c) : highest_kc;
+                    keycode = display_keycode_at(local_layer, r + offset, c);
                     kdisp_enable(true);
                     kdisp_set_contrast((uint8_t)(local_state->contrast-1));
                     if(keycode!=KC_TRNS) {
@@ -1318,7 +1333,8 @@ void kdisp_idle(uint8_t contrast) {
     uint8_t offset = is_left_side() ? 0 : MATRIX_ROWS_PER_SIDE;
     uint8_t skip = 0;
     const bool jitter = get_local_state()->idle_style == IDLE_STYLE_JITTER;
-    const led_t led_state = get_local_layer()->led_state;
+    const poly_layer_t* local_layer = get_local_layer();
+    const led_t led_state = local_layer->led_state;
     sr_shift_out_buffer_latch(disp_row_0.bitmask, sizeof(struct display_info));
 
     //uint8_t idx = 0;
@@ -1328,19 +1344,26 @@ void kdisp_idle(uint8_t contrast) {
 
             //since MATRIX_COLS==8 we don't need to shift multiple times at the end of the row
             //except there was a leading and missing physical key (KC_NO on base layer)
-            uint16_t keycode = keymaps[_BL][r + offset][c];
-            if (keycode == KC_NO) {
+            // base_kc drives the physical-layout skip and the per-key pulse phase (both
+            // layout-, not layer-, dependent); the relocated legend itself is resolved
+            // from the active layer below so it matches the awake render.
+            uint16_t base_kc = keymaps[_BL][r + offset][c];
+            if (base_kc == KC_NO) {
                 skip++;
             } else {
                 if (disp_idx != 255) {
-                    uint8_t idle_brightness = to_brightness((contrast+(c%3+r)*keycode+offset+r)%50);
+                    uint8_t idle_brightness = to_brightness((contrast+(c%3+r)*base_kc+offset+r)%50);
                     if(idle_brightness==0) {
                         // Lit -> dark edge in JITTER style: relocate this key now,
-                        // while it is invisible. render_idle_key() rolls a fresh offset
-                        // within this glyph's own slack; the currently selected display
-                        // is this key's, so it draws straight into it.
-                        if(jitter && !s_idle_was_dark[r][c] && keycode != KC_TRNS) {
-                            render_idle_key(keycode, led_state, s_idle_roll++);
+                        // while it is invisible. The legend is resolved from the active
+                        // layer (display_keycode_at) so it matches the awake render, not
+                        // the base layer; render_idle_key() rolls a fresh offset within
+                        // this glyph's slack and draws into the currently selected display.
+                        if(jitter && !s_idle_was_dark[r][c]) {
+                            uint16_t kc = display_keycode_at(local_layer, r + offset, c);
+                            if(kc != KC_TRNS) {
+                                render_idle_key(kc, led_state, s_idle_roll++);
+                            }
                         }
                         s_idle_was_dark[r][c] = 1;
                         kdisp_enable(false);

--- a/keyboards/handwired/polykybd/poly_keymap.c
+++ b/keyboards/handwired/polykybd/poly_keymap.c
@@ -1182,16 +1182,23 @@ static bool render_idle_key(uint16_t keycode, led_t state, uint32_t seed) {
 }
 
 // Per-key "was dark on the previous kdisp_idle() pass" latch (this half only), so a
-// key relocates exactly once per pulse-dark episode rather than every pass while it
+// key relocates at most once per pulse-dark episode rather than every pass while it
 // is dark. Reset on every wake/suspend/stop-idle path (reset_idle_jitter) so a fresh
 // idle session starts from the centred awake legend and re-relocates cleanly.
 static uint8_t s_idle_was_dark[MATRIX_ROWS_PER_SIDE][MATRIX_COLS];
+// Per-key dark-episode counter: the breathing curve dips dark ~twice per ~15 s pulse
+// cycle, so relocating on every dark edge would move each key ~every 7.5 s. We only
+// relocate every IDLE_JITTER_PERIOD-th dark episode to slow that down (the count is
+// taken mod the period, so a fresh session relocates on the very first episode then
+// every Nth after — it moves off-centre promptly, then drifts more slowly).
+static uint8_t s_idle_episode[MATRIX_ROWS_PER_SIDE][MATRIX_COLS];
 // Rolling seed for the per-key offset hash — bumped on every relocation so each lands
 // somewhere new (no per-key PRNG state to keep).
 static uint16_t s_idle_roll = 0;
 
 void reset_idle_jitter(void) {
     memset(s_idle_was_dark, 0, sizeof(s_idle_was_dark));
+    memset(s_idle_episode, 0, sizeof(s_idle_episode));
 }
 
 void update_displays(enum refresh_mode mode) {
@@ -1370,7 +1377,9 @@ void kdisp_idle(uint8_t contrast) {
                         bool dark_edge = !s_idle_was_dark[r][c];
                         s_idle_was_dark[r][c] = 1;
                         kdisp_enable(false);
-                        if(jitter && dark_edge) {
+                        // Only relocate every IDLE_JITTER_PERIOD-th dark episode, so the
+                        // legend drifts slowly rather than on every ~7.5 s dark valley.
+                        if(jitter && dark_edge && (s_idle_episode[r][c]++ % IDLE_JITTER_PERIOD) == 0) {
                             uint16_t kc = display_keycode_at(local_layer, r + offset, c);
                             if(kc != KC_TRNS) {
                                 render_idle_key(kc, led_state, s_idle_roll++);

--- a/keyboards/handwired/polykybd/poly_keymap.c
+++ b/keyboards/handwired/polykybd/poly_keymap.c
@@ -1104,33 +1104,37 @@ uint16_t keymap_key_to_keycode(uint8_t layer, keypos_t key) {
     return poly_keycode_at(layer, key.row, key.col);
 }
 
-// Clamp a desired idle jitter offset so the legend's bounding box (measured at the
-// draw origin ox/oy) stays inside the visible window [BUFFER_X, BUFFER_X+SCREEN_WIDTH-1]
-// x [0, SCREEN_HEIGHT-1]. Glyph-driven, so it is correct for any script: a narrow
-// Latin letter may travel far, a full-width CJK glyph barely or not at all (clamped
-// to 0 in that axis) — the legend is never partially cut off at any offset.
-static void clamp_idle_offset(const uint32_t* text, int8_t ox, int8_t oy, int8_t* dx, int8_t* dy) {
+// Roll a per-glyph idle jitter offset: a uniform random position within the legend's
+// OWN on-screen slack, measured from its bounding box at the draw origin (ox/oy). The
+// range is glyph-derived — never a global cap — so a slim "i" roams its full free
+// width while a wide "w" stays within its small margin, each using all (and only) the
+// space it actually has. A global ±N envelope would be counter-productive here: it
+// would throttle the slim glyph (lots of slack, but capped) and edge-bias the wide one
+// (most rolls clamp to the same boundary). A glyph with no slack in an axis simply
+// doesn't move in it. The result is always fully on-screen for any script, so no
+// separate clamp step is needed.
+static void roll_idle_offset(const uint32_t* text, int8_t ox, int8_t oy, uint32_t seed,
+                             int8_t* dx, int8_t* dy) {
     int8_t xmin, xmax, ymin, ymax;
     kdisp_gfx_text_bbox(ALL_FONTS, ALL_FONT_SIZE, text, &xmin, &xmax, &ymin, &ymax);
     int16_t axmin = ox + xmin, axmax = ox + xmax;   // glyph extent at the un-jittered origin
     int16_t aymin = oy + ymin, aymax = oy + ymax;
-    int16_t lo, hi;
-    lo = (int16_t)BUFFER_X - axmin;                          // keep left edge >= BUFFER_X
-    hi = (int16_t)(BUFFER_X + SCREEN_WIDTH - 1) - axmax;     // keep right edge <= last visible col
-    *dx = (hi < lo) ? 0 : (int8_t)PK_MIN(PK_MAX((int16_t)*dx, lo), hi);
-    lo = -aymin;                                             // keep top >= 0
-    hi = (int16_t)(SCREEN_HEIGHT - 1) - aymax;               // keep bottom <= last visible row
-    *dy = (hi < lo) ? 0 : (int8_t)PK_MIN(PK_MAX((int16_t)*dy, lo), hi);
+    int16_t xlo = (int16_t)BUFFER_X - axmin;                      // keep left edge >= BUFFER_X
+    int16_t xhi = (int16_t)(BUFFER_X + SCREEN_WIDTH - 1) - axmax; // keep right edge on-screen
+    int16_t ylo = -aymin;                                         // keep top >= 0
+    int16_t yhi = (int16_t)(SCREEN_HEIGHT - 1) - aymax;           // keep bottom on-screen
+    *dx = (xhi < xlo) ? 0 : jitter_axis(seed, 0x0000u, (int8_t)xlo, (int8_t)xhi);
+    *dy = (yhi < ylo) ? 0 : jitter_axis(seed, 0x1000u, (int8_t)ylo, (int8_t)yhi);
 }
 
 // Idle (anti-burn-in) per-key render: draws ONLY the resting normal legend — no
-// shift/AltGr preview, no overlay image, no tab/MRU chrome — relocated by the given
-// (dx,dy) offset, clamped per glyph so it is always fully visible. Renders into the
-// currently selected display's buffer, so it works both from update_displays() and
-// from inside kdisp_idle()'s shift-register walk (the caller selects the key). Keeps
-// all idle-mode rendering in one place instead of threading an "idle" flag through
-// the awake path.
-static void render_idle_key(uint16_t keycode, led_t state, int8_t dx, int8_t dy) {
+// shift/AltGr preview, no overlay image, no tab/MRU chrome — relocated to a fresh
+// random spot within THIS glyph's own slack (roll_idle_offset, seeded by `seed`), so
+// it is always fully visible. Renders into the currently selected display's buffer, so
+// it works from inside kdisp_idle()'s shift-register walk (the caller selects the
+// key). Keeps all idle-mode rendering in one place instead of threading an "idle" flag
+// through the awake path.
+static void render_idle_key(uint16_t keycode, led_t state, uint32_t seed) {
     const poly_sync_t* local_state = get_local_state();
     uint32_t unimap[2] = {0, 0};
     const uint32_t* text = to_static_text(keycode, state);
@@ -1146,7 +1150,8 @@ static void render_idle_key(uint16_t keycode, led_t state, int8_t dx, int8_t dy)
     }
     kdisp_set_buffer(0x00);
     if (text != NULL && text[0] != 0) {
-        clamp_idle_offset(text, BUFFER_X, 23, &dx, &dy);
+        int8_t dx, dy;
+        roll_idle_offset(text, BUFFER_X, 23, seed, &dx, &dy);
         kdisp_set_draw_offset(dx, dy);
         kdisp_write_gfx_text(ALL_FONTS, ALL_FONT_SIZE, BUFFER_X, 23, text);
         kdisp_set_draw_offset(0, 0);
@@ -1331,15 +1336,11 @@ void kdisp_idle(uint8_t contrast) {
                     uint8_t idle_brightness = to_brightness((contrast+(c%3+r)*keycode+offset+r)%50);
                     if(idle_brightness==0) {
                         // Lit -> dark edge in JITTER style: relocate this key now,
-                        // while it is invisible. The currently selected display is
-                        // this key's, so render_idle_key() draws straight into it.
+                        // while it is invisible. render_idle_key() rolls a fresh offset
+                        // within this glyph's own slack; the currently selected display
+                        // is this key's, so it draws straight into it.
                         if(jitter && !s_idle_was_dark[r][c] && keycode != KC_TRNS) {
-                            int8_t dx = jitter_axis(s_idle_roll, ((uint32_t)(r*MATRIX_COLS+c)<<1)|0u,
-                                                    IDLE_JITTER_DX_MIN, IDLE_JITTER_DX_MAX);
-                            int8_t dy = jitter_axis(s_idle_roll, ((uint32_t)(r*MATRIX_COLS+c)<<1)|1u,
-                                                    IDLE_JITTER_DY_MIN, IDLE_JITTER_DY_MAX);
-                            s_idle_roll++;
-                            render_idle_key(keycode, led_state, dx, dy);
+                            render_idle_key(keycode, led_state, s_idle_roll++);
                         }
                         s_idle_was_dark[r][c] = 1;
                         kdisp_enable(false);

--- a/keyboards/handwired/polykybd/state.h
+++ b/keyboards/handwired/polykybd/state.h
@@ -36,12 +36,11 @@ typedef struct _poly_sync_t {
     uint8_t  emj_page;
     // Language layer page — synced so both halves show the same page of languages.
     uint8_t  lang_page;
-    // Anti-burn-in idle jitter offset for the rendered legend (signed pixels).
-    // 0/0 in the legacy pulse style; the master picks a new small random offset
-    // each pulse cycle in JITTER style and syncs it so both halves relocate in
-    // lockstep. update_displays() re-renders only when these change.
-    int8_t   idle_dx;
-    int8_t   idle_dy;
+    // Active idle (anti-burn-in) style, synced so the slave jitters in lockstep
+    // with the master. In JITTER style each half relocates its own keys' legends
+    // independently as they pulse dark (see kdisp_idle); there is no shared offset
+    // to sync — only the style bit (and the pulse `contrast`) cross the link.
+    uint8_t  idle_style;
 } poly_sync_t;
 
 typedef struct _poly_last_t {


### PR DESCRIPTION
## Follow-up to #79

#79 added the `IDLE_STYLE_JITTER` anti-burn-in style with **one global offset** that shifted every legend in lockstep once per ~15 s cycle. This reworks the *implementation* of that same style into a **per-key** effect — nicer to look at and simpler on the wire. The HID protocol, the EEPROM field, and the pulse default are all unchanged (still v4, `idle_style` 0=pulse / 1=jitter); only how jitter renders changed.

## Change

Instead of the master computing one `idle_dx/idle_dy` and syncing it so both halves shift together, **each key relocates its own legend the instant that key's out-of-phase pulse dims it to black**:

- `kdisp_idle()` already computes a per-key brightness and walks every key on its half with the shift register selecting each one. On a key's **lit→dark edge** in JITTER style it rolls a fresh per-key `(dx,dy)` and calls `render_idle_key(keycode, led_state, dx, dy)` to redraw *that one key* straight into the currently-selected display. The key is dark at that moment, so the move is invisible; it reappears at the new spot on its next bright cycle (~once per ~15 s per key). A 1-bit-per-key `s_idle_was_dark` latch gates it to once per dark episode.
- The glyph is **re-derived from the keycode** on every relocation — nothing is stored in the OLED's own memory (the panel only holds the last frame we send).
- The per-glyph clamp (`clamp_idle_offset`) is unchanged, so legends stay fully on-screen for any script.

## Simpler on the wire

Each half relocates only its own keys, so there is **no shared offset to sync**. `poly_sync_t.idle_dx/idle_dy` (2 bytes) are replaced by a single `idle_style` byte (net −1 byte) — the slave only needs to know *whether* to jitter, and it adopts that via the existing `copy_local_state`. `update_displays()` now early-returns at idle and lets `kdisp_idle()` own all idle visuals.

### Files
- `poly_keymap.c` — per-key relocation in `kdisp_idle()`; `render_idle_key()` takes the offset as params and renders into the selected display; `update_displays()` early-returns at idle; drop the global jitter housekeeping computation; sync `idle_style`; add `reset_idle_jitter()`.
- `state.h` — `poly_sync_t.idle_dx/idle_dy` → `idle_style`.
- `hid_com.c` — drop the global-offset resets (cmd 15 now calls `reset_idle_jitter()`; cmd 28 needs none — the style syncs from housekeeping).
- `config.h` — drop the now-unused `IDLE_JITTER_CYCLE_STEPS` / `IDLE_JITTER_REDRAW_CONTRAST`.
- `base/update.h` — declare `reset_idle_jitter()`.
- `CLAUDE.md` — document the per-key model.

## Testing

- `split72:default` and `split42:default` both build clean and link (ARM toolchain in the dev container).
- Not yet flashed/observed on hardware — the visual result is unverified on a real keyboard.

A companion change in **PolyKybdHost** (same branch name) adds the GUI tray toggle (Pulse / Jitter) for this style; that protocol is unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CuPnCAA6syPsWqXx6gPgHj

---
_Generated by [Claude Code](https://claude.ai/code/session_01CuPnCAA6syPsWqXx6gPgHj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated idle display anti-burn-in documentation to match the current per-key jitter behavior and limits

* **Refactor**
  * Changed idle jitter/legend relocation to be per-key and triggered independently to reduce visual conflicts
  * Adjusted idle rendering so it no longer redraws conflicting elements during idle

* **Configuration**
  * Simplified idle anti-burn-in tuning by removing multiple legacy jitter timing knobs and adding a single `IDLE_JITTER_PERIOD` setting

* **Maintenance**
  * Improved wake/suspend/stop-idle handling so the next idle session starts cleanly
<!-- end of auto-generated comment: release notes by coderabbit.ai -->