### PR TITLE
Fix master hanging on the boot splash after firmware flash/apply and reset key

### DIFF
--- a/keyboards/polykybd/base/multicore/core1.c
+++ b/keyboards/polykybd/base/multicore/core1.c
@@ -32,7 +32,21 @@ uint32_t core1_stack_high_water_mark(void) {
 #endif
 
 static void __attribute__ ((naked)) core1_trampoline(void) {
-    __asm volatile ("pop {r0, r1, pc}");
+    // Mask IRQs on core1 as its VERY FIRST instruction, before core1_wrapper or
+    // core1_entry run. core1_entry() also does `cpsid i`, but several instructions
+    // (this trampoline + core1_wrapper's stack-guard install) execute on core1 with
+    // IRQs still enabled before it gets there. In that window the strongly-overridden
+    // ChibiOS Vector80 (SIO_IRQ_PROC1) can fire — its CH_IRQ_EPILOGUE triggers an NMI
+    // via ICSR.NMIPENDSET, which runs the context-switch NMI handler on a core with no
+    // thread state and hangs it (see keyboards/polykybd/base/fw_staging.c and CLAUDE.md).
+    // On a cold power-on that window is usually harmless, but a watchdog-reset boot (the
+    // firmware-apply / QK_REBOOT reset path) can inherit SIO-FIFO/IRQ state a power-on
+    // doesn't, so a stale/pending FIFO IRQ fires here and hangs the MASTER on the boot
+    // splash — core0's launch handshake (multicore_fifo_pop_blocking) then waits forever
+    // for a core1 that is stuck in the NMI (field: "stuck on the PolyKybd splash after
+    // flashing / reset"). Masking here closes the window: core1 has no IRQ-driven work
+    // (it polls FIFO_ST), so keeping IRQs masked for its whole lifetime is safe.
+    __asm volatile ("cpsid i\n\tpop {r0, r1, pc}");
 }
 
 void multicore_launch_core1_raw(void (*entry)(void), uint32_t *sp, uint32_t vector_table) {

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -2253,9 +2253,24 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
                 // the rebooted master can't re-sync to it and hangs on the boot
                 // splash.  QMK resets the master right after we return true (before
                 // housekeeping runs again), so the slave must be told here.
+                //
+                // Hardened handoff — same rationale as CMD_FW_UP_APPLY (hid_fw_up.c,
+                // field 2026-06-22).  This is the reset-key twin of that path and had
+                // the identical flaw: a single dropped USER_SYNC_REBOOT frame at only
+                // 5 retries left the slave alive on stale state, the master rebooted
+                // alone and hung on the boot splash until the slave was replugged
+                // (field 2026-07 — plain reset key, no firmware apply).  Use 20
+                // retries and re-fire the whole round once if the slave still hasn't
+                // acked.  Safe: the slave reboot handler is idempotent (it only arms a
+                // deferred mcu_reset), send_to_bridge is synchronous (returns only
+                // after the slave has handled it), and we're about to reset anyway —
+                // the extra worst-case ~1 s is free insurance on this critical step.
                 fw_up_apply_sync_t reboot_msg = { .crc32 = 0, .magic = FW_UP_SYNC_MAGIC };
-                uint8_t ack = send_to_bridge(USER_SYNC_REBOOT, &reboot_msg, sizeof(reboot_msg), 5);
-                uprintf("Master: slave reboot ack=%d\n", ack);
+                uint8_t ack = send_to_bridge(USER_SYNC_REBOOT, &reboot_msg, sizeof(reboot_msg), 20);
+                if (!sync_succeeded(ack)) {
+                    ack = send_to_bridge(USER_SYNC_REBOOT, &reboot_msg, sizeof(reboot_msg), 20);
+                }
+                uprintf("Master: slave reboot ack=0x%02x\n", ack);
                 return true;   // let QMK's QK_REBOOT handler reset the master
             }
             case KC_A ... KC_Z:


### PR DESCRIPTION
## Description

Fixes the intermittent failure where, after a firmware flash/apply **or** a reset-key
reboot, the master half stays stuck on the "POLY KYBD" boot splash and never enumerates
USB until it is replugged.

There are two independent problems here. The first is the already-known
"reboot-the-slave" handoff; the second is the **actual root cause** of the master hanging
even when both halves *do* reboot.

### 1. `core1` launch-trampoline IRQ mask — the real root cause (`base/multicore/core1.c`)

The splash is the last thing drawn in `keyboard_pre_init_user`; a hang that leaves it on
screen means boot never reached the first real keycap render, i.e. it stalled somewhere
between "splash drawn" and the first `update_displays`. The one call in that window that
can block **forever** is `multicore_launch_core1()`.

`core1_entry()` masks IRQs with `cpsid i`, but that is **not** the first code core1 runs at
launch — the path is `core1_trampoline` → `core1_wrapper` (stack-guard install) →
`core1_entry`, so several instructions execute on core1 with IRQs still enabled first. In
that window the strongly-overridden ChibiOS `Vector80` (`SIO_IRQ_PROC1`) can fire; its
`CH_IRQ_EPILOGUE` triggers an NMI (`ICSR.NMIPENDSET`) that runs the context-switch NMI
handler on a core with no thread state and hangs it — and core0's launch handshake
(`multicore_fifo_pop_blocking`) then waits forever for a core1 that never echoes, freezing
the master on the splash. This is the same `SIO_IRQ_PROC1 → NMI` trap already documented in
`base/fw_staging.c` and `CLAUDE.md`.

A cold power-on rarely trips it. A **watchdog-reset boot** (the flash-apply and QK_REBOOT
reset path) can inherit SIO-FIFO/IRQ state that a cold boot doesn't, which is why it only
bites after flashing/reset — the boot relaunch previously assumed safe isn't always.

Fix: move the IRQ mask to core1's **literal first instruction**, in the naked trampoline
(`cpsid i` before the `pop {r0,r1,pc}`), closing the window entirely. Verified in the
disassembly that the emitted trampoline now starts with `cpsid i`. Safe: core1 has no
IRQ-driven work (it polls `FIFO_ST`), so keeping IRQs masked for its whole lifetime is the
intended state — `core1_entry`'s `cpsid i` is now redundant but kept.

### 2. Harden the QK_REBOOT slave handoff (`poly_keymap.c`)

The reset-key (`QK_REBOOT`) path told the slave to reboot with only **5 retries and no
re-fire**, while its twin `CMD_FW_UP_APPLY` (`hid_fw_up.c`) was already hardened for the
identical failure mode (20 retries + one re-fire, field 2026-06-22). A single dropped
`USER_SYNC_REBOOT` frame left the slave alive on stale state → master reboots alone → same
splash hang. Bring the reboot handoff up to the same guarantee (20 retries + one re-fire,
classified via `sync_succeeded()`). Idempotent slave handler + synchronous `send_to_bridge`
+ we're about to reset anyway, so the worst case is ~1 s on a bad link.

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* Master hangs on the boot splash (no USB enumeration) after a firmware flash/apply or a reset-key reboot, until replug.

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage)

