### PR TITLE
polykybd: log fontpack chunk-relay retries like the firmware path

### DIFF
--- a/keyboards/polykybd/hid_fontpack.c
+++ b/keyboards/polykybd/hid_fontpack.c
@@ -121,7 +121,15 @@ bool hid_fontpack_receive(uint8_t *data, uint8_t length) {
                                                    sizeof(reply), &reply);
                 if (ok_rpc && reply.ack == SYNC_ACK && reply.next_offset > offset) {
                     slave_ack = SYNC_ACK;
+                    if (debug_enable && retry > 0) {
+                        uprintf("FONTPACK_CHUNK relay ok on retry %u (offset=%lu slave_next=%lu)\n",
+                                retry, (unsigned long)offset, (unsigned long)reply.next_offset);
+                    }
                     break;
+                }
+                if (debug_enable) {
+                    uprintf("FONTPACK_CHUNK relay retry %u (offset=%lu success=%d ack=0x%02x slave_next=%lu)\n",
+                            retry, (unsigned long)offset, (int)ok_rpc, reply.ack, (unsigned long)reply.next_offset);
                 }
             }
             bool ok = (slave_ack == SYNC_ACK);


### PR DESCRIPTION
## Summary

The `CMD_FONTPACK_CHUNK` relay loop retried the slave up to 10× **silently**,
while the identical `CMD_FW_UP_CHUNK` loop logs each retry (and the eventual
retry-success) under `debug_enable`. This adds the same per-retry logging to the
font-pack path, tagged `"FONTPACK_CHUNK"`, so a flaky slave link is diagnosable
the same way for both transports. Debug-only (gated on `debug_enable`); no
behaviour change when debug is off.

> Note: if the fw-update / font-pack chunk relay is later unified into one helper
> (the parked `fw_up_relay_chunk_to_slave` work), this logging is subsumed by
> passing a `"FONTPACK_CHUNK"` log tag there instead.

## Version bump label

*(none)* — debug logging only, no behaviour/protocol change (patch bump).

## Testing
- [x] Compiled successfully (`qmk compile -kb polykybd/split72 -km default` **and** `split42`)
- [ ] Flashed and tested on hardware
- [ ] If protocol changed: host updated and tested together — n/a

---
_Generated by [Claude Code](https://claude.ai/code/session_0165wJ8ThcSEiicTmUuaNiQC)_

## Summary by Sourcery

Enhancements:
- Log each fontpack chunk relay retry and eventual success under debug_enable using a FONTPACK_CHUNK tag for easier diagnosis of flaky slave links.