### PR TITLE
Release publishing: one-command publish, notes on release:published, drop doom .plyx asset

### DIFF
--- a/.claude/skills/polykybd-github-release/SKILL.md
+++ b/.claude/skills/polykybd-github-release/SKILL.md
@@ -17,9 +17,10 @@ but applies a **release-specific voice** (below) and adds two things the plain
 notes skill does not: a **mandatory review gate** before anything is created, and
 getting the **release metadata / labels** right.
 
-> **Hard rule: never create the tag, push, or create/publish the release until the
-> user has reviewed and approved the notes + metadata (step 3).** You *prepare* the
-> release; the user (or CI on a tag) creates it.
+> **Hard rule: never stage notes or hand off a publish command until the user has
+> reviewed and approved the notes + metadata (step 3).** You *prepare* the release
+> (stage the notes on the `release-notes` branch); the **user publishes it** — a pushed
+> tag alone does NOT create a release here (see step 5, the `[skip ci]` gotcha).
 
 ## 1. Pick the target & resolve the version range
 
@@ -124,72 +125,93 @@ label" is a PR-time action that decides which version the release carries.
 
 ## 5. Create / publish the release (hand-off)
 
-⚠️ **This environment has no `gh` CLI and the GitHub MCP exposes no create-/edit-release
-tool** — you can't call an API to publish. But both repos' `release.yml` are wired to
-pull the **crafted notes from a `release-notes` branch**, so publishing is a two-push
-job you *can* drive from here.
+⚠️ **A release is created by PUBLISHING it (UI or `gh release create`), NOT by pushing a
+tag.** This is the single most important fact, learned the hard way (2026-07):
 