**Testing note:** both variants (`polykybd/split72` and `polykybd/split42`) build clean with
the ARM toolchain, and the emitted `core1_trampoline` was verified to start with `cpsid i`.
The end-to-end fix (flash/apply and reset-key reboot no longer hang the master) still needs
confirming on real hardware — I could not reproduce the timing race in this environment. To
localize on the bench, build with `-DFW_UP_BOOT_TRACE`: a hang showing digit "2" (never "3")
confirms the core1 launch as the culprit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01964StXnkMZHSNNGcfWnkzQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01964StXnkMZHSNNGcfWnkzQ)_

## Summary by Sourcery

Prevent the master half from hanging on the boot splash after firmware flash/apply or reset-key reboots by hardening the split reboot handshake and making core1 startup fully IRQ-masked.

Bug Fixes:
- Ensure core1 starts with IRQs masked to avoid NMI lockups that stall the master during multicore launch.
- Improve the slave reboot handshake on QK_REBOOT to reduce missed reboot commands that leave halves out of sync and stuck on the splash screen.

Enhancements:
- Align reset-key reboot behavior with the firmware-apply path by increasing reboot message retries and adding a second attempt if the slave does not acknowledge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reboot handling so both sides of the keyboard reset more reliably.
  * Prevented a rare startup hang by blocking interrupts earlier during core startup, reducing the chance of boot-time lockups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->