### PR TITLE
docs+skill: shortcut-hint workflow + font-pack reship notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,6 +279,17 @@ flashes all stale bundles, `flash <id>` force-flashes one).
     renders ASCII text with no pack. The build-time guard fails if a bundle overflows
     its slot. Order in `bundles.list` is **append-only** (the index is the on-wire id
     and the slot order; growth-prone `emoji` is last with `slot_kb: rest`).
+  - **Reshipping a bundle to the host — there is NO ship script.** Regenerate with
+    `generate_fonts.py --emit-bundles DIR --bundle-version ID=N …`, copy the changed
+    `<id>.plyf` to `PolyKybdHost/polyhost/res/fontpack/`, then hand-rebuild
+    `bundles.json` from the firmware `fontpack_bundles.manifest.json` (id / index /
+    slot_offset / slot_size) + each `.plyf` (`size = len(data)`, `sha256 =
+    sha256(data).hexdigest()[:16]`) + the version map. ⚠️ **`--bundle-version`
+    defaults UNSPECIFIED bundles to `content_version 0`** — pass *every* id
+    (`symbol=4 mideast=1 syllabic=1 asia=1 flags=3 emoji=1`) or you silently reset
+    the others. `cmp` each regenerated `.plyf` against the shipped one to see which
+    actually changed, and bump+reship only those (see the gidx note above re: why
+    appending a glyph now changes only the edited bundle).
   - **Flash UX (split72):** while any flash runs the status OLED shows an "Updating
     fonts/firmware — do not unplug" screen with a full-width progress bar, and the RGB
     matrix breathes (cyan = font pack, orange = firmware/bootloader = "can't type");
@@ -297,6 +308,16 @@ flashes all stale bundles, `flash <id>` force-flashes one).
   (Technical/Technical2 = Ctrl/Alt/GUI/Option/Del/Backspace/Esc/PrintScreen), the
   menu icons (Settings ⚙, World 🌐), Brightness moons, Hyper/Meh, GuiKey, Util
   (screenshot/calc/my-computer/paste), EmjLayer, plus the always-resident Arrows.
