### PR TITLE
security: debug-gate keystroke logging and host active-control HID commands

### DIFF
--- a/keyboards/handwired/polykybd/bridge_helper.c
+++ b/keyboards/handwired/polykybd/bridge_helper.c
@@ -73,7 +73,10 @@ uint8_t send_to_bridge(int8_t tid, void* buffer_with4crc_bytes, const uint8_t nu
     // Periodic split-link health line, once per LINK_STATS_LOG_EVERY frames sent.
     // Count-based (no timer): the cadence tracks real traffic. Checked once per
     // call on fully-settled cumulative counts, so it covers every exit path.
-    if (debug_enable && (ls_attempts - ls_last_log) >= LINK_STATS_LOG_EVERY) {
+    // Emitted unconditionally (uprintf, not debug_enable-gated): this is a passive
+    // wire-health diagnostic with no key content, so it stays available even with
+    // debug off (debug_enable now defaults false to suppress keystroke logging).
+    if ((ls_attempts - ls_last_log) >= LINK_STATS_LOG_EVERY) {
         ls_last_log = ls_attempts;
         uint32_t errs    = ls_crc_err + ls_transport_fail;
         uint32_t permille = ls_attempts ? (uint32_t)(((uint64_t)errs * 1000U) / ls_attempts) : 0U;

--- a/keyboards/handwired/polykybd/hid_com.c
+++ b/keyboards/handwired/polykybd/hid_com.c
@@ -446,7 +446,12 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                 raw_hid_send(data, length);
                 break;
             case 14: //key press
-                {
+                // SECURITY: this injects a real key event into QMK (action_exec), i.e.
+                // the keyboard types into the host's focused app on the host's command —
+                // a keystroke-injection primitive. It's a demo/dev feature, so gate it on
+                // debug_enable (off by default; unlock with the DB_TOGG key, which needs
+                // physical access). When debug is off, NACK instead of injecting.
+                if (debug_enable) {
                     uint16_t keycode = ((uint16_t)data[HID_DATA_IDX])<<8 | data[HID_DATA_IDX+1];
                     uint8_t r = 0, c = 0;
                     enum key_split_pos pos = get_split_matrix_pos(keycode, get_highest_layer(local_layer->layer), &r, &c, is_left_side());
@@ -469,6 +474,9 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                     switch_events_poly(r,c, pressed);
                     memset(data, 0, length);
                     memcpy(data, "P\x0e.", 3);
+                } else {
+                    memset(data, 0, length);
+                    memcpy(data, "P\x0e!", 3);   // NACK: key injection requires debug mode
                 }
                 raw_hid_send(data, length);
                 break;
@@ -589,12 +597,25 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                 raw_hid_send(data, length);
                 break;
             case 23: // enter bootloader (host-triggered; mirrors a QK_BOOTLOADER press)
-                uprint("Host requested bootloader.\n");
-                poly_announce_bootloader();
-                memset(data, 0, length);
-                memcpy(data, "P\x17.", 3);
-                raw_hid_send(data, length);
-                reset_keyboard();
+                // SECURITY: dropping into the RP2040 bootloader (BOOTSEL) is destructive
+                // and, ungated, lets any HID-reachable process force the keyboard offline
+                // at will (DoS) and stage a UF2-drive reflash. Gate on debug_enable (off
+                // by default; unlock with DB_TOGG — physical access). The normal staging
+                // firmware-update path (cmds 0x40..0x44) is unaffected; this only gates
+                // the manual "activate bootloader" recovery action.
+                if (debug_enable) {
+                    uprint("Host requested bootloader.\n");
+                    poly_announce_bootloader();
+                    memset(data, 0, length);
+                    memcpy(data, "P\x17.", 3);
+                    raw_hid_send(data, length);
+                    reset_keyboard();
+                } else {
+                    uprint("Host requested bootloader — refused (debug off).\n");
+                    memset(data, 0, length);
+                    memcpy(data, "P\x17!", 3);   // NACK: bootloader entry requires debug mode
+                    raw_hid_send(data, length);
+                }
                 break;
             case 24: //display off
                 poly_suspend();

--- a/keyboards/handwired/polykybd/hid_com.c
+++ b/keyboards/handwired/polykybd/hid_com.c
@@ -597,25 +597,12 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                 raw_hid_send(data, length);
                 break;
             case 23: // enter bootloader (host-triggered; mirrors a QK_BOOTLOADER press)
-                // SECURITY: dropping into the RP2040 bootloader (BOOTSEL) is destructive
-                // and, ungated, lets any HID-reachable process force the keyboard offline
-                // at will (DoS) and stage a UF2-drive reflash. Gate on debug_enable (off
-                // by default; unlock with DB_TOGG — physical access). The normal staging
-                // firmware-update path (cmds 0x40..0x44) is unaffected; this only gates
-                // the manual "activate bootloader" recovery action.
-                if (debug_enable) {
-                    uprint("Host requested bootloader.\n");
-                    poly_announce_bootloader();
-                    memset(data, 0, length);
-                    memcpy(data, "P\x17.", 3);
-                    raw_hid_send(data, length);
-                    reset_keyboard();
-                } else {
-                    uprint("Host requested bootloader — refused (debug off).\n");
-                    memset(data, 0, length);
-                    memcpy(data, "P\x17!", 3);   // NACK: bootloader entry requires debug mode
-                    raw_hid_send(data, length);
-                }
+                uprint("Host requested bootloader.\n");
+                poly_announce_bootloader();
+                memset(data, 0, length);
+                memcpy(data, "P\x17.", 3);
+                raw_hid_send(data, length);
+                reset_keyboard();
                 break;
             case 24: //display off
                 poly_suspend();

--- a/keyboards/handwired/polykybd/poly_keymap.c
+++ b/keyboards/handwired/polykybd/poly_keymap.c
@@ -1355,13 +1355,19 @@ void kdisp_idle(uint8_t contrast) {
 // Handles keypress events including unicode input, language modifications, and special commands.
 bool process_record_user(uint16_t keycode, keyrecord_t* record) {
 
-    uint32_t t = get_time_since_last_update();
-    if(record->event.pressed) {
-        uprintf("wait %ld.%03ld\n", t/1000, t%1000);
-        uprintf("press 0x%04x\n", keycode);
-    } else {
-        uprintf("wait %ld.%03ld\n", t/1000, t%1000);
-        uprintf("release 0x%04x\n", keycode);
+    // SECURITY: the keycode of every keystroke (passwords included) must NOT be
+    // streamed to the HID console in normal operation — any local process can open
+    // that console interface and read it. Gate this logging on debug_enable (off by
+    // default; toggle at runtime with the DB_TOGG key, which needs physical access).
+    if (debug_enable) {
+        uint32_t t = get_time_since_last_update();
+        if(record->event.pressed) {
+            uprintf("wait %ld.%03ld\n", t/1000, t%1000);
+            uprintf("press 0x%04x\n", keycode);
+        } else {
+            uprintf("wait %ld.%03ld\n", t/1000, t%1000);
+            uprintf("release 0x%04x\n", keycode);
+        }
     }
 
     if (emj_process_keycode(keycode, record->event.pressed)) return false;
@@ -1911,7 +1917,11 @@ void keyboard_post_init_user(void) {
     boot_trace(U"1");
 #endif
     // Customise these values to desired behaviour
-    debug_enable = true;
+    // SECURITY: default OFF. debug_enable now gates keystroke logging to the HID
+    // console (process_record_user) and the host-driven active-control HID commands
+    // (cmd 14 key injection, cmd 23 bootloader entry). Enable at runtime with the
+    // DB_TOGG key (physical access required) when you actually want demo/debug.
+    debug_enable = false;
     debug_matrix = false;
     debug_keyboard = false;
     debug_mouse = false;


### PR DESCRIPTION
## Summary

Closes two keylogging-grade exposures in the firmware, both now gated on `debug_enable` (**default OFF**; unlock at runtime with the physical **`DB_TOGG`** key, already mapped in both default keymaps).

### (a) `poly_keymap.c` — keystroke logging
- `process_record_user` logged the keycode of **every** keystroke (passwords included) to the HID console via unconditional `uprintf` — readable by any local process that opens the console interface, with **no debug gate at all** (`uprintf` is not gated by `debug_enable`, only by compile-time `CONSOLE_ENABLE`, which ships enabled via `"console": true`). Wrapped the press/release logging in `if (debug_enable)`.
- `keyboard_post_init_user` forced `debug_enable = true` at boot. Defaulted it to **false** so the gate above (and the cmd 14 gate below) are effective out of the box.

### (b) `hid_com.c` — host key injection
- **case 14 (key press):** injected a real key event via `action_exec` — a remote keystroke-**injection** primitive (the keyboard types into the host's focused app). Now gated on `debug_enable`; NACKs `P\x0e!` when debug is off.

### `bridge_helper.c` — split-link health counter stays always-on
- Defaulting `debug_enable = false` would otherwise have silenced the periodic `Split link: … crc_err=… err=…%` summary in `send_to_bridge()` (it was `if (debug_enable && …)`). That counter is a passive wire-health diagnostic with no key content, so it's now emitted **unconditionally** (via its existing `uprintf`). The per-frame retry/give-up chatter stays `debug_enable`-gated.

### Not gated: bootloader entry (cmd 23)
An earlier revision also gated the host-triggered bootloader (cmd 23). **Reverted** — it was the wrong trade-off:
- Bootloader entry is **loud, not stealthy** (the keyboard disconnects and remounts as a USB mass-storage drive), so forcing it is an obvious, recoverable nuisance — not a silent, high-impact exposure.
- It **breaks the legitimate "Activate Bootloader" recovery path**, whose `DB_TOGG` unlock would itself require a working keyboard.
- Its one security angle (force BOOTSEL → write a malicious UF2) is **redundant with the ungated staging-flash path** (cmds `0x40..0x44`). The real fix for arbitrary firmware is **image signing**, not gating one of the two entries.

## Why this design

`DB_TOGG` requires a **physical** key press to enable, so keystroke logging and host key injection now need someone at the keyboard. `debug_enable` resets to false on every boot/replug (safe default).

## Net effect

| Behavior | Gated on `debug_enable`? |
|---|---|
| Keystroke logging (`press/release 0x…`) | ✅ yes (off by default) |
| HID cmd 14 key injection | ✅ yes (NACK when off) |
| HID cmd 23 bootloader entry | ❌ no — unchanged/always-available |
| Split-link health counter | ❌ no — always on |
| Per-frame retry/give-up chatter | ✅ yes (off by default) |

## Testing

Built from the working tree with the ARM toolchain + qmk CLI: `split72:default` and `split42:default` both link clean (exit 0) at every revision. (Both variants share `poly_keymap.c` + `hid_com.c` + `bridge_helper.c`.)

## Companion PR

Host-side half of the key-injection gate (defense in depth): thpoll83/PolyKybdHost#78 — the host strips `press`/`release` commands unless started with `--debug`; this firmware NACK is the device-side enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)