### PR TITLE
polykybd: firmware code cleanup (dead code + dedup, no behaviour change)

### DIFF
--- a/keyboards/polykybd/base/disp_array.c
+++ b/keyboards/polykybd/base/disp_array.c
@@ -165,15 +165,8 @@ void kdisp_clear_rect(int8_t x_start, int8_t y_start, int8_t width, int8_t heigh
     }
 }
 
-// Draw a character
-/**************************************************************************/
-/*!
-   @brief   Draw a single character
-    @param    x   Bottom left corner x coordinate
-    @param    y   Bottom left corner y coordinate
-    @param    ch  The 32-bit Unicode codepoint (SMP codepoints > 0xFFFF allowed)
-*/
-/**************************************************************************/
+// Draw a single character at bottom-left (x,y); ch is a 32-bit Unicode codepoint
+// (SMP codepoints > 0xFFFF allowed).
 int8_t kdisp_write_gfx_char(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, uint32_t ch, int8_t cy_radius) {
     x += s_draw_ox;   // anti-burn-in jitter offset (0 except during an idle relocation redraw)
     y += s_draw_oy;

--- a/keyboards/polykybd/base/fw_staging.c
+++ b/keyboards/polykybd/base/fw_staging.c
@@ -166,20 +166,29 @@ static uint32_t crc32_large(const uint8_t *data, uint32_t size) {
 }
 
 // ---------------------------------------------------------------------------
-// Flush accumulated page buffer to staging flash
+// flash_range_program wrapped in the IRQ-disable + (conditional) core1-halt guard
+// the bootrom flash ops require.  s_core1_halted lets a caller that has already
+// halted core1 (e.g. inside a wider erase) reuse it without a redundant restart.
 // ---------------------------------------------------------------------------
-static void flush_page(void) {
-    uint32_t flash_offs = target_data_offset() + (s_next_offset - s_buf_fill);
+static void flash_program_guarded(uint32_t flash_offs, const uint8_t *buf, uint32_t size) {
 #ifdef USE_CORE1
     bool already_halted = s_core1_halted;
     if (!already_halted) fw_staging_halt_core1();
 #endif
     uint32_t irq = save_and_disable_interrupts();
-    flash_range_program(flash_offs, s_page_buf, FLASH_PAGE_SIZE);
+    flash_range_program(flash_offs, buf, size);
     restore_interrupts(irq);
 #ifdef USE_CORE1
     if (!already_halted) fw_staging_restart_core1();
 #endif
+}
+
+// ---------------------------------------------------------------------------
+// Flush accumulated page buffer to staging flash
+// ---------------------------------------------------------------------------
+static void flush_page(void) {
+    uint32_t flash_offs = target_data_offset() + (s_next_offset - s_buf_fill);
+    flash_program_guarded(flash_offs, s_page_buf, FLASH_PAGE_SIZE);
     memset(s_page_buf, 0xFF, FLASH_PAGE_SIZE);
     s_buf_fill = 0;
 }
@@ -195,16 +204,7 @@ static void write_staging_header(uint32_t size, uint32_t crc) {
     uint32_t words[3] = { FW_STAGING_MAGIC, size, crc };
     memset(hdr, 0xFF, sizeof(hdr));
     memcpy(hdr, words, sizeof(words));
-#ifdef USE_CORE1
-    bool already_halted = s_core1_halted;
-    if (!already_halted) fw_staging_halt_core1();
-#endif
-    uint32_t irq = save_and_disable_interrupts();
-    flash_range_program(FW_STAGING_OFFSET, hdr, FLASH_PAGE_SIZE);
-    restore_interrupts(irq);
-#ifdef USE_CORE1
-    if (!already_halted) fw_staging_restart_core1();
-#endif
+    flash_program_guarded(FW_STAGING_OFFSET, hdr, FLASH_PAGE_SIZE);
 }
 
 // ---------------------------------------------------------------------------

--- a/keyboards/polykybd/base/overlay.c
+++ b/keyboards/polykybd/base/overlay.c
@@ -142,7 +142,6 @@ void reset_overlay_usage(void) {
     for(int16_t i = 0; i < sizeof(use_overlay); ++i) {
         use_overlay[i] = 0;
     }
-    //memset(&use_overlay, 0, sizeof(use_overlay));
 }
 
 void set_all_overlay_mapping(void) {

--- a/keyboards/polykybd/fill_overlay.c
+++ b/keyboards/polykybd/fill_overlay.c
@@ -60,6 +60,18 @@ uint16_t adjust_overlay_idx_to_mod(uint16_t idx, uint8_t mods) {
     return idx + NUM_OVERLAYS * mods;
 }
 
+// Computes the 0..89 overlay slot index for a (translate_a_to_z'd) overlay keycode.
+// Returns false and logs when the index is out of range.
+static bool overlay_slot_index(uint8_t keycode, uint16_t* out_idx) {
+    uint16_t idx = (keycode > KC_APP) ? (keycode - KC_LEFT_CTRL + 82) : (keycode > KC_NUM_LOCK ? keycode - KC_NUBS + 80 : keycode - KC_A);
+    if (idx >= 90) {
+        uprint("Warning: Calculated index for overlay out of bounds. Dropping overlay.\n");
+        return false;
+    }
+    *out_idx = idx;
+    return true;
+}
+
 // Fills overlay buffer segment with bitmap data and syncs to bridge if needed.
 void fill_overlay_buffer(uint8_t segment_index, uint8_t* buffer) {
     uint8_t keycode = get_fragment_context()->keycode;
@@ -70,9 +82,8 @@ void fill_overlay_buffer(uint8_t segment_index, uint8_t* buffer) {
 
     keycode = translate_a_to_z(keycode);
 
-    uint16_t idx = (keycode > KC_APP) ? (keycode - KC_LEFT_CTRL + 82) : (keycode > KC_NUM_LOCK ? keycode - KC_NUBS + 80 : keycode - KC_A);
-    if (idx >= 90) {
-        uprint("Warning: Calculated index for overlay out of bounds. Dropping overlay.\n");
+    uint16_t idx;
+    if (!overlay_slot_index(keycode, &idx)) {
         return;
     }
 
@@ -108,9 +119,8 @@ void decompress_overlay_buffer(uint8_t* compressed, bool first) {
     }
 
     keycode = translate_a_to_z(keycode);
-    uint16_t idx = (keycode > KC_APP) ? (keycode - KC_LEFT_CTRL + 82) : (keycode > KC_NUM_LOCK ? keycode - KC_NUBS + 80 : keycode - KC_A);
-    if (idx >= 90) {
-        uprint("Warning: Calculated index for overlay out of bounds. Dropping overlay.\n");
+    uint16_t idx;
+    if (!overlay_slot_index(keycode, &idx)) {
         return;
     }
     uint8_t ctx_mod = get_fragment_context()->modifier;
@@ -158,9 +168,8 @@ void fill_roi_overlay_buffer(uint8_t* data, bool first) {
     }
 
     keycode = translate_a_to_z(keycode);
-    uint16_t idx = (keycode > KC_APP) ? (keycode - KC_LEFT_CTRL + 82) : (keycode > KC_NUM_LOCK ? keycode - KC_NUBS + 80 : keycode - KC_A);
-    if (idx >= 90) {
-        uprint("Warning: Calculated index for overlay out of bounds. Dropping overlay.\n");
+    uint16_t idx;
+    if (!overlay_slot_index(keycode, &idx)) {
         return;
     }
     uint8_t ctx_mod = get_fragment_context()->modifier;

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -114,9 +114,6 @@ while lang_key:
 //[[[end]]]
 
 
-//not used at the moment
-#define FLASH_TARGET_OFFSET FW_RESOURCE_OFFSET //4 MB; single source = base/fw_staging.h flash map (staging ends here, resources use the remaining 4 MB)
-const uint8_t *flash_target_contents = (const uint8_t *) (XIP_BASE + FLASH_TARGET_OFFSET);
 static_assert(FLASH_PAGE_SIZE==256, "Flash page size changed");
 
 static enum lang_layer g_lang_init = INIT_LANG;
@@ -142,8 +139,6 @@ void poly_suspend(void);
 void early_hardware_init_post(void) {
     spi_hw_setup();
 }
-
-//void oled_on_off(bool on);
 
 #define BYTE_TO_BINARY_PATTERN "|%s%s%s%s%s%s%s%s"
 #define BYTE_TO_FLAGS(byte)  \

--- a/keyboards/polykybd/split_sync.c
+++ b/keyboards/polykybd/split_sync.c
@@ -34,209 +34,183 @@ void invert_display(uint8_t r, uint8_t c, bool state);
 #include <string.h>
 
 
+// Validates an incoming split-sync transaction: checks the payload/reply sizes and
+// the per-transaction CRC32, NACKing with SYNC_CRC32_ERR on a CRC mismatch. On a
+// size mismatch it bails out leaving the reply untouched (a no-op, as before). The
+// handler body runs only for a verified frame and sets the success ack itself.
+#define SYNC_VALIDATE_OR_RETURN(TYPE)                                            \
+    if (!(in_len == sizeof(TYPE) && in_data != NULL &&                           \
+          out_len == sizeof(poly_sync_reply_t) && out_data != NULL)) {           \
+        return;                                                                  \
+    }                                                                            \
+    if (crc32_1byte(&((uint8_t *)in_data)[4], in_len - 4, 0) !=                  \
+        ((const TYPE *)in_data)->crc32) {                                        \
+        ((poly_sync_reply_t *)out_data)->ack = SYNC_CRC32_ERR;                   \
+        return;                                                                  \
+    }
+
+
 // Handles incoming poly_sync data for the bridge with CRC32 validation.
 void user_sync_poly_data_handler(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data) {
-    if (in_len == sizeof(poly_sync_t) && in_data != NULL && out_len == sizeof(poly_sync_reply_t) && out_data!= NULL) {
-        uint32_t crc32 = crc32_1byte(&((uint8_t *)in_data)[4], in_len-4, 0);
-        if(crc32 == ((const poly_sync_t *)in_data)->crc32) {
-            const poly_sync_t* incoming = (const poly_sync_t *)in_data;
-            const poly_sync_t* current  = get_local_state();
-            if (incoming->lang != current->lang) {
-                mark_settings_dirty();
-            }
-            // Track the master's awake contrast in RAM so the slave's idle/wake
-            // restore uses the right level — but do NOT persist it. In host-auto
-            // mode the master's contrast IS the auto value, and persisting that as
-            // the slave's manual brightness made the slave boot at a stale auto
-            // value (e.g. a night-time 2). The master is authoritative and syncs
-            // brightness on every boot, so the slave never needs its own EEPROM
-            // copy. (Transient suspend/idle/fade levels are still excluded.)
-            if (incoming->contrast != current->contrast && incoming->contrast > DISP_OFF &&
-                (incoming->flags & ((uint8_t)DISP_IDLE | (uint8_t)IDLE_TRANSITION)) == 0) {
-                note_user_brightness(incoming->contrast);
-            }
-            // Detect action flags newly set in this sync and run them immediately,
-            // mirroring the master's case-11 handling. Without this, a mapping
-            // bridge transaction arriving before housekeeping runs would have its
-            // use_overlay bits wiped by a later deferred reset_overlay_usage().
-            uint8_t newly_set     = (incoming->overlay_flags & ~current->overlay_flags);
-#ifdef RGB_MATRIX_ENABLE
-            uint8_t newly_cleared = (current->overlay_flags  & ~incoming->overlay_flags);
-#endif
-            copy_local_state(incoming);
-            emj_apply_sync(incoming->emj_category, incoming->emj_page);
-            lang_apply_sync(incoming->lang_page);
-            if(newly_set & OVERLAY_ACTION_FLAGS) {
-                apply_overlay_action_flags(newly_set);
-                // Clear the bits locally so housekeeping has nothing to do.
-                access_local_state()->overlay_flags &= ~OVERLAY_ACTION_FLAGS;
-                // Housekeeping's state_diff branch (which used to call this at the end)
-                // won't fire now that local matches global — trigger the refresh ourselves.
-                request_disp_refresh();
-            }
-            if(newly_set & BOOTLOADER_DISPLAY) {
-                uprint("Slave: BOOTLOADER_DISPLAY received\n");
-                display_bootloader_message();
-            }
-            if(newly_set & SAVE_EEPROM) {
-                // Master pressed the store key — flush our own EEPROM too, but
-                // defer the write to housekeeping (never inside this handler).
-                request_eeprom_save();
-                // Edge-consumed: clear locally so it doesn't linger as a diff.
-                access_local_state()->overlay_flags &= ~SAVE_EEPROM;
-            }
-#ifdef RGB_MATRIX_ENABLE
-            // Disable RGB so the normal split transport restores master's config cleanly.
-            if(newly_cleared & BOOTLOADER_DISPLAY) {
-                rgb_matrix_disable_noeeprom();
-            }
-#endif
-            ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK;
-        } else {
-            ((poly_sync_reply_t*)out_data)->ack = SYNC_CRC32_ERR;
-        }
+    SYNC_VALIDATE_OR_RETURN(poly_sync_t);
+    const poly_sync_t* incoming = (const poly_sync_t *)in_data;
+    const poly_sync_t* current  = get_local_state();
+    if (incoming->lang != current->lang) {
+        mark_settings_dirty();
     }
+    // Track the master's awake contrast in RAM so the slave's idle/wake
+    // restore uses the right level — but do NOT persist it. In host-auto
+    // mode the master's contrast IS the auto value, and persisting that as
+    // the slave's manual brightness made the slave boot at a stale auto
+    // value (e.g. a night-time 2). The master is authoritative and syncs
+    // brightness on every boot, so the slave never needs its own EEPROM
+    // copy. (Transient suspend/idle/fade levels are still excluded.)
+    if (incoming->contrast != current->contrast && incoming->contrast > DISP_OFF &&
+        (incoming->flags & ((uint8_t)DISP_IDLE | (uint8_t)IDLE_TRANSITION)) == 0) {
+        note_user_brightness(incoming->contrast);
+    }
+    // Detect action flags newly set in this sync and run them immediately,
+    // mirroring the master's case-11 handling. Without this, a mapping
+    // bridge transaction arriving before housekeeping runs would have its
+    // use_overlay bits wiped by a later deferred reset_overlay_usage().
+    uint8_t newly_set     = (incoming->overlay_flags & ~current->overlay_flags);
+#ifdef RGB_MATRIX_ENABLE
+    uint8_t newly_cleared = (current->overlay_flags  & ~incoming->overlay_flags);
+#endif
+    copy_local_state(incoming);
+    emj_apply_sync(incoming->emj_category, incoming->emj_page);
+    lang_apply_sync(incoming->lang_page);
+    if(newly_set & OVERLAY_ACTION_FLAGS) {
+        apply_overlay_action_flags(newly_set);
+        // Clear the bits locally so housekeeping has nothing to do.
+        access_local_state()->overlay_flags &= ~OVERLAY_ACTION_FLAGS;
+        // Housekeeping's state_diff branch (which used to call this at the end)
+        // won't fire now that local matches global — trigger the refresh ourselves.
+        request_disp_refresh();
+    }
+    if(newly_set & BOOTLOADER_DISPLAY) {
+        uprint("Slave: BOOTLOADER_DISPLAY received\n");
+        display_bootloader_message();
+    }
+    if(newly_set & SAVE_EEPROM) {
+        // Master pressed the store key — flush our own EEPROM too, but
+        // defer the write to housekeeping (never inside this handler).
+        request_eeprom_save();
+        // Edge-consumed: clear locally so it doesn't linger as a diff.
+        access_local_state()->overlay_flags &= ~SAVE_EEPROM;
+    }
+#ifdef RGB_MATRIX_ENABLE
+    // Disable RGB so the normal split transport restores master's config cleanly.
+    if(newly_cleared & BOOTLOADER_DISPLAY) {
+        rgb_matrix_disable_noeeprom();
+    }
+#endif
+    ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK;
 }
 
 // Handles incoming latin_sync data with CRC32 validation, saves to EEPROM and refreshes display.
 // Global variables: g_latin
 void user_sync_latin_ex_data_handler(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data) {
-    if (in_len == sizeof(latin_sync_t) && in_data != NULL && out_len == sizeof(poly_sync_reply_t) && out_data!= NULL) {
-        uint32_t crc32 = crc32_1byte(&((uint8_t *)in_data)[4], in_len-4, 0);
-        if(crc32 == ((const latin_sync_t *)in_data)->crc32) {
-            copy_global_latin_table((const latin_sync_t *)in_data);
-            ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK;
-            // Defer the flash write out of this UART transaction callback — the
-            // next flush (suspend / store key, save_all_dirty) persists it.
-            mark_latin_dirty();
-            request_disp_refresh();
-        } else {
-            ((poly_sync_reply_t*)out_data)->ack = SYNC_CRC32_ERR;
-        }
-    }
+    SYNC_VALIDATE_OR_RETURN(latin_sync_t);
+    copy_global_latin_table((const latin_sync_t *)in_data);
+    ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK;
+    // Defer the flash write out of this UART transaction callback — the
+    // next flush (suspend / store key, save_all_dirty) persists it.
+    mark_latin_dirty();
+    request_disp_refresh();
 }
 
 // Handles incoming last key data on bridge with CRC32 validation, updates both local and global state.
 void user_sync_lastkey_data_handler(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data) {
-    if (in_len == sizeof(poly_last_t) && in_data != NULL && out_len == sizeof(poly_sync_reply_t) && out_data!= NULL) {
-        uint32_t crc32 = crc32_1byte(&((uint8_t *)in_data)[4], in_len-4, 0);
-        if(crc32 == ((const poly_last_t *)in_data)->crc32) {
-            copy_local_last_latin((const poly_last_t *)in_data);
-            copy_global_last_latin((const poly_last_t *)in_data);
-            ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK;
-            request_disp_refresh();
-        } else {
-            ((poly_sync_reply_t*)out_data)->ack = SYNC_CRC32_ERR;
-        }
-    }
+    SYNC_VALIDATE_OR_RETURN(poly_last_t);
+    copy_local_last_latin((const poly_last_t *)in_data);
+    copy_global_last_latin((const poly_last_t *)in_data);
+    ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK;
+    request_disp_refresh();
 }
 
 // Handles incoming layer data on bridge with CRC32 validation.
 // Global variables: l_layer
 void user_sync_layer_data_handler(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data) {
-    if (in_len == sizeof(poly_layer_t) && in_data != NULL && out_len == sizeof(poly_sync_reply_t) && out_data!= NULL) {
-        uint32_t crc32 = crc32_1byte(&((uint8_t *)in_data)[4], in_len-4, 0);
-        if(crc32 == ((const poly_layer_t *)in_data)->crc32) {
-            const poly_layer_t* incoming = (const poly_layer_t *)in_data;
-            if (incoming->def_layer != get_local_layer()->def_layer) {
-                defer_default_layer_save(incoming->def_layer);
-            }
-            copy_local_layer(incoming);
-            ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK;
-            //request_disp_refresh();
-        } else {
-            ((poly_sync_reply_t*)out_data)->ack = SYNC_CRC32_ERR;
-        }
+    SYNC_VALIDATE_OR_RETURN(poly_layer_t);
+    const poly_layer_t* incoming = (const poly_layer_t *)in_data;
+    if (incoming->def_layer != get_local_layer()->def_layer) {
+        defer_default_layer_save(incoming->def_layer);
     }
+    copy_local_layer(incoming);
+    ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK;
+    //request_disp_refresh();
 }
 
 // Handles incoming overlay segment data on bridge with CRC32 validation, marks as used when complete.
 void user_sync_overlay_data_handler(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data) {
-    if (in_len == sizeof(overlay_sync_t) && in_data != NULL && out_len == sizeof(poly_sync_reply_t) && out_data!= NULL) {
-        uint32_t crc32 = crc32_1byte(&((uint8_t *)in_data)[4], in_len-4, 0);
-        const overlay_sync_t* ov = ((const overlay_sync_t *)in_data);
-        if(crc32 == ov->crc32) {
-            memcpy(get_overlay(ov->adj_idx) + ov->segment*BYTES_PER_SEGMENT, ov->overlay, BYTES_PER_SEGMENT);
-            if(ov->segment==NUM_SEGMENTS_PER_OVERLAY-1) {
-                set_overlay_usage_post_upload(ov->adj_idx);
-                request_disp_refresh();
-            }
-            ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK;
-        } else {
-            ((poly_sync_reply_t*)out_data)->ack = SYNC_CRC32_ERR;
-        }
+    SYNC_VALIDATE_OR_RETURN(overlay_sync_t);
+    const overlay_sync_t* ov = ((const overlay_sync_t *)in_data);
+    memcpy(get_overlay(ov->adj_idx) + ov->segment*BYTES_PER_SEGMENT, ov->overlay, BYTES_PER_SEGMENT);
+    if(ov->segment==NUM_SEGMENTS_PER_OVERLAY-1) {
+        set_overlay_usage_post_upload(ov->adj_idx);
+        request_disp_refresh();
     }
+    ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK;
 }
 
 // Handles compressed overlay data on bridge with CRC32 validation, decompresses using core1 or local decompression.
 // Global variables: hid_bit_index
 void user_sync_compressed_overlay_data_handler(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data) {
-    if (in_len == sizeof(compressed_overlay_sync_t) && in_data != NULL && out_len == sizeof(poly_sync_reply_t) && out_data!= NULL) {
-        uint32_t crc32 = crc32_1byte(&((uint8_t *)in_data)[4], in_len-4, 0);
-        const compressed_overlay_sync_t* ov = ((const compressed_overlay_sync_t *)in_data);
-        if(crc32 == ov->crc32) {
+    SYNC_VALIDATE_OR_RETURN(compressed_overlay_sync_t);
+    const compressed_overlay_sync_t* ov = ((const compressed_overlay_sync_t *)in_data);
 #ifdef USE_CORE1
-            //keycode info is lost, so KC_NO used (only used for diagnostics)
-            core1_decompress_fragment(KC_NO, 0, ov->adj_idx, ov->compressed);
+    //keycode info is lost, so KC_NO used (only used for diagnostics)
+    core1_decompress_fragment(KC_NO, 0, ov->adj_idx, ov->compressed);
 #else
-            if(ov->len == COMPRESSED_START) {
-                hid_bit_index = 0;
-            }
-            int16_t maxlen = 360 - hid_bit_index/8;
-            hid_bit_index += rle_decompress(get_overlay(ov->adj_idx)+hid_bit_index/8, PK_MAX(0,maxlen), ov->compressed, ov->len, hid_bit_index);
-            if (hid_bit_index >= 360*8) {
-                set_overlay_usage_post_upload(ov->adj_idx);
-                request_disp_refresh();
-                hid_bit_index = 0;
-            }
-#endif
-            ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK;
-        } else {
-            ((poly_sync_reply_t*)out_data)->ack = SYNC_CRC32_ERR;
-        }
+    if(ov->len == COMPRESSED_START) {
+        hid_bit_index = 0;
     }
+    int16_t maxlen = 360 - hid_bit_index/8;
+    hid_bit_index += rle_decompress(get_overlay(ov->adj_idx)+hid_bit_index/8, PK_MAX(0,maxlen), ov->compressed, ov->len, hid_bit_index);
+    if (hid_bit_index >= 360*8) {
+        set_overlay_usage_post_upload(ov->adj_idx);
+        request_disp_refresh();
+        hid_bit_index = 0;
+    }
+#endif
+    ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK;
 }
 
 void user_sync_roi_data_handler(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data) {
-    if (in_len == sizeof(roi_overlay_sync_t) && in_data != NULL && out_len == sizeof(poly_sync_reply_t) && out_data!= NULL) {
-        uint32_t crc32 = crc32_1byte(&((uint8_t *)in_data)[4], in_len-4, 0);
-        const roi_overlay_sync_t* roi_ov = ((const roi_overlay_sync_t *)in_data);
-        if(crc32 == roi_ov->crc32) {
-            bool first = roi_ov->msg_idx==0;
-            const uint8_t* start = roi_ov->data;
-            if(first) {
-                reset_fragment_context();
-                set_fragment_context_key(roi_ov->data[0], roi_ov->data[1]&0x0f);
-                uint8_t x = roi_ov->data[3];
-                uint8_t y = (roi_ov->data[2]&0x03) | ((roi_ov->data[1]>>2)&0x3c);
-                set_fragment_context_roi(x, y, roi_ov->data[4]&0x7f, roi_ov->data[2] >> 2, ((roi_ov->data[4]&0x80)!=0));
-                set_fragment_context_bit_index(y * SCREEN_WIDTH + x);
-                start = &((roi_ov->data)[5]);
-            }
-            const overlay_fragment_context_t* ctx = get_fragment_context();
-
-            #ifdef USE_CORE1
-                if(first) {
-                    core1_roi_start();
-                }
-                core1_update_roi(ctx->keycode, ctx->modifier, roi_ov->adj_idx, start, &ctx->roi);
-                ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK; // we cannot send SIG, we do not know if we are finished
-            #else
-                uint16_t new_index = copy_rectangle_to_overlay(ctx->bit_index, get_overlay(roi_ov->adj_idx), start, &ctx->roi, first?ROI_START:ROI_MAX);
-                if(new_index >= 2880) {
-                    //finished roi update
-                    ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK_SIG;
-                    set_overlay_usage_post_upload(roi_ov->adj_idx);
-                    request_disp_refresh();
-                } else {
-                    ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK;
-                }
-                set_fragment_context_bit_index(new_index);
-            #endif
-        } else {
-            ((poly_sync_reply_t*)out_data)->ack = SYNC_CRC32_ERR;
-        }
+    SYNC_VALIDATE_OR_RETURN(roi_overlay_sync_t);
+    const roi_overlay_sync_t* roi_ov = ((const roi_overlay_sync_t *)in_data);
+    bool first = roi_ov->msg_idx==0;
+    const uint8_t* start = roi_ov->data;
+    if(first) {
+        reset_fragment_context();
+        set_fragment_context_key(roi_ov->data[0], roi_ov->data[1]&0x0f);
+        uint8_t x = roi_ov->data[3];
+        uint8_t y = (roi_ov->data[2]&0x03) | ((roi_ov->data[1]>>2)&0x3c);
+        set_fragment_context_roi(x, y, roi_ov->data[4]&0x7f, roi_ov->data[2] >> 2, ((roi_ov->data[4]&0x80)!=0));
+        set_fragment_context_bit_index(y * SCREEN_WIDTH + x);
+        start = &((roi_ov->data)[5]);
     }
+    const overlay_fragment_context_t* ctx = get_fragment_context();
+
+    #ifdef USE_CORE1
+        if(first) {
+            core1_roi_start();
+        }
+        core1_update_roi(ctx->keycode, ctx->modifier, roi_ov->adj_idx, start, &ctx->roi);
+        ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK; // we cannot send SIG, we do not know if we are finished
+    #else
+        uint16_t new_index = copy_rectangle_to_overlay(ctx->bit_index, get_overlay(roi_ov->adj_idx), start, &ctx->roi, first?ROI_START:ROI_MAX);
+        if(new_index >= 2880) {
+            //finished roi update
+            ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK_SIG;
+            set_overlay_usage_post_upload(roi_ov->adj_idx);
+            request_disp_refresh();
+        } else {
+            ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK;
+        }
+        set_fragment_context_bit_index(new_index);
+    #endif
 }
 
 _Static_assert(DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT <= DYNAMIC_KEYMAP_LAYER_COUNT, "Maximum cannot exceed DYNAMIC_KEYMAP_LAYER_COUNT");
@@ -317,17 +291,11 @@ void user_sync_overlay_map_data_handler(uint8_t in_len, const void* in_data, uin
         user_sync_mru_data_handler(in_len, in_data, out_len, out_data);
         return;
     }
-    if (in_len == sizeof(overlay_map_sync_t) && in_data != NULL && out_len == sizeof(poly_sync_reply_t) && out_data != NULL) {
-        uint32_t crc32 = crc32_1byte(&((uint8_t *)in_data)[4], in_len-4, 0);
-        const overlay_map_sync_t* data = (const overlay_map_sync_t *)in_data;
-        if (crc32 == data->crc32) {
-            set_10bit_overlay_mapping((uint8_t *)data->mapping);
-            request_disp_refresh();
-            ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK;
-        } else {
-            ((poly_sync_reply_t*)out_data)->ack = SYNC_CRC32_ERR;
-        }
-    }
+    SYNC_VALIDATE_OR_RETURN(overlay_map_sync_t);
+    const overlay_map_sync_t* data = (const overlay_map_sync_t *)in_data;
+    set_10bit_overlay_mapping((uint8_t *)data->mapping);
+    request_disp_refresh();
+    ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK;
 }
 
 // Handles incoming MRU recents (emoji + language) on the bridge with CRC32 validation.

--- a/keyboards/polykybd/state.c
+++ b/keyboards/polykybd/state.c
@@ -86,10 +86,6 @@ poly_layer_t* access_local_layer(void) {
     return &l_layer;
 }
 
-void set_local_layer(poly_layer_t value) {
-    l_layer = value;
-}
-
 void copy_local_layer(const poly_layer_t *value) {
     memcpy(&l_layer, value, sizeof(poly_layer_t));
 }
@@ -97,10 +93,6 @@ void copy_local_layer(const poly_layer_t *value) {
 // Getters and setters for g_layer
 const poly_layer_t* get_global_layer(void) {
     return &g_layer;
-}
-
-void set_global_layer(poly_layer_t value) {
-    g_layer = value;
 }
 
 void copy_global_layer(const poly_layer_t *value) {
@@ -117,10 +109,6 @@ poly_sync_t* access_local_state(void) {
     return &l_state;
 }
 
-void set_local_state(poly_sync_t value) {
-    l_state = value;
-}
-
 void copy_local_state(const poly_sync_t* value) {
     memcpy(&l_state, value, sizeof(poly_sync_t));
 }
@@ -132,10 +120,6 @@ const poly_sync_t* get_global_state(void) {
 
 poly_sync_t* access_global_state(void) {
     return &g_state;
-}
-
-void set_global_state(poly_sync_t value) {
-    g_state = value;
 }
 
 void copy_global_state(const poly_sync_t* value) {
@@ -172,10 +156,6 @@ poly_last_t* access_global_last_latin_keycode(void) {
     return &g_last;
 }
 
-void set_global_last_latin_keycode(uint16_t keycode) {
-    g_last.latin_kc = keycode;
-}
-
 void copy_global_last_latin(const poly_last_t* value) {
     memcpy(&g_last, value, sizeof(poly_last_t));
 }
@@ -187,10 +167,6 @@ const latin_sync_t* get_global_latin_table(void) {
 
 latin_sync_t* access_global_latin_table(void) {
     return &g_latin;
-}
-
-void set_global_latin_table(latin_sync_t value) {
-    g_latin = value;
 }
 
 void copy_global_latin_table(const latin_sync_t* value) {

--- a/keyboards/polykybd/state.h
+++ b/keyboards/polykybd/state.h
@@ -130,19 +130,15 @@ void reset_all_states_and_layers(void);
 
 const poly_layer_t* get_local_layer(void);
 poly_layer_t* access_local_layer(void);
-void set_local_layer(poly_layer_t value);
 void copy_local_layer(const poly_layer_t *value);
 const poly_layer_t* get_global_layer(void);
-void set_global_layer(poly_layer_t value);
 void copy_global_layer(const poly_layer_t *value);
 
 const poly_sync_t* get_local_state(void);
 poly_sync_t* access_local_state(void);
-void set_local_state(poly_sync_t value);
 void copy_local_state(const poly_sync_t* value);
 const poly_sync_t* get_global_state(void);
 poly_sync_t* access_global_state(void);
-void set_global_state(poly_sync_t value);
 void copy_global_state(const poly_sync_t* value);
 
 const poly_last_t* get_local_last_latin(void);
@@ -153,13 +149,11 @@ void copy_local_last_latin(const poly_last_t* value);
 
 const poly_last_t* get_global_last_latin(void);
 poly_last_t* access_global_last_latin(void);
-void set_global_last_latin_keycode(uint16_t keycode);
 uint16_t get_global_last_latin_keycode(void);
 void copy_global_last_latin(const poly_last_t* value);
 
 const latin_sync_t* get_global_latin_table(void);
 latin_sync_t* access_global_latin_table(void);
-void set_global_latin_table(latin_sync_t value);
 void copy_global_latin_table(const latin_sync_t* value);
 
 


### PR DESCRIPTION
## Summary

Behaviour-preserving cleanup of the PolyKybd firmware — dead-code removal and de-duplication, no functional change. Four focused commits, each independently reviewable:

1. **Remove dead code & trim a verbose comment**
   - `poly_keymap.c`: drop the unused `flash_target_contents` pointer (+ its `FLASH_TARGET_OFFSET` alias) and the commented-out `oled_on_off` declaration.
   - `state.c`/`state.h`: remove six **unused** value-copy setters (`set_local_layer`, `set_global_layer`, `set_local_state`, `set_global_state`, `set_global_latin_table`, `set_global_last_latin_keycode`). The `copy_*` / `access_*` / `get_*` family and the one *used* setter (`set_local_last_latin_keycode`) are kept.
   - `base/overlay.c`: drop a commented-out `memset` that duplicated the loop above it.
   - `base/disp_array.c`: collapse the 8-line Doxygen block on `kdisp_write_gfx_char` to a one-line brief.

2. **`fill_overlay.c`: factor the overlay slot-index calc into a helper** — `fill_overlay_buffer` / `decompress_overlay_buffer` / `fill_roi_overlay_buffer` each repeated the same keycode→0..89 slot-index computation + out-of-bounds warning verbatim. Extracted `overlay_slot_index()`. `translate_a_to_z()` stays in each caller (they reuse the translated keycode).

3. **`split_sync.c`: collapse the CRC32 prologue into a macro** — the `user_sync_*_data_handler` functions each open-coded the same size-check + per-transaction CRC32 verify + `SYNC_CRC32_ERR` NACK. Introduced `SYNC_VALIDATE_OR_RETURN(TYPE)`. Behaviour-preserving by construction: size mismatch still bails leaving the reply untouched, CRC mismatch still NACKs, success path unchanged (the ROI handler still sets its own `SYNC_ACK`/`SYNC_ACK_SIG`). The two handlers that don't fit the exact `sizeof()`-equality shape are left untouched — the dynamic-keymap handler (`in_len >= …`) and the MRU handler (keyed on `MRU_SYNC_BYTES`). This is the bulk of the diff (~140 fewer lines in that file).

4. **`base/fw_staging.c`: extract `flash_program_guarded()`** — `flush_page()` and `write_staging_header()` repeated the identical IRQ-disable + conditional core1-halt wrapper around `flash_range_program()`. The `s_core1_halted` check is preserved so a caller that already halted core1 isn't restarted early. The unconditional erase path is intentionally left as-is (different guard shape).

Net: **8 files, +176 / −242**.

## Version bump label

No firmware-behaviour or protocol change — default (patch) bump is appropriate.

## Testing
- [x] Compiled successfully — `qmk compile -kb polykybd/split72 -km default` **and** `-kb polykybd/split42 -km default`, both clean with no new warnings. `.uf2` sizes unchanged from baseline (split72 762880, split42 723456).
- [ ] Flashed and tested on hardware
- [ ] If protocol changed: host updated and tested together *(n/a — no protocol change)*

> Verified by build + behaviour-preserving reasoning only; no on-hardware flashing was done in this environment. The `split_sync.c` change touches the most safety-critical handlers, so the CRC32-macro transformation is worth a careful read — it's mechanical and intended to be exactly equivalent to the prior per-handler boilerplate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0165wJ8ThcSEiicTmUuaNiQC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Overlay usage is now properly reset, which should improve consistency when switching overlays.
  * Sync handling is more reliable, with stricter validation for incoming data and clearer error handling.
  * Flash updates now follow a safer programming sequence to reduce risk during write operations.

* **Refactor**
  * Simplified shared validation and index handling across multiple overlay and sync paths.

* **Chores**
  * Removed unused legacy code and outdated comments.
  * Streamlined the public state API by removing direct setter-style functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->