### PR TITLE
docs: cut a fresh branch off the default after a PR merges

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,11 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
 
 - **Docstring coverage: ignore CodeRabbit's "Docstring Coverage … threshold 80%" pre-merge check.** That 80% target is a CodeRabbit default, **not** a project policy — the check is non-blocking and we deliberately do not chase it. Do **not** add docstrings to existing functions just to satisfy it (out-of-scope churn). Document new code where a docstring genuinely helps a reader, and no more.
 
+## Branching (all PolyKybd repos)
+
+- **Give every branch a name that hints at its content** (a short descriptive slug, e.g. `claude/fix-slave-layer-after-fw-apply`, not just the auto-generated `claude/<random-scientist>-<id>`) so the branch list reads as a changelog.
+- **Always start new work on a FRESH branch cut from the updated default branch — never keep committing to a branch whose PR has already merged.** Once a PR is merged, that branch is done: `git fetch origin PolyKybd` then `git checkout -b claude/<new-slug> origin/PolyKybd` for the next change. Cherry-pick only the still-unmerged commits onto the fresh branch if needed. This keeps each PR a clean, focused diff against the current default (**`PolyKybd`** here; `main` in the host/rig repos) and avoids a new PR accidentally re-including already-merged commits.
+
 ## Building & flashing
 
 **The ARM toolchain is installable in the dev / remote container — do not claim it is unavailable.** Verified end-to-end (`split72:default` → `.uf2`, exit 0) on 2026-05-29.


### PR DESCRIPTION
Adds a **Branching (all PolyKybd repos)** convention to `CLAUDE.md`: once a PR merges, that branch is done — fetch the updated default (`PolyKybd` here) and start new work on a fresh branch off it, cherry-picking only still-unmerged commits. Keeps each PR a clean, focused diff and avoids a new PR re-including already-merged commits. Also folds in the existing branch-naming guidance.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dk6a2Uq7qexd1z9G6A9XsJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dk6a2Uq7qexd1z9G6A9XsJ)_

## Summary by Sourcery

Documentation:
- Add branching guidelines covering fresh-branch workflow after PR merges and descriptive branch naming across PolyKybd repositories.