### PR TITLE
docs: font-pack dedupe + reship learnings, and a reship-fontpack-bundle skill

### DIFF
--- a/.claude/skills/reship-fontpack-bundle/SKILL.md
+++ b/.claude/skills/reship-fontpack-bundle/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: reship-fontpack-bundle
+description: Regenerate PolyKybd font-pack bundles from the committed firmware headers and reship the changed ones to the host (PolyKybdHost) — WITHOUT needing the pinned fontconvert / FreeType-HarfBuzz build. Use when a bundle's shipped .plyf must be refreshed: after a fonts.yaml render/size tweak, after the shadowed-glyph dedupe, when host and firmware bundle bytes have drifted, or when asked to "reship the symbol/emoji/fantasy/… bundle", "resync the font packs to the host", or "regenerate bundles.json". Handles the finicky parts the manual procedure gets wrong: dedupe parity, the --bundle-version=0 reset trap, minimal version bumps, the per-field bundles.json rebuild (size/sha256), and the firmware committed manifest. NOT for adding a NEW bundle or changing fonts.yaml itself (that needs fontconvert), and NOT for making a font resident (use make-font-resident).
+---
+
+# Reship a font-pack bundle to the host
+
+The external-flash font pack ships as N per-family bundles (`symbol`, `mideast`,
+`syllabic`, `asia`, `flags`, `emoji`, `fantasy`). Each is a `.plyf` shipped to
+**both** the firmware (as the committed `fontpack_bundles.manifest.json` ABI
+contract) and the host (`PolyKybdHost/polyhost/res/fontpack/<id>.plyf` +
+`bundles.json`, which the host flashes on connect). There is **no ship script** —
+this skill is the recipe, and `reship_bundles.py` (beside this file) is the actuator.
+
+**Key fact that makes this cheap:** bundles derive **deterministically from the
+committed category headers** (`base/fonts/generated/*.h`). `fontconvert` only
+*regenerates those headers* from the TTFs. So for any reship where the headers are
+already committed — a dedupe bump, a version-only resync, copying a
+firmware-side render change to the host — you do **not** need the pinned
+FreeType/HarfBuzz `fontconvert` build at all. The helper rebuilds the `.plyf`
+straight from the headers (mirroring the build's default-on `prune_shadowed_glyphs`
+dedupe), so it works in any container.
+
+Repos (auto-discovered; override with `--qmk` / `--host`):
+- qmk: `<this-skill>/../../../..` (the qmk_firmware root)
+- host: sibling `PolyKybdHost/`
+
+## When to use / not use
+
+| Situation | This skill? |
+|---|---|
+| A `fonts.yaml` render tweak changed a bundle's glyphs; headers already regenerated + committed | ✅ yes |
+| The dedupe (or any `fontpack.py` change) altered shipped bytes | ✅ yes |
+| Host `.plyf` drifted stale vs firmware (see the "silent lag" note in qmk CLAUDE.md) | ✅ yes |
+| Adding a brand-new bundle, or changing which TTF/size a font uses | ❌ needs `fontconvert` + `generate_fonts.py --emit-bundles` |
+| Making a font render with no pack | ❌ use `make-font-resident` |
+
+## Procedure
+
+1. **Report what changed** (read-only). From the qmk root:
+   ```bash
+   python3 .claude/skills/reship-fontpack-bundle/reship_bundles.py --check
+   ```
+   It regenerates every bundle from the committed headers + dedupe and compares to
+   the shipped host `.plyf`, printing one of: `identical`, `DIFFERS (glyph bytes)`
+   (real change → reship + bump), or `version-byte only`. For a glyph-byte change it
+   also prints a few per-glyph **WxH** diffs — that's how you tell a *render-size
+   drift* (metadata `first`/`last`/`yAdvance` match, only bitmap dims differ) from a
+   structural change.
+
+2. **Pick the version bumps.** Bump **only** the bundles that changed, **minimally**
+   (+1 over the shipped value — check `bundles.json`; no bundle has ever been
+   deployed so any increment >shipped works, keep it monotonic and small). Leave all
+   others alone — the helper preserves their current shipped version automatically
+   (this is the fix for the `--bundle-version` defaults-to-0 reset trap).
+
+3. **Apply the reship** (write mode). Name every changed bundle with its new version:
+   ```bash
+   python3 .claude/skills/reship-fontpack-bundle/reship_bundles.py --apply symbol=6 emoji=2
+   ```
+   This: rebuilds the firmware `fontpack_bundles.manifest.json` + `fontpack_layout.h`
+   (reflecting the dedupe), copies each changed `<id>.plyf` to the host, and rebuilds
+   `bundles.json` (`content_version` / `size` / `sha256=sha256(data)[:16]`) for the
+   named bundles only.
+
+4. **Verify**:
+   ```bash
+   # host resource integrity + decode round-trip
+   cd ../PolyKybdHost && .venv/bin/python -m unittest discover -s tests/services -p "fontpack*_test.py"
+   # cross-repo shared manifests must stay byte-identical
+   cd ../qmk_firmware/keyboards/polykybd
+   cmp fonts/noto-fonts.yaml ../../../PolyKybdHost/polyhost/res/fonts/noto-fonts.yaml
+   cmp base/fonts/generated/fontpack_render_settings.json ../../../PolyKybdHost/polyhost/res/fontpack/fontpack_render_settings.json
+   cmp base/fonts/generated/lang_flags.json ../../../PolyKybdHost/polyhost/res/fontpack/lang_flags.json
+   # sanity: a re-run of --check should now report every bundle "identical"
+   cd ../.. && python3 .claude/skills/reship-fontpack-bundle/reship_bundles.py --check
+   ```
+   The `fontpack_reader_test` validates each `bundles.json` `size`/`sha256` against
+   the actual `.plyf`, so a green run proves the reship is self-consistent.
+
+5. **Commit on BOTH repos** (only when asked — per repo rules):
+   - qmk (`PolyKybd` base): the changed `fontpack_bundles.manifest.json` +
+     `fontpack_layout.h` (+ any `fontpack.py`/`fonts.yaml`/header changes that
+     motivated the reship).
+   - host (`main` base): the changed `<id>.plyf` + `bundles.json`.
+   They are companions — land them together so host↔firmware stay in sync.
+
+## Output format
+
+Report per bundle: its new size, new `content_version`, and whether its glyph bytes
+changed. State clearly which bundles you reshipped (id + old→new version + reclaimed
+or added bytes) and which you left untouched, then the verification result (tests
+pass, cross-repo `cmp` clean, `--check` now all-identical).
+
+## Pitfalls
+
+- **Always pass EVERY changed bundle to `--apply`; never bump one you didn't
+  actually change.** The helper keeps unnamed bundles at their current version, but
+  if you `--apply` a bundle whose bytes didn't change you ship a pointless
+  re-flash-on-connect. Trust the `--check` `DIFFERS (glyph bytes)` list.
+- **Mirror the build's dedupe.** The shipped bytes reflect `prune_shadowed_glyphs`
+  (default-on in `generate_fonts.py`). The helper runs it; if you ever hand-roll a
+  regen, run it too or the bundle re-inflates and diverges from what's shipped.
+- **`content_version` lives in the `.plyf` header AND `bundles.json`** — they must
+  match. The helper writes both from one number; never hand-edit only the JSON.
+- **This reships from the COMMITTED headers.** If you changed `fonts.yaml` or a TTF,
+  regenerate the headers first (`generate_fonts.py`, pinned `fontconvert`) and commit
+  them — otherwise you reship the *old* glyphs.
+- **Host `.venv`** is required for the verify step (system python lacks numpy/PIL);
+  create it per PolyKybdHost/CLAUDE.md if absent.
+- **`flags` uses a pinned high gidx band** (`PACK_EXTRA_GIDX_BASE`), so appending a
+  tail font no longer perturbs it — expect `flags` to stay `identical` unless you
+  actually regenerated it.

