### PR TITLE
polykybd: share the status-OLED default-layout name switch

### DIFF
--- a/keyboards/polykybd/oled_helper.c
+++ b/keyboards/polykybd/oled_helper.c
@@ -52,6 +52,17 @@ void hex_to_u32_string(char* buffer, uint8_t buffer_len, uint8_t value) {
     if (i < cap) out[i] = 0;
 }
 
+void oled_draw_layout_name(const GFXfont* const* font, int8_t x, int8_t y, uint8_t def_layer) {
+    // Indexed by def_layer (the _L0.._L4 default-layout enum in each variant's
+    // keymaps/default/layers.h). Keep in sync with the KC_L0..KC_L4 selectors in
+    // poly_keymap.c; an out-of-range value falls back to "Unknown".
+    static const uint32_t* const names[] = {
+        U"Qwerty", U"Qwerty Stag!", U"Colemak DH", U"Neo", U"Workman",
+    };
+    const uint32_t* name = (def_layer < ARRAY_SIZE(names)) ? names[def_layer] : U"Unknown";
+    kdisp_write_gfx_text(font, 1, x, y, name);
+}
+
 void oled_status_screen(void) {
     const poly_sync_t* local_state = get_local_state();
     if ((local_state->flags & STATUS_DISP_ON) == 0) {

--- a/keyboards/polykybd/oled_helper.h
+++ b/keyboards/polykybd/oled_helper.h
@@ -12,6 +12,10 @@ void hex_to_u32_string(char* buffer, uint8_t buffer_len, uint8_t value);
 /* Widen an ASCII string into a UTF-32 buffer for the kdisp text pipeline */
 void ascii_to_u32_string(char* buffer, uint8_t buffer_len, const char* s);
 
+/* Draw the active default-layout name (Qwerty / Colemak DH / …) at (x,y). Shared
+   by both status-OLED variants so the layout list can't drift between them. */
+void oled_draw_layout_name(const GFXfont* const* font, int8_t x, int8_t y, uint8_t def_layer);
+
 /* Board-specific callbacks — implemented in split72/status_oled.c or split42/status_oled.c */
 void oled_update_buffer(void);
 void oled_update_buffer_fw_update(void);   /* "Updating fonts/firmware …" screen */

--- a/keyboards/polykybd/split42/status_oled.c
+++ b/keyboards/polykybd/split42/status_oled.c
@@ -57,14 +57,7 @@ void oled_update_buffer(void) {
         global_layer->led_state.caps_lock ? ICON_CAPSLOCK_ON : ICON_CAPSLOCK_OFF);
 
     /* Row 2: default layout name (both sides — no RGB on split42) */
-    switch (get_local_layer()->def_layer) {
-        case 0: kdisp_write_gfx_text(smallFont, 1, 0, 22, U"Qwerty");      break;
-        case 1: kdisp_write_gfx_text(smallFont, 1, 0, 22, U"Qwerty Stag!"); break;
-        case 2: kdisp_write_gfx_text(smallFont, 1, 0, 22, U"Colemak DH");  break;
-        case 3: kdisp_write_gfx_text(smallFont, 1, 0, 22, U"Neo");          break;
-        case 4: kdisp_write_gfx_text(smallFont, 1, 0, 22, U"Workman");      break;
-        default: kdisp_write_gfx_text(smallFont, 1, 0, 22, U"Unknown");     break;
-    }
+    oled_draw_layout_name(smallFont, 0, 22, get_local_layer()->def_layer);
 
     /* Row 2 right: USB/Batt indicator */
     kdisp_write_gfx_text(smallFont, 1, 112, 22, is_usb_host_side() ? U"H" : U"B");

--- a/keyboards/polykybd/split72/status_oled.c
+++ b/keyboards/polykybd/split72/status_oled.c
@@ -76,14 +76,7 @@ void oled_update_buffer(void) {
             kdisp_write_gfx_text(smallFont, 1, 58, 58, buffer);
         }
     } else {
-        switch(get_local_layer()->def_layer) {
-            case 0: kdisp_write_gfx_text(smallFont, 1, 0, 30, U"Qwerty"); break;
-            case 1: kdisp_write_gfx_text(smallFont, 1, 0, 30, U"Qwerty Stag!"); break;
-            case 2: kdisp_write_gfx_text(smallFont, 1, 0, 30, U"Colemak DH"); break;
-            case 3: kdisp_write_gfx_text(smallFont, 1, 0, 30, U"Neo"); break;
-            case 4: kdisp_write_gfx_text(smallFont, 1, 0, 30, U"Workman"); break;
-            default: kdisp_write_gfx_text(smallFont, 1, 0, 30, U"Unknown"); break;
-        }
+        oled_draw_layout_name(smallFont, 0, 30, get_local_layer()->def_layer);
         const poly_sync_t* local_state = get_local_state();
         kdisp_write_gfx_text(smallFont, 1, 0, 44, U"Dsp*");
         num_to_u32_string((char*) buffer, sizeof(buffer), local_state->contrast);


### PR DESCRIPTION
## Summary

Both status-OLED variants (`split72` 128×64, `split42` 128×32) carried a
byte-identical `switch` mapping `def_layer` → `"Qwerty"` / `"Qwerty Stag!"` /
`"Colemak DH"` / `"Neo"` / `"Workman"` / `"Unknown"`, differing only in the draw
coordinates. This factors it into `oled_draw_layout_name(font, x, y, def_layer)`
in `oled_helper.c` and calls it from both variants — so the layout list can't
silently drift between the two variants (the same class of drift the shared
`poly_keymap.c` guards against).

The rest of `oled_update_buffer()` stays variant-local: the Y coordinates, the
split72-only RGB panel + brightness bar + scroll-lock line, and the wider side
label are genuinely per-variant and don't benefit from a shared abstraction.
Behaviour-preserving.

## Version bump label

*(none)* — internal refactor, no behaviour/protocol change (patch bump).

## Testing
- [x] Compiled successfully (`qmk compile -kb polykybd/split72 -km default` **and** `split42`)
- [ ] Flashed and tested on hardware
- [ ] If protocol changed: host updated and tested together — n/a

---
_Generated by [Claude Code](https://claude.ai/code/session_0165wJ8ThcSEiicTmUuaNiQC)_

## Summary by Sourcery

Factor out shared OLED default-layout name rendering into a common helper used by both split42 and split72 status displays to keep layout naming consistent between variants.

Enhancements:
- Introduce a reusable oled_draw_layout_name helper in oled_helper for mapping default layers to layout names and drawing them at specified coordinates.
- Update split42 and split72 status OLED implementations to call the shared helper instead of maintaining duplicate switch statements.