### PR TITLE
docs: font-pack version + hint display-list learnings; add diagnose-hil-failure skill

### DIFF
--- a/.claude/skills/diagnose-hil-failure/SKILL.md
+++ b/.claude/skills/diagnose-hil-failure/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: diagnose-hil-failure
+description: >
+  Triage a red "HIL test (split72)" check on a PolyKybd `thpoll83/qmk_firmware`
+  PR and drive it to green or a correct root-cause diagnosis. Use when a HIL
+  check fails, a `❌ HIL test failed — rig diagnostics` comment appears, the user
+  asks to "look at the HIL failure / rig test / why is CI red", or when deciding
+  whether to re-run the HIL job. Classifies the failure into stale-rig-code /
+  no-enumeration / boot-burst flake / stale-rig-test / real-firmware-bug, then
+  acts (re-run, fix the ctnd test, or flag the rig). NOT for building firmware
+  (that's the build job) or for non-HIL CI.
+---
+
+# Diagnose a HIL (hardware-in-the-loop) failure
+
+The HIL job flashes both keyboard halves on the RPi4 rig (`polykybd-ctnd`) and
+runs `station/hil_tests.py` over Raw HID. Most red HIL checks are **not** a bug in
+the PR under test — they're a stale rig, a boot-timing flake, or a rig test that
+drifted from the firmware. Classify before acting; a re-run only helps for some
+classes, and re-running against a stale rig just reproduces the same red.
+
+The rig, its self-update model, and the flake history are documented in
+`polykybd-ctnd/CLAUDE.md` (esp. the self-update ⚠️ note) and the "Investigations"
+HIL notes in `qmk_firmware/CLAUDE.md` — read those for background.
+
+## 1. Get the diagnostics
+
+The failing run posts a sanitized `test_runner` log as a PR comment (HTML marker
+`<!-- hil-diagnostics -->`) and to the job Step Summary. Read the whole
+`test_runner output` block — the per-test `[test] PASS/FAIL` lines and the
+`::error::` annotations at the end are the signal. If you only have a `check_run`
+event, get the run/jobs via the GitHub Actions tools:
+
+```
+mcp__github__actions_list  method=list_workflow_runs  resource_id=qmk-test.yml
+                           workflow_runs_filter={branch: "<pr-branch>"}
+mcp__github__actions_list  method=list_workflow_jobs  resource_id=<run_id>  filter=all
+```
+
+## 2. Check rig freshness FIRST — the settle line
+
+Before anything else, read this line:
+
+```
+[runner] master settled — N consecutive GET_LANG replies <= 250 ms after N probe(s)
+```
+
+- **`need=3`** (`3 consecutive … after 3`) → the rig is running **STALE** station
+  code (pre-`df6401d`). Already-merged rig fixes are NOT deployed — CI runs the
+  *installed* `/opt/polykybd-ctnd`, updated only by the rig's self-update timer,
+  which lags. **Do not chase the firmware.** Recovery: get the rig current (tap
+  the **UPDATE** badge on the touch UI, or wait a ~5 min idle timer tick), then
+  re-run. The durable fix is the "Sync station to current ctnd main" step in
+  `qmk-test.yml` (if that PR isn't merged yet, that's why it's still lagging).
+- **`need=15`** (`15 consecutive … after ≥15`) → the rig is current; the
+  sustained settle rode past the boot burst. Proceed to classify the real failure.
+
+## 3. Classify the failure
+
+| Signature in the log | Class | Meaning / action |
+|---|---|---|
+| `raw HID interfaces present: 0` + every test fails `Raw HID interface not found` | **no-enumeration** | The master never enumerated its raw HID interface. NOT a display/font/keymap change (USB inits before rendering). Rig USB/flash/boot wedged or slow → **re-run**; if it persists across re-runs the rig needs physical attention (reseat/power-cycle a half), not a code fix. |
+| An early read (e.g. `GET_ID #2`, a layer/keymap read) times out (`None`), **everything after passes** | **boot-burst flake** | The async slave-connect render burst (~5 s stall) landed on an early test. It *wanders* onto a different adjacent test pair each run. `need=15` settle usually rides past it; a lone straggler → **re-run**. |
+| One test fails on a **wrong value** (`status 0xNN != expected`, byte mismatch — a *response*, not a timeout), everything else passes | **stale rig test** | A rig-side mirror of a firmware constant/enum drifted. Compare the firmware source to the rig's mirror and fix the **ctnd** test, not the firmware. (2026-07: `POLY_OS_COUNT` was 6 on the rig but the firmware enum grew to 8 — `SET_OS(6)`=GNOME is valid, so the "invalid" probe wrongly ACKed.) |
+| Broad failures with genuinely wrong data / NACKs where ACK expected across many commands | **real firmware bug** | Investigate the PR diff. This is the rare case the HIL suite exists to catch. |
+
+Cross-check scope: a display/font/hint change **cannot** affect USB enumeration,
+split master/slave detection, or unrelated command handlers — so "no-enumeration"
+or an unrelated command's failure on such a PR points away from the diff.
+
+## 4. Act
+
+- **Re-run** (boot-burst flake, or after the rig is confirmed current):
+  ```
+  mcp__github__actions_run_trigger  method=rerun_failed_jobs  run_id=<run_id>
+  ```
+  Re-runs only the failed HIL job, reusing the build artifact. **Don't re-run
+  against a stale rig** (step 2) — it reproduces the same red.
+- **Stale rig test** → fix the mirror in `polykybd-ctnd/station/hil_tests.py`
+  (match the firmware source), PR to ctnd `main`; the rig picks it up on its next
+  self-update. Re-run once deployed.
+- **Report** the class + root cause to the user (in chat, not a PR comment — be
+  frugal). For a stale-rig or rig-test cause, say plainly it's not the PR's fault.
+
+## Output
+
+State: (a) rig fresh or stale (from the settle line), (b) the failure class, (c)
+root cause + which repo owns the fix, (d) the action taken (re-run / ctnd fix /
+flag rig). One or two sentences per point.
+
+## Pitfalls
+
+- **Read the settle line before diagnosing.** `need=3` = stale rig; fixing the
+  firmware/test is wasted effort until the rig is current.
+- **Re-running a stale rig reproduces the same red.** Get the rig current first.
+- **`0 interfaces` ≠ the busy-window flake.** Zero enumeration is a boot/USB/flash
+  problem (or genuinely-slow enumeration), not a timed-out query — a longer
+  readiness timeout won't conjure an absent interface.
+- **A wrong-*value* failure (response present) is real** — either a firmware bug
+  or a stale rig-test mirror; distinguish by comparing to the firmware source.
+  Only *timeouts* (`None`) are the transient boot-burst class.
+- **Don't blame a display/font/hint PR for USB/enumeration/unrelated-command
+  failures** — those subsystems are independent of rendering.
+- The HIL suite is **shared**: a stale-rig-test failure reddens *every* PR's HIL
+  until the ctnd fix is merged and deployed, not just the PR that surfaced it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,6 +312,15 @@ flashes all stale bundles, `flash <id>` force-flashes one).
     the others. `cmp` each regenerated `.plyf` against the shipped one to see which
     actually changed, and bump+reship only those (see the gidx note above re: why
     appending a glyph now changes only the edited bundle).
+    - **Bump `content_version` MINIMALLY (+1 over the shipped value), don't jump.**
+      No font-pack bundle has ever been deployed to a device, so the version only
+      needs to exceed what a device already has (0 / nothing) — any increment works,
+      and a small, monotonic step keeps the diff-vs-base readable and the host's
+      `decide_stale_bundles` comparison obvious. Don't ratchet a version up across
+      iterations (e.g. 4→7→8 while tuning); land the reship at base+1 (symbol 4→5,
+      2026-07). ⚠️ The value lives in the `.plyf` header *and* `bundles.json` — they
+      must match, so changing it means regenerating the `.plyf` with the new
+      `--bundle-version`, not just editing the JSON.
   - **Flash UX (split72):** while any flash runs the status OLED shows an "Updating
     fonts/firmware — do not unplug" screen with a full-width progress bar, and the RGB
     matrix breathes (cyan = font pack, orange = firmware/bootloader = "can't type");
@@ -367,14 +376,28 @@ flashes all stale bundles, `flash <id>` force-flashes one).
     intervening `0xA0/0xA1/0xA4` already gaps), just lower the `GFXfont` `last` past
     them instead of leaving trailing gaps — that un-shadows every codepoint above the
     new `last` at once.
