### PR TITLE
fix: drop to the Poly def_layer, not QMK's saved default layer, before a flash

### DIFF
--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -533,7 +533,15 @@ void poly_prepare_for_flash(void) {
         reset_idle_jitter();       // fresh centred legends, not jittered offsets
         update_performed();
     }
-    layer_clear();                 // momentary/toggle layers off -> default layer active
+    // Momentary/toggle layers off, then back onto the PolyKybd default layout.
+    // A bare layer_clear() falls through to QMK's *saved* default layer
+    // (default_layer_state), NOT the Poly def_layer — which is a layer INDEX
+    // driven through layer_on(), same as the KC_L*/KC_BASE selectors and the
+    // boot path — so a Colemak/Neo base dropped to QWERTY here, and that
+    // cleared layer state was bridged to the slave, leaving the slave on the
+    // QMK default layer after the flash.
+    layer_clear();
+    layer_on(access_local_layer()->def_layer);
     request_disp_refresh();
     // Push the base layer + refresh to the SLAVE and render the master, before
     // fw_up freezes display sync — so BOTH halves show legible base legends and


### PR DESCRIPTION
## Description

Fixes the field bug where, after flashing new firmware, the **slave half is left on the QMK default layer** (wrong base layout) while the master corrects itself.

The intentional type-during-flash base-layer drop in `poly_prepare_for_flash()` used a bare `layer_clear()`, which falls through to QMK's *saved* default layer (`default_layer_state`). But PolyKybd drives its default layout as a layer **index** through `layer_on(def_layer)` (same mechanism as the `KC_L0..KC_L4`/`KC_BASE` selectors and the boot path), so the clear also switched a Colemak/Neo base off. `sync_and_refresh_displays()` then bridged that cleared layer state to the slave. After the fw-apply reboot the master restores `layer_on(def_layer)` in `keyboard_post_init_user()`, but the slave stayed on the bridged QMK-default state (the boot-time forced layer resync can give up in the post-apply window) — hence the slave-only symptom.

Fix: re-activate the Poly def_layer right after the clear, mirroring the established `layer_clear()` + `layer_on(def_layer)` pattern. Momentary/toggle layers (language/emoji/function) are still popped as intended, and the layer state bridged to the slave during the flash now carries the correct base layout.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Slave half set to the QMK default layer after a firmware flash (only slave affected)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage) — builds clean for `split72:default` + `split42:default`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwCDGPzwQUfZCcrmGPZHKW

---
_Generated by [Claude Code](https://claude.ai/code/session_01LwCDGPzwQUfZCcrmGPZHKW)_

## Summary by Sourcery

Bug Fixes:
- Prevent the slave half from remaining on QMK's saved default layer after a firmware flash by resetting to the PolyKybd default layer instead.