-### The `release-notes` branch (how the crafted notes reach CI)
-Both `release.yml` workflows, when a tag is created, look for
-**`<TAG>.md` at the root of the unprotected `release-notes` branch** (via `gh api …
-/contents/<TAG>.md?ref=release-notes`). If present, CI publishes with that file's
-**first line `# <title>`** as the release title and the rest as the body; if absent it
-falls back to `--generate-notes` + a generic title. So the file is optional and safe.
+- **Release tags land on the auto-bump `[skip ci]` commit** (`bump-version.yml` commits
+  `chore: bump … version to X.Y.Z [skip ci]`). GitHub's `[skip ci]` **suppresses the
+  `push:` (tag) workflow trigger**, so pushing `PolyKybd-fw-vX.Y.Z` / `vX.Y.Z` runs
+  **nothing** — no build, no release. (Confirmed: every historical firmware release run
+  is a `release: published` event; the host's tag-push workflow had *never* run.)
+- The trigger that actually fires is **`release: published`** — i.e. the user creates &
+  publishes the release in the GitHub UI (or `gh release create`). That's how releases
+  have always been made here.
 
-**Lifecycle: one file per tag, never overwritten or deleted.** `PolyKybd-fw-v0.9.42.md`
-(firmware) / `v0.9.42.md` (host) is written once for that release; the next release adds
-a *new* file. The branch accumulates them as a changelog archive — don't reuse or clear
-old files.
+### This environment's constraints
+- ✅ **Can** push to a normal branch → so you **can** stage the notes file on the
+  `release-notes` branch.
+- ❌ **Cannot** push tags — the session git proxy returns **403 on `refs/tags/*`**.
+- ❌ **Cannot** create/publish a release — no `gh` CLI, and the GitHub MCP has no
+  create-/edit-release tool.
 
-### Automated path (recommended — fully hands-off)
-1. Write the approved notes to a file whose first line is `# <crafted title>` and the
-   rest is the approved body.
-2. Put it on the `release-notes` branch as `<TAG>.md` and push (this branch is
-   unprotected — a direct push works; create the branch if it doesn't exist yet, keeping
-   any existing files):
+So the release itself is **always a user hand-off**. Your job: stage the notes, then give
+the user a one-liner to publish.
+
+### The `release-notes` branch (how crafted notes reach CI)
+Both `release.yml` workflows fire on **`release: published`** (and on a tag push, which is
+normally dead). They fetch **`<TAG>.md` from the root of the unprotected `release-notes`
+branch** (`gh api …/contents/<TAG>.md?ref=release-notes`). If present, CI applies the
+**first line `# <title>`** as the release title and the rest as the body — via
+**`gh release edit`** when the release already exists (the UI-publish case) or
+`gh release create` when it doesn't. If absent, it leaves the user's notes / auto-generates.
+
+**Lifecycle: one file per tag, never overwritten or deleted.** `PolyKybd-fw-vX.Y.Z.md`
+(firmware) / `vX.Y.Z.md` (host) is written once; the next release adds a new file. The
+branch is an accumulating changelog archive — don't reuse or clear old files.
+
+### Recommended flow (near hands-off)
+1. Write the approved notes to a file whose **first line is `# <crafted title>`** and the
+   rest is the body.
+2. Stage it on the `release-notes` branch as `<TAG>.md` and push (use an isolated
+   worktree so your working checkout is untouched; the branch already exists with a
+   README — keep existing files):
    ```bash
-   cd <repo>
-   git fetch origin release-notes 2>/dev/null && git checkout release-notes \
-     || git checkout --orphan release-notes && git rm -rf --cached . 2>/dev/null; true
-   cp <approved-notes> PolyKybd-fw-v0.9.42.md      # or v0.9.42.md for the host
-   git add PolyKybd-fw-v0.9.42.md && git commit -m "release notes: 0.9.42"
-   git push -u origin release-notes
-   git checkout -    # back to your working branch
+   cd <repo>; git fetch origin release-notes
+   wt=$(mktemp -d); git worktree add "$wt" release-notes
+   cp <approved-notes> "$wt/<TAG>.md"          # <TAG> = PolyKybd-fw-v0.9.44  or  v0.9.26
+   git -C "$wt" add "<TAG>.md" && git -C "$wt" commit -m "release notes: <TAG>"
+   git -C "$wt" push -u origin release-notes
+   git worktree remove --force "$wt"
    ```
-3. Create + push the tag on the bumped commit so CI builds and publishes with the
-   crafted notes + title:
-   ```bash
-   git tag PolyKybd-fw-v0.9.42 <bump-commit>   # host: v0.9.42
-   git push origin PolyKybd-fw-v0.9.42
-   ```
-   - **Firmware:** the tag-push (or a later `release: published`) triggers `release.yml`
-     → builds `polykybd/split72:default` (doom-pack flavour) → uploads
-     `polykybd_split72_default.bin`, `.uf2`, `doom_pack_v1.plyx` → creates the release
-     with the crafted notes. **Never attach binaries by hand — CI does.**
-   - **Host:** the `v*` tag-push triggers `release.yml` → creates the release with the
-     crafted notes (no build assets — pure Python).
-   - If pushing the **tag** is blocked by a tag ruleset, fall back to the UI path below;
-     the notes file on `release-notes` is still picked up whenever the release is created.
+3. **Hand the user the publish step** (you can't do it yourself). Give BOTH options:
+   - **`gh` one-liner (fastest)** — creates & publishes the release for the existing tag;
+     for firmware it fires `release: published` → CI builds + attaches `.bin`/`.uf2`/`.plyx`.
+     It reads the crafted body straight from the branch file, so no copy-paste:
+     ```bash
+     # firmware
+     f=$(git show origin/release-notes:PolyKybd-fw-v0.9.44.md)
+     gh release create PolyKybd-fw-v0.9.44 --latest \
+       --title "$(printf '%s' "$f" | head -1 | sed 's/^# //')" \
+       --notes "$(printf '%s' "$f" | tail -n +2)"
+     # host: same with tag v0.9.26 and its file
+     ```
+   - **GitHub UI** — Draft a new release → pick the existing tag → they can leave the body
+     **empty** and Publish; CI's `release: published` run then fills in the crafted
+     title+notes from the branch (`gh release edit`) and, for firmware, attaches assets.
+     (If they type a body, CI's branch notes overwrite it — the branch file is the source
+     of truth.)
 
-### Manual fallback (if you'd rather use the UI, or tag push is blocked)
-The user creates the release in the GitHub UI — tag `PolyKybd-fw-vX.Y.Z` (target
-`PolyKybd`) / `vX.Y.Z` (target `main`), title = crafted title, body = approved notes,
-"Set as latest", **Publish**. For firmware, publishing still kicks CI to attach the
-assets. (The `release: published` trigger exists precisely because release tags land on
-the `[skip ci]` bump commit, which suppresses the tag-push CI trigger.)
-
-**Always also deliver** the approved notes in chat as a ready-to-paste Markdown block +
-a one-line metadata summary (`tag / title / target branch / latest`), so the user can
+**Always also deliver** the approved notes in chat as a ready-to-paste Markdown block + a
+one-line metadata summary (`tag / title / target branch / latest`), so the user can
 review/paste regardless of path.
 
+### Verify after the user publishes
+Confirm with `mcp__github__get_release_by_tag` (title/body/assets) and, for firmware,
+`mcp__github__actions_list` (`release.yml` run succeeded, `event: release`). A 404 means it
+wasn't published yet — a **pushed tag alone never creates the release** (see the `[skip ci]`
+note above).
+
 ## Pitfalls
-- **Publishing goes through CI, not a release API.** There's no create-release tool
-  here; the release is created by CI when the tag lands (with the crafted notes pulled
-  from the `release-notes` branch). Don't claim it's live until the workflow has run —
-  verify with `mcp__github__get_release_by_tag` / `list_releases`. If a tag ruleset
-  blocks the push, hand off to the UI path.
-- **Keep the notes file and the tag in sync** — the `release-notes/<TAG>.md` filename
-  must exactly match the tag CI sees, or CI silently falls back to auto-generated notes.
+- **A pushed tag does NOT publish a release** — `[skip ci]` on the bump commit kills the
+  tag-push trigger. Releases are made by **publishing** (`release: published`). Never tell
+  the user "I pushed the tag, it's releasing" — it isn't.
+- **You cannot publish from this environment** — no tag push (proxy 403), no release API.
+  Always hand the user the `gh release create` one-liner or the UI step; verify afterward.
+- **Keep the notes file name == the tag exactly** — `release-notes/<TAG>.md` must match the
+  published tag, or CI silently skips the crafted notes.
+- **The crafted-notes file is the source of truth** — on `release: published`, CI
+  **overwrites** the release body/title from the branch file (via `gh release edit`). If the
+  user wants their own UI-typed body, don't also stage a notes file for that tag.
 - **In-tree version ≠ released version** — anchor "since the last release" on the GitHub
   release, not the newest bump commit.
 - **Don't hand-attach firmware binaries** — CI builds and uploads them; a manually

--- a/.claude/skills/polykybd-github-release/SKILL.md
+++ b/.claude/skills/polykybd-github-release/SKILL.md
@@ -173,25 +173,23 @@ branch is an accumulating changelog archive — don't reuse or clear old files.
    git -C "$wt" push -u origin release-notes
    git worktree remove --force "$wt"
    ```
-3. **Hand the user the publish step** (you can't do it yourself). Give BOTH options:
-   - **`gh` one-liner (fastest)** — creates & publishes the release for the existing tag;
-     for firmware it fires `release: published` → CI builds + attaches `.bin`/`.uf2`
-     (the doom engine pack `.plyx` is built but deliberately NOT attached — it would
-     reveal the easter egg).
-     It reads the crafted body straight from the branch file, so no copy-paste:
-     ```bash
-     # firmware
-     f=$(git show origin/release-notes:PolyKybd-fw-v0.9.44.md)
-     gh release create PolyKybd-fw-v0.9.44 --latest \
-       --title "$(printf '%s' "$f" | head -1 | sed 's/^# //')" \
-       --notes "$(printf '%s' "$f" | tail -n +2)"
-     # host: same with tag v0.9.26 and its file
-     ```
-   - **GitHub UI** — Draft a new release → pick the existing tag → they can leave the body
-     **empty** and Publish; CI's `release: published` run then fills in the crafted
-     title+notes from the branch (`gh release edit`) and, for firmware, attaches assets.
-     (If they type a body, CI's branch notes overwrite it — the branch file is the source
-     of truth.)
+3. **Hand the user the single publish command** (you can't publish yourself). Each repo
+   ships **`scripts/publish_release.py`** — one OS-independent command (stdlib-only, works
+   on Windows/macOS/Linux):
+   ```
+   python scripts/publish_release.py            # publish
+   python scripts/publish_release.py --dry-run  # preview title+body, change nothing
+   ```
+   It auto-detects the repo, reads the current version (→ tag) from the default branch,
+   pulls the staged `<TAG>.md` from the `release-notes` branch, and creates+publishes the
+   release via the GitHub API. Firmware: publishing fires `release: published` → CI builds
+   and attaches `.bin`/`.uf2` (the doom engine pack `.plyx` is built but deliberately NOT
+   attached — it would reveal the easter egg). Auth: `GH_TOKEN`/`GITHUB_TOKEN` or
+   `gh auth token`. Tell the user to run it in each repo after you've staged the notes.
+   - **Alternatives** (if they prefer): the GitHub UI — Draft a new release → pick the tag →
+     leave the body **empty** → Publish; CI's `release: published` run then fills the
+     crafted title+notes from the branch (`gh release edit`) and, for firmware, attaches
+     assets. (A typed body is overwritten by the branch file — it's the source of truth.)
 
 **Always also deliver** the approved notes in chat as a ready-to-paste Markdown block + a
 one-line metadata summary (`tag / title / target branch / latest`), so the user can

--- a/.claude/skills/polykybd-github-release/SKILL.md
+++ b/.claude/skills/polykybd-github-release/SKILL.md
@@ -175,7 +175,9 @@ branch is an accumulating changelog archive — don't reuse or clear old files.
    ```
 3. **Hand the user the publish step** (you can't do it yourself). Give BOTH options:
    - **`gh` one-liner (fastest)** — creates & publishes the release for the existing tag;
-     for firmware it fires `release: published` → CI builds + attaches `.bin`/`.uf2`/`.plyx`.
+     for firmware it fires `release: published` → CI builds + attaches `.bin`/`.uf2`
+     (the doom engine pack `.plyx` is built but deliberately NOT attached — it would
+     reveal the easter egg).
      It reads the crafted body straight from the branch file, so no copy-paste:
      ```bash
      # firmware

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,10 @@ jobs:
           arm-none-eabi-objcopy -O binary \
             .build/${TARGET}.elf \
             ${TARGET}.bin
-          cp keyboards/polykybd/doom/pack/doom_pack_v1.plyx .
+          # NOTE: the doom engine pack (doom_pack_v1.plyx) is built by
+          # build_pack.sh but deliberately NOT published as a release asset —
+          # the easter egg stays a surprise (a "doom_pack" asset would reveal it,
+          # and the shipping .bin refuses the trigger with no pack flashed).
 
       # Crafted release notes (optional): one file per tag on the unprotected
       # `release-notes` branch — release-notes/<TAG>.md, first line "# <title>",
@@ -98,7 +101,7 @@ jobs:
           TITLE: ${{ steps.notes.outputs.title }}
         run: |
           TARGET=$(echo "${{ env.KB }}" | tr '/' '_')_${{ env.KM }}
-          ASSETS=( "${TARGET}.uf2" "${TARGET}.bin" doom_pack_v1.plyx )
+          ASSETS=( "${TARGET}.uf2" "${TARGET}.bin" )
           if [ "$HAVE_NOTES" = "1" ]; then
             NOTES_ARGS=( --title "$TITLE" --notes-file _release_body.md )
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,18 @@ jobs:
             NOTES_ARGS=( --title "PolyKybd Firmware $TAG" --generate-notes )
           fi
           if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "Release $TAG already exists — uploading assets (clobbering duplicates)."
+            # Release already exists — the normal path here, because release tags
+            # land on the auto-bump "[skip ci]" commit, so the tag-push trigger is
+            # suppressed and this workflow runs on `release: published` (the user
+            # published it in the UI). Apply the crafted notes from the branch if
+            # present (so the user can publish an empty release and let CI fill it),
+            # then upload assets.
+            if [ "$HAVE_NOTES" = "1" ]; then
+              echo "Release $TAG exists — applying crafted notes + uploading assets."
+              gh release edit "$TAG" --title "$TITLE" --notes-file _release_body.md
+            else
+              echo "Release $TAG exists — uploading assets (keeping existing notes)."
+            fi
             gh release upload "$TAG" "${ASSETS[@]}" --clobber
           else
             echo "Creating release $TAG (falls back to upload if a concurrent run won the create)."

--- a/scripts/publish_release.py
+++ b/scripts/publish_release.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Publish the prepared PolyKybd release with one OS-independent command.
+
+Run from anywhere inside either repo checkout:
+
+    python scripts/publish_release.py            # publish
+    python scripts/publish_release.py --dry-run  # show what it would do
+
+What it does (no bash-isms, no extra pip installs — Python 3.7+ stdlib only):
+  1. Auto-detects the repo (firmware qmk_firmware vs host PolyKybdHost) and the
+     current version from the DEFAULT branch (config.h / polyhost/_version.py),
+     so it is independent of whatever branch you have checked out.
+  2. Reads the prepared release notes for that tag from the unprotected
+     `release-notes` branch (`<TAG>.md`, first line `# <title>`, rest = body).
+  3. Creates + publishes the GitHub Release (or updates it if it already exists).
+     Firmware: publishing fires the `release: published` workflow, which builds
+     and attaches the .bin/.uf2 — you do NOT attach anything by hand.
+
+Auth: uses `GH_TOKEN` / `GITHUB_TOKEN` if set, else `gh auth token`. No token and
+no `gh` -> it tells you how to fix it. `gh` is optional; a token alone is enough.
+
+Tags:
+  firmware  PolyKybd-fw-v<version>   (target branch: PolyKybd)
+  host      v<version>               (target branch: main)
+"""
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+
+def run(cmd):
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
+def die(msg):
+    sys.exit("publish_release: " + msg)
+
+
+def repo_root():
+    r = run(["git", "rev-parse", "--show-toplevel"])
+    if r.returncode:
+        die("not inside a git repository.")
+    return r.stdout.strip()
+
+
+def detect(root):
+    """Return (kind, version_path, default_branch, tag_prefix)."""
+    if os.path.exists(os.path.join(root, "keyboards", "polykybd", "config.h")):
+        return ("firmware", "keyboards/polykybd/config.h", "PolyKybd", "PolyKybd-fw-v")
+    if os.path.exists(os.path.join(root, "polyhost", "_version.py")):
+        return ("host", "polyhost/_version.py", "main", "v")
+    die("can't tell which repo this is (no keyboards/polykybd/config.h or polyhost/_version.py).")
+
+
+def show(ref_path):
+    """`git show <ref>:<path>` -> text, or None if absent."""
+    r = run(["git", "show", ref_path])
+    return r.stdout if r.returncode == 0 else None
+
+
+def parse_version(kind, text):
+    if kind == "firmware":
+        m = re.search(r'#define\s+FW_VERSION\s+"(\d+\.\d+\.\d+)"', text)
+        if not m:
+            die("couldn't find FW_VERSION in config.h.")
+        return m.group(1)
+    maj = re.search(r'__major__\s*=\s*(\d+)', text)
+    mnr = re.search(r'__minor__\s*=\s*(\d+)', text)
+    pat = re.search(r'__patch__\s*=\s*(\d+)', text)
+    if not (maj and mnr and pat):
+        die("couldn't parse __major__/__minor__/__patch__ from _version.py.")
+    return f"{maj.group(1)}.{mnr.group(1)}.{pat.group(1)}"
+
+
+def owner_repo(root):
+    r = run(["git", "remote", "get-url", "origin"])
+    m = re.search(r"[:/]([^/]+)/([^/]+?)(?:\.git)?/?$", r.stdout.strip())
+    if not m:
+        die(f"couldn't parse owner/repo from origin remote: {r.stdout.strip()!r}")
+    return m.group(1), m.group(2)
+
+
+def get_token():
+    for var in ("GH_TOKEN", "GITHUB_TOKEN"):
+        if os.environ.get(var):
+            return os.environ[var]
+    r = run(["gh", "auth", "token"])
+    if r.returncode == 0 and r.stdout.strip():
+        return r.stdout.strip()
+    return None
+
+
+def api(token, method, path, payload=None):
+    url = "https://api.github.com" + path
+    data = json.dumps(payload).encode() if payload is not None else None
+    req = urllib.request.Request(url, data=data, method=method, headers={
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Content-Type": "application/json",
+        "User-Agent": "polykybd-publish-release",
+    })
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, json.load(resp)
+    except urllib.error.HTTPError as e:
+        try:
+            return e.code, json.load(e)
+        except Exception:
+            return e.code, {"message": e.read().decode(errors="replace")}
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Publish the prepared PolyKybd release.")
+    ap.add_argument("--dry-run", action="store_true", help="show what would happen, change nothing")
+    args = ap.parse_args()
+
+    root = repo_root()
+    kind, vpath, default_branch, tag_prefix = detect(root)
+
+    # Fetch the refs we read from (best-effort; fall back to whatever is local).
+    run(["git", "fetch", "origin", default_branch, "release-notes"])
+
+    vtext = show(f"origin/{default_branch}:{vpath}")
+    if vtext is None:
+        with open(os.path.join(root, vpath), encoding="utf-8") as fh:
+            vtext = fh.read()
+    version = parse_version(kind, vtext)
+    tag = tag_prefix + version
+
+    notes = show(f"origin/release-notes:{tag}.md")
+    if not notes or not notes.strip():
+        die(
+            f"no prepared notes for {tag} on the release-notes branch "
+            f"(expected release-notes:{tag}.md).\n"
+            f"  Draft + stage them first with the polykybd-github-release skill."
+        )
+    lines = notes.splitlines()
+    title = re.sub(r"^#\s*", "", lines[0]).strip()
+    body = "\n".join(lines[1:]).strip("\n")
+    if not title:
+        die(f"{tag}.md has an empty title line (first line must be '# <title>').")
+
+    owner, repo = owner_repo(root)
+
+    print(f"repo    : {owner}/{repo}  ({kind})")
+    print(f"tag     : {tag}   target: {default_branch}")
+    print(f"title   : {title}")
+    print(f"body    : {len(body)} chars, {body.count(chr(10)) + 1} lines")
+    print("-" * 60)
+    print(body)
+    print("-" * 60)
+
+    if args.dry_run:
+        print("dry-run: nothing published.")
+        return
+
+    token = get_token()
+    if not token:
+        die("no GitHub token. Set GH_TOKEN / GITHUB_TOKEN, or install gh and run `gh auth login`.")
+
+    status, rel = api(token, "GET", f"/repos/{owner}/{repo}/releases/tags/{tag}")
+    if status == 200:
+        st, res = api(token, "PATCH", f"/repos/{owner}/{repo}/releases/{rel['id']}",
+                      {"name": title, "body": body, "make_latest": "true", "draft": False})
+        if st >= 300:
+            die(f"updating existing release failed ({st}): {res.get('message')}")
+        print(f"updated existing release {tag}")
+        print(res.get("html_url"))
+        print("note: an already-published release does not re-trigger the build; "
+              "assets are only (re)built when the release is first published.")
+        return
+
+    st, res = api(token, "POST", f"/repos/{owner}/{repo}/releases", {
+        "tag_name": tag,
+        "target_commitish": default_branch,
+        "name": title,
+        "body": body,
+        "make_latest": "true",
+        "draft": False,
+        "prerelease": False,
+    })
+    if st >= 300:
+        die(f"creating release failed ({st}): {res.get('message')}")
+    print(f"published release {tag}")
+    print(res.get("html_url"))
+    if kind == "firmware":
+        print("firmware CI (release: published) will now build and attach the .bin/.uf2.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Makes cutting a release a single OS-independent command and fixes an incorrect assumption in the earlier release-notes automation.

**Background — a pushed tag does NOT create a release here.** Release tags land on the auto-bump `[skip ci]` commit, and `[skip ci]` suppresses the `push:` (tag) workflow trigger, so pushing `PolyKybd-fw-vX.Y.Z` runs nothing. Every historical firmware release run is a `release: published` event; releases are created by *publishing*.

### Changes
- **`scripts/publish_release.py`** — one command to publish the prepared release, OS-independent (Python 3.7+ stdlib only; works on Windows/macOS/Linux):
  ```
  python scripts/publish_release.py            # publish
  python scripts/publish_release.py --dry-run  # preview title+body
  ```
  Auto-detects the repo, reads the current version → tag from the default branch, pulls the staged `<TAG>.md` from the `release-notes` branch, and creates+publishes the release via the GitHub API (auth: `GH_TOKEN`/`GITHUB_TOKEN` or `gh auth token`). Publishing fires `release: published`, so CI builds and attaches the assets. Idempotent (updates an existing release).
- **`release.yml` — apply crafted notes on `release: published`.** On the "release already exists" path (the normal publish case) it now applies the crafted notes from the `release-notes` branch via `gh release edit`, then uploads assets. Previously that path only uploaded assets, so a published release never picked up the crafted notes.
- **`release.yml` — stop publishing the doom `.plyx` as a release asset.** The engine pack is still built by `build_pack.sh` but no longer uploaded — keeps the easter egg a surprise (a `doom_pack` asset would give it away; the shipping `.bin` refuses the trigger with no pack flashed). Release assets are now just `.bin` + `.uf2`.
- **Skill (`polykybd-github-release`)** updated to document the correct workflow and make `publish_release.py` the primary publish step.

⚠️ **Merge order:** because firmware CI runs on `release: published` using the **default-branch** workflow, merge this before publishing 0.9.44 so the release carries only `.bin`/`.uf2` (no `.plyx`).

## Version bump label

*(none)* — CI/tooling + skill docs only, no firmware or protocol change. Default patch bump is correct.

## Testing
- [x] `python scripts/publish_release.py --dry-run` in both repos: correct repo/tag/title/body parsed from the version file + release-notes branch
- [x] `release.yml` parses as valid YAML; notes-fetch falls back to `--generate-notes` when no branch file exists (backwards-compatible)
- [ ] Firmware compile — N/A, no firmware code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HRMsh3rzy2XbYjDaTGh7iF