### PR TITLE
doom: game-data downloader + docs/howto, rename build_all.sh

### DIFF
--- a/keyboards/polykybd/doom/README.md
+++ b/keyboards/polykybd/doom/README.md
@@ -26,6 +26,40 @@ same objects at `0x10600000`.
 > the firmware partition entirely. Without a WHX the PSX-fire placeholder
 > still runs as the pipeline proof.
 
+## How to install & play (for humans)
+
+You need **three** files — grab them from a GitHub release (or build them with
+`build_all.sh`, below):
+
+| File | What it is |
+|---|---|
+| `polykybd_doom_pack.bin` | the firmware (pack flavour) |
+| `doom_pack_v1.plyx` | the DOOM engine ("cartridge") |
+| `doom1.whx` | the game data (shareware) |
+
+Then, once:
+
+1. **Get the game data** — `keyboards/polykybd/doom/tools/dl-doom-data.sh`
+   downloads `doom1.whx` for you (or use the copy from the release).
+2. **Flash the firmware** — open **PolyKybdHost**, use the firmware updater to
+   flash `polykybd_doom_pack.bin` over USB, and **Apply**. (No PolyKybdHost?
+   Flash the matching `.uf2` by holding BOOTSEL while plugging each half.)
+3. **Install the game data** — `polyctl doom install doom1.whx`
+   (writes to both halves; survives future firmware updates — do this only once).
+4. **Install the engine** — `polyctl doom install-pack doom_pack_v1.plyx`
+   (redo only when a new release changes the engine; the loader warns if a pack
+   is stale).
+5. **Play** — trigger the egg (the incantation is left as an exercise for the
+   reader 😉). Move **W/A/S/D**, turn with the **arrows**, **Ctrl** fires,
+   **Space** opens doors, **Shift** runs, **Enter/Esc** work the menus. On the
+   split, one half is your 3D view and the other shows the live automap.
+6. **Quit** — hold **Esc** for ~1.5 s to leave the game; your keycaps snap
+   back to normal instantly. (As a *screensaver*, any key dismisses it.)
+
+> Everything lives in the keyboard's spare flash, so once installed it just
+> waits there — a firmware update won't wipe your game, and nobody looking at
+> the keyboard would ever know it's in there.
+
 ## Building
 
 **One-shot (everything):**

--- a/keyboards/polykybd/doom/README.md
+++ b/keyboards/polykybd/doom/README.md
@@ -29,7 +29,7 @@ same objects at `0x10600000`.
 ## How to install & play (for humans)
 
 You need **three** files — grab them from a GitHub release (or build them with
-`build_all.sh`, below):
+`build_all_doom.sh`, below):
 
 | File | What it is |
 |---|---|
