### PR TITLE
fix(split): transport-gated one-shot boot layer-resync (fixes HIL boot-window stall)

### DIFF
--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -27,6 +27,7 @@
 #include "debug.h"
 
 #include <transactions.h>
+#include "split_util.h"   // is_transport_connected() — gate the boot layer-resync one-shot
 #include <hardware/flash.h>
 
 #include "polykybd.h"
@@ -369,13 +370,25 @@ void sync_and_refresh_displays(void) {
         // `global` (e.g. _L0/Qwerty = all-zero after a fresh boot/fw-apply reboot),
         // a slave that booted with a stale default layer would never be corrected
         // until the next manual layer change. The one-shot resync fixes that.
-        if ( layer_diff || g_force_layer_resync ) {
-            if(sync_succeeded(send_to_bridge(USER_SYNC_LAYER_DATA, (void *)access_local_layer(), sizeof(poly_layer_t), PERIODIC_SYNC_RETRIES))) {
+        //
+        // It is a TRUE one-shot: fired only once the split transport is connected,
+        // then cleared regardless of the ACK. The old version re-fired every
+        // housekeeping pass until the slave ACKed, which on a slow-ACK link spun the
+        // master main loop for ~3 × bridge-timeout per pass and stalled the host's
+        // first HID queries (the HIL boot-window flake). Gating on
+        // is_transport_connected() gives the single try a real chance; if it still
+        // drops, a genuinely-stale slave is corrected by the next real layer diff.
+        bool force_resync = g_force_layer_resync && is_transport_connected();
+        if ( layer_diff || force_resync ) {
+            bool sent = sync_succeeded(send_to_bridge(USER_SYNC_LAYER_DATA, (void *)access_local_layer(), sizeof(poly_layer_t), PERIODIC_SYNC_RETRIES));
+            if (force_resync) {
+                g_force_layer_resync = false;  // one-shot: never re-fire, even on a drop
+            }
+            if (sent) {
                 layer_diff = true;             // ensure global advances (copy_global_layer below)
-                g_force_layer_resync = false;  // boot resync delivered to the slave
             } else {
-                layer_diff = false; // failed: skip copy_global_layer() below so the diff
-                                    // persists and the send re-fires next pass (force flag stays set)
+                layer_diff = false; // failed: skip copy_global_layer() below so a real diff
+                                    // persists and the send re-fires next pass
                 uprint("USER_SYNC_LAYER_DATA failed to send\n");
             }
         }


### PR DESCRIPTION
## Summary

Fixes the recurring **HIL boot-window flake** (early `lang-list` / `get default layer` / VIA-reset commands timing out in the first ~second, then recovering) at its root cause: the boot-time forced layer-resync.

`g_force_layer_resync` starts `true` and the master re-sent `USER_SYNC_LAYER_DATA` **every housekeeping pass until the slave ACKed**, at `PERIODIC_SYNC_RETRIES` per attempt. On a slow-ACK link (the HIL rig) the slave is slow to ACK at boot, so the resync **spun the master main loop** for ~3 × bridge-timeout per pass — exactly in the window where the host issues its first HID queries, deterministically timing them out. On real hardware (reliable full-duplex link) the slave ACKs the first try and the flake never reproduces, but the spin is latent.

## Fix

Make the forced push a **true one-shot, gated on the transport being connected**:

```c
bool force_resync = g_force_layer_resync && is_transport_connected();
if ( layer_diff || force_resync ) {
    bool sent = sync_succeeded(send_to_bridge(USER_SYNC_LAYER_DATA, ...));
    if (force_resync) g_force_layer_resync = false;  // one-shot: never re-fire
    ...
}
```

- It fires only once `is_transport_connected()` (so the single try has a real chance to land), then clears the flag **regardless of the ACK** — no per-pass re-fire, no blocking spin.
- A genuinely-stale slave is still corrected by the **next real layer diff** (the documented, accepted trade-off).
- On good hardware behaviour is unchanged: transport is up on pass 1, the push lands, the flag clears.
- The normal **real-diff** retry path (persist on failure → re-fire next pass) is untouched.

## Why now

Surfaced (again) as red HIL runs on the FW-1/FW-4 security PRs, which it has nothing to do with. This is the documented "If hardening is wanted" follow-up from CLAUDE.md's *HIL get-language flake* investigation.

## Testing

- Builds clean for `polykybd/split72:default` and `polykybd/split42:default`.
- The mechanism is the exact stall the rig diagnostics show; this removes the per-pass spin while preserving the fresh-boot correction on good hardware. Best validated by a green early-command sequence on the next rig run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NinUrR5rxUWk1w9RKz5unE)_

## Summary by Sourcery

Gate the boot-time split layer resync on transport connectivity and make it a true one-shot to eliminate host boot-window stalls while preserving normal layer sync behavior.

Bug Fixes:
- Resolve HIL boot-window stalls caused by repeated boot-time layer resync attempts on slow-ACK split links.

Enhancements:
- Refine split layer synchronization logic to clear the forced-resync flag after the first gated attempt, relying on subsequent real layer changes for any remaining corrections.