### PR TITLE
docs: Releases section in CLAUDE.md + ship the doom .plyx again

### DIFF
--- a/.claude/skills/polykybd-github-release/SKILL.md
+++ b/.claude/skills/polykybd-github-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: polykybd-github-release
-description: Cut a GitHub Release for the PolyKybd firmware (qmk_firmware) or the host app (PolyKybdHost) — draft customer-facing release notes (newest version first, maintenance-only bumps skipped, concise, informative-over-funny), get the user's review, then publish with the correct tag, title, "latest" flag and (firmware) CI-built .bin/.uf2 assets. Use when asked to "cut/create/make/publish a release", "release the firmware/host", "release vX.Y.Z", "draft the release for …".
+description: Cut a GitHub Release for the PolyKybd firmware (qmk_firmware) or the host app (PolyKybdHost) — draft customer-facing release notes (newest version first, maintenance-only bumps skipped, concise, informative-over-funny), get the user's review, then publish with the correct tag, title, "latest" flag and (firmware) CI-built .bin/.uf2/.plyx assets. Use when asked to "cut/create/make/publish a release", "release the firmware/host", "release vX.Y.Z", "draft the release for …".
 ---
 
 # PolyKybd GitHub release
@@ -185,8 +185,8 @@ branch is an accumulating changelog archive — don't reuse or clear old files.
    robust to the version auto-bump every PR merge causes (the tree drifts ahead of the
    prepared release; the branch does not). `--tag <TAG>` targets a specific prepared tag.
    It creates+publishes via the GitHub API; firmware publishing fires `release: published`
-   → CI builds and attaches `.bin`/`.uf2` (the doom engine pack `.plyx` is built but
-   deliberately NOT attached — it would reveal the easter egg). Auth: `GH_TOKEN`/
+   → CI builds and attaches `.bin`/`.uf2`/`.plyx` (the last is the DOOM engine pack).
+   Auth: `GH_TOKEN`/
    `GITHUB_TOKEN` or `gh auth token`. Tell the user to run it in each repo after you've
    staged the notes. ⚠️ **Merging the notes/tooling PR bumps the version past the prepared
    one** — that's expected; the script still publishes the prepared tag from the branch.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,10 +53,7 @@ jobs:
           arm-none-eabi-objcopy -O binary \
             .build/${TARGET}.elf \
             ${TARGET}.bin
-          # NOTE: the doom engine pack (doom_pack_v1.plyx) is built by
-          # build_pack.sh but deliberately NOT published as a release asset —
-          # the easter egg stays a surprise (a "doom_pack" asset would reveal it,
-          # and the shipping .bin refuses the trigger with no pack flashed).
+          cp keyboards/polykybd/doom/pack/doom_pack_v1.plyx .
 
       # Crafted release notes (optional): one file per tag on the unprotected
       # `release-notes` branch — release-notes/<TAG>.md, first line "# <title>",
@@ -101,7 +98,7 @@ jobs:
           TITLE: ${{ steps.notes.outputs.title }}
         run: |
           TARGET=$(echo "${{ env.KB }}" | tr '/' '_')_${{ env.KM }}
-          ASSETS=( "${TARGET}.uf2" "${TARGET}.bin" )
+          ASSETS=( "${TARGET}.uf2" "${TARGET}.bin" doom_pack_v1.plyx )
           if [ "$HAVE_NOTES" = "1" ]; then
             NOTES_ARGS=( --title "$TITLE" --notes-file _release_body.md )
           else

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,38 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
 - **Docker is NOT usable** in the remote container (no daemon) — use the native toolchain above, not the qmk docker image.
 - The `firmware-size-diff` skill builds HEAD vs working tree and diffs sizes / `.text`.
 
