### PR TITLE
Rename manufacturer PolyFabriq → PolyTasten

### DIFF
--- a/keyboards/polykybd/split42-hw-refactoring-plan.md
+++ b/keyboards/polykybd/split42-hw-refactoring-plan.md
@@ -243,7 +243,7 @@ void matrix_slave_scan_kb(void) { matrix_scan_kb(); }
 ```json
 {
     "keyboard_name": "PolyKybd Split42",
-    "manufacturer": "PolyFabriq",
+    "manufacturer": "PolyTasten",
     "url": "https://ko-fi.com/polykb",
     "maintainer": "[thpoll]",
     "bootloader": "rp2040",
@@ -450,7 +450,7 @@ void suspend_wakeup_init_kb(void) {
 | BITMASK macro SR ordering | `split42/split42.h` | Which bitmask index corresponds to which physical shift register |
 | 128×32 logo bitmaps | `split42/status_oled.c` | New `oled_draw_kybd()` and `oled_draw_poly()` arrays (512 bytes each) |
 | keyboard.json layout | `split42/keyboard.json` | All 42 key positions with x/y and matrix[] coordinates |
-| USB PID uniqueness | `split42/keyboard.json` | Confirm `0x2008` is not in use by another PolyFabriq device |
+| USB PID uniqueness | `split42/keyboard.json` | Confirm `0x2008` is not in use by another PolyTasten device |
 
 ---
 

--- a/keyboards/polykybd/split42/keyboard.json
+++ b/keyboards/polykybd/split42/keyboard.json
@@ -1,6 +1,6 @@
 {
     "keyboard_name": "PolyKybd Split42",
-    "manufacturer": "PolyFabriq",
+    "manufacturer": "PolyTasten",
     "url": "https://ko-fi.com/polykb",
     "maintainer": "[thpoll]",
     "bootloader": "rp2040",

--- a/keyboards/polykybd/split72/keyboard.json
+++ b/keyboards/polykybd/split72/keyboard.json
@@ -1,6 +1,6 @@
 {
     "keyboard_name": "PolyKybd Split72",
-    "manufacturer": "PolyFabriq",
+    "manufacturer": "PolyTasten",
     "url": "https://ko-fi.com/polykb",
     "maintainer": "[thpoll]",
     "bootloader": "rp2040",


### PR DESCRIPTION
## Summary

Rebrand the (not-yet-registered) company name from **PolyFabriq** to **PolyTasten**.

## Changes
- `split72/keyboard.json` and `split42/keyboard.json` — `"manufacturer": "PolyTasten"`. ⚠️ **Functional**: this is the USB manufacturer string descriptor the OS shows for the device.
- `split42-hw-refactoring-plan.md` — doc references.

## Verification
- Both `keyboard.json` files parse and `qmk lint -kb polykybd/split72` passes.
- The host-side firmware validator keys off the variant-agnostic `"Poly"` USB-descriptor prefix, which still matches `PolyTasten`, so firmware validation is unaffected.
- The USB VID `0x2021` is unchanged — that's a registered number tied to the company, not the name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014SxvJKToHaLeWBnmEAGqHd)_

## Summary by Sourcery

Rename the keyboard manufacturer from PolyFabriq to PolyTasten across configuration and documentation.

Enhancements:
- Change the USB manufacturer string in split42 and split72 keyboard.json definitions to use PolyTasten.

Documentation:
- Update split42 hardware refactoring plan to reference the PolyTasten manufacturer name instead of PolyFabriq.