### PR TITLE
feat: progressive boot splash as an always-on boot-progress indicator

### DIFF
--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -2757,18 +2757,70 @@ void post_process_record_user(uint16_t keycode, keyrecord_t* record) {
     update_performed();
 };
 
-// Displays splash screen with polykybd/split72 logo and initializes displays with refresh.
-void show_splash_screen(void) {
-    clear_all_displays();
-    if(is_left_side()) {
-        display_message(1, 1, U"POLY", &FreeSansBold24pt7b);
-        display_message(2, 1, U"KYBD", &FreeSansBold24pt7b);
-    } else {
-        display_message(1, 1, POLY_SPLASH_R1, &FreeSansBold24pt7b);
-        display_message(POLY_SPLASH_R2_ROW, 1, POLY_SPLASH_R2, &FreeSansBold24pt7b);
+// Progressive boot splash — an always-on boot-progress indicator (no compile
+// flag). The splash is revealed a little more at each boot milestone: stage 0
+// from keyboard_pre_init_user(), stages 1..4 from points in
+// keyboard_post_init_user(). A boot that HANGS therefore freezes the reveal
+// exactly where it stalled, instead of showing a complete, uninformative splash.
+// A healthy boot fills in to the full "POLY KYBD" / "SPLIT 72" in well under a
+// second and then hands the keycaps over to the real key legends.
+//
+//   Frozen state (see readme.md "Boot splash progress")   ->  where it stalled
+//   ---------------------------------------------------       ----------------
+//   row 1 half word ("PO" / "SP")                             QMK split/USB init
+//                                                             (fw-apply: the
+//                                                              slave never
+//                                                              rebooted)
+//   row 1 full, row 2 blank ("POLY" / "SPLIT")                early post_init /
+//                                                             core1 launch
+//   full splash, never replaced by legends                   late post_init /
+//                                                             first render
+//   full splash briefly, then real key legends               healthy boot
+//
+// Only the last stage renders the real legends, so on a healthy boot the splash
+// visibly completes before the keyboard "comes alive". is_left_side() must be
+// resolved (set_side()) before any call — it is, at every call site.
+enum { SPLASH_STAGES = 5 };
+static void splash_progress(uint8_t stage) {
+    if (stage >= SPLASH_STAGES) {
+        stage = SPLASH_STAGES - 1;
     }
-    wait_ms(400);
-    update_displays(ALL_AT_ONCE);
+    const uint32_t* r1_word = is_left_side() ? U"POLY" : POLY_SPLASH_R1;
+    const uint32_t* r2_word = is_left_side() ? U"KYBD" : POLY_SPLASH_R2;
+    const uint8_t   r2_row  = is_left_side() ? 2       : POLY_SPLASH_R2_ROW;
+    // Number of row-1 glyphs revealed at each stage (255 = the whole word). The
+    // half-word stage 0 is the pre-split-init state, so a split/USB-init hang
+    // (the fw-apply "slave not rebooted" case) freezes on a visibly partial word.
+    static const uint8_t r1_reveal[SPLASH_STAGES] = { 2, 4, 255, 255, 255 };
+
+    // NUL-terminated truncated copy of the row-1 word (words are <= 5 glyphs).
+    uint32_t r1buf[9];
+    uint8_t n = r1_reveal[stage];
+    uint8_t i = 0;
+    for (; i < n && i < 8 && r1_word[i] != 0; ++i) {
+        r1buf[i] = r1_word[i];
+    }
+    r1buf[i] = 0;
+
+    clear_all_displays();
+    display_message(1, 1, r1buf, &FreeSansBold24pt7b);
+    if (stage >= 3) {                       // row 2 only once we're nearly booted
+        display_message(r2_row, 1, r2_word, &FreeSansBold24pt7b);
+    }
+    if (stage >= SPLASH_STAGES - 1) {
+        // Boot complete: dwell on the finished splash, then hand the keycaps
+        // over to the real legends — the same tail show_splash_screen() always
+        // ran, now deferred to the end of boot so the reveal is meaningful.
+        wait_ms(400);
+        update_displays(ALL_AT_ONCE);
+    }
+}
+
+// Displays the FIRST boot-splash stage (partial). Kept as the external symbol /
+// pre-init call site; the later stages are driven directly from
+// keyboard_post_init_user() via splash_progress().
+void show_splash_screen(void) {
+    splash_progress(0);
 }
 
 // Configures all displays with contrast level; shows idle pulsating animation if enabled.
@@ -2876,6 +2928,11 @@ void keyboard_post_init_user(void) {
     set_com_state(is_keyboard_master() ? USB_HOST : BRIDGE);
     set_side(is_keyboard_left() ? LEFT_SIDE : RIGHT_SIDE);
 
+    // Boot-splash progress: reaching post_init proves QMK's split/USB init got
+    // past the point where the fw-apply "slave not rebooted" hang stalls. Reveal
+    // more of the splash here (right after set_side, so is_left_side() is valid).
+    splash_progress(1);
+
 #ifdef POLYKYBD_LTR559
     // Probe for the LTR-559 on BOTH halves — it can be soldered to either half's
     // expansion port (GP0/GP1 I2C exists on both). The half that finds it uses it;
@@ -2906,12 +2963,14 @@ void keyboard_post_init_user(void) {
 #ifdef FW_UP_BOOT_TRACE
     boot_trace(U"2");
 #endif
+    splash_progress(2);                 // before core1 launch: row 1 completes
 #ifdef USE_CORE1
     multicore_launch_core1();
 #endif
 #ifdef FW_UP_BOOT_TRACE
     boot_trace(U"3");
 #endif
+    splash_progress(3);                 // core1 up: row 2 appears
 
     transaction_register_rpc(USER_SYNC_POLY_DATA,           user_sync_poly_data_handler);
     transaction_register_rpc(USER_SYNC_LAYER_DATA,          user_sync_layer_data_handler);
@@ -2967,6 +3026,7 @@ void keyboard_post_init_user(void) {
 #ifdef FW_UP_BOOT_TRACE
     boot_trace(U"4");
 #endif
+    splash_progress(4);                 // boot complete: full splash, then legends
 }
 
 // Pre-initialization setup: initializes display hardware, loads EEPROM config, shows splash screen.

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -2758,56 +2758,69 @@ void post_process_record_user(uint16_t keycode, keyrecord_t* record) {
 };
 
 // Progressive boot splash — an always-on boot-progress indicator (no compile
-// flag). The splash is revealed a little more at each boot milestone: stage 0
-// from keyboard_pre_init_user(), stages 1..4 from points in
-// keyboard_post_init_user(). A boot that HANGS therefore freezes the reveal
-// exactly where it stalled, instead of showing a complete, uninformative splash.
-// A healthy boot fills in to the full "POLY KYBD" / "SPLIT 72" in well under a
-// second and then hands the keycaps over to the real key legends.
+// flag). The splash fills in ONE glyph at a time as boot advances, so a boot that
+// HANGS freezes the reveal at the exact glyph where it stalled — count the lit
+// letters to read how far boot got. A healthy boot fills to the full "POLY KYBD" /
+// "SPLIT 72" in well under a second and then hands the keycaps to the real key
+// legends.
 //
-//   Frozen state (see readme.md "Boot splash progress")   ->  where it stalled
-//   ---------------------------------------------------       ----------------
-//   row 1 half word ("PO" / "SP")                             QMK split/USB init
-//                                                             (fw-apply: the
-//                                                              slave never
-//                                                              rebooted)
-//   row 1 full, row 2 blank ("POLY" / "SPLIT")                early post_init /
-//                                                             core1 launch
-//   full splash, never replaced by legends                   late post_init /
-//                                                             first render
-//   full splash briefly, then real key legends               healthy boot
+// splash_progress(reveal) shows the first `reveal` glyphs of the splash (row 1,
+// then spilling into row 2). SPLASH_DONE reveals everything AND performs the final
+// dwell + legend handoff. Call sites, in boot order (see readme.md "Boot splash
+// progress" for the per-half letter -> milestone table):
+//   reveal 1     keyboard_pre_init_user()          before QMK split/USB init
+//   reveal 2     post_init, after set_side()        split/USB init PASSED
+//   reveal 3     post_init, after emj/lang/mru init
+//   reveal 4     post_init, before core1 launch
+//   reveal 5     post_init, after core1 launch
+//   reveal 6     post_init, after RPC registration
+//   reveal 7     post_init, after EEPROM config load
+//   SPLASH_DONE  post_init end                      boot complete -> legends
 //
-// Only the last stage renders the real legends, so on a healthy boot the splash
-// visibly completes before the keyboard "comes alive". is_left_side() must be
-// resolved (set_side()) before any call — it is, at every call site.
-enum { SPLASH_STAGES = 5 };
-static void splash_progress(uint8_t stage) {
-    if (stage >= SPLASH_STAGES) {
-        stage = SPLASH_STAGES - 1;
+// So a frozen SINGLE letter ("P" / "S") is the split/USB-init hang (the fw-apply
+// "slave not rebooted" case); the more letters are lit, the later boot stalled;
+// only a fully booted keyboard replaces the splash with real legends. Left
+// "POLY KYBD" gives 8 clean steps; right "SPLIT 72" gives ~7 (the leading space
+// in " 7 2" makes one step invisible). is_left_side() must be resolved
+// (set_side()) before any call — it is, at every call site.
+#define SPLASH_DONE 0xFF
+
+static uint8_t utext_len(const uint32_t* s) {
+    uint8_t n = 0;
+    while (n < 15 && s[n] != 0) {
+        n++;
     }
+    return n;
+}
+
+// NUL-terminated copy of the first `n` glyphs of `src` into `dst` (>= 16 words).
+static void utext_prefix(uint32_t* dst, const uint32_t* src, uint8_t n) {
+    uint8_t i = 0;
+    for (; i < n && i < 15 && src[i] != 0; ++i) {
+        dst[i] = src[i];
+    }
+    dst[i] = 0;
+}
+
+static void splash_progress(uint8_t reveal) {
     const uint32_t* r1_word = is_left_side() ? U"POLY" : POLY_SPLASH_R1;
     const uint32_t* r2_word = is_left_side() ? U"KYBD" : POLY_SPLASH_R2;
     const uint8_t   r2_row  = is_left_side() ? 2       : POLY_SPLASH_R2_ROW;
-    // Number of row-1 glyphs revealed at each stage (255 = the whole word). The
-    // half-word stage 0 is the pre-split-init state, so a split/USB-init hang
-    // (the fw-apply "slave not rebooted" case) freezes on a visibly partial word.
-    static const uint8_t r1_reveal[SPLASH_STAGES] = { 2, 4, 255, 255, 255 };
-
-    // NUL-terminated truncated copy of the row-1 word (words are <= 5 glyphs).
-    uint32_t r1buf[9];
-    uint8_t n = r1_reveal[stage];
-    uint8_t i = 0;
-    for (; i < n && i < 8 && r1_word[i] != 0; ++i) {
-        r1buf[i] = r1_word[i];
+    const uint8_t   r1_len  = utext_len(r1_word);
+    const bool      final   = (reveal == SPLASH_DONE);
+    if (final) {
+        reveal = r1_len + utext_len(r2_word);   // reveal the whole splash
     }
-    r1buf[i] = 0;
 
+    uint32_t buf[16];
     clear_all_displays();
-    display_message(1, 1, r1buf, &FreeSansBold24pt7b);
-    if (stage >= 3) {                       // row 2 only once we're nearly booted
-        display_message(r2_row, 1, r2_word, &FreeSansBold24pt7b);
+    utext_prefix(buf, r1_word, reveal < r1_len ? reveal : r1_len);
+    display_message(1, 1, buf, &FreeSansBold24pt7b);
+    if (reveal > r1_len) {                       // remaining glyphs spill to row 2
+        utext_prefix(buf, r2_word, reveal - r1_len);
+        display_message(r2_row, 1, buf, &FreeSansBold24pt7b);
     }
-    if (stage >= SPLASH_STAGES - 1) {
+    if (final) {
         // Boot complete: dwell on the finished splash, then hand the keycaps
         // over to the real legends — the same tail show_splash_screen() always
         // ran, now deferred to the end of boot so the reveal is meaningful.
@@ -2816,11 +2829,10 @@ static void splash_progress(uint8_t stage) {
     }
 }
 
-// Displays the FIRST boot-splash stage (partial). Kept as the external symbol /
-// pre-init call site; the later stages are driven directly from
-// keyboard_post_init_user() via splash_progress().
+// Displays the FIRST boot-splash glyph. Kept as the external symbol / pre-init
+// call site; later reveal steps are driven from keyboard_post_init_user().
 void show_splash_screen(void) {
-    splash_progress(0);
+    splash_progress(1);
 }
 
 // Configures all displays with contrast level; shows idle pulsating animation if enabled.
@@ -2930,8 +2942,8 @@ void keyboard_post_init_user(void) {
 
     // Boot-splash progress: reaching post_init proves QMK's split/USB init got
     // past the point where the fw-apply "slave not rebooted" hang stalls. Reveal
-    // more of the splash here (right after set_side, so is_left_side() is valid).
-    splash_progress(1);
+    // the next glyph here (right after set_side, so is_left_side() is valid).
+    splash_progress(2);
 
 #ifdef POLYKYBD_LTR559
     // Probe for the LTR-559 on BOTH halves — it can be soldered to either half's
@@ -2954,6 +2966,7 @@ void keyboard_post_init_user(void) {
     emj_init();
     lang_init();
     mru_init();
+    splash_progress(3);                 // language/emoji/MRU init done
 
     reset_overlay_buffers();
     reset_overlay_usage();
@@ -2963,14 +2976,14 @@ void keyboard_post_init_user(void) {
 #ifdef FW_UP_BOOT_TRACE
     boot_trace(U"2");
 #endif
-    splash_progress(2);                 // before core1 launch: row 1 completes
+    splash_progress(4);                 // before core1 launch
 #ifdef USE_CORE1
     multicore_launch_core1();
 #endif
 #ifdef FW_UP_BOOT_TRACE
     boot_trace(U"3");
 #endif
-    splash_progress(3);                 // core1 up: row 2 appears
+    splash_progress(5);                 // core1 up
 
     transaction_register_rpc(USER_SYNC_POLY_DATA,           user_sync_poly_data_handler);
     transaction_register_rpc(USER_SYNC_LAYER_DATA,          user_sync_layer_data_handler);
@@ -2988,6 +3001,7 @@ void keyboard_post_init_user(void) {
 #endif
 
     fw_staging_init();
+    splash_progress(6);                 // split RPCs registered, fw-staging up
 
     poly_eeconf_t ee = load_user_eeconf();
     poly_sync_t* local_state = access_local_state();
@@ -3021,12 +3035,13 @@ void keyboard_post_init_user(void) {
 
     // Restore the MRU recents and schedule a one-time push to the slave half.
     mru_load(ee.mru_emoji, ee.mru_lang);
+    splash_progress(7);                 // EEPROM config (brightness/lang/OS/MRU) loaded
 
     set_displays(local_state->contrast, false);   // active brightness (auto value if restored, else manual)
 #ifdef FW_UP_BOOT_TRACE
     boot_trace(U"4");
 #endif
-    splash_progress(4);                 // boot complete: full splash, then legends
+    splash_progress(SPLASH_DONE);       // boot complete: full splash, dwell, then legends
 }
 
 // Pre-initialization setup: initializes display hardware, loads EEPROM config, shows splash screen.

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -2764,25 +2764,36 @@ void post_process_record_user(uint16_t keycode, keyrecord_t* record) {
 // "SPLIT 72" in well under a second and then hands the keycaps to the real key
 // legends.
 //
-// splash_progress(reveal) shows the first `reveal` glyphs of the splash (row 1,
-// then spilling into row 2). SPLASH_DONE reveals everything AND performs the final
-// dwell + legend handoff. Call sites, in boot order (see readme.md "Boot splash
-// progress" for the per-half letter -> milestone table):
-//   reveal 1     keyboard_pre_init_user()          before QMK split/USB init
-//   reveal 2     post_init, after set_side()        split/USB init PASSED
-//   reveal 3     post_init, after emj/lang/mru init
-//   reveal 4     post_init, before core1 launch
-//   reveal 5     post_init, after core1 launch
-//   reveal 6     post_init, after RPC registration
-//   reveal 7     post_init, after EEPROM config load
+// splash_progress(step) draws the splash frame for boot milestone `step`
+// (1..7); SPLASH_DONE draws the whole splash AND performs the final dwell +
+// legend handoff. Call sites, in boot order:
+//   step 1       keyboard_pre_init_user()          before QMK split/USB init
+//   step 2       post_init, after set_side()        split/USB init PASSED
+//   step 3       post_init, after emj/lang/mru init
+//   step 4       post_init, before core1 launch
+//   step 5       post_init, after core1 launch
+//   step 6       post_init, after RPC registration
+//   step 7       post_init, after EEPROM config load
 //   SPLASH_DONE  post_init end                      boot complete -> legends
 //
-// So a frozen SINGLE letter ("P" / "S") is the split/USB-init hang (the fw-apply
-// "slave not rebooted" case); the more letters are lit, the later boot stalled;
-// only a fully booted keyboard replaces the splash with real legends. Left
-// "POLY KYBD" gives 8 clean steps; right "SPLIT 72" gives ~7 (the leading space
-// in " 7 2" makes one step invisible). is_left_side() must be resolved
-// (set_side()) before any call — it is, at every call site.
+// Each step advances the splash by one distinguishable frame, so a hang freezes
+// it at the exact milestone it reached (see readme.md "Boot splash progress"):
+//
+//   step  left "POLY KYBD"   right "SPLIT 72"
+//   ----  ----------------   ----------------
+//    1    P                  S           <- pre_init: split/USB-init hang here =
+//    2    PO                 SP             the fw-apply "slave not rebooted" case
+//    3    POL                SPL
+//    4    POLY               SPLI
+//    5    POLY K             SPLII       <- right "types in" its last letter over
+//    6    POLY KY            SPLIT          two steps (SPLII -> SPLIT) so the
+//    7    POLY KYB           SPLIT 7        leading space in " 7 2" doesn't cost
+//   DONE  POLY KYBD          SPLIT 72       it a frame — both halves get 8 steps
+//
+// A frozen SINGLE letter ("P" / "S") is the split/USB-init hang; the more letters
+// are lit, the later boot stalled; only a fully booted keyboard replaces the
+// splash with real legends. is_left_side() must be resolved (set_side()) before
+// any call — it is, at every call site.
 #define SPLASH_DONE 0xFF
 
 static uint8_t utext_len(const uint32_t* s) {
@@ -2802,23 +2813,57 @@ static void utext_prefix(uint32_t* dst, const uint32_t* src, uint8_t n) {
     dst[i] = 0;
 }
 
-static void splash_progress(uint8_t reveal) {
-    const uint32_t* r1_word = is_left_side() ? U"POLY" : POLY_SPLASH_R1;
-    const uint32_t* r2_word = is_left_side() ? U"KYBD" : POLY_SPLASH_R2;
-    const uint8_t   r2_row  = is_left_side() ? 2       : POLY_SPLASH_R2_ROW;
+static void splash_progress(uint8_t step) {
+    const bool      final   = (step == SPLASH_DONE);
+    const bool      left    = is_left_side();
+    const uint32_t* r1_word = left ? U"POLY" : POLY_SPLASH_R1;
+    const uint32_t* r2_word = left ? U"KYBD" : POLY_SPLASH_R2;
+    const uint8_t   r2_row  = left ? 2 : POLY_SPLASH_R2_ROW;
     const uint8_t   r1_len  = utext_len(r1_word);
-    const bool      final   = (reveal == SPLASH_DONE);
-    if (final) {
-        reveal = r1_len + utext_len(r2_word);   // reveal the whole splash
+    const uint8_t   r2_len  = utext_len(r2_word);
+
+    uint32_t r1buf[16];
+    uint32_t r2buf[16];
+    r1buf[0] = 0;
+    r2buf[0] = 0;
+
+    if (final) {                                  // whole splash
+        utext_prefix(r1buf, r1_word, r1_len);
+        utext_prefix(r2buf, r2_word, r2_len);
+    } else if (left) {
+        // Left "POLY KYBD" = 8 glyphs, one revealed per step -> 8 clean frames.
+        utext_prefix(r1buf, r1_word, step < r1_len ? step : r1_len);
+        if (step > r1_len) {
+            utext_prefix(r2buf, r2_word, step - r1_len);
+        }
+    } else {
+        // Right "SPLIT 72": the leading space in " 7 2" would otherwise hide the
+        // first row-2 reveal (two consecutive steps both showing "SPLIT"). So the
+        // LAST row-1 letter is "typed in" over two steps — step r1_len shows a
+        // placeholder ("SPLII", last glyph = the penultimate one), step r1_len+1
+        // corrects it ("SPLIT") — reclaiming the lost frame so the right half also
+        // gets 8 distinct steps.
+        if (step < r1_len) {                      // S, SP, SPL, SPLI
+            utext_prefix(r1buf, r1_word, step);
+        } else if (step == r1_len) {              // SPLII (placeholder last glyph)
+            utext_prefix(r1buf, r1_word, r1_len);
+            if (r1_len >= 2) {
+                r1buf[r1_len - 1] = r1_word[r1_len - 2];
+            }
+        } else {                                  // full row 1, then row 2
+            utext_prefix(r1buf, r1_word, r1_len);
+            uint8_t r2_show = step - r1_len - 1;  // 0 at the "SPLIT" correction step
+            if (r2_show > 0) {
+                // +1 so the leading space is included (the visible digit is next).
+                utext_prefix(r2buf, r2_word, r2_show + 1);
+            }
+        }
     }
 
-    uint32_t buf[16];
     clear_all_displays();
-    utext_prefix(buf, r1_word, reveal < r1_len ? reveal : r1_len);
-    display_message(1, 1, buf, &FreeSansBold24pt7b);
-    if (reveal > r1_len) {                       // remaining glyphs spill to row 2
-        utext_prefix(buf, r2_word, reveal - r1_len);
-        display_message(r2_row, 1, buf, &FreeSansBold24pt7b);
+    display_message(1, 1, r1buf, &FreeSansBold24pt7b);
+    if (r2buf[0] != 0) {
+        display_message(r2_row, 1, r2buf, &FreeSansBold24pt7b);
     }
     if (final) {
         // Boot complete: dwell on the finished splash, then hand the keycaps

--- a/keyboards/polykybd/readme.md
+++ b/keyboards/polykybd/readme.md
@@ -122,20 +122,21 @@ on (`splash_progress()` in `poly_keymap.c`, driven from `keyboard_pre_init_user(
 Each lit letter maps to a boot milestone (read the **hung half** — in the
 firmware-apply hang that's the master/USB half):
 
-| Letters lit | Milestone reached | |
-|---|---|---|
-| | **Left (`POLY KYBD`)** | **Right (`SPLIT 72`)** |
-| 1 | `P` — `pre_init` (before split/USB init) | `S` |
-| 2 | `PO` — after `set_side()` (**split/USB init passed**) | `SP` |
-| 3 | `POL` — language/emoji/MRU init done | `SPL` |
-| 4 | `POLY` — before core 1 launch | `SPLI` |
-| 5 | `POLY K` — after core 1 launch | `SPLIT` |
-| 6 | `POLY KY` — split RPCs + fw-staging up | `SPLIT` \* |
-| 7 | `POLY KYB` — EEPROM config loaded | `SPLIT 7` |
-| all | `POLY KYBD` → then real key legends | `SPLIT 72` → legends |
+| Step | Milestone reached | Left (`POLY KYBD`) | Right (`SPLIT 72`) |
+|---|---|---|---|
+| 1 | `pre_init` (before split/USB init) | `P` | `S` |
+| 2 | after `set_side()` (**split/USB init passed**) | `PO` | `SP` |
+| 3 | language/emoji/MRU init done | `POL` | `SPL` |
+| 4 | before core 1 launch | `POLY` | `SPLI` |
+| 5 | after core 1 launch | `POLY K` | `SPLII` \* |
+| 6 | split RPCs + fw-staging up | `POLY KY` | `SPLIT` |
+| 7 | EEPROM config loaded | `POLY KYB` | `SPLIT 7` |
+| all | boot complete → real key legends | `POLY KYBD` | `SPLIT 72` |
 
-\* On the right half the leading space in `" 7 2"` makes step 6 look identical to
-step 5 (`SPLIT`); the first *visible* second-row glyph (`7`) appears at step 7.
+\* The right half "types in" its last letter over two steps — step 5 shows a
+placeholder `SPLII` (last glyph repeated), step 6 corrects it to `SPLIT` — so the
+leading space in `" 7 2"` doesn't cost the right half a distinguishable frame.
+Both halves therefore give 8 distinct steps.
 
 So a frozen **single letter** (`P` / `S`) is the split/USB-init hang — the
 **"hangs on the boot splash after a firmware apply"** case (`hid_fw_up.c`

--- a/keyboards/polykybd/readme.md
+++ b/keyboards/polykybd/readme.md
@@ -109,6 +109,31 @@ keyboards/polykybd/create_fonts.sh     # invoke fontconvert per range; writes ba
 
 ## Diagnostics
 
+### Boot splash progress (always on)
+
+The boot splash (`POLY KYBD` on the left half, `SPLIT 72` / `SPLIT 42` on the
+right) is drawn **progressively** as boot advances — one keycap-letter group per
+milestone — instead of appearing complete at once. Because each keycap OLED holds
+the last frame it was sent, a boot that **hangs** simply freezes the reveal at the
+stage that stalled, so the partial splash on screen tells you where boot stopped.
+No compile flag: this is always on (`splash_progress()` in `poly_keymap.c`, driven
+from `keyboard_pre_init_user()` + several points in `keyboard_post_init_user()`).
+
+| Frozen splash on screen | Where boot stalled |
+|---|---|
+| **Half word** — `PO` / `SP` | QMK's split-transport / USB init, *before* `keyboard_post_init_user()`. This is the **"hangs on the boot splash after a firmware apply"** case (`hid_fw_up.c` `CMD_FW_UP_APPLY` — the slave never rebooted, so the master waits for a split handshake that never comes). Recovery: replug / reset, or re-run Apply. |
+| **Full first row, second row blank** — `POLY` / `SPLIT` | Early `post_init`, at/around the core 1 launch (`multicore_launch_core1()`). |
+| **Full splash, never replaced by legends** | Late `post_init` or the first legend render. |
+| **Full splash for a moment, then the real key legends** | Healthy boot. |
+
+The reveal completes in well under a second on a healthy boot, so it reads as a
+brief splash animation; only a genuine hang leaves it parked on a partial frame.
+The letter-count schedule and stage placement are in `splash_progress()` /
+`keyboard_post_init_user()`. (A more granular, keycap-digit boot tracer also
+exists behind the `FW_UP_BOOT_TRACE` compile flag — see `boot_trace()` — for
+pinning a hang down to a numbered milestone when the splash resolution isn't
+enough.)
+
 ### Core 1 stack high-water mark (`CORE1_STACK_HWM`)
 
 `base/multicore/core1.c` ships a small stack-painting probe that measures how deep core 1 actually drives its stack. It is **off by default** (the painting loop and walk add cycles to `multicore_launch_core1` and to every overlay/ROI dispatch) and gated by `CORE1_STACK_HWM`.

--- a/keyboards/polykybd/readme.md
+++ b/keyboards/polykybd/readme.md
@@ -112,27 +112,43 @@ keyboards/polykybd/create_fonts.sh     # invoke fontconvert per range; writes ba
 ### Boot splash progress (always on)
 
 The boot splash (`POLY KYBD` on the left half, `SPLIT 72` / `SPLIT 42` on the
-right) is drawn **progressively** as boot advances — one keycap-letter group per
-milestone — instead of appearing complete at once. Because each keycap OLED holds
-the last frame it was sent, a boot that **hangs** simply freezes the reveal at the
-stage that stalled, so the partial splash on screen tells you where boot stopped.
-No compile flag: this is always on (`splash_progress()` in `poly_keymap.c`, driven
-from `keyboard_pre_init_user()` + several points in `keyboard_post_init_user()`).
+right) fills in **one glyph at a time** as boot advances, instead of appearing
+complete at once. Because each keycap OLED holds the last frame it was sent, a
+boot that **hangs** freezes the reveal at the exact glyph it reached — so you read
+how far boot got by **counting the lit letters**. No compile flag: this is always
+on (`splash_progress()` in `poly_keymap.c`, driven from `keyboard_pre_init_user()`
++ several points in `keyboard_post_init_user()`).
 
-| Frozen splash on screen | Where boot stalled |
-|---|---|
-| **Half word** — `PO` / `SP` | QMK's split-transport / USB init, *before* `keyboard_post_init_user()`. This is the **"hangs on the boot splash after a firmware apply"** case (`hid_fw_up.c` `CMD_FW_UP_APPLY` — the slave never rebooted, so the master waits for a split handshake that never comes). Recovery: replug / reset, or re-run Apply. |
-| **Full first row, second row blank** — `POLY` / `SPLIT` | Early `post_init`, at/around the core 1 launch (`multicore_launch_core1()`). |
-| **Full splash, never replaced by legends** | Late `post_init` or the first legend render. |
-| **Full splash for a moment, then the real key legends** | Healthy boot. |
+Each lit letter maps to a boot milestone (read the **hung half** — in the
+firmware-apply hang that's the master/USB half):
+
+| Letters lit | Milestone reached | |
+|---|---|---|
+| | **Left (`POLY KYBD`)** | **Right (`SPLIT 72`)** |
+| 1 | `P` — `pre_init` (before split/USB init) | `S` |
+| 2 | `PO` — after `set_side()` (**split/USB init passed**) | `SP` |
+| 3 | `POL` — language/emoji/MRU init done | `SPL` |
+| 4 | `POLY` — before core 1 launch | `SPLI` |
+| 5 | `POLY K` — after core 1 launch | `SPLIT` |
+| 6 | `POLY KY` — split RPCs + fw-staging up | `SPLIT` \* |
+| 7 | `POLY KYB` — EEPROM config loaded | `SPLIT 7` |
+| all | `POLY KYBD` → then real key legends | `SPLIT 72` → legends |
+
+\* On the right half the leading space in `" 7 2"` makes step 6 look identical to
+step 5 (`SPLIT`); the first *visible* second-row glyph (`7`) appears at step 7.
+
+So a frozen **single letter** (`P` / `S`) is the split/USB-init hang — the
+**"hangs on the boot splash after a firmware apply"** case (`hid_fw_up.c`
+`CMD_FW_UP_APPLY`: the slave never rebooted, so the master waits for a split
+handshake that never comes; recovery = replug/reset or re-run Apply). The more
+letters are lit, the later boot stalled; a keyboard that reaches the real key
+legends booted cleanly.
 
 The reveal completes in well under a second on a healthy boot, so it reads as a
-brief splash animation; only a genuine hang leaves it parked on a partial frame.
-The letter-count schedule and stage placement are in `splash_progress()` /
-`keyboard_post_init_user()`. (A more granular, keycap-digit boot tracer also
-exists behind the `FW_UP_BOOT_TRACE` compile flag — see `boot_trace()` — for
-pinning a hang down to a numbered milestone when the splash resolution isn't
-enough.)
+brief splash animation; only a genuine hang parks it on a partial frame. The
+milestone placement is in `keyboard_post_init_user()`. (A keycap-**digit** boot
+tracer also exists behind the `FW_UP_BOOT_TRACE` compile flag — see `boot_trace()`
+— for numbered milestones if the letter resolution isn't enough.)
 
 ### Core 1 stack high-water mark (`CORE1_STACK_HWM`)
 


### PR DESCRIPTION
## Summary

The keycap boot splash now reveals itself **progressively** as boot advances,
instead of appearing complete at once — so a boot that **hangs** freezes the
reveal at the stage that stalled, and the partial splash on screen tells you
where boot stopped. Always on (no compile flag, no keycap-digit debug view);
+16 bytes `.text`.

`splash_progress()` (`poly_keymap.c`) is called at five boot milestones:

| Stage | Call site | Reveals |
|---|---|---|
| 0 | `keyboard_pre_init_user()` (before QMK split/USB init) | half word — `PO` / `SP` |
| 1 | `keyboard_post_init_user()`, right after `set_side()` | more of row 1 |
| 2 | before `multicore_launch_core1()` | row 1 completes |
| 3 | after core1 launch | row 2 appears |
| 4 | end of `post_init` | full splash → dwell → hand off to real key legends |

Reaching `post_init` proves QMK's split/USB init got past the point where the
**"hangs on the boot splash after a firmware apply"** bug stalls (`hid_fw_up.c`
`CMD_FW_UP_APPLY` — the slave never rebooted, so the master waits for a split
handshake that never comes). With this change that failure freezes on a visibly
**half** word rather than a normal-looking full splash:

| Frozen splash | Where boot stalled |
|---|---|
| Half word (`PO` / `SP`) | QMK split/USB init — the fw-apply "slave not rebooted" hang |
| Full row 1, blank row 2 (`POLY` / `SPLIT`) | early `post_init` / core1 launch |
| Full splash, never replaced by legends | late `post_init` / first render |
| Full splash briefly, then legends | healthy boot |

The reveal completes in well under a second on a healthy boot, so it reads as a
brief splash animation; only a genuine hang parks it on a partial frame. Only the
final stage renders the real legends, so the splash visibly completes before the
keyboard "comes alive". The pre-existing `FW_UP_BOOT_TRACE` keycap-digit tracer is
untouched, as a finer-grained fallback.

Files:
- `keyboards/polykybd/poly_keymap.c` — `splash_progress()` + the five call sites.
- `keyboards/polykybd/readme.md` — "Boot splash progress" (frozen-state → stall-point table).

## Version bump label

New user-visible, backwards-compatible firmware behaviour — `bump:minor` is the
natural fit (leaving it unlabelled just makes it a patch bump; either is fine).
No protocol/wire change, so no `bump:protocol` and no host update needed.

## Testing
- [x] Compiled successfully — **both** variants (`polykybd/split72` and
  `polykybd/split42`; the splash uses the per-variant `POLY_SPLASH_*` macros).
- [ ] Flashed and tested on hardware — pending (the reveal timing / dwell is a
  one-line `wait_ms` tweak if it wants adjusting on real keycaps).
- [x] No protocol change — host untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R386Yi5Fwopkq3VrSGoHJp

---
_Generated by [Claude Code](https://claude.ai/code/session_01R386Yi5Fwopkq3VrSGoHJp)_

## Summary by Sourcery

Implement a progressive, always-on boot splash that visually indicates boot progress and where startup stalls.

Enhancements:
- Replace the single-frame splash screen with a multi-stage splash progression driven from keymap init hooks.
- Ensure the splash completes and then hands off cleanly to real key legends once boot finishes.

Documentation:
- Document the new progressive boot splash behaviour and the mapping from frozen splash states to boot stall points in the keyboard README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a progressive boot splash that reveals the PolyKybd/Split72 logos as startup advances.
  - The display now transitions automatically to normal key legends when initialization completes.

- **Documentation**
  - Added guidance for interpreting boot progress from the revealed logo letters.
  - Documented milestone indicators and troubleshooting details for startup hangs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->