### PR TITLE
security(FW-1): clamp HID overlay ROI bounds to the display (OOB write fix)

### DIFF
--- a/keyboards/polykybd/base/overlay.c
+++ b/keyboards/polykybd/base/overlay.c
@@ -6,6 +6,11 @@
 
 #include <string.h>
 
+// Bit capacity of one keycap overlay row (72x40 = 2880 bits = 360 bytes). Single
+// source of truth for the copy-loop "done"/overflow sentinel so the bounds stay
+// correct if the display geometry ever changes.
+#define OVERLAY_BIT_CAPACITY (SCREEN_WIDTH * SCREEN_HEIGHT)
+
 static volatile uint8_t use_overlay[(NUM_OVERLAYS*NUM_VARIATIONS_WITH_MAP/8)+1];
 static /*volatile*/ uint8_t overlays [NUM_OVERLAYS*NUM_VARIATIONS][72*40/8]; // ResX*ResY/PixelPerByte
 static uint16_t overlay_map [NUM_OVERLAYS*NUM_VARIATIONS_WITH_MAP];
@@ -44,6 +49,10 @@ void set_fragment_context_from_buffer(const uint8_t *buffer) {
     if (g_fragment_context.roi.yy > SCREEN_HEIGHT)  g_fragment_context.roi.yy = SCREEN_HEIGHT;
     if (g_fragment_context.roi.x  >= SCREEN_WIDTH)  g_fragment_context.roi.x  = SCREEN_WIDTH  - 1;
     if (g_fragment_context.roi.y  >= SCREEN_HEIGHT) g_fragment_context.roi.y  = SCREEN_HEIGHT - 1;
+    // Enforce the x<=xx / y<=yy invariant: an inverted/empty range from malformed
+    // host input must produce no write (degenerate ROI), never an underflowing loop.
+    if (g_fragment_context.roi.x > g_fragment_context.roi.xx) g_fragment_context.roi.x = g_fragment_context.roi.xx;
+    if (g_fragment_context.roi.y > g_fragment_context.roi.yy) g_fragment_context.roi.y = g_fragment_context.roi.yy;
 }
 
 void set_fragment_context_key(uint8_t keycode, uint8_t modifier) {
@@ -139,11 +148,12 @@ uint16_t copy_rectangle_to_overlay_xy(uint16_t bit_index, uint8_t* dest, const v
         }
         for (uint8_t dest_x = start_x; dest_x < roi->xx; dest_x++) {
             bit_index = dest_y * SCREEN_WIDTH + dest_x;
-            // SECURITY backstop: dest is a single 360-byte (2880-bit) overlay row.
-            // Even if a caller hands us an out-of-range roi (e.g. via the split
-            // bridge), never write past it — bail at the row boundary.
-            if (bit_index >= SCREEN_WIDTH * SCREEN_HEIGHT) {
-                return 2880;
+            // SECURITY backstop: dest is a single SCREEN_WIDTH*SCREEN_HEIGHT-bit
+            // (360-byte) overlay row. Even if a caller hands us an out-of-range roi
+            // (e.g. via the split bridge), never write past it — bail at the row
+            // boundary, returning the geometry-derived "done" sentinel callers test.
+            if (bit_index >= OVERLAY_BIT_CAPACITY) {
+                return OVERLAY_BIT_CAPACITY;
             }
             uint8_t data_byte   = data[bit_cnt / 8];
             uint8_t bit_in_byte = bit_cnt % 8;
@@ -162,7 +172,7 @@ uint16_t copy_rectangle_to_overlay_xy(uint16_t bit_index, uint8_t* dest, const v
             }
         }
     }
-    return 2880;
+    return OVERLAY_BIT_CAPACITY;
 }
 
 uint16_t copy_rectangle_to_overlay(uint16_t bit_index, uint8_t* dest, const volatile uint8_t* data, const volatile roi_update_data_t* roi, const uint8_t data_len) {
@@ -171,12 +181,12 @@ uint16_t copy_rectangle_to_overlay(uint16_t bit_index, uint8_t* dest, const vola
             uint8_t buffer[16];
             uint16_t num_bits = rle_decompress(buffer, 16, &data[i], 1, 0);
             bit_index = copy_rectangle_to_overlay_xy(bit_index, dest, buffer, roi, num_bits);
-            if( bit_index >= 2880) {
+            if( bit_index >= OVERLAY_BIT_CAPACITY) {
                 return bit_index;
             }
         }
     } else {
         bit_index = copy_rectangle_to_overlay_xy(bit_index, dest, data, roi, data_len*8);
     }
-    return bit_index >= ((roi->yy-1) * SCREEN_WIDTH + roi->xx) ? 2880 : bit_index;
+    return bit_index >= ((roi->yy-1) * SCREEN_WIDTH + roi->xx) ? OVERLAY_BIT_CAPACITY : bit_index;
 }

