### PR TITLE
fix(idle): idle timer robust past 24.8-day uptime + host start-idle works right after boot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -826,6 +826,57 @@ is non-zero; classify it with `sync_succeeded()`.
 
 ---
 
+### Bug: idle mode sometimes never starts; host "start idle" (cmd 15) is a no-op right after boot
+
+**Symptom**: (1) Once in a while the keycaps never enter the idle
+fade/pulse/turn-off animation at all — the displays just stay at full brightness
+until suspend. (2) The host-side "start idle" HID command (cmd 15, payload ≠ 0)
+does nothing when sent within the first ~2 minutes after the keyboard powers on —
+the keyboard keeps waiting the full idle timeout instead of idling immediately.
+
+**Root cause (2026-07-07 — FIXED)**: both trace to `base/update.c`'s activity
+timestamp `last_update` being a **signed `int32_t` that overloaded a `uint32_t`
+timestamp with sentinels** (`-1` = "idle tracking off"), and the housekeeping loop
+gating idle on `if(get_last_update() >= 0)`.
+- **(1) The 24.86-day sign-bit window.** `update_performed()` stores
+  `timer_read32()` (a `uint32_t` ms counter) into the signed `last_update`. Once
+  uptime passes ~24.86 days (`timer_read32() ≥ 2³¹`), that value reads back
+  **negative**, so `if(update >= 0)` is false and the **entire idle/turn-off block
+  in `housekeeping_task_user()` is skipped** — idle silently stops working for the
+  ~25-day window until the 49.7-day `uint32` wrap. Intermittent, uptime-dependent →
+  "sometimes it doesn't idle".
+- **(2) Backdating underflow near boot.** `hid_com.c` case 15's "start idle" set
+  `last_update = timer_read32() - FADE_OUT_TIME` to make idle begin one fade-out
+  interval "ago". In the first `FADE_OUT_TIME` (120 s) of uptime `timer_read32() <
+  120000`, so the signed subtraction went **negative and was clamped to 0** — which
+  reads as "just became active", not "idle now", so the fade never triggered. (The
+  code even logged `Starting idle in N msec` and then didn't.)
+
+**Fix**: separate the "idle tracking enabled" state from the timestamp.
+`base/update.c` now stores `last_update` as a real **`uint32_t`** plus a distinct
+`bool idle_tracking` flag; `get_time_since_last_update()` uses `timer_elapsed32()`
+(correct modular `uint32` arithmetic at any uptime, including across the wrap).
+Housekeeping gates on **`is_idle_tracking()`** instead of the sign of the
+timestamp, so idle works for the full 49.7-day timer range. The host "start idle"
+path calls the new **`backdate_last_update(FADE_OUT_TIME)`** — modular
+`timer_read32() - ms`, correct even when `now < ms`, so idle begins on the next
+pass regardless of uptime. The old `set_last_update(-1)` "idle off" calls are now
+the clearer **`disable_idle_tracking()`** (suspend / host display-off cmd 24 /
+turn-off-reached); `set_last_update(int32_t)` is kept as a thin compat shim (`<0`
+disables, `≥0` sets+enables). No wire-protocol change (cmd 15 payload identical),
+so no `PROTOCOL_VERSION`/`__protocol__` bump.
+
+**Relevant files**:
+- `keyboards/polykybd/base/update.c` / `update.h` — `uint32_t last_update` +
+  `idle_tracking`; `is_idle_tracking()`, `disable_idle_tracking()`,
+  `backdate_last_update()`
+- `keyboards/polykybd/poly_keymap.c` — `housekeeping_task_user()` idle gate
+  (`is_idle_tracking()`), the turn-off + `suspend_power_down_kb()` disable calls
+- `keyboards/polykybd/hid_com.c` — cmd 15 start branch (`backdate_last_update`),
+  cmd 24 display-off (`disable_idle_tracking`)
+
+---
+
 ### Bug: keyboard hangs on the boot splash after a firmware apply (slave not rebooted)
 
 **Symptom (field, 2026-06-22)**: After a successful HID firmware flash + apply, the

--- a/keyboards/polykybd/base/update.c
+++ b/keyboards/polykybd/base/update.c
@@ -2,22 +2,44 @@
 
 #include "timer.h"
 
-static volatile int32_t last_update = 0;
+static volatile uint32_t last_update = 0;
+// Idle-timeout tracking active by default so a fresh boot idles like before. Kept
+// SEPARATE from last_update (was the sign bit of a signed int32) — see update.h.
+static volatile bool     idle_tracking = true;
 static volatile enum refresh_mode g_refresh = DONE_ALL;
 
 void update_performed(void) {
-    last_update = timer_read32();
+    last_update   = timer_read32();
+    idle_tracking = true;
 }
 
-int32_t get_last_update(void) {
+uint32_t get_last_update(void) {
     return last_update;
 }
 
 void set_last_update(int32_t update) {
-    last_update = update;
+    if (update < 0) {
+        idle_tracking = false;
+    } else {
+        last_update   = (uint32_t)update;
+        idle_tracking = true;
+    }
 }
 
-int32_t get_time_since_last_update(void) {
+void disable_idle_tracking(void) {
+    idle_tracking = false;
+}
+
+bool is_idle_tracking(void) {
+    return idle_tracking;
+}
+
+void backdate_last_update(uint32_t ms) {
+    last_update   = timer_read32() - ms;   // modular; correct even when now < ms
+    idle_tracking = true;
+}
+
+uint32_t get_time_since_last_update(void) {
     return timer_elapsed32(last_update);
 }
 

--- a/keyboards/polykybd/base/update.h
+++ b/keyboards/polykybd/base/update.h
@@ -1,18 +1,39 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdbool.h>
 
 enum refresh_mode { START_FIRST_HALF, START_SECOND_HALF, DONE_ALL, ALL_AT_ONCE };
 
 // Records current timestamp for idle timeout tracking and idle display animation.
-// Global variables: last_update
+// Marks idle tracking active. Global variables: last_update, idle_tracking
 void update_performed(void);
 
-int32_t get_last_update(void);
+uint32_t get_last_update(void);
 
+// Legacy sentinel API: a negative value disables idle-timeout tracking (the old
+// `set_last_update(-1)` = "idle off"); a non-negative value sets the activity
+// timestamp and (re)enables tracking. Prefer the explicit helpers below.
 void set_last_update(int32_t update);
 
-int32_t get_time_since_last_update(void);
+// Disables idle-timeout tracking (suspend / host display-off / turn-off reached).
+void disable_idle_tracking(void);
+
+// True while the idle-timeout logic in housekeeping should run. The timestamp is a
+// full uint32_t, so this is a SEPARATE flag rather than a sign bit — that is what
+// keeps idle working past ~24.86 days of uptime (when timer_read32() sets bit 31)
+// and lets the timestamp be backdated below the epoch without colliding with a
+// sentinel. Global variables: idle_tracking
+bool is_idle_tracking(void);
+
+// Backdate the activity timestamp by `ms` milliseconds and (re)enable tracking, so
+// the idle fade begins `ms` ms sooner (used by the host "start idle" command to make
+// it begin immediately). Uses modular uint32 arithmetic, so it is correct even in
+// the first `ms` ms after boot — the old signed `timer_read32() - ms` underflowed
+// there and was clamped to 0, which read as "just active" and never idled.
+void backdate_last_update(uint32_t ms);
+
+uint32_t get_time_since_last_update(void);
 
 // Requests full display refresh on all displays at once.
 // Global variables: g_refresh

--- a/keyboards/polykybd/config.h
+++ b/keyboards/polykybd/config.h
@@ -94,7 +94,7 @@
 //######################################
 //#          PolyKybd specific         #
 //######################################
-#define FW_VERSION "0.9.38"
+#define FW_VERSION "0.9.39"
 // v2: adds GET_LANG_LIST_PACKED (cmd 27) — language list as 2-byte ISO index pairs.
 // v3: SEND_OVERLAY_MAPPING (cmd 21) no longer ACKs per chunk — like every other
 //     bulk overlay command (10, 16/17, 18/19) it is silent. The per-chunk ACK

--- a/keyboards/polykybd/config.h
+++ b/keyboards/polykybd/config.h
@@ -94,7 +94,7 @@
 //######################################
 //#          PolyKybd specific         #
 //######################################
-#define FW_VERSION "0.9.39"
+#define FW_VERSION "0.9.38"
 // v2: adds GET_LANG_LIST_PACKED (cmd 27) — language list as 2-byte ISO index pairs.
 // v3: SEND_OVERLAY_MAPPING (cmd 21) no longer ACKs per chunk — like every other
 //     bulk overlay command (10, 16/17, 18/19) it is silent. The per-chunk ACK

--- a/keyboards/polykybd/hid_com.c
+++ b/keyboards/polykybd/hid_com.c
@@ -557,14 +557,13 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                     }
                     uprint("Stop idle.\n");
                 } else {
-                    int32_t update = timer_read32() - FADE_OUT_TIME;
-                    if(update<0) {
-                        uprintf("Starting idle in %ld msec .\n", -update);
-                        update=0;
-                    } else {
-                        uprint("Start idle.\n");
-                    }
-                    set_last_update(update);
+                    // Backdate the activity timestamp by a full fade-out interval so
+                    // the idle fade begins on the next housekeeping pass. Modular
+                    // uint32 arithmetic makes this correct even in the first
+                    // FADE_OUT_TIME ms after boot — the old signed subtraction
+                    // underflowed there, was clamped to 0, and idle never started.
+                    backdate_last_update(FADE_OUT_TIME);
+                    uprint("Start idle.\n");
                 }
                 memset(data, 0, length);
                 hid_reply(data, 0x0f, true);
@@ -672,7 +671,7 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                 // Treat host display-off (e.g. system going to sleep) as a cue to
                 // flush all dirty user state to EEPROM (dirty-gated, so cheap).
                 save_all_dirty();
-                set_last_update(-1);
+                disable_idle_tracking();
                 memset(data, 0, length);
                 hid_reply(data, 0x18, true);
                 raw_hid_send(data, length);

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -595,10 +595,11 @@ void housekeeping_task_user(void) {
         save_all_if_requested();
         sync_and_refresh_displays();
     }
-    int32_t update = get_last_update();
-    if(update>=0) {
+    if(is_idle_tracking()) {
         //turn off displays
-        uint32_t elapsed_time_since_update = timer_elapsed32(update);
+        // Full uint32 elapsed via timer_elapsed32 — no sign gate, so idle keeps
+        // working past ~24.86 days of uptime (when timer_read32() sets bit 31).
+        uint32_t elapsed_time_since_update = get_time_since_last_update();
         if (is_usb_host_side()) {
             poly_sync_t* local_state = access_local_state();
             uint8_t  contrast = local_state->contrast;
@@ -626,7 +627,7 @@ void housekeeping_task_user(void) {
             } else if(elapsed_time_since_update > TURN_OFF_TIME) {
                 uprint("Turning off\n");
                 poly_suspend();
-                set_last_update(-1);
+                disable_idle_tracking();
                 contrast = local_state->contrast;
                 flags = local_state->flags;
             } else if((flags & DISP_IDLE)!=0) {
@@ -2675,7 +2676,7 @@ void suspend_power_down_kb(void) {
     // corrupt a live split transaction.
     save_all_dirty();
     suspend_power_down_user();
-    set_last_update(-1);
+    disable_idle_tracking();
 }
 
 // Called by QMK before every reset (QK_REBOOT, QK_BOOTLOADER, and the host-triggered


### PR DESCRIPTION
## Summary

Two idle-mode issues share one root cause in `keyboards/polykybd/base/update.c`: the activity timestamp `last_update` was a **signed `int32_t`** that overloaded a `uint32_t` millisecond counter with a `-1` "idle off" sentinel, and `housekeeping_task_user()` gated idle on `if(get_last_update() >= 0)`.

- **Idle sometimes never starts.** `update_performed()` stores `timer_read32()` (unsigned) into the signed field. Once uptime crosses **~24.86 days** (`timer_read32() ≥ 2³¹`), the value reads back negative → the entire idle/turn-off block is skipped → idle silently stops for the ~25-day window until the 49.7-day timer wrap. Intermittent and uptime-dependent.
- **Host "start idle" (cmd 15) is a no-op right after boot.** It backdated the timestamp with `timer_read32() - FADE_OUT_TIME` so the fade begins immediately; in the first `FADE_OUT_TIME` (120 s) of uptime that signed subtraction underflowed and was **clamped to 0**, which reads as "just became active", so idle never began.

### Fix

Separate the *"idle tracking enabled"* state from the timestamp:

- `last_update` is now a real **`uint32_t`** plus a distinct `bool idle_tracking` flag (was the sign bit).
- Housekeeping gates on **`is_idle_tracking()`** and measures elapsed via `timer_elapsed32()` — correct modular arithmetic across the full 49.7-day timer range and its wrap.
- Host start-idle calls the new **`backdate_last_update(FADE_OUT_TIME)`** — modular `timer_read32() - ms`, correct even when `now < ms`, so it begins on the next housekeeping pass at any uptime including seconds after boot.
- The `-1` "idle off" calls become the clearer **`disable_idle_tracking()`** (suspend / host display-off cmd 24 / turn-off reached); `set_last_update(int32_t)` is kept as a thin compat shim (`<0` disables, `≥0` sets+enables).

No wire-protocol change — cmd 15's payload is identical, so the host needs no change and `PROTOCOL_VERSION` is unchanged.

Files: `base/update.c` / `update.h`, `poly_keymap.c` (idle gate + disable calls), `hid_com.c` (cmd 15 start branch, cmd 24 display-off). Investigation entry added to the firmware `CLAUDE.md`.

## Version bump label

None — bug fix, so the default patch bump (`0.0.x`) is correct. (Reverted the manual `FW_VERSION` bump so CI owns it.)

## Testing
- [x] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`) — also `split42:default`, both clean (shared `poly_keymap.c`)
- [ ] Flashed and tested on hardware
- [ ] If protocol changed: host updated and tested together *(N/A — no protocol change)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9fjak2bLGZqRNJZoTU8jq

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9fjak2bLGZqRNJZoTU8jq)_

## Summary by Sourcery

Fix idle mode so it reliably starts and stops across all uptimes and host commands by separating idle tracking state from the millisecond timestamp and updating callers accordingly.

Bug Fixes:
- Prevent idle mode from silently disabling itself after ~24.8 days of uptime due to signed/unsigned timestamp overflow.
- Ensure the host "start idle" HID command correctly triggers idle immediately even when sent shortly after boot instead of being ignored.

Enhancements:
- Introduce explicit idle tracking helpers (`is_idle_tracking`, `disable_idle_tracking`, `backdate_last_update`, `get_time_since_last_update`) to replace overloading timestamp sentinels and simplify idle-related call sites.

Documentation:
- Document the idle-timer overflow and startup-underflow bugs and their fix in CLAUDE.md for future reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed idle behavior so the display timeout now works reliably, including shortly after startup and after long uptime.
  * “Start idle” now takes effect consistently, and turning the display off no longer interferes with future idle tracking.
  * Improved timing handling so idle timeout calculations remain accurate over time.  

* **Documentation**
  * Added notes describing the idle-state behavior update and the related command changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->