### PR TITLE
Reclaim 2 split-transaction slots: drop dead FW_UP_QUERY, merge apply+reboot into RESET

### DIFF
--- a/keyboards/polykybd/bridge_helper.c
+++ b/keyboards/polykybd/bridge_helper.c
@@ -57,11 +57,11 @@ const char* tid_to_str(int8_t tid) {
     case USER_SYNC_ROI_DATA: return "UserRoi";
     case USER_SYNC_DYNAMIC_KEYMAP_DATA: return "UserDynMap";
     case USER_SYNC_OVERLAY_MAP_DATA: return "UserOverlayMap";
-    case USER_SYNC_FW_UP_QUERY:  return "FwUpQuery";
     case USER_SYNC_FW_UP_BEGIN:  return "FwUpBegin";
     case USER_SYNC_FW_UP_CHUNK:  return "FwUpChunk";
     case USER_SYNC_FW_UP_COMMIT: return "FwUpCommit";
     case USER_SYNC_FW_UP_STATUS: return "FwUpStatus";
+    case USER_SYNC_RESET:        return "Reset";
     default: return "Not registered";
     }
 }

--- a/keyboards/polykybd/config.h
+++ b/keyboards/polykybd/config.h
@@ -36,11 +36,13 @@
 // #define SPLIT_LED_STATE_ENABLE
 // #define SPLIT_MODS_ENABLE
 #define SPLIT_WPM_ENABLE
-// NOTE: the QMK transaction table is FULL (NUM_TOTAL_TRANSACTIONS == 32, the
-// hard cap) — a new sync must MULTIPLEX onto an existing id by a distinct
-// payload size, like the MRU snapshots and the doom mirror messages both do
-// on USER_SYNC_OVERLAY_MAP_DATA (dispatch in user_sync_overlay_map_data_handler).
-#define SPLIT_TRANSACTION_IDS_USER USER_SYNC_POLY_DATA, USER_SYNC_LAYER_DATA, USER_SYNC_LASTKEY_DATA, USER_SYNC_LATIN_EX_DATA, USER_SYNC_OVERLAY_DATA, USER_SYNC_COMPRESSED_DATA, USER_SYNC_ROI_DATA, USER_SYNC_DYNAMIC_KEYMAP_DATA, USER_SYNC_OVERLAY_MAP_DATA, USER_SYNC_FW_UP_QUERY, USER_SYNC_FW_UP_BEGIN, USER_SYNC_FW_UP_CHUNK, USER_SYNC_FW_UP_COMMIT, USER_SYNC_FW_UP_STATUS, USER_SYNC_FW_UP_APPLY, USER_SYNC_REBOOT
+// NOTE: the QMK transaction table is near-full (NUM_TOTAL_TRANSACTIONS <= 32, the
+// hard cap). This list dropped the dead USER_SYNC_FW_UP_QUERY and merged the apply
+// + reboot transactions into one USER_SYNC_RESET (action byte selects apply vs
+// reboot), freeing 2 slots. A new sync can still MULTIPLEX onto an existing id by a
+// distinct payload size, like the MRU snapshots and the doom mirror messages both
+// do on USER_SYNC_OVERLAY_MAP_DATA (dispatch in user_sync_overlay_map_data_handler).
+#define SPLIT_TRANSACTION_IDS_USER USER_SYNC_POLY_DATA, USER_SYNC_LAYER_DATA, USER_SYNC_LASTKEY_DATA, USER_SYNC_LATIN_EX_DATA, USER_SYNC_OVERLAY_DATA, USER_SYNC_COMPRESSED_DATA, USER_SYNC_ROI_DATA, USER_SYNC_DYNAMIC_KEYMAP_DATA, USER_SYNC_OVERLAY_MAP_DATA, USER_SYNC_FW_UP_BEGIN, USER_SYNC_FW_UP_CHUNK, USER_SYNC_FW_UP_COMMIT, USER_SYNC_FW_UP_STATUS, USER_SYNC_RESET
 
 #define EE_HANDS
 

