### PR TITLE
HIL CI: sync the installed station to ctnd main before running

### DIFF
--- a/.github/workflows/qmk-test.yml
+++ b/.github/workflows/qmk-test.yml
@@ -103,6 +103,38 @@ jobs:
           fi
           echo "dir=$dir" >> "$GITHUB_OUTPUT"
 
+      - name: Sync station to current ctnd main
+        # CI runs the *installed* station copy located above, NOT a fresh checkout
+        # — it relies on the rig's polykybd-update.timer to keep that copy current.
+        # When that self-update lags (rig busy/offline for a while), HIL runs stale
+        # station code and already-merged fixes don't apply — so the suite flakes on
+        # a problem that was fixed days ago (e.g. the sustained-settle boot-burst
+        # gate). Force the install to origin/main before every run so CI always
+        # exercises current station code. Best-effort: a fetch/network failure logs
+        # a warning and proceeds on the installed copy (config.yaml / venv / firmware
+        # are untracked, so a hard checkout leaves them intact).
+        run: |
+          dir="${{ steps.ctnd.outputs.dir }}"
+          if [ ! -d "$dir/.git" ]; then
+            echo "WARNING: $dir is not a git checkout — running the installed station as-is" >&2
+            exit 0
+          fi
+          before=$(git -C "$dir" rev-parse --short HEAD 2>/dev/null || echo none)
+          req_before=$(sha1sum "$dir/requirements.txt" 2>/dev/null | cut -d' ' -f1 || true)
+          if git -C "$dir" fetch --quiet origin main \
+             && git -C "$dir" checkout -q -f -B main origin/main; then
+            after=$(git -C "$dir" rev-parse --short HEAD)
+            echo "station synced to origin/main: $before -> $after"
+            req_after=$(sha1sum "$dir/requirements.txt" 2>/dev/null | cut -d' ' -f1 || true)
+            if [ "$req_before" != "$req_after" ]; then
+              echo "requirements.txt changed — reinstalling station deps"
+              "$dir/venv/bin/pip" install -q -r "$dir/requirements.txt" \
+                || echo "WARNING: pip install failed — continuing with existing deps" >&2
+            fi
+          else
+            echo "WARNING: could not sync $dir to origin/main — running the installed station as-is" >&2
+          fi
+
       - uses: actions/download-artifact@v4
         with:
           name: firmware


### PR DESCRIPTION
## Problem

The `HIL test (split72)` job runs the **installed** polykybd-ctnd copy (`/opt/polykybd-ctnd`, located via `CTND_DIR`), not a fresh checkout — it trusts the rig's `polykybd-update.timer` to keep that copy current. When that self-update lags (rig busy or offline for a while), CI runs **stale station code**, so already-merged rig fixes silently don't apply and the suite flakes on problems that were fixed days ago.

Two recent HIL failures on #104 show exactly this. The runner logged the **old `need=3` settle**:

```
[runner] master settled — 3 consecutive GET_LANG replies <= 250 ms after 3 probe(s)
```

…even though ctnd `main` has carried the **sustained `need=15`** boot-burst settle (`df6401d`, 2026-06-26). With only ~0.6 s of settle, the async slave-connect render burst lands mid-suite on a different adjacent test pair each run:

- run A → `fresh-boot marker` + `raw HID GET_ID` timed out
- run B → `get default layer` + `reset dynamic keymap` timed out

Everything else (language, overlays, GET_ID stress 50/50 @ 3–7 ms, full firmware stage+verify) passed both times — i.e. the firmware is healthy; the rig is just running a stale runner.

## Fix

Add a best-effort **"Sync station to current ctnd main"** step before the flash/test step that fast-forwards the install to `origin/main` (fetch + hard checkout of `main`; reinstall deps only if `requirements.txt` changed). So every HIL run exercises current station code regardless of whether the self-update timer has fired.

- `config.yaml` / `venv` / `firmware/` are untracked, so the hard checkout leaves them intact.
- Best-effort: a non-git dir or a fetch/network failure logs a warning and proceeds on the installed copy — this step can never turn a HIL run red by itself.

## Notes

This addresses the *deployment* root cause. The timing fix it lets run (`need=15` sustained settle) should ride past the boot burst; if any residual flake remains once the rig is actually running current `main`, the follow-up is a per-test transient-timeout retry so a wandering burst can't fail a single read test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019SAsmcPAmDro3EwKeYujdG)_

## Summary by Sourcery

CI:
- Add a workflow step to fast-forward the installed station repository to origin/main before running HIL tests, reinstalling dependencies only when requirements.txt changes.