-  - **Compositing a smaller second glyph inside a hint** (e.g. the 🗘 reload inside
-    the Win+Ctrl+Shift+B monitor): `kdisp_draw_glyph_half_at()` (`disp_array.c`) blits
-    any pack/resident glyph at half size (2×2-OR downsample — keeps thin strokes that
-    plain decimation drops) at fixed **buffer** coords (x offset by `BUFFER_X`=28, y
-    NOT offset). A `keycode_hint_wants_*()` gate in `poly_keymap.c` (mirroring the
-    Win+R frame pattern) triggers it in `update_displays()` after the base hint text.
-    Derive the buffer coords from `tools/gfx_font.py` (it replicates the baseline-align
-    math, so its rendered bbox matches hardware).
+  - **A shortcut-hint string is a mini DISPLAY LIST, not just text** (2026-07). The
+    hint returned by `keycode_to_disp_overlay()` is interpreted by
+    `kdisp_write_gfx_text_cy()` (`disp_array.c`), which understands control-code ops
+    on top of the plain glyphs — so extra art (frames, composited icons, drawn signs)
+    lives **in the hint string**, and `update_displays()` has **no per-keycode
+    special-case** (the old `keycode_hint_wants_frame/_gfx_restart/_mag` gates were
+    removed). The ops, built via the `HINT_*` macros in `lang/named_glyphs.h`:
+    - `HINT_MOVE(pos)` = `\x0E` + 2 codepoints (x,y) — move the cursor to buffer coords.
+    - `HINT_HALF` = `\x0F` — draw the NEXT glyph at half size (2×2-OR downsample via
+      `kdisp_draw_glyph_half_at()`; keeps thin strokes plain decimation drops; **round
+      the halved dims up** `(w+1)/2` + bounds-check, or an odd-width glyph loses its
+      last column — the 🗘 reload is 27×35). Used for the Win+Ctrl+Shift+B monitor+🗘.
+    - `HINT_FRAME(sz)` = `\x12` + 2 codepoints (w,h) — 2px nested rounded rect at the
+      cursor (the Win+R run-dialog box). `HINT_RESET` = `\x18` resets to the origin.
+    - Magnifier `+`/`-` are just base-font `"+"`/`"-"` MOVE-positioned into the lens —
+      no bespoke primitive (dropped the `\x10`/`\x11` draw ops as too special-purpose).
+    - Fixed positions/sizes are named `HINT_POS_*` / `HINT_SZ_*`. ⚠️ **You cannot write
+      decimal coords in a `U"…"` literal** (no way to turn a number into a byte), hence
+      named position macros holding `\xHH\xHH`; and **each `\xHH` escape must be
+      followed by `\x`/`\u` or a split literal** or the compiler greedily merges the
+      hex into one huge codepoint. Derive buffer coords from `tools/gfx_font.py` (it
+      replicates the baseline-align math + the ops, so its render matches hardware).
   - **Pack-category headers (`symbol_fonts.h`, etc.) are NOT compiled into the
     firmware** — only `RESIDENT_FONTS[]` + `IconsFont` are `#include`d. So adding pack
     glyphs (⍇/⍈, 🖧) does **not** grow the image; *removing* a resident glyph shrinks