+- **A single bigger/custom glyph → inject it into the resident IconsFont
+  (`base/fonts/gfx_icons.h`), NOT a new resident font.** `IconsFont` is `g_all_fonts[0]`
+  (prepended), so *extending it with another glyph* (append bitmap bytes + a `GFXglyph`
+  record, bump the font's `last`) shifts **no pack index** and needs no reship — it
+  ships with the firmware. The Win+R `>_` hint does this: a 16 pt `>`/`_` (2 pt over the
+  14 pt base) generated via `fontconvert` and injected at PUA `0x9A`/`0x9B`
+  (`ICON_PROMPT_GT`/`_US`), referenced only by that hint so normal `>`/`_` keycaps keep
+  the base size. ⚠️ Adding a whole **new resident *font*** instead (an extra entry in
+  `index.resident_fonts`) prepends ahead of the pack → **every pack font's gidx shifts**
+  → a full-pack reship; avoid that for one or two glyphs.
 - **Regenerate** with `FONTCONVERT=<pinned> python3 generate_fonts.py`. **Byte-repro
   gotcha:** the per-category headers embed the fontconvert *binary path* in a
   provenance comment, so run from the **same path** the committed headers used

--- a/keyboards/polykybd/.claude/skills/add-polykybd-shortcut-hint/SKILL.md
+++ b/keyboards/polykybd/.claude/skills/add-polykybd-shortcut-hint/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: add-polykybd-shortcut-hint
+description: >
+  Add an OS-aware keycap shortcut-hint glyph to the PolyKybd firmware — a
+  display-only preview icon shown on a key while a modifier is held (e.g. Win+V
+  clipboard, Cmd+Tab app-switch, Ctrl+Left word-nav). Use when asked to "add a
+  hint for Win/Cmd/Super+X", "show an icon when <modifier>+<key> is held", "wire
+  a shortcut preview", or to extend the wave-A/B/C OS-aware hint set in
+  keycode_to_disp_overlay(). Handles glyph selection + legibility check, the
+  per-glyph leading-space tuning, adding a NEW glyph (symbol font-pack bundle or
+  resident IconsFont), wiring the correct OS branch, the byte-repro regenerate +
+  host reship, build, and real-keycap preview. NOT for full keyboard languages
+  (use add-polykybd-language) or app overlay PNGs (use generate-app-overlays).
+---
+
+# Add an OS-aware keycap shortcut-hint glyph
+
+Hints are returned by `keycode_to_disp_overlay(keycode, state)` in
+`keyboards/polykybd/poly_keymap.c` as a `U"..."` string = **N leading spaces +
+the glyph codepoint(s)**. They render through the normal text path (full
+`g_all_fonts` lookup, baseline-aligned), so a hint glyph must resolve in either
+the **resident** set or a **shipped pack bundle**.
+
+## 0. Decide the glyph + the OS branch
+
+For each shortcut, pick a codepoint and which OS the chord belongs to. The branch
+structure in `keycode_to_disp_overlay()`:
+
+- `apple` (macOS): editing on **Cmd (GUI)**, word-nav on **Option+arrows**.
+- non-mac (`else`): editing on **Ctrl**; window-mgmt on **GUI/Super** via the
+  `wm_held` switch. Gate per-OS inside it:
+  - `win_or_unknown` — Windows-only chords (Win+H/I/M/R/T/K/V/X/`,`/`.`, etc.).
+  - `gnome` / `linux_any` — desktop-specific (GNOME vs KDE differ; see wave-B/C).
+
+⚠️ Confirm the chord is **real for that OS**. e.g. dictation is **Windows-only**
+(Win+H): macOS triggers it with a double-tap Fn/Ctrl — not a held GUI+letter
+chord the hint engine can preview — and Linux/Android bind nothing standard.
+
+## 1. Check the glyph renders (reject notdef)
+
+From the **PolyKybdHost repo root** (so `tools/gfx_font.py` imports):
+
+```bash
+cd PolyKybdHost
+HP=../qmk_firmware/keyboards/polykybd/.claude/skills/add-polykybd-shortcut-hint/hint_preview.py
+python3 $HP --check 1F5E3 1F4DC 1F4D1 2699   # owning font + lit-pixel count per cp
+```
+
+`lit px == 0` ⇒ the glyph is **notdef** in the font that claims its range — pick
+another glyph or another source (this is how 🗃 1F5C3 / 🗂 1F5C2 were rejected:
+notdef in `_Util_`). Many `1F5xx` "symbol" emoji are **notdef in NotoSansSymbols2
+but present in NotoEmoji-Medium** (`noto-emoji`) — source those from the emoji
+font.
+
+## 2. Tune the leading-space count (centering)
+
+```bash
+python3 $HP --sweep 1F4DC        # prints x-range per space count + a recommendation
+python3 $HP --string '   ' 1F4DC --out /tmp/v.png   # render the exact firmware string
+```
+
+Hints sit **right-of-center (~x46-50** in the 72px window), NOT mathematically
+centered — match the existing hints. The sweep picks the **largest space count
+with `max_x <= 69`** (no clip). **Wide emoji need fewer spaces than narrow
+symbol/math glyphs** (4 clipped every wide emoji at x71 this session; 3 was
+right; a narrow glyph like 📑 took 4).
+
+## 3. Named-glyph defines
+
+Add to the **hand-defined wave section** at the BOTTOM of
+`keyboards/polykybd/lang/named_glyphs.h` (after `ICON_CLOSE`), NOT the cog table
+at the top (that round-trips through `lang_lut.xlsx` and strips cached formula
+values headlessly):
+
+```c
+#define ICON_CLIP_HISTORY  U"\x1F4DC"   // 📜 scroll — Win+V clipboard history
+```
+
+Reference them in `poly_keymap.c` with the tuned spaces, e.g.
+`case KC_V: if (win_or_unknown) return U"   " ICON_CLIP_HISTORY;`.
+
+## 4. A NEW glyph (not already shipped) — pick the cheapest home
+
+- **Reuse a shipped glyph** (resident or already in a pack bundle): nothing to
+  generate — just steps 3 + 5. (Most hints land here.)
+- **Symbol-bundle singleton** (a new mono glyph, matching the crisp hint style):
+  append to `fonts/fonts.yaml` symbols **last** (highest index), e.g.
+  `- {category: symbols, variant: _Dictation_, source: noto-emoji, bits: 32, ranges: [[0x1f5e3, 0x1f5e3]]}`.
+  Regenerate (step 6), bump the `symbol` `content_version`, reship `symbol.plyf`.
+  Thanks to the **pack_extra gidx pin** this changes **only** `symbol.plyf` now
+  (flags no longer shifts).
+- **A single bigger/custom glyph** (e.g. the Win+R `>_` at 16 pt): inject into the
+  **resident IconsFont** `base/fonts/gfx_icons.h` at a free PUA slot (`0x9A`…) —
+  it is `g_all_fonts[0]`, so adding a glyph shifts no pack index and needs **no
+  reship**. Generate the glyph with the pinned `fontconvert`, append its bitmap
+  bytes + a `GFXglyph` record, bump the `GFXfont` `last`. Do NOT add a whole new
+  *resident font* (that prepends ahead of the pack and shifts every pack gidx).
+
+## 5. Wire the case(s)
+
+Add `case KC_<x>:` returns in the correct branch of `keycode_to_disp_overlay()`,
+each gated on its OS predicate, with the step-2 leading spaces.
+
+## 6. Regenerate (byte-repro) + reship
+
+```bash
+cd keyboards/polykybd/fonts
+FONTCONVERT=/tmp/fontconvert_pinned python3 generate_fonts.py --check   # should be clean before
+FONTCONVERT=/tmp/fontconvert_pinned python3 generate_fonts.py \
+  --emit-bundles /tmp/b \
+  --bundle-version symbol=N --bundle-version mideast=1 --bundle-version syllabic=1 \
+  --bundle-version asia=1 --bundle-version flags=3 --bundle-version emoji=1
+# cmp /tmp/b/<id>.plyf vs PolyKybdHost/polyhost/res/fontpack/<id>.plyf -> copy + bump only changed
+```
+
+⚠️ Pass **every** `--bundle-version` id or unspecified ones reset to 0. Rebuild
+`bundles.json` from the firmware manifest + each `.plyf` (`size=len`,
+`sha256=hexdigest()[:16]`). Use `/tmp/fontconvert_pinned` (FreeType 2.13.3) or
+category headers show 1-line provenance diffs. (Full reship recipe: qmk
+`CLAUDE.md` "Font pack".)
+
+## 7. Build + preview the real keycaps
+
+```bash
+QMK_HOME=$PWD/../../.. /tmp/qmkvenv/bin/qmk compile -kb polykybd/split72 -km default
+python3 $HP --string '   ' <cp> --out /tmp/key.png   # send to the user before committing
+```
+
+Build `split42` too (shared keymap). Commit firmware (poly_keymap.c +
+named_glyphs.h + fonts.yaml + generated/) and, if a bundle changed, the host
+(`res/fontpack/*.plyf` + `bundles.json`) — separate repos, separate commits.
+
+## Output
+
+Per shortcut: the chosen glyph + codepoint, owning font, lit-pixel count, tuned
+space count, OS branch, and whether it needed a new glyph (and where it landed).
+Always **send the user a real-keycap render** (step 7) before committing.
+
+## Pitfalls
+
+- **notdef renders blank.** Always `--check` lit-pixel count > 0 before choosing a
+  glyph; `1F5xx` "symbols" are often notdef in NotoSansSymbols2 → use `noto-emoji`.
+- **4 leading spaces clips wide emoji.** Sweep per glyph; hints are right-of-center
+  (~46-50), not centered. Don't hand-pick a fixed count.
+- **Don't touch the cog table.** Add named defines to the hand-defined wave section
+  of `named_glyphs.h`, not `lang_lut.xlsx`.
+- **`--bundle-version` resets unlisted bundles to 0.** Pass all ids; `cmp` to find
+  the changed `.plyf`; only the edited bundle changes now (flags gidx is pinned).
+- **Run the preview from PolyKybdHost** (so `gfx_font`/`tools` resolve) and use the
+  pinned `fontconvert` for byte-repro.
+- **A new resident *font* shifts every pack gidx** → full reship. For one/two glyphs
+  inject into the resident IconsFont (`gfx_icons.h`, `g_all_fonts[0]`) instead.
+- **Verify the chord is real for the gated OS** (e.g. mac dictation is Fn-Fn, not a
+  Cmd chord — so it's Windows-only). Don't show a hint for a chord the OS doesn't bind.

--- a/keyboards/polykybd/.claude/skills/add-polykybd-shortcut-hint/hint_preview.py
+++ b/keyboards/polykybd/.claude/skills/add-polykybd-shortcut-hint/hint_preview.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Preview + tune PolyKybd keycap shortcut-hint glyphs the way the firmware draws
+them, straight from the generated GFX headers (no live TTF).
+
+Run from the PolyKybdHost repo root so `tools/gfx_font.py` imports cleanly:
+
+    cd PolyKybdHost
+    python3 ../qmk_firmware/keyboards/polykybd/.claude/skills/add-polykybd-shortcut-hint/hint_preview.py \
+        --check 1F5E3 2699 1F4DC               # do these codepoints resolve? lit-pixel count
+    python3 .../hint_preview.py --sweep 1F4DC  # best leading-space count for one glyph
+    python3 .../hint_preview.py --string '   ' 1F4DC   # render an exact firmware string (spaces+cp) -> PNG
+
+The firmware draws a hint as a text string: N leading U+0020 spaces then the glyph
+codepoint, starting at BUFFER_X, advancing by each glyph's xAdvance, baseline-aligned
+per font. Hints sit RIGHT-of-center (~x46-50 in the 72px window), not mathematically
+centered — match that. Wide emoji need FEWER leading spaces than narrow symbol glyphs.
+"""
+import argparse, sys, os
+
+# Resolve the gfx_font loader from the PolyKybdHost tools dir.
+HERE = os.path.dirname(os.path.abspath(__file__))
+for cand in ("tools",  # cwd == PolyKybdHost
+             os.path.join(HERE, "../../../../../PolyKybdHost/tools"),
+             "/home/user/PolyKybdHost/tools"):
+    if os.path.exists(os.path.join(cand, "gfx_font.py")):
+        sys.path.insert(0, cand); break
+from gfx_font import GfxGlyphRenderer, load_all_fonts, OLED_W, OLED_H, BUFFER_X  # noqa: E402
+
+def _fontdir():
+    for cand in ("../qmk_firmware/keyboards/polykybd/base/fonts",
+                 "/home/user/qmk_firmware/keyboards/polykybd/base/fonts",
+                 os.path.join(HERE, "../../base/fonts")):
+        if os.path.isdir(cand):
+            return cand
+    sys.exit("cannot locate base/fonts — run from the PolyKybdHost repo root")
+
+R = GfxGlyphRenderer(_fontdir())
+SP = 0x20
+
+def lit(cps):
+    from PIL import Image
+    img = Image.new("L", (OLED_W, OLED_H), 0); px = img.load(); x = BUFFER_X
+    for cp in cps:
+        x = R._blit(px, cp, x)
+    pts = [(xx, yy) for yy in range(OLED_H) for xx in range(OLED_W) if px[xx, yy]]
+    return img, pts
+
+def owning_font(cp):
+    for f in load_all_fonts(_fontdir()):
+        if f.first <= cp <= f.last:
+            g = f.glyphs[cp - f.first]
+            _, pts = lit([cp])
+            return f.name, len(pts)
+    return None, 0
+
+def cmd_check(cps):
+    print("codepoint  owning font (lit px)               verdict")
+    for cp in cps:
+        name, n = owning_font(cp)
+        if name is None:
+            v = "NOT IN ANY FONT — add to symbol bundle / IconsFont"
+        elif n == 0:
+            v = "notdef/blank — pick another glyph or another source"
+        else:
+            v = "ok"
+        print(f"  U+{cp:05X}  {str(name):42} {n:5d}  {v}")
+
+def cmd_sweep(cp):
+    print(f"leading-space sweep for U+{cp:05X} (pick the largest with max_x <= 69, no clip):")
+    best = None
+    for nsp in range(0, 7):
+        _, pts = lit([SP] * nsp + [cp])
+        if not pts:
+            print(f"  {nsp} sp -> BLANK"); continue
+        xs = [p[0] for p in pts]; mn, mx = min(xs), max(xs)
+        clip = mx >= 71 or mn <= 0
+        print(f"  {nsp} sp -> x[{mn:2d}..{mx:2d}] center={(mn+mx)//2}{'  CLIP' if clip else ''}")
+        if mx <= 69:
+            best = nsp
+    print(f"  --> recommended: {best} leading spaces")
+
+def cmd_string(spaces, cps, out):
+    from PIL import Image
+    img, pts = lit([SP] * len(spaces) + cps)
+    scale = 8
+    big = img.convert("RGB").resize((OLED_W * scale, OLED_H * scale), Image.NEAREST)
+    big.save(out)
+    xs = [p[0] for p in pts] or [0]
+    print(f"wrote {out}  ({len(pts)} lit px, x[{min(xs)}..{max(xs)}])")
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--check", nargs="+", metavar="HEXCP")
+    ap.add_argument("--sweep", metavar="HEXCP")
+    ap.add_argument("--string", metavar="SPACES")
+    ap.add_argument("cps", nargs="*", metavar="HEXCP")
+    ap.add_argument("--out", default="/tmp/hint_preview.png")
+    a = ap.parse_args()
+    if a.check:
+        cmd_check([int(c, 16) for c in a.check])
+    elif a.sweep:
+        cmd_sweep(int(a.sweep, 16))
+    elif a.string is not None:
+        cmd_string(a.string, [int(c, 16) for c in a.cps], a.out)
+    else:
+        ap.print_help()

--- a/keyboards/polykybd/.claude/skills/add-polykybd-shortcut-hint/hint_preview.py
+++ b/keyboards/polykybd/.claude/skills/add-polykybd-shortcut-hint/hint_preview.py
@@ -68,6 +68,7 @@ def cmd_check(cps):
 def cmd_sweep(cp):
     print(f"leading-space sweep for U+{cp:05X} (pick the largest with max_x <= 69, no clip):")
     best = None
+    least_clip = None          # fallback: (max_x, nsp) with the smallest right overrun
     for nsp in range(0, 7):
         _, pts = lit([SP] * nsp + [cp])
         if not pts:
@@ -77,7 +78,18 @@ def cmd_sweep(cp):
         print(f"  {nsp} sp -> x[{mn:2d}..{mx:2d}] center={(mn+mx)//2}{'  CLIP' if clip else ''}")
         if mx <= 69:
             best = nsp
-    print(f"  --> recommended: {best} leading spaces")
+        if least_clip is None or mx < least_clip[0]:
+            least_clip = (mx, nsp)
+    if best is not None:
+        print(f"  --> recommended: {best} leading spaces")
+    elif least_clip is not None:
+        # Every count clipped — the glyph is too wide to sit fully in the 72px
+        # window at any offset. Surface the least-bad option; the glyph likely
+        # needs to be rendered smaller (e.g. a smaller pt size in the bundle).
+        print(f"  --> no non-clipping fit (glyph too wide); least-clipping is "
+              f"{least_clip[1]} sp (max_x={least_clip[0]}) — consider a smaller glyph")
+    else:
+        print("  --> glyph is BLANK at every offset — wrong codepoint / notdef")
 
 def cmd_string(spaces, cps, out):
     from PIL import Image

--- a/keyboards/polykybd/.claude/skills/add-polykybd-shortcut-hint/hint_preview.py
+++ b/keyboards/polykybd/.claude/skills/add-polykybd-shortcut-hint/hint_preview.py
@@ -15,21 +15,28 @@ codepoint, starting at BUFFER_X, advancing by each glyph's xAdvance, baseline-al
 per font. Hints sit RIGHT-of-center (~x46-50 in the 72px window), not mathematically
 centered — match that. Wide emoji need FEWER leading spaces than narrow symbol glyphs.
 """
-import argparse, sys, os
+import argparse
+import os
+import sys
 
-# Resolve the gfx_font loader from the PolyKybdHost tools dir.
+# Resolve the gfx_font loader from the PolyKybdHost tools dir. HERE is this skill
+# dir (qmk_firmware/keyboards/polykybd/.claude/skills/add-polykybd-shortcut-hint),
+# so PolyKybdHost (a sibling of qmk_firmware) is six levels up.
 HERE = os.path.dirname(os.path.abspath(__file__))
 for cand in ("tools",  # cwd == PolyKybdHost
-             os.path.join(HERE, "../../../../../PolyKybdHost/tools"),
+             os.path.abspath(os.path.join(HERE, "../../../../../../PolyKybdHost/tools")),
              "/home/user/PolyKybdHost/tools"):
     if os.path.exists(os.path.join(cand, "gfx_font.py")):
-        sys.path.insert(0, cand); break
+        sys.path.insert(0, cand)
+        break
 from gfx_font import GfxGlyphRenderer, load_all_fonts, OLED_W, OLED_H, BUFFER_X  # noqa: E402
 
+
 def _fontdir():
+    # base/fonts is three levels up from this skill dir (…/polykybd/base/fonts).
     for cand in ("../qmk_firmware/keyboards/polykybd/base/fonts",
                  "/home/user/qmk_firmware/keyboards/polykybd/base/fonts",
-                 os.path.join(HERE, "../../base/fonts")):
+                 os.path.abspath(os.path.join(HERE, "../../../base/fonts"))):
         if os.path.isdir(cand):
             return cand
     sys.exit("cannot locate base/fonts — run from the PolyKybdHost repo root")
@@ -39,7 +46,9 @@ SP = 0x20
 
 def lit(cps):
     from PIL import Image
-    img = Image.new("L", (OLED_W, OLED_H), 0); px = img.load(); x = BUFFER_X
+    img = Image.new("L", (OLED_W, OLED_H), 0)
+    px = img.load()
+    x = BUFFER_X
     for cp in cps:
         x = R._blit(px, cp, x)
     pts = [(xx, yy) for yy in range(OLED_H) for xx in range(OLED_W) if px[xx, yy]]
@@ -48,7 +57,6 @@ def lit(cps):
 def owning_font(cp):
     for f in load_all_fonts(_fontdir()):
         if f.first <= cp <= f.last:
-            g = f.glyphs[cp - f.first]
             _, pts = lit([cp])
             return f.name, len(pts)
     return None, 0
@@ -72,11 +80,13 @@ def cmd_sweep(cp):
     for nsp in range(0, 7):
         _, pts = lit([SP] * nsp + [cp])
         if not pts:
-            print(f"  {nsp} sp -> BLANK"); continue
-        xs = [p[0] for p in pts]; mn, mx = min(xs), max(xs)
+            print(f"  {nsp} sp -> BLANK")
+            continue
+        xs = [p[0] for p in pts]
+        mn, mx = min(xs), max(xs)
         clip = mx >= 71 or mn <= 0
         print(f"  {nsp} sp -> x[{mn:2d}..{mx:2d}] center={(mn+mx)//2}{'  CLIP' if clip else ''}")
-        if mx <= 69:
+        if not clip:                       # exclude left- or right-clipped offsets
             best = nsp
         if least_clip is None or mx < least_clip[0]:
             least_clip = (mx, nsp)
@@ -91,9 +101,12 @@ def cmd_sweep(cp):
     else:
         print("  --> glyph is BLANK at every offset — wrong codepoint / notdef")
 
-def cmd_string(spaces, cps, out):
+def cmd_string(prefix, cps, out):
+    # Render the prefix verbatim (its actual codepoints), not len(prefix) spaces,
+    # so a literal firmware prefix like U"\t\b\b" previews faithfully — not just
+    # the common leading-space case.
     from PIL import Image
-    img, pts = lit([SP] * len(spaces) + cps)
+    img, pts = lit([ord(ch) for ch in prefix] + cps)
     scale = 8
     big = img.convert("RGB").resize((OLED_W * scale, OLED_H * scale), Image.NEAREST)
     big.save(out)
@@ -104,7 +117,7 @@ if __name__ == "__main__":
     ap = argparse.ArgumentParser()
     ap.add_argument("--check", nargs="+", metavar="HEXCP")
     ap.add_argument("--sweep", metavar="HEXCP")
-    ap.add_argument("--string", metavar="SPACES")
+    ap.add_argument("--string", metavar="PREFIX")
     ap.add_argument("cps", nargs="*", metavar="HEXCP")
     ap.add_argument("--out", default="/tmp/hint_preview.png")
     a = ap.parse_args()


### PR DESCRIPTION
## Summary

Session-retro capture of the OS-aware shortcut-hint + font-pack reship workflow that's recurred several times (wave A/B/C). Documentation + tooling only — no firmware code change.

**`CLAUDE.md` "Font pack" learnings:**
- Reshipping a bundle to the host has **no ship script**: `bundles.json` is hand-rebuilt from the firmware `fontpack_bundles.manifest.json` + each `.plyf` (`size = len`, `sha256 = hexdigest()[:16]`). `--bundle-version` resets **unspecified** bundles to `content_version 0`, so every id must be passed.
- A single bigger/custom hint glyph → **inject into the resident IconsFont** (`gfx_icons.h`, `g_all_fonts[0]`) → no pack-index shift, no reship. A whole new *resident font* instead shifts every pack gidx (full reship).

**New skill `keyboards/polykybd/.claude/skills/add-polykybd-shortcut-hint/`** — end-to-end: glyph pick + notdef/lit-pixel check, per-glyph leading-space tuning, new-glyph homing (symbol bundle vs resident IconsFont), wiring the correct OS branch in `keycode_to_disp_overlay()`, byte-repro regenerate + reship, build, real-keycap preview. Ships a reusable `hint_preview.py` helper (`--check` / `--sweep` / `--string`), validated this session.

## Version bump label

*(none — patch)*. Docs + a `.claude/skills` addition only; no compiled change.

## Testing
- [x] No firmware change (docs + skill helper only); `hint_preview.py --check/--sweep` run against the current generated headers
- [ ] Flashed and tested on hardware — n/a
- [ ] If protocol changed: host updated and tested together — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kw75EAENmp8spXaGqJYf2Y)_

## Summary by Sourcery

Document the workflow for reshipping font-pack bundles and adding OS-aware shortcut-hint glyphs, and add a helper script to preview and tune hint glyph rendering from generated font headers.

Enhancements:
- Introduce a hint_preview.py utility to validate glyph availability, tune leading-space centering, and render shortcut-hint previews directly from generated GFX font headers.

Documentation:
- Expand CLAUDE.md with detailed instructions for reshipping font-pack bundles and using the resident IconsFont for single custom glyphs.
- Add SKILL.md documentation describing the end-to-end process for adding OS-aware keycap shortcut-hint glyphs, including glyph selection, spacing, regeneration, reship, and preview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer guidance for shipping font bundles and handling custom glyphs.
  * Added a step-by-step guide for creating and previewing shortcut-hint glyphs.

* **New Features**
  * Added a preview tool to check glyph availability, test spacing, and generate rendered samples for hint text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->