### PR TITLE
fontpack: pin pack_extra (flags) to a reserved high gidx band

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,6 +279,27 @@ flashes all stale bundles, `flash <id>` force-flashes one).
     renders ASCII text with no pack. The build-time guard fails if a bundle overflows
     its slot. Order in `bundles.list` is **append-only** (the index is the on-wire id
     and the slot order; growth-prone `emoji` is last with `slot_kb: rest`).
+  - **The per-font `reserved` gidx is a SORT KEY, not a dense array position.**
+    `fontpack_assemble()` (`base/fontpack.c`) places the resident set first, then
+    **insertion-sorts the pack fonts by their stored gidx** — nothing indexes an
+    array *by* gidx, so gaps / sparse / out-of-order values are all fine, and the
+    order only changes a *lookup* for two pack fonts that share a codepoint. The
+    build keeps pack ranges **disjoint across bundles** (verified: 0 cross-bundle
+    `[first,last]` overlaps), so for the pack the gidx order is functionally
+    irrelevant — a stale gidx in an un-reshipped bundle is **harmless**. ⚠️ The one
+    invariant: if two pack fonts intentionally overlap, keep them in the **same
+    bundle** (intra-bundle order is fixed and never goes stale) — never split an
+    overlapping pair across bundles.
+  - **Appending a hint/glyph font only reships the EDITED bundle (since the
+    pack_extra pin).** Appending a font at the tail of `fonts.yaml` used to shift
+    the trailing `pack_extra` (flags) font's dense gidx → `flags.plyf` changed too,
+    forcing a second reship+bump (e.g. symbol v3→v4 *and* flags v2→v3). Fixed in
+    `fonts/fontpack.py`: `pack_extra` fonts get a **fixed high gidx band**
+    (`PACK_EXTRA_GIDX_BASE = 0xF000`) instead of their dense position, so a tail
+    append no longer moves them. flags is disjoint PUA (0xE000+) and still sorts
+    last, so the assembled order is byte-identical (asserted during the change).
+    The first flags regen after this lands adopts the pinned gidx (a one-time
+    `flags.plyf` reship); thereafter only the bundle you actually edited changes.
   - **Flash UX (split72):** while any flash runs the status OLED shows an "Updating
     fonts/firmware — do not unplug" screen with a full-width progress bar, and the RGB
     matrix breathes (cyan = font pack, orange = firmware/bootloader = "can't type");

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,10 +263,11 @@ flashes all stale bundles, `flash <id>` force-flashes one).
   in a **2 MB** window at `FW_RESOURCE_OFFSET` (`fontpack_layout.h`, generated). The
   set of valid slot headers **is** the directory — there is **no separate directory
   sector** (avoids a consistency class of bug). Each bundle's per-font record carries
-  the font's **global ALL_FONTS index** (the spare `reserved` u16); `fontpack_load()`
-  reads every slot and `fontpack_assemble()` merge-sorts all present bundles' fonts
-  back into global priority order, reproducing the old single-pack `g_all_fonts`
-  exactly. The build emits per-bundle `.plyf` + `fontpack_bundles.manifest.json`
+  the font's **gidx sort key** (the spare `reserved` u16 — a dense ALL_FONTS position
+  for normal fonts, a pinned high band for `pack_extra`; it is a *sort key*, not a
+  dense array position — see the gidx note below); `fontpack_load()` reads every slot
+  and `fontpack_assemble()` insertion-sorts all present bundles' fonts by it back into
+  global priority order, reproducing the old single-pack `g_all_fonts` exactly. The build emits per-bundle `.plyf` + `fontpack_bundles.manifest.json`
   (ABI contract) + `fontpack_layout.h` (the X-macro slot table firmware **and** host
   share) via `generate_fonts.py --emit-bundles DIR` / `--bundle-version ID=N`.
   - **Auto on connect:** the firmware reports every bundle's `content_version` in the