--- a/keyboards/polykybd/hid_com.c
+++ b/keyboards/polykybd/hid_com.c
@@ -692,9 +692,10 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                 {
                     bool master_is_left = (data[HID_DATA_IDX] == 0);
                     eeconfig_update_handedness(master_is_left);
-                    fw_up_apply_sync_t msg = { .crc32 = 0, .magic = FW_UP_SYNC_MAGIC,
-                                               .set_handedness = 1, .is_left = master_is_left ? 0 : 1 };
-                    uint8_t ack = send_to_bridge(USER_SYNC_REBOOT, &msg, sizeof(msg), 5);
+                    poly_reset_sync_t msg = { .crc32 = 0, .magic = POLY_RESET_MAGIC,
+                                              .action = RESET_ACTION_REBOOT,
+                                              .set_handedness = 1, .is_left = master_is_left ? 0 : 1 };
+                    uint8_t ack = send_to_bridge(USER_SYNC_RESET, &msg, sizeof(msg), 5);
                     uprintf("Set handedness: master=%s, slave ack=%d.\n", master_is_left ? "LEFT" : "RIGHT", ack);
                     memset(data, 0, length);
                     hid_reply(data, 0x19, true);

--- a/keyboards/polykybd/hid_fw_up.c
+++ b/keyboards/polykybd/hid_fw_up.c
@@ -289,7 +289,7 @@ bool hid_fw_up_receive(uint8_t *data, uint8_t length) {
                 if (slave_ack != SYNC_ACK) {
                     slave_ack = send_to_bridge(USER_SYNC_RESET, &apply_msg, sizeof(apply_msg), 20);
                 }
-                uprintf("FW_UP_APPLY: slave apply+reboot ack=0x%02x\n", slave_ack);
+                uprintf("FW_UP_APPLY: slave apply+reboot (USER_SYNC_RESET) ack=0x%02x\n", slave_ack);
                 fw_staging_arm_apply();   // housekeeping → fw_staging_apply_and_reboot()
             }
             return true;

--- a/keyboards/polykybd/hid_fw_up.c
+++ b/keyboards/polykybd/hid_fw_up.c
@@ -273,7 +273,8 @@ bool hid_fw_up_receive(uint8_t *data, uint8_t length) {
                 // image but, before this, was never told to apply it.  (The slave
                 // obeys this only once it already runs firmware that has the apply
                 // handler — see FW_UP_BASELINE.md for the OLD→NEW bootstrap note.)
-                fw_up_apply_sync_t apply_msg = { .crc32 = 0, .magic = FW_UP_SYNC_MAGIC };
+                poly_reset_sync_t apply_msg = { .crc32 = 0, .magic = POLY_RESET_MAGIC,
+                                                .action = RESET_ACTION_APPLY };
                 // Hardened handoff (field 2026-06-22): an under-retried bridge here
                 // let the slave miss the apply once — the master then rebooted alone
                 // and hung on the boot splash waiting for a slave that never
@@ -284,9 +285,9 @@ bool hid_fw_up_receive(uint8_t *data, uint8_t length) {
                 // has handled it, so it's safe to reboot the master once we see the
                 // ack), and we're about to reboot anyway — the extra worst-case ~1 s
                 // is free insurance against a one-shot drop on this critical step.
-                uint8_t slave_ack = send_to_bridge(USER_SYNC_FW_UP_APPLY, &apply_msg, sizeof(apply_msg), 20);
+                uint8_t slave_ack = send_to_bridge(USER_SYNC_RESET, &apply_msg, sizeof(apply_msg), 20);
                 if (slave_ack != SYNC_ACK) {
-                    slave_ack = send_to_bridge(USER_SYNC_FW_UP_APPLY, &apply_msg, sizeof(apply_msg), 20);
+                    slave_ack = send_to_bridge(USER_SYNC_RESET, &apply_msg, sizeof(apply_msg), 20);
                 }
                 uprintf("FW_UP_APPLY: slave apply+reboot ack=0x%02x\n", slave_ack);
                 fw_staging_arm_apply();   // housekeeping → fw_staging_apply_and_reboot()

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -2256,19 +2256,20 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
                 //
                 // Hardened handoff — same rationale as CMD_FW_UP_APPLY (hid_fw_up.c,
                 // field 2026-06-22).  This is the reset-key twin of that path and had
-                // the identical flaw: a single dropped USER_SYNC_REBOOT frame at only
-                // 5 retries left the slave alive on stale state, the master rebooted
-                // alone and hung on the boot splash until the slave was replugged
-                // (field 2026-07 — plain reset key, no firmware apply).  Use 20
-                // retries and re-fire the whole round once if the slave still hasn't
-                // acked.  Safe: the slave reboot handler is idempotent (it only arms a
-                // deferred mcu_reset), send_to_bridge is synchronous (returns only
-                // after the slave has handled it), and we're about to reset anyway —
-                // the extra worst-case ~1 s is free insurance on this critical step.
-                fw_up_apply_sync_t reboot_msg = { .crc32 = 0, .magic = FW_UP_SYNC_MAGIC };
-                uint8_t ack = send_to_bridge(USER_SYNC_REBOOT, &reboot_msg, sizeof(reboot_msg), 20);
+                // the identical flaw: a single dropped reboot frame at only 5 retries
+                // left the slave alive on stale state, the master rebooted alone and
+                // hung on the boot splash until the slave was replugged (field 2026-07
+                // — plain reset key, no firmware apply).  Use 20 retries and re-fire the
+                // whole round once if the slave still hasn't acked.  Safe: the slave
+                // reset handler is idempotent (it only arms a deferred mcu_reset),
+                // send_to_bridge is synchronous (returns only after the slave has
+                // handled it), and we're about to reset anyway — the extra worst-case
+                // ~1 s is free insurance on this critical step.
+                poly_reset_sync_t reboot_msg = { .crc32 = 0, .magic = POLY_RESET_MAGIC,
+                                                 .action = RESET_ACTION_REBOOT };
+                uint8_t ack = send_to_bridge(USER_SYNC_RESET, &reboot_msg, sizeof(reboot_msg), 20);
                 if (!sync_succeeded(ack)) {
-                    ack = send_to_bridge(USER_SYNC_REBOOT, &reboot_msg, sizeof(reboot_msg), 20);
+                    ack = send_to_bridge(USER_SYNC_RESET, &reboot_msg, sizeof(reboot_msg), 20);
                 }
                 uprintf("Master: slave reboot ack=0x%02x\n", ack);
                 return true;   // let QMK's QK_REBOOT handler reset the master
@@ -2708,13 +2709,11 @@ void keyboard_post_init_user(void) {
     transaction_register_rpc(USER_SYNC_ROI_DATA,            user_sync_roi_data_handler);
     transaction_register_rpc(USER_SYNC_DYNAMIC_KEYMAP_DATA, user_sync_dynamic_keymap_data_handler);
     transaction_register_rpc(USER_SYNC_OVERLAY_MAP_DATA,    user_sync_overlay_map_data_handler);
-    transaction_register_rpc(USER_SYNC_FW_UP_QUERY,         user_sync_fw_up_query_handler);
     transaction_register_rpc(USER_SYNC_FW_UP_BEGIN,         user_sync_fw_up_begin_handler);
     transaction_register_rpc(USER_SYNC_FW_UP_CHUNK,         user_sync_fw_up_chunk_handler);
     transaction_register_rpc(USER_SYNC_FW_UP_COMMIT,        user_sync_fw_up_commit_handler);
     transaction_register_rpc(USER_SYNC_FW_UP_STATUS,        user_sync_fw_up_status_handler);
-    transaction_register_rpc(USER_SYNC_FW_UP_APPLY,         user_sync_fw_up_apply_handler);
-    transaction_register_rpc(USER_SYNC_REBOOT,              user_sync_reboot_handler);
+    transaction_register_rpc(USER_SYNC_RESET,               user_sync_reset_handler);
 
     fw_staging_init();
 

--- a/keyboards/polykybd/split_fw_up.c
+++ b/keyboards/polykybd/split_fw_up.c
@@ -56,16 +56,6 @@ bool fw_up_relay_chunk_to_slave(uint32_t offset, const uint8_t *chunk_data, cons
 // HID firmware update — slave-side split transaction handlers
 // ---------------------------------------------------------------------------
 
-// Boot-time version query.  Slave fills out_data with its own version+size.
-void user_sync_fw_up_query_handler(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data) {
-    if (in_len != sizeof(fw_up_query_sync_t) || !in_data || out_len != sizeof(fw_up_query_sync_t) || !out_data) return;
-    fw_up_query_sync_t *reply = (fw_up_query_sync_t *)out_data;
-    memset(reply, 0, sizeof(*reply));
-    strncpy(reply->version, FW_VERSION, FW_UP_VERSION_LEN - 1);
-    reply->fw_size = fw_staging_get_own_fw_size();
-    reply->crc32   = crc32_1byte(reply->version, sizeof(*reply) - 4, 0);
-}
-
 // Diagnostic status query: slave returns its fw_staging internal counters
 // + state so the master can uprintf them after a failed chunk to distinguish
 // "slave hung before handler" vs "slave handler ran and rejected".  See
@@ -224,43 +214,44 @@ void user_sync_fw_up_commit_handler(uint8_t in_len, const void* in_data, uint8_t
     ((poly_sync_reply_t *)out_data)->ack = ok ? SYNC_ACK : SYNC_CRC32_ERR;
 }
 
-// Master commands the slave to install its staged image and reboot, so BOTH
-// halves restart together (like a replug).  Without this the slave keeps running
-// its old firmware in a stale state, and the rebooted master cannot re-establish
-// the split link — it hangs on the boot splash (the right half's "SPLIT 72").
-// Guarded by a magic + CRC and a valid-staged-image check so a stray transaction
-// can never trigger an apply.  The apply is deferred to the slave's housekeeping
-// so we ACK the master before our split link goes dark.
-void user_sync_fw_up_apply_handler(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data) {
-    if (in_len != sizeof(fw_up_apply_sync_t) || !in_data || out_len != sizeof(poly_sync_reply_t) || !out_data) return;
-    const fw_up_apply_sync_t *msg = (const fw_up_apply_sync_t *)in_data;
+// Master commands the slave to restart, so BOTH halves come back together (like a
+// replug).  Without this the slave keeps running its old firmware / stale state,
+// and the rebooted master cannot re-establish the split link — it hangs on the
+// boot splash (the right half's "SPLIT 72").  ONE transaction (USER_SYNC_RESET)
+// serves every restart path; the `action` byte selects apply-and-reboot vs plain
+// reboot.  Guarded by a magic + CRC (and, for apply, a valid-staged-image check)
+// so a stray transaction can never trigger an unexpected reset.  The restart is
+// deferred to the slave's housekeeping so we ACK the master before our split link
+// goes dark.
+void user_sync_reset_handler(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data) {
+    if (in_len != sizeof(poly_reset_sync_t) || !in_data || out_len != sizeof(poly_sync_reply_t) || !out_data) return;
+    const poly_reset_sync_t *msg = (const poly_reset_sync_t *)in_data;
     uint32_t crc32 = crc32_1byte(&((const uint8_t *)in_data)[4], in_len - 4, 0);
-    if (crc32 != msg->crc32 || msg->magic != FW_UP_SYNC_MAGIC || !fw_staging_has_valid_staged_image()) {
+    if (crc32 != msg->crc32 || msg->magic != POLY_RESET_MAGIC) {
         ((poly_sync_reply_t *)out_data)->ack = SYNC_CRC32_ERR;
         return;
     }
-    fw_staging_arm_apply();   // housekeeping_task_user() → fw_staging_apply_and_reboot()
-    ((poly_sync_reply_t *)out_data)->ack = SYNC_ACK;
-}
-
-// Master commands the slave to reboot (QK_REBOOT path — no firmware apply).
-// Same rationale as the apply handler: a master-only reset leaves the slave
-// stale and the master stuck on the splash; rebooting both mirrors a replug.
-// Deferred to the slave's housekeeping so we ACK first, then reset cleanly.
-void user_sync_reboot_handler(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data) {
-    if (in_len != sizeof(fw_up_apply_sync_t) || !in_data || out_len != sizeof(poly_sync_reply_t) || !out_data) return;
-    const fw_up_apply_sync_t *msg = (const fw_up_apply_sync_t *)in_data;
-    uint32_t crc32 = crc32_1byte(&((const uint8_t *)in_data)[4], in_len - 4, 0);
-    if (crc32 != msg->crc32 || msg->magic != FW_UP_SYNC_MAGIC) {
+    if (msg->action == RESET_ACTION_APPLY) {
+        // Install the staged image, then reboot — reject unless a valid image is staged.
+        if (!fw_staging_has_valid_staged_image()) {
+            ((poly_sync_reply_t *)out_data)->ack = SYNC_CRC32_ERR;
+            return;
+        }
+        fw_staging_arm_apply();    // housekeeping_task_user() → fw_staging_apply_and_reboot()
+    } else if (msg->action == RESET_ACTION_REBOOT) {
+        // Reboot only (QK_REBOOT path). Handedness-change carrier (see
+        // poly_reset_sync_t): when requested, persist this (slave) half's new
+        // EE_HANDS marker before the reboot so it comes up on the corrected
+        // left/right assignment.  Plain QK_REBOOT leaves this zero.
+        if (msg->set_handedness) {
+            eeconfig_update_handedness(msg->is_left != 0);
+        }
+        fw_staging_arm_reboot();   // housekeeping_task_user() → mcu_reset()
+    } else {
+        // Unknown action — refuse rather than guess (magic+CRC already passed, so
+        // this only happens on a genuinely malformed request).
         ((poly_sync_reply_t *)out_data)->ack = SYNC_CRC32_ERR;
         return;
     }
-    // Handedness-change carrier (see fw_up_apply_sync_t): when requested, persist
-    // this (slave) half's new EE_HANDS marker before the reboot so it comes up on
-    // the corrected left/right assignment.  Plain QK_REBOOT leaves this zero.
-    if (msg->set_handedness) {
-        eeconfig_update_handedness(msg->is_left != 0);
-    }
-    fw_staging_arm_reboot();   // housekeeping_task_user() → mcu_reset()
     ((poly_sync_reply_t *)out_data)->ack = SYNC_ACK;
 }

--- a/keyboards/polykybd/split_fw_up.h
+++ b/keyboards/polykybd/split_fw_up.h
@@ -13,13 +13,6 @@
 
 #define FW_UP_VERSION_LEN 16
 
-// Boot-time version query: master sends its FW_VERSION + fw_size; slave replies with its own.
-typedef struct _fw_up_query_sync_t {
-    uint32_t crc32;
-    char     version[FW_UP_VERSION_LEN];
-    uint32_t fw_size;
-} fw_up_query_sync_t;
-
 // Announce incoming firmware/font-pack size + expected CRC32 to slave.
 // `target` (fw_target_t) selects which flash region the slave stages into and how
 // it finalizes — 0 = FIRMWARE (also what older senders leave it), 1 = FONTPACK.
@@ -74,37 +67,45 @@ typedef struct _fw_up_status_reply_t {
     fw_staging_status_t status;
 } fw_up_status_reply_t;
 
-// Apply/reboot coordination (master → slave).  A magic guard — on top of the
-// CRC32 and QMK's own transport checksum — makes it extremely unlikely that a
-// stray transaction triggers an unexpected reboot.  Shared by the FW_UP
-// apply-and-reboot and the plain QK_REBOOT paths; the transaction ID
-// (USER_SYNC_FW_UP_APPLY vs USER_SYNC_REBOOT) selects the slave's action.
-//
-// The USER_SYNC_REBOOT path also doubles as the handedness-change carrier: QMK
-// caps split transactions at 32 and the table is already full, so rather than
-// add a dedicated transaction the reboot message gains two optional fields.
-// When set_handedness != 0 the slave persists `is_left` to its EE_HANDS marker
-// before rebooting, so both halves come up on the corrected left/right
-// assignment (see hid_com.c case 25).  The plain reboot/apply senders leave
-// these zero via designated initialisers, so their behaviour is unchanged.
-#define FW_UP_SYNC_MAGIC 0xB007B007u
+// Reset/apply coordination (master → slave).  ONE transaction (USER_SYNC_RESET)
+// carries every "make the other half restart" action; the `action` byte selects
+// which.  A magic guard — on top of the CRC32 and QMK's own transport checksum —
+// makes it extremely unlikely that a stray transaction triggers an unexpected
+// reset.  Actions:
+//   RESET_ACTION_APPLY  — install the staged firmware image, then reboot (the
+//                         second phase of a firmware update; the slave NACKs
+//                         unless it holds a valid staged image).
+//   RESET_ACTION_REBOOT — reboot only, no apply (the QK_REBOOT path).  Doubles as
+//                         the handedness-change carrier: when set_handedness != 0
+//                         the slave persists `is_left` to its EE_HANDS marker
+//                         before rebooting, so both halves come up on the
+//                         corrected left/right assignment (see hid_com.c case 25).
+// The plain reboot/apply senders leave set_handedness zero via designated
+// initialisers, so their behaviour is unchanged.
+#define POLY_RESET_MAGIC 0xB007B007u
 
-typedef struct _fw_up_apply_sync_t {
+enum reset_action {
+    RESET_ACTION_APPLY  = 0,  // install the staged image, then reboot
+    RESET_ACTION_REBOOT = 1,  // reboot only (optionally persisting handedness first)
+};
+
+typedef struct _poly_reset_sync_t {
     uint32_t crc32;          // [0..3] CRC over the bytes below, filled in by send_to_bridge()
-    uint32_t magic;          // [4..7] must equal FW_UP_SYNC_MAGIC
-    uint8_t  set_handedness; // [8]    reboot path only: 1 = persist `is_left` before reboot
-    uint8_t  is_left;        // [9]    slave's new handedness when set_handedness != 0 (1 = left)
-} fw_up_apply_sync_t;
+    uint32_t magic;          // [4..7] must equal POLY_RESET_MAGIC
+    uint8_t  action;         // [8]    enum reset_action
+    uint8_t  set_handedness; // [9]    reboot action only: 1 = persist `is_left` before reboot
+    uint8_t  is_left;        // [10]   slave's new handedness when set_handedness != 0 (1 = left)
+} poly_reset_sync_t;
 
 // Master-side: relay one upload chunk (offset + FW_UP_CHUNK_SIZE bytes) to the
 // slave with retries. `log_tag` non-NULL enables per-retry debug logging (pass
 // NULL for a quiet relay). Returns true on slave ACK. See split_fw_up.c.
 bool fw_up_relay_chunk_to_slave(uint32_t offset, const uint8_t *chunk_data, const char *log_tag);
 
-void user_sync_fw_up_query_handler  (uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data);
 void user_sync_fw_up_begin_handler  (uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data);
 void user_sync_fw_up_chunk_handler  (uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data);
 void user_sync_fw_up_commit_handler (uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data);
 void user_sync_fw_up_status_handler (uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data);
-void user_sync_fw_up_apply_handler  (uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data);
-void user_sync_reboot_handler       (uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data);
+// One transaction (USER_SYNC_RESET) for apply-and-reboot, plain reboot, and the
+// handedness-change reboot; the poly_reset_sync_t `action` byte selects which.
+void user_sync_reset_handler        (uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data);


### PR DESCRIPTION
## Summary

The split transaction table is hard-capped at **32** (`NUM_TOTAL_TRANSACTIONS <= 1<<5` — the transaction id is a 5-bit handshake field), and **split72 sits right at that limit** (≈16 built-in + 16 user). This PR reclaims **two** user slots with no behaviour change, as the first step of the split-transaction consolidation (font-pack/fw-update staging unification follows in a separate PR).

**1. Delete the dead `USER_SYNC_FW_UP_QUERY`.** It was registered *and* handled but **never invoked from the master** — the host firmware-version check goes entirely through the HID `CMD_FW_UP_GET_VERSION` path (which returns the master's own version), never the split query. Removes the enum entry, the handler, the registration, the bridge-log name, and the now-unused `fw_up_query_sync_t` struct.

**2. Merge `USER_SYNC_FW_UP_APPLY` + `USER_SYNC_REBOOT` into one `USER_SYNC_RESET`.** They already shared a single message struct + magic guard and differed only in the slave action — the *transaction ID* was the discriminator. Now a `poly_reset_sync_t.action` byte (`RESET_ACTION_APPLY` / `RESET_ACTION_REBOOT`) selects apply-and-reboot vs. plain reboot, with the handedness-change carrier unchanged on the reboot action. `FW_UP_SYNC_MAGIC` → `POLY_RESET_MAGIC` and `fw_up_apply_sync_t` → `poly_reset_sync_t` to reflect the broader scope.

All hard-won invariants preserved: the magic + CRC32 guard, the apply valid-staged-image check, the deferred `fw_staging_arm_apply()` / `arm_reboot()`, and the field-hardened 20-retries-plus-re-fire apply handoff (2026-06-22 boot-splash-hang fix). Unknown `action` bytes NACK rather than guess.

**User split transactions: 16 → 14** (2 free slots).

## Version bump label

No label — internal split-transport refactor, no functional or protocol change → patch bump.

## Testing
- [x] Compiled successfully — **both** `qmk compile -kb polykybd/split72 -km default` **and** `-kb polykybd/split42 -km default` link clean
- [ ] Flashed and tested on hardware
- [ ] If protocol changed: host updated and tested together — n/a (split-link wire only; `PROTOCOL_VERSION` unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhhNb2C1KHUBUY9J9KKx7N

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhhNb2C1KHUBUY9J9KKx7N)_

## Summary by Sourcery

Consolidate split firmware-update reset handling into a single transaction and reclaim two user split-transaction slots without changing observable behaviour.

New Features:
- Introduce a unified USER_SYNC_RESET transaction that covers firmware apply-and-reboot, plain reboot, and handedness-change reboot actions via an action selector.

Enhancements:
- Replace FW_UP_SYNC_MAGIC and fw_up_apply_sync_t with POLY_RESET_MAGIC and poly_reset_sync_t to reflect the broader reset scope and action-based dispatch.
- Update HID, keymap, and bridge logging code paths to use the new reset transaction and struct while preserving existing retry and safety guards.

Chores:
- Remove the unused USER_SYNC_FW_UP_QUERY transaction, handler, struct, registration, and bridge log entry to free a split-transaction slot.
- Simplify and shrink the user split-transaction ID list by merging USER_SYNC_FW_UP_APPLY and USER_SYNC_REBOOT into USER_SYNC_RESET.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified split-keyboard reset workflow using a single synchronization message for both reboot and “apply then reboot” coordination.
  * Enhanced reset synchronization to optionally persist handedness during reboot actions.

* **Bug Fixes**
  * Updated the bridge communication contract to replace the prior firmware-apply/reboot split, improving consistency across split devices.
  * Removed the obsolete boot-time version query step and cleaned up transaction mappings to match the new reset flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->