### PR TITLE
polykybd: share the fw-update / font-pack chunk relay loop

### DIFF
--- a/keyboards/polykybd/hid_fontpack.c
+++ b/keyboards/polykybd/hid_fontpack.c
@@ -16,7 +16,6 @@
 #include "config.h"
 #include "split_fw_up.h"
 #include "bridge_helper.h"
-#include "polymod_crc32.h"
 #include <transactions.h>
 #include "base/fw_staging.h"
 #include "base/fontpack.h"
@@ -108,31 +107,10 @@ bool hid_fontpack_receive(uint8_t *data, uint8_t length) {
             // Relay to the slave FIRST (identity-bound reply: a chunk only counts
             // once the slave's write cursor moved PAST this offset), then write the
             // master's own copy — so a failed relay leaves both cursors in lock-step.
-            fw_up_chunk_sync_t chunk_msg;
-            chunk_msg.offset = offset;
-            memcpy(chunk_msg.data, chunk_data, FW_UP_CHUNK_SIZE);
-            chunk_msg.crc32 = crc32_1byte(&((const uint8_t *)&chunk_msg)[4], sizeof(chunk_msg) - 4, 0);
-            uint8_t slave_ack = SYNC_CRC32_ERR;
-            for (uint8_t retry = 0; retry < 10; ++retry) {
-                fw_up_chunk_reply_t reply;
-                memset(&reply, 0, sizeof(reply));
-                reply.ack = SYNC_CRC32_ERR;
-                bool ok_rpc = transaction_rpc_exec(USER_SYNC_FW_UP_CHUNK, sizeof(chunk_msg), &chunk_msg,
-                                                   sizeof(reply), &reply);
-                if (ok_rpc && reply.ack == SYNC_ACK && reply.next_offset > offset) {
-                    slave_ack = SYNC_ACK;
-                    if (debug_enable && retry > 0) {
-                        uprintf("FONTPACK_CHUNK relay ok on retry %u (offset=%lu slave_next=%lu)\n",
-                                retry, (unsigned long)offset, (unsigned long)reply.next_offset);
-                    }
-                    break;
-                }
-                if (debug_enable) {
-                    uprintf("FONTPACK_CHUNK relay retry %u (offset=%lu success=%d ack=0x%02x slave_next=%lu)\n",
-                            retry, (unsigned long)offset, (int)ok_rpc, reply.ack, (unsigned long)reply.next_offset);
-                }
-            }
-            bool ok = (slave_ack == SYNC_ACK);
+            // "FONTPACK_CHUNK" tag = the same per-retry / retry-success debug
+            // logging the standalone fontpack loop had (added for link diagnostics),
+            // now produced by the shared helper.
+            bool ok = fw_up_relay_chunk_to_slave(offset, chunk_data, "FONTPACK_CHUNK");
             if (ok) ok = fw_staging_write_chunk(offset, chunk_data, FW_UP_CHUNK_SIZE);
 
             memset(data, 0, length);

--- a/keyboards/polykybd/hid_fw_up.c
+++ b/keyboards/polykybd/hid_fw_up.c
@@ -183,30 +183,7 @@ bool hid_fw_up_receive(uint8_t *data, uint8_t length) {
             // ended up one chunk behind and rejected the whole rest of the stream
             // (2026-06-10, updates dying at 6% / 83%).  A duplicate re-send of an
             // already-staged chunk has next_offset > offset and passes (idempotent).
-            fw_up_chunk_sync_t chunk_msg;
-            chunk_msg.offset = offset;
-            memcpy(chunk_msg.data, chunk_data, FW_UP_CHUNK_SIZE);
-            chunk_msg.crc32 = crc32_1byte(&((const uint8_t *)&chunk_msg)[4], sizeof(chunk_msg) - 4, 0);
-            uint8_t slave_ack = SYNC_CRC32_ERR;
-            for (uint8_t retry = 0; retry < 10; ++retry) {
-                fw_up_chunk_reply_t chunk_reply;
-                memset(&chunk_reply, 0, sizeof(chunk_reply));
-                chunk_reply.ack = SYNC_CRC32_ERR;
-                bool sync_success = transaction_rpc_exec(USER_SYNC_FW_UP_CHUNK, sizeof(chunk_msg), &chunk_msg,
-                                                         sizeof(chunk_reply), &chunk_reply);
-                if (sync_success && chunk_reply.ack == SYNC_ACK && chunk_reply.next_offset > offset) {
-                    slave_ack = SYNC_ACK;
-                    if (debug_enable && retry > 0) {
-                        uprintf("FW_UP_CHUNK relay ok on retry %u (offset=%lu slave_next=%lu)\n",
-                                retry, offset, chunk_reply.next_offset);
-                    }
-                    break;
-                }
-                if (debug_enable) {
-                    uprintf("FW_UP_CHUNK relay retry %u (offset=%lu success=%d ack=0x%02x slave_next=%lu)\n",
-                            retry, offset, (int)sync_success, chunk_reply.ack, chunk_reply.next_offset);
-                }
-            }
+            uint8_t slave_ack = fw_up_relay_chunk_to_slave(offset, chunk_data, "FW_UP_CHUNK") ? SYNC_ACK : SYNC_CRC32_ERR;
             // First-failure diagnostic: when a chunk doesn't reach the slave,
             // immediately query the slave's internal state so we can tell from
             // the master serial log whether the slave is fully hung (status RPC

--- a/keyboards/polykybd/split_fw_up.c
+++ b/keyboards/polykybd/split_fw_up.c
@@ -7,7 +7,50 @@
 #include "base/fw_staging.h"   // fw_staging_set_fontpack_slot
 #include "base/fontpack.h"     // fontpack_slot, FW_TARGET_FONTPACK via fw_staging.h
 
+#include <transactions.h>
+#include <print.h>
 #include <string.h>
+
+// ---------------------------------------------------------------------------
+// HID firmware update — master-side chunk relay
+// ---------------------------------------------------------------------------
+
+// Relay one upload chunk to the slave with up to 10 retries. Builds the CRC'd
+// fw_up_chunk_sync_t and sends USER_SYNC_FW_UP_CHUNK, accepting only an
+// identity-bound reply whose write cursor advanced PAST `offset` (so a stale
+// previous-chunk ACK can't silently desynchronise the two halves' cursors).
+// Returns true on a slave ACK. Shared by the firmware-update and font-pack
+// chunk paths, which used to carry a byte-identical copy of this loop. When
+// `log_tag` is non-NULL and debug is enabled it logs each retry (the
+// firmware-update path passes "FW_UP_CHUNK"); the font-pack path passes NULL
+// for a quiet relay, matching its prior behaviour.
+bool fw_up_relay_chunk_to_slave(uint32_t offset, const uint8_t *chunk_data, const char *log_tag) {
+    fw_up_chunk_sync_t chunk_msg;
+    chunk_msg.offset = offset;
+    memcpy(chunk_msg.data, chunk_data, FW_UP_CHUNK_SIZE);
+    chunk_msg.crc32 = crc32_1byte(&((const uint8_t *)&chunk_msg)[4], sizeof(chunk_msg) - 4, 0);
+    uint8_t slave_ack = SYNC_CRC32_ERR;
+    for (uint8_t retry = 0; retry < 10; ++retry) {
+        fw_up_chunk_reply_t reply;
+        memset(&reply, 0, sizeof(reply));
+        reply.ack = SYNC_CRC32_ERR;
+        bool ok_rpc = transaction_rpc_exec(USER_SYNC_FW_UP_CHUNK, sizeof(chunk_msg), &chunk_msg,
+                                           sizeof(reply), &reply);
+        if (ok_rpc && reply.ack == SYNC_ACK && reply.next_offset > offset) {
+            slave_ack = SYNC_ACK;
+            if (log_tag && debug_enable && retry > 0) {
+                uprintf("%s relay ok on retry %u (offset=%lu slave_next=%lu)\n",
+                        log_tag, retry, offset, reply.next_offset);
+            }
+            break;
+        }
+        if (log_tag && debug_enable) {
+            uprintf("%s relay retry %u (offset=%lu success=%d ack=0x%02x slave_next=%lu)\n",
+                    log_tag, retry, offset, (int)ok_rpc, reply.ack, reply.next_offset);
+        }
+    }
+    return slave_ack == SYNC_ACK;
+}
 
 // ---------------------------------------------------------------------------
 // HID firmware update — slave-side split transaction handlers

--- a/keyboards/polykybd/split_fw_up.h
+++ b/keyboards/polykybd/split_fw_up.h
@@ -96,6 +96,11 @@ typedef struct _fw_up_apply_sync_t {
     uint8_t  is_left;        // [9]    slave's new handedness when set_handedness != 0 (1 = left)
 } fw_up_apply_sync_t;
 
+// Master-side: relay one upload chunk (offset + FW_UP_CHUNK_SIZE bytes) to the
+// slave with retries. `log_tag` non-NULL enables per-retry debug logging (pass
+// NULL for a quiet relay). Returns true on slave ACK. See split_fw_up.c.
+bool fw_up_relay_chunk_to_slave(uint32_t offset, const uint8_t *chunk_data, const char *log_tag);
+
 void user_sync_fw_up_query_handler  (uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data);
 void user_sync_fw_up_begin_handler  (uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data);
 void user_sync_fw_up_chunk_handler  (uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data);


### PR DESCRIPTION
## Summary

`CMD_FW_UP_CHUNK` (`hid_fw_up.c`) and `CMD_FONTPACK_CHUNK` (`hid_fontpack.c`)
carried a byte-identical copy of the chunk-relay loop — "build the CRC'd
`fw_up_chunk_sync_t`, relay it to the slave with up to 10 retries, accept only an
identity-bound reply whose cursor advanced past the offset". Extract it into
`fw_up_relay_chunk_to_slave(offset, chunk_data, log_tag)` in `split_fw_up.c` and
call it from both.

Behaviour-preserving, **including both paths' diagnostics**: the helper takes a
`log_tag`, so `hid_fw_up.c` passes `"FW_UP_CHUNK"` and `hid_fontpack.c` passes
`"FONTPACK_CHUNK"` — reproducing the exact per-retry / retry-success debug logging
each side already had:
- fw_up's diagnostics from the 6 %/83 % cursor-drift investigation, and
- fontpack's link-diagnostics logging from **#114**, which this is rebased on top of (the merged `"FONTPACK_CHUNK"` logging is now produced by the shared helper's `log_tag` instead of an inline loop).

Passing `NULL` gives a silent relay. The surrounding fw_up diagnostics (pre-chunk
probe, first-failure slave-status query, master staging write, resume-offset reply)
are untouched, and `hid_fontpack.c` drops its now-unused `polymod_crc32.h` include
(the helper owns the CRC).

> ⚠️ **Not yet hardware-tested** — this touches the live firmware/font-pack flash
> path. Both variants build clean, but please flash + run a firmware update **and**
> a font-pack sync before merging. Happy to keep it open until you've verified on
> hardware.

## Version bump label

*(none)* — internal refactor, no behaviour/protocol change (patch bump).

## Testing
- [x] Compiled successfully (`qmk compile -kb polykybd/split72 -km default` **and** `split42`)
- [ ] Flashed and tested on hardware — **firmware flash + font-pack sync both need a real flash to verify**
- [ ] If protocol changed: host updated and tested together — n/a

---
_Generated by [Claude Code](https://claude.ai/code/session_0165wJ8ThcSEiicTmUuaNiQC)_