--- a/keyboards/polykybd/base/overlay.c
+++ b/keyboards/polykybd/base/overlay.c
@@ -45,6 +45,9 @@ void set_fragment_context_from_buffer(const uint8_t *buffer) {
     // would index a 360-byte overlay row well past its end (OOB write into adjacent
     // overlays[]). Clip to the visible window so x/y are valid start coords and
     // xx/yy are valid exclusive ends. (A second backstop lives in the copy loop.)
+    // NOTE: x/y are INCLUSIVE start pixels (max SCREEN_-1) while xx/yy are
+    // EXCLUSIVE ends (max SCREEN_); width = xx-x, so a 1px ROI (xx==x+1) is valid
+    // and x==xx is an empty (no-write) region — this clamp imposes no min size.
     if (g_fragment_context.roi.xx > SCREEN_WIDTH)   g_fragment_context.roi.xx = SCREEN_WIDTH;
     if (g_fragment_context.roi.yy > SCREEN_HEIGHT)  g_fragment_context.roi.yy = SCREEN_HEIGHT;
     if (g_fragment_context.roi.x  >= SCREEN_WIDTH)  g_fragment_context.roi.x  = SCREEN_WIDTH  - 1;

--- a/keyboards/polykybd/base/overlay.c
+++ b/keyboards/polykybd/base/overlay.c
@@ -30,7 +30,7 @@ void reset_fragment_context(void) {
     memset(&g_fragment_context, 0, sizeof(overlay_fragment_context_t));
 }
 
-bool set_fragment_context_from_buffer(const uint8_t *buffer) {
+roi_bounds_t set_fragment_context_from_buffer(const uint8_t *buffer) {
     g_fragment_context.msg_count= 0;
     g_fragment_context.bit_index = 0;
     g_fragment_context.keycode = buffer[0];
@@ -59,7 +59,7 @@ bool set_fragment_context_from_buffer(const uint8_t *buffer) {
     if (g_fragment_context.roi.y > g_fragment_context.roi.yy) { g_fragment_context.roi.y = g_fragment_context.roi.yy; clamped = true; }
     // Report clamping so the HID layer can log a misbehaving/hostile host instead
     // of silently swallowing out-of-bounds ROI bounds.
-    return clamped;
+    return clamped ? ROI_BOUNDS_CLAMPED : ROI_BOUNDS_OK;
 }
 
 void set_fragment_context_key(uint8_t keycode, uint8_t modifier) {

--- a/keyboards/polykybd/base/overlay.c
+++ b/keyboards/polykybd/base/overlay.c
@@ -35,6 +35,15 @@ void set_fragment_context_from_buffer(const uint8_t *buffer) {
     g_fragment_context.roi.x = buffer[3];
     g_fragment_context.roi.xx = buffer[4]&0x7f;
     g_fragment_context.roi.compressed = ((buffer[4]&0x80)!=0);
+    // SECURITY: the ROI bounds are raw host bytes (y/yy up to 63, x up to 255,
+    // xx up to 127) but the keycap is only 72x40. Unclamped, copy_rectangle_to_overlay_xy
+    // would index a 360-byte overlay row well past its end (OOB write into adjacent
+    // overlays[]). Clip to the visible window so x/y are valid start coords and
+    // xx/yy are valid exclusive ends. (A second backstop lives in the copy loop.)
+    if (g_fragment_context.roi.xx > SCREEN_WIDTH)   g_fragment_context.roi.xx = SCREEN_WIDTH;
+    if (g_fragment_context.roi.yy > SCREEN_HEIGHT)  g_fragment_context.roi.yy = SCREEN_HEIGHT;
+    if (g_fragment_context.roi.x  >= SCREEN_WIDTH)  g_fragment_context.roi.x  = SCREEN_WIDTH  - 1;
+    if (g_fragment_context.roi.y  >= SCREEN_HEIGHT) g_fragment_context.roi.y  = SCREEN_HEIGHT - 1;
 }
 
 void set_fragment_context_key(uint8_t keycode, uint8_t modifier) {
@@ -130,6 +139,12 @@ uint16_t copy_rectangle_to_overlay_xy(uint16_t bit_index, uint8_t* dest, const v
         }
         for (uint8_t dest_x = start_x; dest_x < roi->xx; dest_x++) {
             bit_index = dest_y * SCREEN_WIDTH + dest_x;
+            // SECURITY backstop: dest is a single 360-byte (2880-bit) overlay row.
+            // Even if a caller hands us an out-of-range roi (e.g. via the split
+            // bridge), never write past it — bail at the row boundary.
+            if (bit_index >= SCREEN_WIDTH * SCREEN_HEIGHT) {
+                return 2880;
+            }
             uint8_t data_byte   = data[bit_cnt / 8];
             uint8_t bit_in_byte = bit_cnt % 8;
             bool    bit_is_set  = ((0x80 >> bit_in_byte) & data_byte) != 0;

--- a/keyboards/polykybd/base/overlay.c
+++ b/keyboards/polykybd/base/overlay.c
@@ -30,7 +30,7 @@ void reset_fragment_context(void) {
     memset(&g_fragment_context, 0, sizeof(overlay_fragment_context_t));
 }
 
-void set_fragment_context_from_buffer(const uint8_t *buffer) {
+bool set_fragment_context_from_buffer(const uint8_t *buffer) {
     g_fragment_context.msg_count= 0;
     g_fragment_context.bit_index = 0;
     g_fragment_context.keycode = buffer[0];
@@ -48,14 +48,18 @@ void set_fragment_context_from_buffer(const uint8_t *buffer) {
     // NOTE: x/y are INCLUSIVE start pixels (max SCREEN_-1) while xx/yy are
     // EXCLUSIVE ends (max SCREEN_); width = xx-x, so a 1px ROI (xx==x+1) is valid
     // and x==xx is an empty (no-write) region — this clamp imposes no min size.
-    if (g_fragment_context.roi.xx > SCREEN_WIDTH)   g_fragment_context.roi.xx = SCREEN_WIDTH;
-    if (g_fragment_context.roi.yy > SCREEN_HEIGHT)  g_fragment_context.roi.yy = SCREEN_HEIGHT;
-    if (g_fragment_context.roi.x  >= SCREEN_WIDTH)  g_fragment_context.roi.x  = SCREEN_WIDTH  - 1;
-    if (g_fragment_context.roi.y  >= SCREEN_HEIGHT) g_fragment_context.roi.y  = SCREEN_HEIGHT - 1;
+    bool clamped = false;
+    if (g_fragment_context.roi.xx > SCREEN_WIDTH)   { g_fragment_context.roi.xx = SCREEN_WIDTH;      clamped = true; }
+    if (g_fragment_context.roi.yy > SCREEN_HEIGHT)  { g_fragment_context.roi.yy = SCREEN_HEIGHT;     clamped = true; }
+    if (g_fragment_context.roi.x  >= SCREEN_WIDTH)  { g_fragment_context.roi.x  = SCREEN_WIDTH  - 1; clamped = true; }
+    if (g_fragment_context.roi.y  >= SCREEN_HEIGHT) { g_fragment_context.roi.y  = SCREEN_HEIGHT - 1; clamped = true; }
     // Enforce the x<=xx / y<=yy invariant: an inverted/empty range from malformed
     // host input must produce no write (degenerate ROI), never an underflowing loop.
-    if (g_fragment_context.roi.x > g_fragment_context.roi.xx) g_fragment_context.roi.x = g_fragment_context.roi.xx;
-    if (g_fragment_context.roi.y > g_fragment_context.roi.yy) g_fragment_context.roi.y = g_fragment_context.roi.yy;
+    if (g_fragment_context.roi.x > g_fragment_context.roi.xx) { g_fragment_context.roi.x = g_fragment_context.roi.xx; clamped = true; }
+    if (g_fragment_context.roi.y > g_fragment_context.roi.yy) { g_fragment_context.roi.y = g_fragment_context.roi.yy; clamped = true; }
+    // Report clamping so the HID layer can log a misbehaving/hostile host instead
+    // of silently swallowing out-of-bounds ROI bounds.
+    return clamped;
 }
 
 void set_fragment_context_key(uint8_t keycode, uint8_t modifier) {

--- a/keyboards/polykybd/base/overlay.h
+++ b/keyboards/polykybd/base/overlay.h
@@ -21,13 +21,21 @@ typedef struct _overlay_fragment_context_t {
     uint8_t           msg_count; //only used for the bridge
 } overlay_fragment_context_t;
 
+// Outcome of decoding an ROI overlay header (see set_fragment_context_from_buffer).
+// Named so the call site reads unambiguously instead of testing a bare bool.
+typedef enum {
+    ROI_BOUNDS_OK = 0,       // host bounds were within the display
+    ROI_BOUNDS_CLAMPED = 1,  // out-of-range bounds had to be clamped (log it)
+} roi_bounds_t;
+
 const overlay_fragment_context_t* get_fragment_context(void);
 overlay_fragment_context_t* access_fragment_context(void);
 void reset_fragment_context(void);
 // Decode an ROI overlay header from a HID payload into the fragment context,
-// clamping out-of-range ROI coords to the display. Returns true if any value had
-// to be clamped (i.e. the host sent out-of-bounds bounds), so the caller can log it.
-bool set_fragment_context_from_buffer(const uint8_t* buffer);
+// clamping out-of-range ROI coords to the display. Returns ROI_BOUNDS_CLAMPED if
+// any value had to be clamped (the host sent out-of-bounds bounds), so the caller
+// can log it, else ROI_BOUNDS_OK.
+roi_bounds_t set_fragment_context_from_buffer(const uint8_t* buffer);
 void set_fragment_context_key(uint8_t keycode, uint8_t modifier);
 void set_fragment_context_bit_index(uint16_t bit_index);
 void set_fragment_context_byte_len(uint8_t byte_len);

--- a/keyboards/polykybd/base/overlay.h
+++ b/keyboards/polykybd/base/overlay.h
@@ -24,7 +24,10 @@ typedef struct _overlay_fragment_context_t {
 const overlay_fragment_context_t* get_fragment_context(void);
 overlay_fragment_context_t* access_fragment_context(void);
 void reset_fragment_context(void);
-void set_fragment_context_from_buffer(const uint8_t* buffer);
+// Decode an ROI overlay header from a HID payload into the fragment context,
+// clamping out-of-range ROI coords to the display. Returns true if any value had
+// to be clamped (i.e. the host sent out-of-bounds bounds), so the caller can log it.
+bool set_fragment_context_from_buffer(const uint8_t* buffer);
 void set_fragment_context_key(uint8_t keycode, uint8_t modifier);
 void set_fragment_context_bit_index(uint16_t bit_index);
 void set_fragment_context_byte_len(uint8_t byte_len);

--- a/keyboards/polykybd/hid_com.c
+++ b/keyboards/polykybd/hid_com.c
@@ -548,7 +548,12 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                 }
                 break;
             case 18: //start roi overlay
-                set_fragment_context_from_buffer(&data[HID_DATA_IDX]);
+                if (set_fragment_context_from_buffer(&data[HID_DATA_IDX])) {
+                    const overlay_fragment_context_t *fc = get_fragment_context();
+                    uprintf("ROI overlay: host sent out-of-bounds ROI for keycode %u — "
+                            "clamped to x=%u y=%u xx=%u yy=%u.\n",
+                            fc->keycode, fc->roi.x, fc->roi.y, fc->roi.xx, fc->roi.yy);
+                }
                 //fall through
             case 19: //receive roi overlay
                 {

--- a/keyboards/polykybd/hid_com.c
+++ b/keyboards/polykybd/hid_com.c
@@ -548,7 +548,7 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                 }
                 break;
             case 18: //start roi overlay
-                if (set_fragment_context_from_buffer(&data[HID_DATA_IDX])) {
+                if (set_fragment_context_from_buffer(&data[HID_DATA_IDX]) == ROI_BOUNDS_CLAMPED) {
                     const overlay_fragment_context_t *fc = get_fragment_context();
                     uprintf("ROI overlay: host sent out-of-bounds ROI for keycode %u — "
                             "clamped to x=%u y=%u xx=%u yy=%u.\n",


### PR DESCRIPTION
## Summary (Critical)

The HID overlay/ROI commands let the host set a region-of-interest (`x/y/xx/yy`) that `copy_rectangle_to_overlay_xy()` writes into the `overlays[][]` buffer. The ROI fields came straight off the wire with **no bounds check**, so a crafted overlay/ROI report could drive the write cursor past the per-keycap buffer — an attacker-controlled out-of-bounds write in firmware (memory corruption / potential code-exec on the RP2040).

## Fix

- Clamp the incoming ROI (`x`, `y`, `xx`, `yy`) to the physical display bounds (72×40) where the fragment context is set from the HID payload, so `xx/yy` can never exceed the buffer geometry and `x≤xx`, `y≤yy` hold.
- Row-boundary backstop inside `copy_rectangle_to_overlay_xy()` so the per-scanline cursor cannot run past the clamped region even on malformed input.
- `SET_PIXEL_CLIPPED` remains the last-resort memory-safety net; this fix stops the bad geometry at the source instead of relying on it.

## Testing

- `polykybd/split72:default` and `polykybd/split42:default` build clean.
- Legitimate overlay/ROI transfers are unaffected (in-bounds regions pass through unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NinUrR5rxUWk1w9RKz5unE)_

## Summary by Sourcery

Bug Fixes:
- Prevent out-of-bounds writes in the overlay buffer by clamping ROI coordinates to the display dimensions and enforcing a row-level bounds check during rectangle copying.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety when rendering overlay regions so unexpected coordinates can’t extend beyond the visible screen.
  * Added a safeguard to prevent drawing operations from writing outside the overlay area, reducing the risk of display corruption or crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->