### PR TITLE
skill: investigate-kicad-pcb — Python PCB net/variant/DRC investigation

### DIFF
--- a/.claude/skills/investigate-kicad-pcb/SKILL.md
+++ b/.claude/skills/investigate-kicad-pcb/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: investigate-kicad-pcb
+description: >-
+  Investigate a PolyKybd KiCad PCB with Python — trace what sits on a net, compare
+  two board variants or revisions, hunt a suspected design fault (short/open/routing/
+  BOM/passive difference), or run DRC. Use when asked to "check the PCB traces/nets",
+  "is this a design fault", "compare split42 vs split72 layout", "what's on
+  SERIAL_COM/net X", "did the plane short the line", or during hardware bring-up when
+  deciding whether a symptom is firmware vs board. Operates on the thpoll83/PolyKybd
+  KiCad repo (/home/user/PolyKybd/poly_kybd). Knows which Python libs work and which
+  mislead, and that KiCad 9 / pcbnew is unavailable here. NOT for firmware config
+  (that's the qmk repo) or gerber/fab output.
+---
+
+# Investigate a KiCad PCB (PolyKybd) with Python
+
+The PolyKybd hardware lives in the **thpoll83/PolyKybd** repo (KiCad 9 files under
+`/home/user/PolyKybd/poly_kybd`). This skill is the tool-aware way to answer "what
+is on this net?", "do these two boards differ?", and "is the symptom a board fault
+or firmware?" — without the KiCad GUI, which is **not installable here**.
+
+The recurring high-value move is a **variant diff**: compare the same net (by NAME)
+between a *failing* board and a *known-good* one (e.g. split42 vs split72). Identical
+routing exonerates the design and points at build/assembly; a real difference is a
+concrete lead.
+
+## Tools — what to reach for (and what to avoid)
+
+| Tool | Use for | Notes |
+|------|---------|-------|
+| **plain regex over the `.kicad_pcb` text** | nets, pads, track len/width/layer, vias | Most robust. The bundled `kicad_net_diff.py` does exactly this. |
+| **kiutils** | structured parse (footprints, pads, positions) | Correct pad world-position needs rotation **sign = −1**; validate against a known-good board. |
+| **kicad-tools** (`rjwalters` PyPI, `import kicad_tools as kt`) | pure-Python **DRC** | `IncrementalDRC(pcb, DesignRules(track_w, clearance, via_d, via_drill, hole))` then `.full_check()`; `kt.PCB.load(path)`; `.get_ratsnest()`. `net_count` is an **attribute**, not a method. `DRCReport.load` only *parses* a report — it does not run DRC. |
+| **kicad-skip** | alt structured parse | installed; interchangeable with kiutils for most reads. |
+| ~~pcbnew / KiCad GUI~~ | — | **UNAVAILABLE** (see Pitfalls). Don't try to install it. |
+
+## Procedure
+
+1. **Locate the boards.** `find /home/user/PolyKybd -iname '*.kicad_pcb'`. The real
+   PolyKybd boards are `<variant>_left.kicad_pcb` / `<variant>_right.kicad_pcb`;
+   `*_left2`/`*_right2` are stubs (no `U26`/`USB2`) and `*_plate_*` are mechanical.
+2. **Work by net NAME, not number** (numbers are per-file — see Pitfalls). For a
+   quick look: `grep -nE '\(net [0-9]+ "<NAME>"\)' board.kicad_pcb`.
+3. **Extract / diff** with the helper (schematic side is a separate check — parse
+   `.kicad_sch` for the components on the net + their values):
+   ```bash
+   python3 kicad_net_diff.py SERIAL_COM1 SERIAL_COM2 -- \
+       /home/user/PolyKybd/poly_kybd/variations/poly_corne/poly_corne_split42_left.kicad_pcb \
+       /home/user/PolyKybd/poly_kybd/poly_kybd_split72_left.kicad_pcb
+   ```
+   It prints, per net: the pads on it (footprint.pad), total track length, segment
+   count, via count, widths, and layers — so a variant diff is a glance.
+4. **Reason about the electrical path** from the pad list, e.g. COM is
+   `U10.6/7 (MCU GP4/GP5) → U26 (shunt ESD array) → USB2 (bridge connector)`, no
+   series element (the 22 Ω `R1/R2` are on USB D±, not COM). Same-length, same-pad,
+   same-layer between variants ⇒ design equivalent.
+5. **DRC** (shorts/clearance) via kicad-tools when a short is suspected — do **not**
+   hand-roll a zone-overlap check (see Pitfalls).
+6. **Report** what's identical vs different, and state the conclusion at the
+   confidence the files support — "design equivalent to the known-good board, so the
+   fault is not in the layout" is a valid, valuable result. Do **not** upgrade a
+   layout delta into a claimed physical mechanism (joint/cap) the files can't show.
+
+## Pitfalls (the expensive lessons)
+
+- **Net numbers are PER-FILE.** `SERIAL_COM1` is net **226** on `split42_left` but
+  net **400** on `split42_right` and `split72`. Resolve name→number **in each file**
+  (the helper does). Reusing a number across files silently analyzes the *wrong* net
+  (once made `split42_right` COM look like it hung off a stray cap + connector).
+- **Validate every custom geometry check against a KNOWN-GOOD board first.** A
+  hand-rolled pad-position check falsely reported "USB2 unrouted (15.9 mm no copper)"
+  from a **rotation-sign bug** — caught only by running it on the *working* split72
+  and seeing the identical bogus number. If your check flags the good board too, the
+  check is wrong, not the board.
+- **shapely zone-short checks are UNRELIABLE.** kiutils drops zone-fill clearance
+  holes, so a pad inside a plane's *clearance pocket* reads as overlapping copper —
+  289/1230 known-good pads flagged as GND-shorted. Use **kicad-tools DRC** for
+  shorts, not a hand-rolled polygon overlap.
+- **KiCad 9 / pcbnew is UNAVAILABLE.** `add-apt-repository` breaks (`ModuleNotFoundError:
+  apt_pkg`), the KiCad PPA is proxy-blocked, and the distro **KiCad 7 cannot open v9
+  `.kicad_pcb`** (or run its DRC). Don't burn time installing it — the Python-only
+  path above is the whole toolkit.
+- **A layout diff is a lead, not a verdict.** Identical files exonerate the design;
+  a delta (trace layer, GND-pour clearance) is worth flagging but is rarely, on its
+  own, proof of a fault. Keep hardware-mechanism claims (joints, coupling) as
+  hypotheses until a bench measurement confirms them.

--- a/.claude/skills/investigate-kicad-pcb/kicad_net_diff.py
+++ b/.claude/skills/investigate-kicad-pcb/kicad_net_diff.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Per-net PCB inspector / variant-diff for KiCad v9 .kicad_pcb files.
+
+Resolves a net by NAME in each file (net *numbers* are per-file — never reuse a
+number across boards), then reports the pads on it, total track length, track
+widths, layers used, and via count. Give it one file to inspect a net, or two+
+files to diff the same net name across board variants/revisions.
+
+    python3 kicad_net_diff.py SERIAL_COM1 SERIAL_COM2 -- board_a.kicad_pcb board_b.kicad_pcb
+
+Pure stdlib (regex over the S-expr text) — deliberately NOT kiutils/pcbnew:
+KiCad 9 / pcbnew is unavailable in this environment (see the skill's Pitfalls),
+and text parsing is the most robust way to pull nets/pads/tracks/vias.
+"""
+import re, sys, math
+
+
+def net_numbers_by_name(text):
+    """Map net NAME -> number for this file (numbers are per-file)."""
+    out = {}
+    for m in re.finditer(r'\(net (\d+) "([^"]*)"\)', text):
+        out.setdefault(m.group(2), int(m.group(1)))
+    return out
+
+
+def refs_index(text):
+    return [(m.start(), m.group(1))
+            for m in re.finditer(r'\(property "Reference" "([^"]+)"', text)]
+
+
+def ref_before(refs, idx):
+    best = None
+    for pos, r in refs:
+        if pos < idx:
+            best = r
+        else:
+            break
+    return best
+
+
+def analyze(path, names):
+    text = open(path).read()
+    name2num = net_numbers_by_name(text)
+    nums = {name2num[n]: n for n in names if n in name2num}
+    refs = refs_index(text)
+    pads = {n: set() for n in nums}
+    for m in re.finditer(r'\(pad\s+"([^"]+)"', text):
+        seg = text[m.start():m.start() + 800]
+        nm = re.search(r'\(net (\d+) "[^"]*"\)', seg)
+        if nm and int(nm.group(1)) in nums:
+            pads[int(nm.group(1))].add(f"{ref_before(refs, m.start())}.{m.group(1)}")
+    segs = {n: [] for n in nums}
+    seg_re = re.compile(
+        r'\(segment\s+\(start ([\-\d.]+) ([\-\d.]+)\)\s*\(end ([\-\d.]+) ([\-\d.]+)\)'
+        r'\s*\(width ([\-\d.]+)\)\s*\(layer "([^"]+)"\)[^)]*\(net (\d+)\)')
+    for m in seg_re.finditer(text):
+        n = int(m.group(7))
+        if n in nums:
+            x1, y1, x2, y2, w = map(float, m.group(1, 2, 3, 4, 5))
+            segs[n].append((math.hypot(x2 - x1, y2 - y1), w, m.group(6)))
+    vias = {n: 0 for n in nums}
+    for m in re.finditer(r'\(via\b(.*?)\(net (\d+)\)', text, re.S):
+        n = int(m.group(2))
+        if n in nums and len(m.group(1)) < 400:
+            vias[n] += 1
+    missing = [n for n in names if n not in name2num]
+    return nums, pads, segs, vias, missing
+
+
+def report(path, names):
+    nums, pads, segs, vias, missing = analyze(path, names)
+    print(f"\n### {path}")
+    if missing:
+        print(f"    (net name(s) not in this file: {missing})")
+    for num, name in nums.items():
+        tot = sum(L for L, w, ly in segs[num])
+        widths = sorted({round(w, 3) for L, w, ly in segs[num]})
+        layers = sorted({ly for L, w, ly in segs[num]})
+        print(f"    {name} (net {num}): len={tot:.2f}mm  segs={len(segs[num])}  "
+              f"vias={vias[num]}  widths={widths}  layers={layers}")
+        print(f"        pads={sorted(pads[num])}")
+
+
+def main(argv):
+    if "--" in argv:
+        i = argv.index("--")
+        names, files = argv[:i], argv[i + 1:]
+    else:  # last token that ends in .kicad_pcb splits names from files
+        files = [a for a in argv if a.endswith(".kicad_pcb")]
+        names = [a for a in argv if not a.endswith(".kicad_pcb")]
+    if not names or not files:
+        print(__doc__)
+        return 2
+    for f in files:
+        report(f, names)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Adds a Claude Code skill for investigating the PolyKybd KiCad boards from Python — trace what sits on a net, diff the same net across board variants/revisions, and hunt a suspected design fault — without the KiCad GUI (which is not installable in the dev container).

- `.claude/skills/investigate-kicad-pcb/SKILL.md` — procedure + tool inventory (kiutils, kicad-tools pure-Python DRC, plain regex) and the hard-won **Pitfalls**: net numbers are **per-file** (resolve by name, not number), validate custom geometry checks against a known-good board, shapely zone-short checks are unreliable, KiCad 9 / pcbnew is unavailable here, and `left2`/`right2` PCBs are stubs.
- `.claude/skills/investigate-kicad-pcb/kicad_net_diff.py` — resolves a net by **name** per file and reports pads, track length/width/layer, and via count; pass one or more boards for an instant variant diff.

Distilled from the split42-vs-split72 split-link investigation, where these tools and traps were worked out by hand (e.g. the false "USB2 unrouted" from a rotation-sign bug, caught only by running the check on the working split72).

Tooling/docs only — **no firmware code changes**.

## Version bump label

None expected (skill/tooling only, no firmware change). Maintainer's call.

## Testing
- [x] `kicad_net_diff.py` smoke-tested against the real split42/split72 boards (variant diff of `SERIAL_COM1/COM2`)
- [ ] No firmware compiled — this PR touches no firmware source

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QeEo7SamJAXEykbNebEdvL)_

## Summary by Sourcery

Introduce a Python-based KiCad PCB net inspection and variant-diff skill for PolyKybd boards, along with accompanying procedural documentation for using Python-only tooling in the dev environment.

New Features:
- Add kicad_net_diff.py helper script to inspect KiCad PCB nets by name and compare routing across board variants without the KiCad GUI.
- Document the investigate-kicad-pcb skill, including where PolyKybd KiCad files live and how to run Python-based PCB investigations and DRC.

Enhancements:
- Clarify preferred and discouraged Python tooling for KiCad PCB analysis in this environment, including limitations of KiCad 9/pcbnew and common pitfalls when analyzing nets and zones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Python-based tool for inspecting KiCad PCB net connectivity across board files.
  * Reports net assignments, connected pads, track lengths, track layers and widths, vias, and missing nets.
  * Supports comparing multiple board variants without requiring KiCad or its PCB editor.

* **Documentation**
  * Added guidance for investigating PCB net and trace behavior, comparing variants, validating findings, and using design-rule checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->