### PR TITLE
security(FW-4): bounds-check get_overlay() index (latent OOB hardening)

### DIFF
--- a/keyboards/polykybd/base/overlay.c
+++ b/keyboards/polykybd/base/overlay.c
@@ -4,6 +4,7 @@
 #include "disp_array.h"
 #include "polymod_rle.h"
 
+#include <print.h>
 #include <string.h>
 
 static volatile uint8_t use_overlay[(NUM_OVERLAYS*NUM_VARIATIONS_WITH_MAP/8)+1];
@@ -67,14 +68,27 @@ uint8_t (* get_overlays(void))[72*40/8] {
     return overlays;
 }
 
+// Throwaway row returned for an out-of-range overlay index — so an OOB access
+// neither reads past the pool nor corrupts a real slot. Writes land here and are
+// dropped; reads come back blank instead of slot 0's legitimate keycap image.
+static uint8_t s_overlay_discard[72*40/8];
+
 uint8_t* get_overlay(uint16_t overlay_idx) {
     // SECURITY: this is the single place overlays[] is dereferenced. The index
     // arrives from the host-programmed mapping (get_overlay_mapping -> overlay_map[],
-    // cmd 21) and is only validated at write time today; bound it here so a stale or
-    // missing mapping can never index past the pool (OOB read/write). Out-of-range
-    // falls back to slot 0.
+    // cmd 21) and is only validated at write time today, so an out-of-range value
+    // here would read/write past the pool. Route it to a discard row instead —
+    // memory-safe AND non-destructive (no real slot is read or overwritten; slot 0
+    // would have been a legitimate keycap image). Logged once so a stale/buggy
+    // mapping doesn't disappear silently, one-shot to avoid flooding the render path.
     if (overlay_idx >= NUM_OVERLAYS*NUM_VARIATIONS) {
-        overlay_idx = 0;
+        static bool s_logged = false;
+        if (!s_logged) {
+            s_logged = true;
+            uprintf("get_overlay: index %u out of range (max %u) — discarding.\n",
+                    (unsigned)overlay_idx, (unsigned)(NUM_OVERLAYS*NUM_VARIATIONS - 1));
+        }
+        return s_overlay_discard;
     }
     return overlays[overlay_idx];
 }

--- a/keyboards/polykybd/base/overlay.c
+++ b/keyboards/polykybd/base/overlay.c
@@ -68,6 +68,14 @@ uint8_t (* get_overlays(void))[72*40/8] {
 }
 
 uint8_t* get_overlay(uint16_t overlay_idx) {
+    // SECURITY: this is the single place overlays[] is dereferenced. The index
+    // arrives from the host-programmed mapping (get_overlay_mapping -> overlay_map[],
+    // cmd 21) and is only validated at write time today; bound it here so a stale or
+    // missing mapping can never index past the pool (OOB read/write). Out-of-range
+    // falls back to slot 0.
+    if (overlay_idx >= NUM_OVERLAYS*NUM_VARIATIONS) {
+        overlay_idx = 0;
+    }
     return overlays[overlay_idx];
 }
 


### PR DESCRIPTION
## Summary

`get_overlay(idx)` returns `overlays[idx]` and is the single dereference chokepoint for overlay memory — reached from the HID overlay path, the core1 RLE/ROI worker, and the slave split-bridge handlers. The index was used unchecked, so any path that computed a bad `overlay_idx` (`keycode_slot + 90*modifier_variant`) would read/write out of bounds.

## Fix

Add a bounds check in `get_overlay()` (idx `< NUM_OVERLAYS*NUM_VARIATIONS`, i.e. 630) and return a safe pointer / no-op on an out-of-range index, closing the latent OOB at the one place every caller funnels through. Defence-in-depth alongside FW-1 (which clamps the ROI geometry upstream).

## Testing

- `polykybd/split72:default` and `polykybd/split42:default` build clean.
- Normal overlay indexing (all 90 slots × 9 modifier variants) is within range and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NinUrR5rxUWk1w9RKz5unE)_

## Summary by Sourcery

Bug Fixes:
- Guard overlay index in get_overlay() against out-of-range values to avoid potential out-of-bounds reads and writes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented invalid overlay selections from causing out-of-bounds access.
  * Out-of-range overlay requests now return a safe fallback overlay without impacting current layouts.
  * Added one-time warning logging for invalid overlay indices to aid troubleshooting while avoiding repeated messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->