--- a/keyboards/polykybd/base/fonts/generated/fontpack_bundles.manifest.json
+++ b/keyboards/polykybd/base/fonts/generated/fontpack_bundles.manifest.json
@@ -319,7 +319,7 @@
       "font_count": 1,
       "fonts": [
         {
-          "all_fonts_index": 145,
+          "all_fonts_index": 61440,
           "symbol": "NotoColorEmoji_Regular_LangFlags_20pt7b",
           "first": 57344,
           "last": 57503

--- a/keyboards/polykybd/fonts/fontpack.py
+++ b/keyboards/polykybd/fonts/fontpack.py
@@ -388,6 +388,18 @@ def manifest_from_texts(order: list[str], category_texts: dict[str, str],
 
 SECTOR_SIZE = 0x1000   # 4 KB flash sector — slot offsets/sizes are sector-aligned
 
+# Reserved high gidx band for `pack_extra` fonts (currently just the LangFlags
+# pack font in the `flags` bundle). The stored `reserved` u16 is ONLY a sort key
+# for the firmware's merge (fontpack_assemble insertion-sorts pack fonts by it);
+# a pack_extra font like the flags glyph lives in disjoint PUA (0xE000+) and
+# overlaps nothing, so its exact rank never changes a lookup — it just needs to
+# sort last. Pinning it into a fixed high band (instead of its dense position at
+# the END of ALL_FONTS) means appending a hint font at the tail of fonts.yaml no
+# longer shifts the trailing pack_extra's index, so only the EDITED bundle's
+# .plyf changes — flags.plyf stays byte-stable and needs no reship/version bump.
+# See CLAUDE.md "Font pack" → "gidx is a sort key, not a dense position".
+PACK_EXTRA_GIDX_BASE = 0xF000
+
 
 def compute_bundle_layout(cfg: dict) -> dict:
     """Resolve fonts.yaml `bundles:` into concrete slot offsets/sizes.
@@ -453,6 +465,7 @@ def build_bundles(order: list[str], resident: set[str], parsed: dict[str, Parsed
             sym2bi[s] = i
 
     members: list[list[tuple[int, ParsedFont]]] = [[] for _ in lst]
+    extra_n = 0
     for gi, sym in enumerate(order):
         if sym in resident:
             continue
@@ -460,13 +473,18 @@ def build_bundles(order: list[str], resident: set[str], parsed: dict[str, Parsed
             raise ValueError(f"ALL_FONTS entry {sym!r} not found in generated headers")
         if sym in sym2bi:
             bi = sym2bi[sym]
+            # pack_extra (trailing, disjoint) → pinned high band, not dense `gi`,
+            # so tail appends don't shift it (see PACK_EXTRA_GIDX_BASE above).
+            stored = PACK_EXTRA_GIDX_BASE + extra_n
+            extra_n += 1
         else:
             cat = sym2cat.get(sym)
             if cat not in cat2bi:
                 raise ValueError(f"font {sym!r} (category {cat!r}) maps to no bundle "
                                  f"— add its category to a fonts.yaml bundle")
             bi = cat2bi[cat]
-        members[bi].append((gi, parsed[sym]))
+            stored = gi
+        members[bi].append((stored, parsed[sym]))
 
     cvers = content_versions or {}
     bundles = []

--- a/keyboards/polykybd/fonts/fontpack.py
+++ b/keyboards/polykybd/fonts/fontpack.py
@@ -476,6 +476,12 @@ def build_bundles(order: list[str], resident: set[str], parsed: dict[str, Parsed
             # pack_extra (trailing, disjoint) → pinned high band, not dense `gi`,
             # so tail appends don't shift it (see PACK_EXTRA_GIDX_BASE above).
             stored = PACK_EXTRA_GIDX_BASE + extra_n
+            # `reserved`/gidx is a u16; fail the build loudly rather than wrap if the
+            # reserved band ever fills (and keep it clear of a real font's dense gi).
+            if stored > 0xFFFF:
+                raise ValueError(
+                    f"pack_extra gidx overflow: {stored:#06x} > 0xFFFF — too many "
+                    f"pack_extra fonts for the band at {PACK_EXTRA_GIDX_BASE:#06x}")
             extra_n += 1
         else:
             cat = sym2cat.get(sym)


### PR DESCRIPTION
## Summary

The per-font `reserved` gidx stored in each `.plyf` is **only a sort key** for `fontpack_assemble()` (resident first, then pack fonts insertion-sorted by gidx) — nothing indexes an array *by* it, and pack ranges are **disjoint across bundles** (verified: 0 cross-bundle `[first,last]` overlaps), so the pack order is functionally irrelevant and a stale gidx is harmless.

Previously gidx was the dense ALL_FONTS position, so appending a hint font at the tail of `fonts.yaml` shifted the trailing `pack_extra` (flags) font's index → `flags.plyf` changed too, forcing an extra reship + version bump every time (e.g. last round bumped symbol v3→v4 **and** flags v2→v3).

This pins `pack_extra` fonts into a fixed high band (`PACK_EXTRA_GIDX_BASE = 0xF000`) in `fonts/fontpack.py` instead of their dense position. flags is disjoint PUA (0xE000+) and still sorts last, so:

- the assembled order is **byte-identical** (asserted pre/post),
- **only `flags.plyf` changes** (symbol/mideast/syllabic/asia/emoji untouched),
- from the next regen on, appending a glyph touches **only the edited bundle**.

Firmware-only: the host's currently-shipped `flags.plyf` keeps working (sorts last regardless); the pinned gidx becomes the baseline its next reship adopts. Also documents the gidx-is-a-sort-key rule + the disjoint-bundle invariant in `CLAUDE.md`.

## Version bump label

*(none — patch)*. Build-pipeline/serialization change; no firmware behavior or protocol change.

## Testing
- [x] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`)
- [x] `generate_fonts.py --check` clean; assembled font order asserted byte-identical; `cmp` confirms only `flags.plyf` differs
- [ ] Flashed and tested on hardware
- [ ] If protocol changed: host updated and tested together — n/a (no protocol change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kw75EAENmp8spXaGqJYf2Y)_

## Summary by Sourcery

Pin pack_extra fonts to a fixed high gidx band to keep flags bundle indices stable when new fonts are appended, and document the gidx sort-key semantics and bundle invariants.

Enhancements:
- Assign pack_extra fonts a reserved high gidx band instead of their dense ALL_FONTS position to avoid unintended index shifts across regenerations.

Documentation:
- Expand CLAUDE.md font pack documentation to clarify that reserved gidx is only a sort key, describe the disjoint-bundle invariant, and explain the pack_extra pin behavior.

Chores:
- Regenerate font pack manifest to reflect the updated gidx assignments for pack_extra fonts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how font packs are ordered when building firmware bundles, preventing unrelated font changes from forcing extra updates to bundled font assets.
  * Made font ordering more stable so later edits only update the affected bundle in common cases.
* **Documentation**
  * Clarified font-pack behavior and ordering rules for bundled and external fonts, including how sparse ordering values are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->