### PR TITLE
fix(overlay): reframe plain overlay upload — pack modifier+segment (protocol 11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,10 +120,20 @@ extraction fixed: `corne42` had silently fallen ~98 languages behind split72).
   legend instead of NACKing. This **decouples "add a font face" from the protocol**: within
   v10 the script set can grow freely (the host may offer more scripts than a keyboard has;
   older keyboards degrade gracefully), so **adding scripts never bumps the protocol again** —
-  only a real wire/semantic change would. `0xFF` stays the query sentinel. **Bump `FW_VERSION` +
+  only a real wire/semantic change would. `0xFF` stays the query sentinel.
+  **v11** reframes the **plain (uncompressed) overlay upload** (cmd `10` / `0x0A`): `modifier`
+  and `segment` now share **one** header byte — `(segment << 4) | (modifier & 0x0F)` — so the
+  header is 4 bytes (`id, cmd, keycode, packed`) and a full 60-byte segment fits the 64-byte
+  report **exactly**. The pre-v11 layout carried modifier and segment in *separate* bytes (5-byte
+  header), leaving only 59 bytes for a 60-byte segment, so the firmware `memcpy`'d 60 bytes and
+  read **1 byte past the report** — harmless on the no-MMU RP2040 but the last byte of each
+  segment was undefined (the old FW-7 finding; fixed in the wire format instead of a bounce
+  buffer). The firmware unpacks the byte in `hid_com.c` case 10 *before* `set_fragment_context_key`,
+  so `adjust_overlay_idx_to_mod` is unchanged; **compressed (`0x10`/`0x11`) and ROI (`0x12`/`0x13`)
+  paths are untouched** (their headers already fit). **Bump `FW_VERSION` +
   `PROTOCOL_VERSION` (config.h) and `__protocol__` (PolyKybdHost `_version.py`) in
   lockstep** — the host connect gate is exact-match.
-- Overlay transmission: each keycap overlay (360 bytes) is split into 6 × 60-byte segments (cmd `0x0A`), or sent RLE-compressed in 1–2 packets (cmds `0x10`/`0x11`)
+- Overlay transmission: each keycap overlay (360 bytes) is split into 6 × 60-byte segments (cmd `0x0A`, protocol 11+: modifier+segment packed into one header byte), or sent RLE-compressed in 1–2 packets (cmds `0x10`/`0x11`)
 - ROI updates (cmds `0x12`/`0x13`) allow partial refresh of a keycap's display area
 - Overlay index = `keycode_slot + 90 * modifier_variant` (9 variants: bare, Ctrl, Shift, Ctrl+Shift, Alt, Ctrl+Alt, Alt+Shift, Ctrl+Alt+Shift, GUI)
 

--- a/keyboards/polykybd/config.h
+++ b/keyboards/polykybd/config.h
@@ -94,7 +94,7 @@
 //######################################
 //#          PolyKybd specific         #
 //######################################
-#define FW_VERSION "0.9.36"
+#define FW_VERSION "0.9.37"
 // v2: adds GET_LANG_LIST_PACKED (cmd 27) — language list as 2-byte ISO index pairs.
 // v3: SEND_OVERLAY_MAPPING (cmd 21) no longer ACKs per chunk — like every other
 //     bulk overlay command (10, 16/17, 18/19) it is silent. The per-chunk ACK
@@ -146,7 +146,15 @@
 //     0xFF stays the query sentinel. (v10 is the one-time bump that establishes this
 //     open-ended contract, distinguishing it from the pre-v10 Tengwar-only firmware
 //     that NACKed unknown indices.)
-#define PROTOCOL_VERSION 10
+// v11: plain (uncompressed) overlay upload (cmd 10 / 0x0A) reframed. modifier and
+//      segment now share ONE header byte — (segment << 4) | (modifier & 0x0F) — so
+//      the header shrinks from 5 to 4 bytes and a full 60-byte segment fits the
+//      64-byte report exactly. The old layout carried modifier and segment in
+//      separate bytes, leaving only 59 bytes for the 60-byte segment, so the
+//      firmware read 1 byte past the report (harmless on a no-MMU MCU, but the
+//      last data byte of each segment was undefined). Compressed/ROI paths are
+//      unchanged. Host must match v11 to connect (exact-match gate).
+#define PROTOCOL_VERSION 11
 
 #define FULL_BRIGHT 50
 #define MIN_BRIGHT 1