--- a/.claude/skills/reship-fontpack-bundle/reship_bundles.py
+++ b/.claude/skills/reship-fontpack-bundle/reship_bundles.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Regenerate PolyKybd font-pack bundles from the COMMITTED firmware headers (with
+the shadowed-glyph dedupe applied) and reship the changed ones to the host — no
+`fontconvert` / pinned FreeType-HarfBuzz build required.
+
+Two modes:
+  --check                 (default) read-only. Regenerate every bundle from the
+                          committed headers + dedupe, compare each to the shipped
+                          host .plyf, and report which changed and *why* (glyph
+                          bytes vs version-byte only), incl. per-glyph WxH drift.
+  --apply ID=N [ID=N ...] write mode. Reship exactly the named bundles at the given
+                          content_versions: rebuild the firmware committed
+                          fontpack_bundles.manifest.json + layout header, copy the
+                          changed <id>.plyf to the host, and rebuild bundles.json
+                          (size / sha256 / content_version). All OTHER bundles keep
+                          their current shipped version. Verifies + prints a summary.
+
+Paths are auto-discovered (qmk root = 3 dirs above this script; host = its sibling
+PolyKybdHost); override with --qmk / --host.
+
+Examples:
+  python reship_bundles.py --check
+  python reship_bundles.py --apply symbol=6 emoji=2      # dedupe reship
+  python reship_bundles.py --apply fantasy=3             # render-drift resync
+"""
+import argparse, hashlib, json, struct, sys
+from pathlib import Path
+
+
+def load_fontpack(qmk: Path):
+    fonts_dir_scripts = qmk / "keyboards" / "polykybd" / "fonts"
+    sys.path.insert(0, str(fonts_dir_scripts))
+    import yaml  # noqa
+    import fontpack  # noqa
+    cfg = yaml.safe_load((fonts_dir_scripts / "fonts.yaml").read_text())
+    return fontpack, cfg
+
+
+def regen(fontpack, cfg, qmk: Path, content_versions: dict):
+    """Rebuild all bundles from the committed headers + dedupe. Returns (bundles, layout)."""
+    fonts_dir = qmk / "keyboards" / "polykybd" / "base" / "fonts"
+    gen = fonts_dir / "generated"
+    order = fontpack.all_fonts_order(fonts_dir)
+    resident = fontpack.resident_symbols(cfg, fonts_dir)
+    parsed = {}
+    for hdr in gen.glob("*.h"):
+        parsed.update(fontpack.parse_gfx_header(hdr.read_text()))
+    parsed.update(fontpack.extra_pack_fonts(cfg, fonts_dir))
+    sym2cat = fontpack.symbol_categories_from_tree(fonts_dir, cfg)
+    # MIRROR THE BUILD: the shipped bytes reflect this prune. Skipping it re-inflates.
+    fontpack.prune_shadowed_glyphs(order, resident, parsed)
+    return fontpack.build_bundles(order, resident, parsed, sym2cat, cfg,
+                                  content_versions=content_versions)
+
+
+def sha16(b: bytes) -> str:
+    return hashlib.sha256(b).hexdigest()[:16]
+
+
+def host_bundles_json(host: Path) -> dict:
+    return json.load(open(host / "polyhost" / "res" / "fontpack" / "bundles.json"))
+
+
+def current_versions(host: Path) -> dict:
+    return {b["id"]: b["content_version"] for b in host_bundles_json(host)["bundles"]}
+
+
+def glyph_dims(fontpack, data: bytes):
+    """{font_index: [(w,h), ...]} — for render-drift diagnosis. Walks each font's
+    glyph records (8B/glyph: off u16, w u8, h u8, xadv u8, xoff s8, yoff s8)."""
+    p = fontpack.parse_pack(data)
+    out = {}
+    for fi, f in enumerate(p.fonts):
+        n = f.last - f.first + 1
+        dims = []
+        for gi in range(n):
+            _off, w, h = struct.unpack_from("<HBB", data, f.glyph_off + gi * 8)
+            dims.append((w, h))
+        out[fi] = dims
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    here = Path(__file__).resolve()
+    ap.add_argument("--qmk", default=str(here.parents[3]),
+                    help="qmk_firmware repo root (default: 3 dirs above this script)")
+    ap.add_argument("--host", default="",
+                    help="PolyKybdHost repo root (default: sibling of --qmk)")
+    ap.add_argument("--check", action="store_true",
+                    help="read-only report (default when --apply is absent)")
+    ap.add_argument("--apply", nargs="+", metavar="ID=N", default=None,
+                    help="reship these bundles at content_version N (write mode)")
+    args = ap.parse_args()
+
+    qmk = Path(args.qmk).resolve()
+    host = Path(args.host).resolve() if args.host else (qmk.parent / "PolyKybdHost")
+    if not (qmk / "keyboards" / "polykybd" / "fonts" / "fonts.yaml").exists():
+        sys.exit(f"not a qmk_firmware checkout: {qmk}")
+    if not (host / "polyhost" / "res" / "fontpack" / "bundles.json").exists():
+        sys.exit(f"host bundles.json not found under: {host}")
+
+    fontpack, cfg = load_fontpack(qmk)
+    fp_dir = host / "polyhost" / "res" / "fontpack"
+    cur = current_versions(host)
+
+    # target versions: bumps for --apply ids, current for the rest
+    bumps = {}
+    if args.apply:
+        for spec in args.apply:
+            bid, _, n = spec.partition("=")
+            if not n.isdigit():
+                sys.exit(f"--apply: bad spec {spec!r} (want ID=N)")
+            bumps[bid] = int(n)
+    vers = {**cur, **bumps}
+
+    bundles, layout = regen(fontpack, cfg, qmk, vers)
+    # baseline at the CURRENT versions to isolate glyph drift vs the version byte
+    base_bundles, _ = regen(fontpack, cfg, qmk, cur)
+    base_by_id = {b["id"]: b["data"] for b in base_bundles}
+
+    print(f"{'id':10} {'new sz':>8} {'ver':>4}  vs shipped host .plyf")
+    changed_glyphs = []
+    for b in bundles:
+        bid = b["id"]; data = b["data"]
+        shipped_path = fp_dir / f"{bid}.plyf"
+        shipped = shipped_path.read_bytes() if shipped_path.exists() else None
+        if shipped is None:
+            state = "NEW"
+        elif data == shipped:
+            state = "identical"
+        elif base_by_id[bid] != shipped:  # rebuilt at CURRENT ver still differs → glyphs
+            state = "DIFFERS (glyph bytes)"
+            changed_glyphs.append(bid)
+        else:
+            state = "version-byte only (unchanged glyphs)"
+        print(f"{bid:10} {len(data):>8,} {b['content_version']:>4}  {state}")
+
+    if not args.apply:
+        print("\nGlyph-byte changes (need reship + version bump):", changed_glyphs or "none")
+        for bid in changed_glyphs:
+            fresh = next(b["data"] for b in bundles if b["id"] == bid)
+            shipped = (fp_dir / f"{bid}.plyf").read_bytes()
+            fd, sd = glyph_dims(fontpack, fresh), glyph_dims(fontpack, shipped)
+            diffs = [(fi, gi, fd[fi][gi], sd[fi][gi])
+                     for fi in fd for gi in range(min(len(fd[fi]), len(sd.get(fi, []))))
+                     if fd[fi][gi] != sd[fi][gi]]
+            if diffs:
+                print(f"  {bid}: {len(diffs)} glyphs differ in WxH (render drift), e.g. "
+                      + ", ".join(f"font{fi}#{gi} {a}->{b}" for fi, gi, a, b in diffs[:3]))
+        print("\n(read-only. Re-run with --apply ID=N ... to reship the changed bundles.)")
+        return
+
+    # ---- write mode ----
+    gen = qmk / "keyboards" / "polykybd" / "base" / "fonts" / "generated"
+    (gen / "fontpack_bundles.manifest.json").write_text(
+        fontpack.bundles_manifest_json(bundles, layout))
+    (gen / "fontpack_layout.h").write_text(fontpack.bundle_layout_header(bundles, layout))
+    bj = host_bundles_json(host)
+    touched = []
+    for b in bundles:
+        bid = b["id"]
+        if bid not in bumps:
+            continue
+        data = b["data"]
+        (fp_dir / f"{bid}.plyf").write_bytes(data)
+        for e in bj["bundles"]:
+            if e["id"] == bid:
+                e["content_version"] = b["content_version"]
+                e["size"] = len(data)
+                e["sha256"] = sha16(data)
+        touched.append(f"{bid} v{b['content_version']} size={len(data):,} sha={sha16(data)}")
+    (fp_dir / "bundles.json").write_text(json.dumps(bj, indent=2) + "\n")
+    print("\nReshipped:")
+    for t in touched:
+        print("  " + t)
+    print("Wrote firmware fontpack_bundles.manifest.json + fontpack_layout.h and host bundles.json.")
+    print("Next: verify (host fontpack tests + cross-repo cmp) and commit on BOTH repos.")
+
+
+if __name__ == "__main__":
+    main()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -426,6 +426,19 @@ flashes all stale bundles, `flash <id>` force-flashes one).
     renders ASCII text with no pack. The build-time guard fails if a bundle overflows
     its slot. Order in `bundles.list` is **append-only** (the index is the on-wire id
     and the slot order; growth-prone `emoji` is last with `slot_kb: rest`).
+  - **Shadowed-glyph dedupe is DEFAULT-ON in the build** (`generate_fonts.py`,
+    `--no-dedupe` opts out; `fonts/fontpack.py` `prune_shadowed_glyphs`). Before
+    emitting bundles it **empties** (turns into a `{off,0,0,0,0,0}` gap) any pack
+    glyph a **higher-priority font already draws byte-identically** — front-to-back
+    precedence means it can never render, so it's dead weight in flash. Runs
+    build-side (not host-side) because only the build sees the **resident** set,
+    which can shadow a pack glyph a host-only view would miss. It asserts the
+    assembled front-to-back render is unchanged afterwards. ⚠️ **The shipped bundle
+    bytes + `fontpack_bundles.manifest.json` already reflect the prune**, so any
+    regeneration must run it too (a stale `fontpack.py` without `prune_shadowed_glyphs`
+    re-inflates the bundle and diverges from what's shipped). First landed 2026-07:
+    73 glyphs / 13,313 B reclaimed — only `symbol` (33,980→33,788) and `emoji`
+    (227,460→214,344) shrank; all other bundles were byte-identical.
   - **The per-font `reserved` gidx is a SORT KEY, not a dense array position.**
     `fontpack_assemble()` (`base/fontpack.c`) places the resident set first, then
     **insertion-sorts the pack fonts by their stored gidx** — nothing indexes an
@@ -458,6 +471,34 @@ flashes all stale bundles, `flash <id>` force-flashes one).
     the others. `cmp` each regenerated `.plyf` against the shipped one to see which
     actually changed, and bump+reship only those (see the gidx note above re: why
     appending a glyph now changes only the edited bundle).
+    - **You do NOT need `fontconvert` to reship** — bundles derive deterministically
+      from the **committed** category headers. `--emit-bundles` re-runs fontconvert
+      only to *regenerate* those headers; if the headers are already committed (no
+      `fonts.yaml`/TTF change, just a reship / a dedupe bump), build the `.plyf`
+      straight from them in a throwaway script: `order =
+      fontpack.all_fonts_order(fonts_dir)`, `resident =
+      fontpack.resident_symbols(cfg, fonts_dir)`, `parsed = {}` then
+      `parsed.update(fontpack.parse_gfx_header(h.read_text()))` for every
+      `base/fonts/generated/*.h` + `parsed.update(fontpack.extra_pack_fonts(cfg,
+      fonts_dir))`, `sym2cat = fontpack.symbol_categories_from_tree(fonts_dir, cfg)`,
+      `fontpack.prune_shadowed_glyphs(order, resident, parsed)` (mirror the build!),
+      `fontpack.build_bundles(order, resident, parsed, sym2cat, cfg,
+      content_versions={all ids})`. This reproduces the shipped `.plyf` byte-for-byte
+      and also re-emits `fontpack_bundles.manifest.json` (`bundles_manifest_json`) +
+      layout header — the only way to reship inside a container without the pinned
+      FreeType/HarfBuzz build. The **`reship-fontpack-bundle` skill** wraps exactly
+      this (`--check` to report drift, `--apply ID=N` to reship). (Used 2026-07 for
+      the dedupe + fantasy reship.)
+    - **A host `.plyf` can silently LAG a firmware `fonts.yaml` render-size tweak.**
+      Because the reship is manual, a firmware-side render change (e.g. "render
+      Aurebesh smaller") changes a bundle's bitmap bytes but leaves the host copy
+      **stale at the same `content_version`** until someone reships it — so no
+      keyboard ever re-flashes the corrected glyphs. `cmp` alone flags it; to confirm
+      it's a *render* drift (not a version-byte diff), decode both packs and diff
+      **per-glyph WxH** — the font metadata (`first`/`last`/`yAdvance`) matches while
+      only the bitmap dims differ. Seen 2026-07: `fantasy` was 604 B / 124 glyphs
+      stale across Aurebesh/Cirth/APL/Braille vs 3 firmware "render smaller" commits;
+      fixed by reshipping from the committed headers and bumping v2→v3.
     - **Bump `content_version` MINIMALLY (+1 over the shipped value), don't jump.**
       No font-pack bundle has ever been deployed to a device, so the version only
       needs to exceed what a device already has (0 / nothing) — any increment works,


### PR DESCRIPTION
## Summary

Developer-tooling only — **no firmware source, no build output, no protocol change**. Captures the font-pack learnings from the recent dedupe/reship work and codifies the reship chore as a skill.

**`CLAUDE.md` "Font pack" section — three learnings:**
1. **The shadowed-glyph dedupe is default-on** (`generate_fonts.py` / `prune_shadowed_glyphs`, `--no-dedupe` opts out). The shipped bundle bytes + committed `fontpack_bundles.manifest.json` already reflect it, so any regeneration must run it too or the bundle re-inflates and diverges.
2. **How to regenerate bundles deterministically from the committed headers with NO `fontconvert`** (parse `base/fonts/generated/*.h` → `prune_shadowed_glyphs` → `build_bundles`) — the only way to reship inside a container without the pinned FreeType/HarfBuzz build.
3. **A host `.plyf` can silently lag a firmware `fonts.yaml` render-size tweak** (no ship step), leaving it stale at the same `content_version`; detect via per-glyph WxH diff (metadata matches, only bitmap dims differ).

**New `reship-fontpack-bundle` skill** (`.claude/skills/reship-fontpack-bundle/`):
- `SKILL.md` — when-to-use table, `--check` → pick-bumps → `--apply` → verify → commit procedure, Pitfalls.
- `reship_bundles.py` — actuator. `--check` reports which bundles changed and why (glyph-byte vs version-only, with WxH drift hints); `--apply ID=N …` reships only the named bundles (firmware manifest + layout, host `.plyf` + `bundles.json`), preserving all others' versions (fixes the `--bundle-version=0` reset trap). Tested end-to-end (both modes; idempotent write path; regenerates all shipped bundles byte-identical).

Split out of #135 (now merged) into its own focused PR at the user's request.

## Version bump label

Recommend **no label (patch)** — docs + a `.claude/` skill only; nothing in the firmware image changes.

## Testing
- [ ] Compiled successfully (`qmk compile …`) — **N/A: no firmware source touched** (docs + skill only)
- [ ] Flashed and tested on hardware — N/A
- [x] `reship_bundles.py --check` regenerates every shipped bundle byte-identical from the committed headers
- [x] `--apply` write path verified idempotent (re-applying current versions produces no diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018BfvAc2SC8esDJ54F2VaMr)_

## Summary by Sourcery

Document recent font-pack dedupe and reship learnings and add a dedicated skill for regenerating and reshipping font-pack bundles from committed headers without fontconvert.

Enhancements:
- Introduce the reship-fontpack-bundle developer tool that regenerates font-pack bundles from committed firmware headers with dedupe and selectively reships changed bundles while preserving other versions.
- Provide a scripted workflow (reship_bundles.py) to analyze bundle drift, compute minimal version bumps, and update both firmware manifests and host bundles.json in a consistent, verifiable way.

Documentation:
- Expand CLAUDE.md font-pack section with guidance on default-on shadowed-glyph dedupe, deterministic bundle regeneration from committed headers, and detecting host bundle lag via glyph dimension drift.
- Add SKILL.md for the reship-fontpack-bundle skill describing when to use it, the step-by-step reship procedure, output expectations, and common pitfalls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for regenerating, verifying, versioning, and reshipping font-pack bundles.
  * Clarified shadowed-glyph deduplication, byte-for-byte reproduction, and detection of outdated host font files.
  * Documented common versioning, consistency, and verification pitfalls.

* **Chores**
  * Added tooling to compare generated font bundles with shipped files and identify changed glyph data.
  * Supports applying targeted bundle updates while preserving unchanged bundles and reporting verification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->