### PR DESCRIPTION
Session-retro capture — documentation + one new skill, no code changes.

## CLAUDE.md (Font pack §)

- **Minimal version bumps for never-deployed packs.** Bump `content_version` by **+1 over the shipped base**, don't ratchet across iterations (symbol went 4→7→8 while tuning this session; it should land at base+1 — 4→5). No device has ever had a pack, so any value over what a device has (0) works; a small monotonic step keeps the diff readable. Notes the value lives in the `.plyf` header *and* `bundles.json`, so changing it means a regen, not a JSON edit.
- **Hint strings are a display list.** Rewrote the now-stale "composite a smaller glyph" note (it described the removed `keycode_hint_wants_frame/_gfx_restart/_mag` gates) into the current mechanism: `kdisp_write_gfx_text_cy` interprets control-code ops — `HINT_MOVE(x,y)` `\x0E`, `HINT_HALF` `\x0F` (2×2-OR, round halved dims up), `HINT_FRAME(w,h)` `\x12`, `HINT_RESET` `\x18` — built via the `HINT_*` macros in `named_glyphs.h`, so extra art lives in the hint string and `update_displays()` has no per-keycode special-case. Records the two gotchas: a `U"…"` literal can't hold decimal coords (named `HINT_POS_*` macros instead), and each `\xHH` escape must be followed by `\x`/`\u` or a split literal or the compiler greedily merges the hex.

## New skill: `.claude/skills/diagnose-hil-failure`

Triage a red `HIL test (split72)` check: read the diagnostics comment → check rig freshness via the settle line (`need=3` stale / `need=15` current) → classify (stale-rig / no-enumeration / boot-burst flake / stale-rig-test / real firmware bug) → act (re-run, fix the ctnd test, or flag the rig). Includes a Pitfalls section (read the settle line first; re-running a stale rig reproduces the red; `0 interfaces` ≠ busy-window flake; a wrong-*value* failure is real vs a *timeout* being transient).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019SAsmcPAmDro3EwKeYujdG)_

## Summary by Sourcery

Document recent font-pack versioning rules and hint display-list behavior, and add a new skill for diagnosing hardware-in-the-loop test failures.

Documentation:
- Clarify how to minimally bump font pack content_version and note required regeneration of bundles to keep metadata in sync.
- Update shortcut hint documentation to describe the current display-list style control codes and positioning macros used for composite hint art.

Chores:
- Add a diagnose-hil-failure skill that guides classification and handling of HIL test failures on the split72 rig, including pitfalls and recommended actions.