@@ -65,7 +65,7 @@ Then, once:
 **One-shot (everything):**
 
 ```bash
-keyboards/polykybd/doom/build_all.sh [--version N] [--tag NAME] [--out DIR]
+keyboards/polykybd/doom/build_all_doom.sh [--version N] [--tag NAME] [--out DIR]
 ```
 
 Downloads `doom1.whx` if missing (cached; + the `doom1_whx.uf2` BOOTSEL
@@ -83,7 +83,7 @@ keyboards/polykybd/doom/tools/dl-doom-data.sh [--out DIR] [--wad] [--force]
 Fetches the installable `doom1.whx` (size + `IWHX` magic verified); `--wad`
 also pulls the raw shareware `doom1.wad` (SHA-256 verified) for re-running
 `whd_gen`. Use this when you grabbed a release `.bin` + `.plyx` and only need
-the data to `polyctl doom install`. `build_all.sh` calls it internally, so the
+the data to `polyctl doom install`. `build_all_doom.sh` calls it internally, so the
 URLs/checksums live here alone (provenance: `engine/PROVENANCE.md`). The
 shareware data is **not** committed to the repo — it is downloaded on demand.
 

--- a/keyboards/polykybd/doom/README.md
+++ b/keyboards/polykybd/doom/README.md
@@ -40,6 +40,26 @@ collects every artifact in `--out` (default: repo root) and prints the
 install steps: flash the pack-flavour `.bin` over HID → `polyctl doom
 install <whx>` (once) → `polyctl doom install-pack <plyx>` → IDDQD.
 
+**Just the game data (no build):**
+
+```bash
+keyboards/polykybd/doom/tools/dl-doom-data.sh [--out DIR] [--wad] [--force]
+```
+
+Fetches the installable `doom1.whx` (size + `IWHX` magic verified); `--wad`
+also pulls the raw shareware `doom1.wad` (SHA-256 verified) for re-running
+`whd_gen`. Use this when you grabbed a release `.bin` + `.plyx` and only need
+the data to `polyctl doom install`. `build_all.sh` calls it internally, so the
+URLs/checksums live here alone (provenance: `engine/PROVENANCE.md`). The
+shareware data is **not** committed to the repo — it is downloaded on demand.
+
+**Who builds what:** the `.plyx` engine pack is produced by
+`pack/build_pack.sh` (monolith build → stash engine objects → pack-flavour
+build → relink at the DoomPack slot → `pack/mkpack.py` wraps the `PlyX`
+header). CI (`.github/workflows/release.yml`) runs it per tag and uploads
+`doom_pack_v1.plyx` as a release asset. The `.plyx` is a build/release
+artifact — never committed (gitignored).
+
 **Individual pieces:**
 
 ```bash

--- a/keyboards/polykybd/doom/build_all.sh
+++ b/keyboards/polykybd/doom/build_all.sh
@@ -41,19 +41,11 @@ done
 mkdir -p "$OUT"
 
 # ── 1. game data (cached — the WHX never changes) ────────────────────────────
-# Pre-converted shareware WAD in rp2040-doom's WHX format; provenance + the
-# raw-IWAD/whd_gen alternative in engine/PROVENANCE.md.
+# Delegated to tools/dl-doom-data.sh (single source for the URL/size/magic);
+# the raw-IWAD/whd_gen alternative is in engine/PROVENANCE.md.
+echo "== 1/3 game data (tools/dl-doom-data.sh) =="
 WHX="$OUT/doom1.whx"
-WHX_URL="https://raw.githubusercontent.com/kilograham/rp2040-doom/rp2040/doom1.whx"
-WHX_SIZE=1800344
-if [[ -f "$WHX" && $(wc -c < "$WHX") -eq $WHX_SIZE ]]; then
-    echo "== 1/3 game data: cached $WHX =="
-else
-    echo "== 1/3 game data: downloading doom1.whx =="
-    curl -sSL -o "$WHX" "$WHX_URL"
-    [[ $(wc -c < "$WHX") -eq $WHX_SIZE ]] || { echo "build_all: doom1.whx size $(wc -c < "$WHX") != $WHX_SIZE" >&2; exit 1; }
-fi
-head -c4 "$WHX" | grep -q IWHX || { echo "build_all: $WHX has no IWHX magic" >&2; exit 1; }
+"$DOOM_DIR/tools/dl-doom-data.sh" --out "$OUT"
 python3 "$DOOM_DIR/tools/whx2uf2.py" "$WHX" "$OUT/doom1_whx.uf2"
 
 # ── 2. firmware (both flavours) + the RAM-paired engine pack ─────────────────

--- a/keyboards/polykybd/doom/build_all_doom.sh
+++ b/keyboards/polykybd/doom/build_all_doom.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # One-shot doom build: game data + engine pack + both firmware flavours.
 #
-#   keyboards/polykybd/doom/build_all.sh [--version N] [--tag NAME] [--out DIR]
+#   keyboards/polykybd/doom/build_all_doom.sh [--version N] [--tag NAME] [--out DIR]
 #
 # Produces (in --out, default: the repo root — the usual delivery spot):
 #   doom1.whx                    game data (downloaded once, cached; PROVENANCE.md)

--- a/keyboards/polykybd/doom/engine/PROVENANCE.md
+++ b/keyboards/polykybd/doom/engine/PROVENANCE.md
@@ -30,7 +30,14 @@ crawling the CMake source lists + transitive `#include` closure:
 `../tools/mirror_rp2040_doom.py` (verify any file with
 `https://raw.githubusercontent.com/kilograham/rp2040-doom/<sha>/<path>`).
 
-Game data (NOT committed here — fetch into the working container when needed):
+Game data (NOT committed here — fetch when needed). The convenience script
+`../tools/dl-doom-data.sh` fetches + verifies both (`--wad` for the raw IWAD):
+
+```bash
+keyboards/polykybd/doom/tools/dl-doom-data.sh --out . --wad
+```
+
+Equivalent raw fetches (what the script does), if you prefer curl:
 
 ```bash
 # pre-converted shareware WAD in rp2040-doom's WHX format, 1,800,344 bytes

--- a/keyboards/polykybd/doom/tools/dl-doom-data.sh
+++ b/keyboards/polykybd/doom/tools/dl-doom-data.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Download the DOOM easter-egg game data (provenance: engine/PROVENANCE.md).
+#
+#   tools/dl-doom-data.sh [--out DIR] [--wad] [--force]
+#
+# By default fetches ONLY doom1.whx — the pre-converted shareware data in
+# rp2040-doom's WHX format. That is the file the keyboard actually installs
+# (`polyctl doom install <out>/doom1.whx`); nothing else is needed to play.
+#
+#   --wad     also fetch the raw shareware IWAD doom1.wad (4 MB). Only needed to
+#             RE-CONVERT the data yourself with the engine's whd_gen — the WHX
+#             above is already converted, so most people never need this.
+#   --out DIR where to write (default: the repo root, the usual delivery spot).
+#   --force   re-download even if a correctly-sized copy is already present.
+#
+# Both files are size-verified; the WHX is magic-checked (IWHX) and the raw WAD
+# is SHA-256-verified. The DOOM 1 shareware data is freely redistributable by
+# id Software's shareware terms; it is deliberately NOT committed to this repo.
+# Requires: curl, sha256sum (only for --wad).
+set -euo pipefail
+
+cd "$(dirname "$0")"
+REPO=$(cd ../../../.. && pwd)
+OUT="$REPO"
+WANT_WAD=0
+FORCE=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --out)   OUT="$2"; shift 2 ;;
+        --wad)   WANT_WAD=1; shift ;;
+        --force) FORCE=1; shift ;;
+        -h|--help) sed -n '2,20p' "$0"; exit 0 ;;
+        *) echo "usage: $0 [--out DIR] [--wad] [--force]" >&2; exit 2 ;;
+    esac
+done
+mkdir -p "$OUT"
+
+# Pre-converted shareware WAD in rp2040-doom's WHX format (the installable data).
+WHX="$OUT/doom1.whx"
+WHX_URL="https://raw.githubusercontent.com/kilograham/rp2040-doom/rp2040/doom1.whx"
+WHX_SIZE=1800344
+# Raw shareware IWAD v1.9 (only for re-running whd_gen).
+WAD="$OUT/doom1.wad"
+WAD_URL="https://raw.githubusercontent.com/Akbar30Bill/DOOM_wads/master/doom1.wad"
+WAD_SIZE=4196020
+WAD_SHA=1d7d43be501e67d927e415e0b8f3e29c3bf33075e859721816f652a526cac771
+
+sizeof() { wc -c < "$1" 2>/dev/null || echo 0; }
+
+echo "== doom1.whx (game data) =="
+if [[ $FORCE -eq 0 && -f "$WHX" && $(sizeof "$WHX") -eq $WHX_SIZE ]]; then
+    echo "   cached: $WHX"
+else
+    curl -fSL -o "$WHX" "$WHX_URL"
+    [[ $(sizeof "$WHX") -eq $WHX_SIZE ]] || { echo "dl-doom-data: doom1.whx size $(sizeof "$WHX") != $WHX_SIZE" >&2; exit 1; }
+    echo "   downloaded: $WHX ($WHX_SIZE B)"
+fi
+head -c4 "$WHX" | grep -q IWHX || { echo "dl-doom-data: $WHX missing IWHX magic" >&2; exit 1; }
+
+if [[ $WANT_WAD -eq 1 ]]; then
+    echo "== doom1.wad (raw shareware IWAD; whd_gen input) =="
+    if [[ $FORCE -eq 0 && -f "$WAD" && $(sizeof "$WAD") -eq $WAD_SIZE ]]; then
+        echo "   cached: $WAD"
+    else
+        curl -fSL -o "$WAD" "$WAD_URL"
+        [[ $(sizeof "$WAD") -eq $WAD_SIZE ]] || { echo "dl-doom-data: doom1.wad size $(sizeof "$WAD") != $WAD_SIZE" >&2; exit 1; }
+        echo "   downloaded: $WAD ($WAD_SIZE B)"
+    fi
+    echo "$WAD_SHA  $WAD" | sha256sum -c - || { echo "dl-doom-data: doom1.wad SHA-256 mismatch" >&2; exit 1; }
+fi
+
+echo "dl-doom-data: OK — install with 'polyctl doom install $WHX'"

--- a/keyboards/polykybd/doom/tools/dl-doom-data.sh
+++ b/keyboards/polykybd/doom/tools/dl-doom-data.sh
@@ -26,7 +26,8 @@ WANT_WAD=0
 FORCE=0
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --out)   OUT="$2"; shift 2 ;;
+        --out)   [[ $# -ge 2 ]] || { echo "--out requires a DIR" >&2; exit 2; }
+                 OUT="$2"; shift 2 ;;
         --wad)   WANT_WAD=1; shift ;;
         --force) FORCE=1; shift ;;
         -h|--help) sed -n '2,20p' "$0"; exit 0 ;;


### PR DESCRIPTION
## Summary
Docs-and-tooling follow-up to the merged DOOM easter-egg work (#122). No firmware/runtime code changes.

- **New `tools/dl-doom-data.sh`** — standalone game-data downloader: fetches the installable `doom1.whx` (size + `IWHX` magic verified) and, with `--wad`, the raw shareware `doom1.wad` (SHA-256 verified) for re-running `whd_gen`. Lets anyone who grabbed a release `.bin` + `.plyx` pull just the data to `polyctl doom install`. The shareware data stays **out of the repo** (freely redistributable, not GPL) — downloaded on demand.
- **`build_all_doom.sh`** (renamed from `build_all.sh`) now delegates its data fetch to the new script, so the URLs/checksums live in one place.
- **Docs**: a short **"How to install & play (for humans)"** walkthrough at the top of `doom/README.md` (three files → flash → install data → install engine → play → quit, plus in-game controls); a "just the game data" section; a note recording that `pack/build_pack.sh` produces the `.plyx` and the release workflow uploads it per tag. `engine/PROVENANCE.md` now points at the downloader as the convenience path over raw curl.
- Also folds in the earlier session-retro doc edits: the final grid-space screensaver-placement write-up + `tools/keycap_dispmap.py` reference, the overlay-arena hand-back note, and the overlay-pool minimum-size remark (`base/overlay.c` / `doom/doom_arena.h`) for when the pool is shrunk.

## Version bump label
*(none — docs + build scripts only, patch bump)*

## Testing
- [x] `dl-doom-data.sh` run end-to-end: `doom1.whx` (IWHX magic OK) and `--wad` `doom1.wad` (SHA-256 `OK`) both verified.
- [x] `bash -n` syntax-checked `build_all_doom.sh` and `dl-doom-data.sh`; confirmed no stale `build_all.sh` references remain.
- [x] `keycap_dispmap.py` verifier still reports `ALL GOOD ✓`.
- [ ] No firmware compile / hardware flash needed (no `.c`/`.h` runtime changes).

---
_Generated by [Claude Code](https://claude.ai/code/session_01C9Uiuz2SNtoTVAdjm6dE8V)_

## Summary by Sourcery

Add a dedicated DOOM game-data downloader script, wire builds to use it, and expand user-facing DOOM installation and provenance documentation.

New Features:
- Introduce a dl-doom-data.sh helper script to download and verify DOOM shareware game-data assets on demand.

Enhancements:
- Rename the DOOM one-shot build script to build_all_doom.sh and delegate its game-data fetch to the shared downloader for a single source of URLs and checksums.
- Document a step-by-step DOOM install-and-play workflow, game-data-only workflow, and build/release provenance for the DOOM engine pack in README and PROVENANCE files.