--- a/keyboards/polykybd/hid_com.c
+++ b/keyboards/polykybd/hid_com.c
@@ -393,7 +393,7 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
             case 10: //receive overlay
                 {
                     reset_fragment_context();
-                    // Protocol 10: modifier (low nibble, 0..8) and segment index
+                    // Protocol 11: modifier (low nibble, 0..8) and segment index
                     // (high nibble, 0..5) share one header byte, so the 60-byte
                     // segment payload starts at HID_DATA_IDX+2 and fits the report
                     // exactly (2 fixed + keycode + packed + 60 = 64). The old

--- a/keyboards/polykybd/hid_com.c
+++ b/keyboards/polykybd/hid_com.c
@@ -393,10 +393,17 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
             case 10: //receive overlay
                 {
                     reset_fragment_context();
-                    set_fragment_context_key(data[HID_DATA_IDX], data[HID_DATA_IDX+1]);
-                    uint8_t segment = data[HID_DATA_IDX+2];
+                    // Protocol 10: modifier (low nibble, 0..8) and segment index
+                    // (high nibble, 0..5) share one header byte, so the 60-byte
+                    // segment payload starts at HID_DATA_IDX+2 and fits the report
+                    // exactly (2 fixed + keycode + packed + 60 = 64). The old
+                    // layout put modifier and segment in separate bytes, leaving
+                    // only 59 bytes for a 60-byte segment -> a 1-byte over-read.
+                    uint8_t packed  = data[HID_DATA_IDX+1];
+                    uint8_t segment = packed >> 4;
+                    set_fragment_context_key(data[HID_DATA_IDX], packed & 0x0F);
                     if(get_fragment_context()->keycode>=KC_A && get_fragment_context()->keycode<=KC_RIGHT_GUI && segment<NUM_SEGMENTS_PER_OVERLAY) {
-                        fill_overlay_buffer(segment, &data[HID_DATA_IDX+3]);
+                        fill_overlay_buffer(segment, &data[HID_DATA_IDX+2]);
                         if(segment==NUM_SEGMENTS_PER_OVERLAY-1) {
                             update_performed();
                             request_disp_refresh();


### PR DESCRIPTION
## Summary

Fixes a **by-design 1-byte over-read** on the plain (uncompressed) overlay upload path (HID cmd `0x0A`).

The old framing was `[id, cmd, keycode, modifier, segment]` (5-byte header) + a 60-byte segment = **65 bytes**, one more than a 64-byte HID report holds. `fill_overlay_buffer` then `memcpy`'d 60 bytes from an offset that left only 59 in the report, reading **1 byte past it**. Harmless on the no-MMU RP2040 — and the plain path is a rarely-used fallback behind the compressed/MRU paths — but the last data byte of every segment was undefined. (This is the "FW-7" audit finding; fixing the wire format is the right fix, not the zero-padded bounce buffer that was reverted from the hardening PR.)

Rather than paper over the read, this fixes the framing: `modifier` (0..8, a nibble) and `segment` (0..5) now share **one** header byte — `(segment << 4) | (modifier & 0x0F)`. The header shrinks to 4 bytes, so a full 60-byte segment fits the 64-byte report **exactly** (`id + cmd + keycode + packed + 60 = 64`). The firmware unpacks the byte in `hid_com.c` case 10 *before* `set_fragment_context_key`, so `adjust_overlay_idx_to_mod` is unchanged. Compressed (`0x10`/`0x11`) and ROI (`0x12`/`0x13`) paths are **untouched** — their headers already fit.

**Protocol 10 → 11** (exact-match connect gate). This is a lockstep set — merge together with:
- Host: thpoll83/PolyKybdHost#96
- Rig: thpoll83/polykybd-ctnd#43

## Version bump label

Manually bumped `PROTOCOL_VERSION` 10 → 11 and `FW_VERSION` → 0.9.34 in this PR, matching the v10 glyph-script precedent (`64a6fe4c`). **Do NOT add the `bump:protocol` label** — the version is already bumped in-source, so the label would double-bump protocol to 12 and break host lockstep. CI's default patch-bump of `FW_VERSION` on merge is fine.

## Testing
- [x] Compiled successfully — **split72 + split42 both build clean**
- [ ] Flashed and tested on hardware
- [x] Host + rig updated in lockstep (linked PRs); rig HIL test gated `min_protocol: 11`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NinUrR5rxUWk1w9RKz5unE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated overlay upload handling to use the newer packet layout, allowing reports to fit the expected data more cleanly.

* **Bug Fixes**
  * Fixed overlay transmission sizing to better match the 64-byte HID report limit.
  * Improved compatibility checks by requiring matching firmware and protocol versions during connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->