+## Releases
+
+Firmware releases are **GitHub Releases** (tag `PolyKybd-fw-vX.Y.Z`; `FW_VERSION` in
+`config.h`), created by **publishing** — *not* by pushing a tag. Use the
+`polykybd-github-release` skill to draft the notes and drive the flow. The mechanics
+that cost real debugging to learn (2026-07):
+
+- **A pushed tag does NOT create a release.** Release tags land on the auto-bump
+  `chore: … [skip ci]` commit (`bump-version.yml`), and `[skip ci]` **suppresses the
+  tag-push workflow trigger** — so `release.yml` runs on **`release: published`** (every
+  historical run is a `release` event; a bare tag push builds nothing). Publishing
+  (UI / `gh release create` / the script below) is what starts the build + asset upload.
+- **`scripts/publish_release.py`** — one OS-independent command (stdlib only). It
+  publishes the **newest prepared `<TAG>.md` on the `release-notes` branch**, which is
+  the **source of truth for what's ready**: the tree version drifts *ahead* of the
+  prepared release because every PR merge auto-bumps it, so don't derive the tag from
+  the tree. `--dry-run` previews; `--tag` targets a specific prepared tag. It forces
+  `encoding="utf-8"` on git output — on Windows the default cp1252 codec crashes on the
+  emoji/em-dashes in the notes (`UnicodeDecodeError` → notes read as `None`).
+- **Crafted notes** live one-file-per-tag on the unprotected `release-notes` branch
+  (`<TAG>.md`, first line `# <title>`, rest = body; never overwritten/deleted — a
+  changelog archive). `release.yml` applies them on `release: published` via
+  `gh release edit`, then attaches the built `.bin`/`.uf2`/`.plyx` (the `.plyx` is the
+  DOOM engine pack — license-OK to ship; the shareware WAD is *not* a release asset, it's
+  downloaded on demand by `doom/tools/dl-doom-data.sh`).
+- **Version bump is label-driven**: the merged PR's `bump:major`/`bump:minor`/
+  `bump:protocol` label (else patch) drives `bump-version.yml`. Protocol PRs often bump
+  `PROTOCOL_VERSION` in-source and *omit* `bump:protocol` (the label would double-bump).
+- ⚠️ **From Claude Code on the web you can neither push tags (git proxy returns 403 on
+  `refs/tags/*`) nor create a release (no `gh` CLI, no create-release MCP tool)** — stage
+  the notes on the branch and hand the user `python scripts/publish_release.py`.
+
 ## Firmware overview (`keyboards/polykybd/`)
 
 The firmware runs on a **Raspberry Pi RP2040** (133 MHz dual-core ARM M0+) and is a heavily customised QMK build. This is **custom hardware with 8 MB of external QSPI flash** (NOT the stock 2 MB). The 8 MB is **partitioned** (see `base/fw_staging.h` for the authoritative map): **0–2 MB running firmware** (the linker `flash1` XIP window), **2–4 MB firmware-update staging**, **4–8 MB resource/overlay data** (`FLASH_TARGET_OFFSET`). So the budget that matters for adding languages/fonts is the **2 MB firmware partition**, of which `split72:default` currently uses ~0.76 MB (~38 %). `FW_STAGING_OFFSET` is kept equal to the linker `flash1` length so a build that exceeds 2 MB fails to *link* rather than silently growing into the staging area (this firmware/staging split was raised from 1 MB → 2 MB in 2026-06 as the image neared the old boundary). The keyboard is split (left + right halves connected via UART) with up to 72 per-keycap OLED displays (72×40 px monochrome, SPI-driven) plus a 128×64 status OLED.


### PR DESCRIPTION
## Summary

Session-retro doc capture plus a revert of the earlier `.plyx` removal.

- **`CLAUDE.md` — new `## Releases` section.** Documents the release mechanism that cost real debugging this session: a **pushed tag does NOT create a release** (release tags land on the auto-bump `[skip ci]` commit, which suppresses the tag-push trigger — CI runs on `release: published`); `scripts/publish_release.py` (the `release-notes` branch is the source of truth, since the tree version drifts ahead on every merge; forces UTF-8 for Windows); label-driven version bumps; and the web-env constraints (can't push tags — proxy 403 — or create a release).
- **`release.yml` — restore `doom_pack_v1.plyx` as a release asset.** Shipping the GPL rp2040-doom engine pack is license-OK, and the doom README already documents grabbing the `.plyx` from a release; the shareware **WAD** stays download-on-demand (never a release asset). Reverts the "keep it a surprise" removal — the notes already headline DOOM. (Applies to future releases; 0.9.44 is left as published.)
- **Skill:** `.plyx` is attached again.

## Version bump label

*(none)* — docs + CI asset list; no firmware or protocol change.

## Testing
- [x] `release.yml` parses as valid YAML; ASSETS = `.uf2` + `.bin` + `doom_pack_v1.plyx`, `.plyx` copied into the workspace before upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HRMsh3rzy2XbYjDaTGh7iF

---
_Generated by [Claude Code](https://claude.ai/code/session_01HRMsh3rzy2XbYjDaTGh7iF)_