### PR TITLE
Unify flash-staging split transactions into one op-dispatched USER_SYNC_FLASH_STAGE

### DIFF
--- a/keyboards/polykybd/base/fw_staging.c
+++ b/keyboards/polykybd/base/fw_staging.c
@@ -460,7 +460,7 @@ bool fw_staging_finalize(void) {
 // Slave-side finalize. Identical to fw_staging_finalize() EXCEPT the heavy
 // FONTPACK reload (a full-body CRC32 + reassemble over the whole ~459 KB pack,
 // ~50 ms) is DEFERRED to housekeeping instead of run inline. The slave runs
-// finalize inside the USER_SYNC_FW_UP_COMMIT split-transaction callback, whose
+// finalize inside the USER_SYNC_FLASH_STAGE (COMMIT op) split-transaction callback, whose
 // receive window is ~20 ms — the inline reload overran it, so the master timed
 // out and mis-reported COMMIT as a CRC failure even though the pack loaded fine
 // (same class of bug as the master-side re-scan, run 6). The O(1) transport CRC

--- a/keyboards/polykybd/bridge_helper.c
+++ b/keyboards/polykybd/bridge_helper.c
@@ -57,10 +57,7 @@ const char* tid_to_str(int8_t tid) {
     case USER_SYNC_ROI_DATA: return "UserRoi";
     case USER_SYNC_DYNAMIC_KEYMAP_DATA: return "UserDynMap";
     case USER_SYNC_OVERLAY_MAP_DATA: return "UserOverlayMap";
-    case USER_SYNC_FW_UP_BEGIN:  return "FwUpBegin";
-    case USER_SYNC_FW_UP_CHUNK:  return "FwUpChunk";
-    case USER_SYNC_FW_UP_COMMIT: return "FwUpCommit";
-    case USER_SYNC_FW_UP_STATUS: return "FwUpStatus";
+    case USER_SYNC_FLASH_STAGE:  return "FlashStage";
     case USER_SYNC_RESET:        return "Reset";
     default: return "Not registered";
     }

--- a/keyboards/polykybd/config.h
+++ b/keyboards/polykybd/config.h
@@ -37,12 +37,14 @@
 // #define SPLIT_MODS_ENABLE
 #define SPLIT_WPM_ENABLE
 // NOTE: the QMK transaction table is near-full (NUM_TOTAL_TRANSACTIONS <= 32, the
-// hard cap). This list dropped the dead USER_SYNC_FW_UP_QUERY and merged the apply
+// hard cap). This list dropped the dead USER_SYNC_FW_UP_QUERY, folded the four
+// flash-staging transactions (BEGIN/CHUNK/COMMIT/STATUS) into one
+// USER_SYNC_FLASH_STAGE (op word selects the sub-operation), and merged the apply
 // + reboot transactions into one USER_SYNC_RESET (action byte selects apply vs
-// reboot), freeing 2 slots. A new sync can still MULTIPLEX onto an existing id by a
-// distinct payload size, like the MRU snapshots and the doom mirror messages both
-// do on USER_SYNC_OVERLAY_MAP_DATA (dispatch in user_sync_overlay_map_data_handler).
-#define SPLIT_TRANSACTION_IDS_USER USER_SYNC_POLY_DATA, USER_SYNC_LAYER_DATA, USER_SYNC_LASTKEY_DATA, USER_SYNC_LATIN_EX_DATA, USER_SYNC_OVERLAY_DATA, USER_SYNC_COMPRESSED_DATA, USER_SYNC_ROI_DATA, USER_SYNC_DYNAMIC_KEYMAP_DATA, USER_SYNC_OVERLAY_MAP_DATA, USER_SYNC_FW_UP_BEGIN, USER_SYNC_FW_UP_CHUNK, USER_SYNC_FW_UP_COMMIT, USER_SYNC_FW_UP_STATUS, USER_SYNC_RESET
+// reboot) — freeing 5 slots total. A new sync can still MULTIPLEX onto an existing
+// id by a distinct payload size, like the MRU snapshots and the doom mirror
+// messages both do on USER_SYNC_OVERLAY_MAP_DATA (user_sync_overlay_map_data_handler).
+#define SPLIT_TRANSACTION_IDS_USER USER_SYNC_POLY_DATA, USER_SYNC_LAYER_DATA, USER_SYNC_LASTKEY_DATA, USER_SYNC_LATIN_EX_DATA, USER_SYNC_OVERLAY_DATA, USER_SYNC_COMPRESSED_DATA, USER_SYNC_ROI_DATA, USER_SYNC_DYNAMIC_KEYMAP_DATA, USER_SYNC_OVERLAY_MAP_DATA, USER_SYNC_FLASH_STAGE, USER_SYNC_RESET
 
 #define EE_HANDS
 

--- a/keyboards/polykybd/hid_fontpack.c
+++ b/keyboards/polykybd/hid_fontpack.c
@@ -75,6 +75,7 @@ bool hid_fontpack_receive(uint8_t *data, uint8_t length) {
 
             fw_up_begin_sync_t begin_msg;
             memset(&begin_msg, 0, sizeof(begin_msg));   // deterministic padding for the CRC
+            begin_msg.op         = FLASH_STAGE_BEGIN;
             begin_msg.image_size = pack_size;
             begin_msg.image_crc  = pack_crc;
             begin_msg.target     = target;
@@ -101,13 +102,13 @@ bool hid_fontpack_receive(uint8_t *data, uint8_t length) {
                 fw_staging_begin_deferred_target(pack_size, pack_crc, target);
                 // Fire-and-forget: kicks the slave's deferred erase. Readiness is
                 // polled by the slave_ack send_to_bridge below (and on re-polls).
-                send_to_bridge(USER_SYNC_FW_UP_BEGIN, &begin_msg, sizeof(begin_msg), 3);
+                send_to_bridge(USER_SYNC_FLASH_STAGE, &begin_msg, sizeof(begin_msg), 3);
                 uprintf("FONTPACK_BEGIN: bundle=%u size=%lu crc=0x%08lx (master+slave staging)\n",
                         bundle, (unsigned long)pack_size, (unsigned long)pack_crc);
             }
 
             uint8_t slave_ack = master_ok
-                ? send_to_bridge(USER_SYNC_FW_UP_BEGIN, &begin_msg, sizeof(begin_msg), 1)
+                ? send_to_bridge(USER_SYNC_FLASH_STAGE, &begin_msg, sizeof(begin_msg), 1)
                 : SYNC_CRC32_ERR;
             bool slave_ok    = (slave_ack == SYNC_ACK);
             bool master_done = !fw_staging_erase_pending();
@@ -152,8 +153,8 @@ bool hid_fontpack_receive(uint8_t *data, uint8_t length) {
         }
 
         case CMD_FONTPACK_COMMIT: {   // slave finalize+reload, then master finalize+reload (no reboot)
-            uint32_t dummy = 0;
-            uint8_t slave_ack = send_to_bridge(USER_SYNC_FW_UP_COMMIT, &dummy, sizeof(dummy), 10);
+            fw_up_commit_sync_t commit_msg = { .crc32 = 0, .op = FLASH_STAGE_COMMIT };
+            uint8_t slave_ack = send_to_bridge(USER_SYNC_FLASH_STAGE, &commit_msg, sizeof(commit_msg), 10);
             bool master_ok = fw_staging_finalize();   // FONTPACK target: verifies CRC + fontpack_reload()
             bool is_doom = s_fontpack_bundle == FONTPACK_BUNDLE_DOOMWAD ||
                            s_fontpack_bundle == FONTPACK_BUNDLE_DOOMPACK;

--- a/keyboards/polykybd/hid_fw_up.c
+++ b/keyboards/polykybd/hid_fw_up.c
@@ -25,12 +25,12 @@
 // the slave is alive at all, whether the chunk handler ran, and what its
 // next_offset / counters look like.  See FW_UP_DEBUG_NOTES.md.
 static void fw_up_log_slave_status(const char *tag) {
-    fw_up_status_request_t req = { .crc32 = 0, .dummy = 0 };
+    fw_up_status_request_t req = { .crc32 = 0, .op = FLASH_STAGE_STATUS, .dummy = 0 };
     fw_up_status_reply_t   reply;
     memset(&reply, 0, sizeof(reply));
     // Use transaction_rpc_exec directly — send_to_bridge hardcodes the
     // 1-byte poly_sync_reply_t and can't carry our bigger status struct.
-    bool ok = transaction_rpc_exec(USER_SYNC_FW_UP_STATUS,
+    bool ok = transaction_rpc_exec(USER_SYNC_FLASH_STAGE,
                                    sizeof(req), &req,
                                    sizeof(reply), &reply);
     if (!ok) {
@@ -63,6 +63,7 @@ bool hid_fw_up_receive(uint8_t *data, uint8_t length) {
 
             fw_up_begin_sync_t begin_msg;
             memset(&begin_msg, 0, sizeof(begin_msg));   // deterministic padding for the CRC
+            begin_msg.op         = FLASH_STAGE_BEGIN;
             begin_msg.image_size = image_size;
             begin_msg.image_crc  = image_crc;
             begin_msg.target     = FW_TARGET_FIRMWARE;
@@ -86,7 +87,7 @@ bool hid_fw_up_receive(uint8_t *data, uint8_t length) {
                 // begin_deferred also halts the master's core1 and sets fw_up_active.
                 fw_staging_begin_deferred(image_size, image_crc);
                 // Kick the slave's deferred erase so both halves erase in parallel.
-                send_to_bridge(USER_SYNC_FW_UP_BEGIN, &begin_msg, sizeof(begin_msg), 3);
+                send_to_bridge(USER_SYNC_FLASH_STAGE, &begin_msg, sizeof(begin_msg), 3);
                 uprintf("FW_UP_BEGIN: new image size=%lu crc=0x%08lx (master+slave staging)\n",
                         image_size, image_crc);
             }
@@ -95,7 +96,7 @@ bool hid_fw_up_receive(uint8_t *data, uint8_t length) {
             // ready we return '~' and the host re-polls after a short delay, letting
             // the QMK main loop advance both deferred erases between polls.
             uint8_t slave_ack = master_ok
-                ? send_to_bridge(USER_SYNC_FW_UP_BEGIN, &begin_msg, sizeof(begin_msg), 1)
+                ? send_to_bridge(USER_SYNC_FLASH_STAGE, &begin_msg, sizeof(begin_msg), 1)
                 : SYNC_CRC32_ERR;
             bool slave_ok    = (slave_ack == SYNC_ACK);
             bool master_done = !fw_staging_erase_pending();   // master's own staging erased?
@@ -163,8 +164,10 @@ bool hid_fw_up_receive(uint8_t *data, uint8_t length) {
                 uint8_t              big_req[64];
                 fw_up_status_reply_t big_reply;
                 memset(big_req, 0xA5, sizeof(big_req));
+                uint32_t st_op = FLASH_STAGE_STATUS;   // op selector routes to the STATUS handler
+                memcpy(&big_req[4], &st_op, sizeof(st_op));
                 memset(&big_reply, 0, sizeof(big_reply));
-                bool big_ok = transaction_rpc_exec(USER_SYNC_FW_UP_STATUS,
+                bool big_ok = transaction_rpc_exec(USER_SYNC_FLASH_STAGE,
                                                    sizeof(big_req), big_req,
                                                    sizeof(big_reply), &big_reply);
                 uprintf("FW_UP probe: pre-chunk 64B-M2S status xfer -> %s\n",
@@ -219,10 +222,10 @@ bool hid_fw_up_receive(uint8_t *data, uint8_t length) {
                 // is unreachable its cursor is unknown — report the master's own
                 // (the host will retry the current chunk with backoff).
                 uint32_t resume = fw_staging_next_offset();
-                fw_up_status_request_t sreq = { .crc32 = 0, .dummy = 0 };
+                fw_up_status_request_t sreq = { .crc32 = 0, .op = FLASH_STAGE_STATUS, .dummy = 0 };
                 fw_up_status_reply_t   srep;
                 memset(&srep, 0, sizeof(srep));
-                if (transaction_rpc_exec(USER_SYNC_FW_UP_STATUS, sizeof(sreq), &sreq, sizeof(srep), &srep) &&
+                if (transaction_rpc_exec(USER_SYNC_FLASH_STAGE, sizeof(sreq), &sreq, sizeof(srep), &srep) &&
                     srep.crc32 == crc32_1byte((const uint8_t *)&srep.status, sizeof(srep.status), 0) &&
                     srep.status.next_offset < resume) {
                     resume = srep.status.next_offset;
@@ -240,8 +243,8 @@ bool hid_fw_up_receive(uint8_t *data, uint8_t length) {
             // milestone: fw_staging_finalize() verifies the O(1) running CRC, clears
             // fw_up_active and restarts core1 — it does NOT apply or reboot.  Actually
             // installing the staged image is the explicit FW_UP_APPLY step (phase 2).
-            uint32_t dummy_crc = 0;
-            uint8_t slave_ack  = send_to_bridge(USER_SYNC_FW_UP_COMMIT, &dummy_crc, sizeof(dummy_crc), 10);
+            fw_up_commit_sync_t commit_msg = { .crc32 = 0, .op = FLASH_STAGE_COMMIT };
+            uint8_t slave_ack  = send_to_bridge(USER_SYNC_FLASH_STAGE, &commit_msg, sizeof(commit_msg), 10);
             bool master_ok = fw_staging_finalize();   // also clears fw_up_active + restarts master core1
             bool ok = (slave_ack == SYNC_ACK) && master_ok;
             memset(data, 0, length);

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -2709,10 +2709,7 @@ void keyboard_post_init_user(void) {
     transaction_register_rpc(USER_SYNC_ROI_DATA,            user_sync_roi_data_handler);
     transaction_register_rpc(USER_SYNC_DYNAMIC_KEYMAP_DATA, user_sync_dynamic_keymap_data_handler);
     transaction_register_rpc(USER_SYNC_OVERLAY_MAP_DATA,    user_sync_overlay_map_data_handler);
-    transaction_register_rpc(USER_SYNC_FW_UP_BEGIN,         user_sync_fw_up_begin_handler);
-    transaction_register_rpc(USER_SYNC_FW_UP_CHUNK,         user_sync_fw_up_chunk_handler);
-    transaction_register_rpc(USER_SYNC_FW_UP_COMMIT,        user_sync_fw_up_commit_handler);
-    transaction_register_rpc(USER_SYNC_FW_UP_STATUS,        user_sync_fw_up_status_handler);
+    transaction_register_rpc(USER_SYNC_FLASH_STAGE,         user_sync_flash_stage_handler);
     transaction_register_rpc(USER_SYNC_RESET,               user_sync_reset_handler);
 
     fw_staging_init();

--- a/keyboards/polykybd/split_fw_up.c
+++ b/keyboards/polykybd/split_fw_up.c
@@ -206,9 +206,16 @@ static void flash_stage_chunk(uint8_t in_len, const void* in_data, uint8_t out_l
 // The actual flash apply is deferred to housekeeping_task_user() so the ACK
 // can be returned before the split link goes dark during the reboot.
 static void flash_stage_commit(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data) {
-    if (out_len != sizeof(poly_sync_reply_t) || !out_data) return;
-    (void)in_len;
-    (void)in_data;
+    if (in_len != sizeof(fw_up_commit_sync_t) || !in_data || out_len != sizeof(poly_sync_reply_t) || !out_data) return;
+    // Verify the request CRC (covers the `op` selector) so COMMIT carries the same
+    // size + integrity guard as BEGIN/CHUNK — send_to_bridge always fills a valid
+    // CRC, so this only rejects a corrupted/misrouted frame, which the master retries.
+    const fw_up_commit_sync_t *msg = (const fw_up_commit_sync_t *)in_data;
+    uint32_t crc32 = crc32_1byte(&((const uint8_t *)in_data)[4], in_len - 4, 0);
+    if (crc32 != msg->crc32) {
+        ((poly_sync_reply_t *)out_data)->ack = SYNC_CRC32_ERR;
+        return;
+    }
     // Defer the heavy FONTPACK reload out of this transaction callback: the
     // ~50 ms full-body verify+reassemble overran the ~20 ms split-transaction
     // window, so the master timed out and mis-reported COMMIT as a CRC failure
@@ -219,12 +226,12 @@ static void flash_stage_commit(uint8_t in_len, const void* in_data, uint8_t out_
 
 // Single slave-side dispatcher for the flash-staging stream.  Reads the `op`
 // word (immediately after the CRC32) and routes to the per-op handler above.
-// The op is covered by each request's CRC32 (verified inside BEGIN/CHUNK), and
-// every per-op handler guards on its exact in_len/out_len — so a corrupted op
-// that misroutes lands on a size-guard mismatch and the handler returns without
-// a valid ACK, which the master reads as a failure and retries.  (STATUS stays
-// best-effort and un-CRC'd by design; a misroute to it just fails the out_len
-// guard unless the caller genuinely asked for a status-sized reply.)
+// BEGIN / CHUNK / COMMIT each verify the request CRC32 (which covers `op`) and
+// guard their exact in_len/out_len — so a corrupted or misrouted op lands on a
+// size/CRC mismatch and the handler returns without a valid ACK, which the master
+// reads as a failure and retries.  STATUS is intentionally best-effort: un-CRC'd
+// and guarding only on out_len (so it can still answer the deliberately-oversized
+// diagnostic probe) — it is read-only, so a misroute to it is harmless.
 void user_sync_flash_stage_handler(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data) {
     if (!in_data || in_len < 8) return;   // need at least crc32 + op
     uint32_t op;

--- a/keyboards/polykybd/split_fw_up.c
+++ b/keyboards/polykybd/split_fw_up.c
@@ -16,16 +16,17 @@
 // ---------------------------------------------------------------------------
 
 // Relay one upload chunk to the slave with up to 10 retries. Builds the CRC'd
-// fw_up_chunk_sync_t and sends USER_SYNC_FW_UP_CHUNK, accepting only an
-// identity-bound reply whose write cursor advanced PAST `offset` (so a stale
-// previous-chunk ACK can't silently desynchronise the two halves' cursors).
-// Returns true on a slave ACK. Shared by the firmware-update and font-pack
-// chunk paths, which used to carry a byte-identical copy of this loop. When
-// `log_tag` is non-NULL and debug is enabled it logs each retry (the
+// fw_up_chunk_sync_t (op = FLASH_STAGE_CHUNK) and sends USER_SYNC_FLASH_STAGE,
+// accepting only an identity-bound reply whose write cursor advanced PAST `offset`
+// (so a stale previous-chunk ACK can't silently desynchronise the two halves'
+// cursors). Returns true on a slave ACK. Shared by the firmware-update and
+// font-pack chunk paths, which used to carry a byte-identical copy of this loop.
+// When `log_tag` is non-NULL and debug is enabled it logs each retry (the
 // firmware-update path passes "FW_UP_CHUNK"); the font-pack path passes NULL
 // for a quiet relay, matching its prior behaviour.
 bool fw_up_relay_chunk_to_slave(uint32_t offset, const uint8_t *chunk_data, const char *log_tag) {
     fw_up_chunk_sync_t chunk_msg;
+    chunk_msg.op     = FLASH_STAGE_CHUNK;
     chunk_msg.offset = offset;
     memcpy(chunk_msg.data, chunk_data, FW_UP_CHUNK_SIZE);
     chunk_msg.crc32 = crc32_1byte(&((const uint8_t *)&chunk_msg)[4], sizeof(chunk_msg) - 4, 0);
@@ -34,7 +35,7 @@ bool fw_up_relay_chunk_to_slave(uint32_t offset, const uint8_t *chunk_data, cons
         fw_up_chunk_reply_t reply;
         memset(&reply, 0, sizeof(reply));
         reply.ack = SYNC_CRC32_ERR;
-        bool ok_rpc = transaction_rpc_exec(USER_SYNC_FW_UP_CHUNK, sizeof(chunk_msg), &chunk_msg,
+        bool ok_rpc = transaction_rpc_exec(USER_SYNC_FLASH_STAGE, sizeof(chunk_msg), &chunk_msg,
                                            sizeof(reply), &reply);
         if (ok_rpc && reply.ack == SYNC_ACK && reply.next_offset > offset) {
             slave_ack = SYNC_ACK;
@@ -60,7 +61,7 @@ bool fw_up_relay_chunk_to_slave(uint32_t offset, const uint8_t *chunk_data, cons
 // + state so the master can uprintf them after a failed chunk to distinguish
 // "slave hung before handler" vs "slave handler ran and rejected".  See
 // FW_UP_DEBUG_NOTES.md.
-void user_sync_fw_up_status_handler(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data) {
+static void flash_stage_status(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data) {
     if (out_len != sizeof(fw_up_status_reply_t) || !out_data) return;
     // The request payload only exists to give the framework something to send;
     // CRC verification is best-effort — we still want to return a status snapshot
@@ -86,7 +87,7 @@ void user_sync_fw_up_status_handler(uint8_t in_len, const void* in_data, uint8_t
 //
 // The deferred erase is rate-limited to one sector per 70 ms in housekeeping so
 // the split UART stays responsive between 50 ms erase blackouts.
-void user_sync_fw_up_begin_handler(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data) {
+static void flash_stage_begin(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data) {
     if (in_len != sizeof(fw_up_begin_sync_t) || !in_data || out_len != sizeof(poly_sync_reply_t) || !out_data) return;
     fw_staging_note_begin_call();
     const fw_up_begin_sync_t *msg = (const fw_up_begin_sync_t *)in_data;
@@ -160,7 +161,7 @@ void user_sync_fw_up_begin_handler(uint8_t in_len, const void* in_data, uint8_t 
 // Replies with the identity-bound fw_up_chunk_reply_t (ack + post-RPC write
 // cursor) so the master can tell a genuine ACK from a stale previous reply —
 // see the struct comment in split_fw_up.h.
-void user_sync_fw_up_chunk_handler(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data) {
+static void flash_stage_chunk(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data) {
     if (in_len != sizeof(fw_up_chunk_sync_t) || !in_data || out_len != sizeof(fw_up_chunk_reply_t) || !out_data) return;
     const fw_up_chunk_sync_t *msg = (const fw_up_chunk_sync_t *)in_data;
     fw_up_chunk_reply_t *reply = (fw_up_chunk_reply_t *)out_data;
@@ -204,14 +205,37 @@ void user_sync_fw_up_chunk_handler(uint8_t in_len, const void* in_data, uint8_t 
 // Slave verifies staged CRC and arms the commit flag.
 // The actual flash apply is deferred to housekeeping_task_user() so the ACK
 // can be returned before the split link goes dark during the reboot.
-void user_sync_fw_up_commit_handler(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data) {
+static void flash_stage_commit(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data) {
     if (out_len != sizeof(poly_sync_reply_t) || !out_data) return;
+    (void)in_len;
+    (void)in_data;
     // Defer the heavy FONTPACK reload out of this transaction callback: the
     // ~50 ms full-body verify+reassemble overran the ~20 ms split-transaction
     // window, so the master timed out and mis-reported COMMIT as a CRC failure
     // even though the pack loaded. Firmware-target finalize is O(1) (unaffected).
     bool ok = fw_staging_finalize_defer_reload();
     ((poly_sync_reply_t *)out_data)->ack = ok ? SYNC_ACK : SYNC_CRC32_ERR;
+}
+
+// Single slave-side dispatcher for the flash-staging stream.  Reads the `op`
+// word (immediately after the CRC32) and routes to the per-op handler above.
+// The op is covered by each request's CRC32 (verified inside BEGIN/CHUNK), and
+// every per-op handler guards on its exact in_len/out_len — so a corrupted op
+// that misroutes lands on a size-guard mismatch and the handler returns without
+// a valid ACK, which the master reads as a failure and retries.  (STATUS stays
+// best-effort and un-CRC'd by design; a misroute to it just fails the out_len
+// guard unless the caller genuinely asked for a status-sized reply.)
+void user_sync_flash_stage_handler(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data) {
+    if (!in_data || in_len < 8) return;   // need at least crc32 + op
+    uint32_t op;
+    memcpy(&op, &((const uint8_t *)in_data)[4], sizeof(op));
+    switch (op) {
+        case FLASH_STAGE_BEGIN:  flash_stage_begin (in_len, in_data, out_len, out_data); break;
+        case FLASH_STAGE_CHUNK:  flash_stage_chunk (in_len, in_data, out_len, out_data); break;
+        case FLASH_STAGE_COMMIT: flash_stage_commit(in_len, in_data, out_len, out_data); break;
+        case FLASH_STAGE_STATUS: flash_stage_status(in_len, in_data, out_len, out_data); break;
+        default: break;   // unknown op — leave out_data untouched → master retries
+    }
 }
 
 // Master commands the slave to restart, so BOTH halves come back together (like a

--- a/keyboards/polykybd/split_fw_up.h
+++ b/keyboards/polykybd/split_fw_up.h
@@ -13,6 +13,20 @@
 
 #define FW_UP_VERSION_LEN 16
 
+// The flash-staging stream (firmware AND font-pack alike) is carried by ONE split
+// transaction, USER_SYNC_FLASH_STAGE, whose sub-operation is selected by an `op`
+// word right after the CRC32 in every request.  Keeping the four begin/chunk/
+// commit/status transactions folded into one reclaims scarce transaction slots
+// (QMK caps the table at 32).  `op` is a uint32_t, not a byte, so the u32 fields
+// that follow stay 4-byte aligned — the RP2040 (Cortex-M0+) cannot do unaligned
+// word access.  The single slave-side dispatcher is user_sync_flash_stage_handler.
+enum flash_stage_op {
+    FLASH_STAGE_BEGIN  = 0,  // announce size/crc + kick the deferred erase
+    FLASH_STAGE_CHUNK  = 1,  // one FW_UP_CHUNK_SIZE-byte fragment
+    FLASH_STAGE_COMMIT = 2,  // verify staged CRC + finalize (no reboot)
+    FLASH_STAGE_STATUS = 3,  // diagnostic: return fw_staging internal counters
+};
+
 // Announce incoming firmware/font-pack size + expected CRC32 to slave.
 // `target` (fw_target_t) selects which flash region the slave stages into and how
 // it finalizes — 0 = FIRMWARE (also what older senders leave it), 1 = FONTPACK.
@@ -20,6 +34,7 @@
 // from this begin.
 typedef struct _fw_up_begin_sync_t {
     uint32_t crc32;
+    uint32_t op;         // = FLASH_STAGE_BEGIN
     uint32_t image_size;
     uint32_t image_crc;
     uint8_t  target;
@@ -27,12 +42,20 @@ typedef struct _fw_up_begin_sync_t {
 } fw_up_begin_sync_t;
 
 // One chunk of firmware data (FW_UP_CHUNK_SIZE bytes).
-// Total struct = 4+4+56 = 64 bytes < RPC_M2S_BUFFER_SIZE (72).
+// Total struct = 4+4+4+56 = 68 bytes < RPC_M2S_BUFFER_SIZE (72).
 typedef struct _fw_up_chunk_sync_t {
     uint32_t crc32;
+    uint32_t op;         // = FLASH_STAGE_CHUNK
     uint32_t offset;
     uint8_t  data[FW_UP_CHUNK_SIZE];
 } fw_up_chunk_sync_t;
+
+// COMMIT carries no payload beyond the op selector (the slave finalizes whatever
+// it has staged for the target it remembered from BEGIN).
+typedef struct _fw_up_commit_sync_t {
+    uint32_t crc32;
+    uint32_t op;         // = FLASH_STAGE_COMMIT
+} fw_up_commit_sync_t;
 
 // Chunk reply — identity-bound ACK.  Every chunk used to be answered with the
 // same bare 1-byte ACK (poly_sync_reply_t), so a stale reply left over from
@@ -58,7 +81,8 @@ typedef struct _fw_up_chunk_reply_t {
 // observed — distinguishes "slave never received the chunk" from "slave
 // received it and rejected".  See FW_UP_DEBUG_NOTES.md.
 typedef struct _fw_up_status_request_t {
-    uint32_t crc32;       // CRC over the dummy field below
+    uint32_t crc32;       // CRC over the fields below
+    uint32_t op;          // = FLASH_STAGE_STATUS
     uint32_t dummy;       // present so the struct has bytes to checksum
 } fw_up_status_request_t;
 
@@ -102,10 +126,9 @@ typedef struct _poly_reset_sync_t {
 // NULL for a quiet relay). Returns true on slave ACK. See split_fw_up.c.
 bool fw_up_relay_chunk_to_slave(uint32_t offset, const uint8_t *chunk_data, const char *log_tag);
 
-void user_sync_fw_up_begin_handler  (uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data);
-void user_sync_fw_up_chunk_handler  (uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data);
-void user_sync_fw_up_commit_handler (uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data);
-void user_sync_fw_up_status_handler (uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data);
+// One slave-side dispatcher for the whole flash-staging stream (BEGIN / CHUNK /
+// COMMIT / STATUS); it reads the `op` word and routes to the per-op logic.
+void user_sync_flash_stage_handler  (uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data);
 // One transaction (USER_SYNC_RESET) for apply-and-reboot, plain reboot, and the
 // handedness-change reboot; the poly_reset_sync_t `action` byte selects which.
 void user_sync_reset_handler        (uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data);


### PR DESCRIPTION
## Summary

Second step of the split-transaction consolidation (the split table is hard-capped at **32**). The four staging-stream transactions — `BEGIN` / `CHUNK` / `COMMIT` / `STATUS` — are the **generic flash-staging channel shared by both the firmware update *and* the per-bundle font-pack flash**, not firmware-specific. This folds them into a **single `USER_SYNC_FLASH_STAGE`** transaction whose sub-operation is selected by an `op` word carried right after the CRC32 in every request. **Reclaims 3 slots.**

The rename drops the misleading `FW_UP_` prefix on the transaction level — the channel does more than firmware writes (it's how font-pack bundles get flashed too).

### What changed
- **New `enum flash_stage_op { BEGIN, CHUNK, COMMIT, STATUS }`.** `op` is a `uint32_t` (not a byte) so the `u32` fields after it stay 4-byte aligned — the RP2040 (Cortex-M0+) can't do unaligned word access. Added to `fw_up_begin_sync_t`, `fw_up_chunk_sync_t`, `fw_up_status_request_t`, plus a new `fw_up_commit_sync_t`. The chunk struct grows 64 → **68 bytes**, still < `RPC_M2S_BUFFER_SIZE` (72).
- **Slave side:** one dispatcher `user_sync_flash_stage_handler` reads `op` and routes to the (now `static`) per-op handlers, whose bodies are otherwise byte-identical to before. `op` is covered by each request's CRC32 (verified in BEGIN/CHUNK), and every per-op handler guards its exact `in_len`/`out_len` — so a corrupted `op` that misroutes lands on a size-guard mismatch and returns without a valid ACK → the master retries. STATUS stays best-effort / un-CRC'd by design.
- **Master side:** the BEGIN/CHUNK/COMMIT/STATUS senders in `hid_fw_up.c` and `hid_fontpack.c` set the `op` and target `USER_SYNC_FLASH_STAGE`; the shared `fw_up_relay_chunk_to_slave` sets `op = FLASH_STAGE_CHUNK`.

All hard-won invariants preserved: the identity-bound chunk reply (`next_offset > offset`) cursor-desync guard (2026-06-10), the deferred-erase readiness protocol, and the deferred FONTPACK finalize (2026-run-6).

**User split transactions: 16 → 13.**

> Note: overlaps with the companion PR (drop `FW_UP_QUERY` + merge apply/reboot into `RESET`) on `config.h`, `bridge_helper.c`, and `poly_keymap.c`. Whichever lands second needs a trivial rebase; together they take the user table to 11.

## Version bump label

No label — internal split-transport refactor, no functional or protocol change → patch bump.

## Testing
- [x] Compiled successfully — **both** `qmk compile -kb polykybd/split72 -km default` **and** `-kb polykybd/split42 -km default` link clean
- [ ] Flashed and tested on hardware — **fw-update + font-pack flash paths should be exercised on the rig** (this is the safety-critical staging stream)
- [ ] If protocol changed: n/a (split-link wire only; `PROTOCOL_VERSION` unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhhNb2C1KHUBUY9J9KKx7N

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhhNb2C1KHUBUY9J9KKx7N)_

## Summary by Sourcery

Consolidate the firmware/font-pack flash staging split transactions into a single USER_SYNC_FLASH_STAGE RPC with sub-operations selected by an op field, reducing user transaction IDs while preserving existing staging behavior.

New Features:
- Introduce a flash_stage_op enum to represent BEGIN, CHUNK, COMMIT, and STATUS operations within the unified flash-staging transaction.

Enhancements:
- Refactor slave-side firmware update handlers into static per-op functions behind a single user_sync_flash_stage_handler dispatcher.
- Update master-side firmware and font-pack paths to use the unified USER_SYNC_FLASH_STAGE transaction and op selector for begin, chunk, commit, and status flows.
- Simplify transaction ID registration, logging, and string mapping to reflect the new FlashStage channel instead of multiple FW_UP_* entries.

Build:
- Adjust SPLIT_TRANSACTION_IDS_USER config to register USER_SYNC_FLASH_STAGE in place of the four separate FW_UP_* staging transactions.