### PR TITLE
split42: fresh rebuild mirroring the working split72

### DIFF
--- a/keyboards/polykybd/hid_com.c
+++ b/keyboards/polykybd/hid_com.c
@@ -163,7 +163,13 @@ bool legacy_command_kb(uint8_t *data, uint8_t length) {
 // Handles HID commands: device ID, language change, overlay reception, mapping, and display control.
 // Global variables: hid_keycode, hid_modifier, hid_roi, hid_bit_index, hid_bit_index_bridge
 void raw_hid_receive(uint8_t *data, uint8_t length) {
-    const char * name = "P\x06.Split72 " FW_VERSION " P" STR(PROTOCOL_VERSION) " HW" STR(DEVICE_VER) " ";
+    // A variant may name itself via POLY_KB_NAME in its config.h (split42 does).
+    // The fallback stays "Split72" so split72 — which does not define it — reports
+    // the exact same GET_ID string it always has (no change to the shipping board).
+#ifndef POLY_KB_NAME
+#    define POLY_KB_NAME "Split72"
+#endif
+    const char * name = "P\x06." POLY_KB_NAME " " FW_VERSION " P" STR(PROTOCOL_VERSION) " HW" STR(DEVICE_VER) " ";
 
     if (length<1) {
         return;

--- a/keyboards/polykybd/split42/config.h
+++ b/keyboards/polykybd/split42/config.h
@@ -20,6 +20,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
+/* Reported in the GET_ID string (cmd 6) so the host shows the right variant. */
+#define POLY_KB_NAME "Split42"
+
 /* Key matrix — 4 rows per side, 6 columns (standard CRKBD layout) */
 #define MATRIX_ROWS_PER_SIDE 4
 #define MATRIX_ROWS          8
@@ -30,19 +33,23 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Shift registers — 3×8=24 bits, covers 21 keycap displays per side */
 #define NUM_SHIFT_REGISTERS 3
 
-/* Matrix pin assignments — update to match actual PCB schematic */
+/* Matrix pin assignments (per the LEFT-half KiCad schematic) */
 #define MATRIX_COL_PINS \
     { GP10, GP11, GP12, GP13, GP14, GP15 }
 #define MATRIX_ROW_PINS \
     { GP18, GP19, GP20, GP21 }
 
-/* SPI interface for keycap displays — adjust if wired differently from split72 */
+/* SPI interface for keycap displays (same wiring as split72) */
 #define SPI_DRIVER   SPID0
 #define SPI_SS_PIN   GP17
 #define SPI_DC_PIN   GP8
 #define HW_RST_PIN   GP9
 #define SPI_SCK_PIN  GP6
 #define SPI_MOSI_PIN GP7
+// Mirror the working split72 exactly (GP4). NOTE: since the full-duplex split
+// UART switch GP4 doubles as SERIAL_USART_RX_PIN; whether spi_master claiming it
+// as MISO matters is being evaluated against the split72 baseline, so it is left
+// as-is here rather than pre-emptively changed.
 #define SPI_MISO_PIN GP4
 #define SPI_DIVISOR  (CPU_CLOCK / 10000000)
 
@@ -51,7 +58,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define SR_DATA_PIN  GP26
 #define SR_LATCH_PIN GP28
 
-/* Rotary encoder */
+/* Rotary encoder (ENC_A/ENC_B per schematic; pins declared in keyboard.json) */
 #define ENCODER_RESOLUTION 2
 
 /* Status OLED — 128×32 SSD1306 (half-height vs split72's 128×64) */

--- a/keyboards/polykybd/split42/keyboard.json
+++ b/keyboards/polykybd/split42/keyboard.json
@@ -29,8 +29,8 @@
     "encoder": {
         "rotary": [
             {
-                "pin_a": "GP25",
-                "pin_b": "GP29"
+                "pin_a": "GP2",
+                "pin_b": "GP3"
             }
         ]
     },

--- a/keyboards/polykybd/split42/rules.mk
+++ b/keyboards/polykybd/split42/rules.mk
@@ -4,21 +4,31 @@
 SERIAL_DRIVER = vendor
 SPLIT_KEYBOARD = yes
 
-# OLED — 128×32 SSD1306
+# OLED — 128×32 SSD1306 status display
 OLED_ENABLE = yes
 OLED_DRIVER = ssd1306
 
 # No RGB matrix — split42 has no underglow or per-key LEDs
 
-# Source files — status_oled.c resolves to split42/status_oled.c via QMK search order
+# Source files — status_oled.c resolves to split42/status_oled.c via QMK search order.
+# Same shared base sources as split72, minus the RGB/pointing/LTR-559 sources
+# (split42 has none). base/text_helper.c is also omitted: it switches over the
+# RGB_MATRIX_* effect enums to name effects, which don't exist without RGB, so it
+# can't compile here — split42.c/status_oled.c only need the header, not the TU.
 QUANTUM_LIB_SRC += spi_master.c
 SRC += status_oled.c base/update.c base/e2prom.c base/com.c base/helpers.c base/disp_array.c base/shift_reg.c base/spi_helper.c base/overlay.c base/multicore/core1.c lang/lang_lut.c base/fw_staging.c base/fontpack.c
 
 # No pointing device (no Cirque trackpad on split42)
 
-RAW_ENABLE     = yes
-WPM_ENABLE     = yes
-SEND_STRING_ENABLE      = yes
+# Allow raw hid communication (for bi-directional data transfer)
+RAW_ENABLE = yes
+
+# collect words per minute data
+WPM_ENABLE = yes
+
+SEND_STRING_ENABLE = yes
+
 HOLD_ON_OTHER_KEY_PRESS = yes
-PERMISSIVE_HOLD         = yes
-DYNAMIC_KEYMAP_ENABLE   = yes
+PERMISSIVE_HOLD = yes
+
+DYNAMIC_KEYMAP_ENABLE = yes

--- a/keyboards/polykybd/split42/split42.c
+++ b/keyboards/polykybd/split42/split42.c
@@ -4,34 +4,44 @@
 
 #include "quantum.h"
 
-#include "../side.h"
-#include "../base/com.h"
-#include "../base/disp_array.h"
-#include "../base/helpers.h"
-#include "../base/spi_helper.h"
-#include "../base/shift_reg.h"
-#include "../base/text_helper.h"
+#include "side.h"
+#include "base/com.h"
+#include "base/disp_array.h"
+#include "base/helpers.h"
+#include "base/spi_helper.h"
+#include "base/shift_reg.h"
+#include "base/text_helper.h"
 
 #include <string.h>
 
 /*
  * key_display[] maps matrix slot LAYOUT_TO_INDEX(row, col) to shift-register
- * bitmasks. 4 rows × 6 cols = 24 entries per side.
+ * bitmasks. split42 is CRKBD: 4 matrix rows × 6 cols per side.
  *
- * CRKBD physical layout per side:
- *   Rows 0–2: 6 keys each (top / home / bottom alphanumeric rows)
- *   Row 3:    thumb cluster — only 3 of 6 col positions are physically wired.
- *             The remaining 3 slots are dummies (no display attached).
+ * ⚠️ The table is indexed LAYOUT_TO_INDEX(r,c) = r*MATRIX_COLS + c = r*6 + c, so it
+ * MUST be laid out 6-WIDE (one row per matrix row). It was originally copied from
+ * split72's table, which is 8-wide because split72 has MATRIX_COLS = 8 — with 6-wide
+ * indexing that 8-wide fill drifted every row past row 0 by 2 (8-6), so pressing a
+ * key inverted the display two positions earlier (field, 2026-07-10). Fixed by making
+ * each matrix row map to its own shift register's low 6 bits:
+ *   Row 0 -> BITMASK1(0..5)   (hardware-verified at bring-up: esc q w e r t)
+ *   Row 1 -> BITMASK2(0..5)   (confirmed: shift(r2c0) lit BITMASK2(4)=f, z lit (5)=g)
+ *   Row 2 -> BITMASK3(0..5)   (natural completion; verify on hardware)
  *
- * TODO: Verify bitmask assignments against the actual PCB wiring:
- *   - Which shift register drives which row group
- *   - Which col positions in row 3 are the thumb keys
- *   - Whether the SR chain order matches BITMASK1/2/3 ordering in split42.h
+ * CRKBD physical layout per side: rows 0–2 are 6 keys each; row 3 is the thumb
+ * cluster — only cols 3,4,5 are wired (idx 21,22,23); cols 0,1,2 (idx 18,19,20) have
+ * no key and are never inverted, so their entries are unused placeholders.
+ *
+ * TODO(bring-up): the 3 thumb displays (idx 21-23) are a best guess — the 6 free SR
+ * bits after rows 0–2 are BITMASK1(6),(7) / BITMASK2(6),(7) / BITMASK3(6),(7). Press
+ * each thumb, see which display inverts, and correct these three entries.
  */
 static const struct display_info key_display[] = {
-        {BITMASK1(0)}, {BITMASK1(1)}, {BITMASK1(2)}, {BITMASK1(3)}, {BITMASK1(4)}, {BITMASK1(5)}, {BITMASK1(6)}, {BITMASK1(7)},
-        {BITMASK2(0)}, {BITMASK2(1)}, {BITMASK2(2)}, {BITMASK2(3)}, {BITMASK2(4)}, {BITMASK2(5)}, {BITMASK2(6)}, {BITMASK2(7)},
-        {BITMASK3(0)}, {BITMASK3(1)}, {BITMASK3(2)}, {BITMASK3(3)}, {BITMASK3(4)}, {BITMASK3(5)}, {BITMASK3(6)}, {BITMASK3(7)}
+        /* row 0 (idx  0.. 5) */ {BITMASK1(0)}, {BITMASK1(1)}, {BITMASK1(2)}, {BITMASK1(3)}, {BITMASK1(4)}, {BITMASK1(5)},
+        /* row 1 (idx  6..11) */ {BITMASK2(0)}, {BITMASK2(1)}, {BITMASK2(2)}, {BITMASK2(3)}, {BITMASK2(4)}, {BITMASK2(5)},
+        /* row 2 (idx 12..17) */ {BITMASK3(0)}, {BITMASK3(1)}, {BITMASK3(2)}, {BITMASK3(3)}, {BITMASK3(4)}, {BITMASK3(5)},
+        /* row 3: idx 18-20 = no key (placeholders); idx 21-23 = thumbs (VERIFY) */
+        {BITMASK1(6)}, {BITMASK1(7)}, {BITMASK2(6)}, {BITMASK2(7)}, {BITMASK3(6)}, {BITMASK3(7)}
 };
 
 const uint8_t* get_key_disp_bitmask(uint8_t index) {
@@ -44,9 +54,9 @@ uint8_t get_disp_bitmask_size(void) {
 
 void invert_display(uint8_t r, uint8_t c, bool state) {
     /*
-     * Right-side rows are 4–7. On split72 the right side had col 0 absent,
-     * requiring c--. Check whether split42 needs the same adjustment.
-     * TODO: update this offset if the right-half matrix layout requires it.
+     * split42 is a symmetric CRKBD: the right-half rows (4–7) carry all 6 columns,
+     * so there is NO absent col-0 and NO c-- shift like split72 needs on its upper
+     * right rows. Fold the matrix row into this half's 0..3 range and index directly.
      */
     r = r % MATRIX_ROWS_PER_SIDE;
     const uint8_t disp_idx = LAYOUT_TO_INDEX(r, c);

--- a/keyboards/polykybd/split42/split42.h
+++ b/keyboards/polykybd/split42/split42.h
@@ -31,8 +31,8 @@ struct display_info {
 /*
  * BITMASK macros select one keycap display via the shift-register chain.
  * Each macro pulls one bit low; all others stay high (displays deselected).
- * Ordering: bitmask[0] is the byte shifted in LAST (farthest from MCU in chain).
- * Verify this matches the actual PCB shift-register chain direction.
+ * Ordering matches split72's convention: bitmask[0] is the byte shifted in
+ * LAST (farthest from the MCU in the chain).
  */
 #define BITMASK1(x) .bitmask = {~0, ~0, (uint8_t)(~(1 << (x)))}
 #define BITMASK2(x) .bitmask = {~0, (uint8_t)(~(1 << (x))), ~0}


### PR DESCRIPTION
## Summary

Recreate the `split42` variant cleanly from the known-good `split72` on the default branch, so it shares split72's exact working configuration and only diverges where split42's hardware forces it. The goal is a **clean split42 baseline with no accumulated firmware drift** to take into hardware bring-up — deliberately **not** an attempt to fix the split-link issue. `split72` is left byte-for-byte untouched, and the split-UART / MISO configuration is kept identical to it (`SPI_MISO_PIN GP4` on both).

Method: deleted `keyboards/polykybd/split42` and recreated it from `split72`. That confirmed `status_oled.c`, `halconf.h`, `mcuconf.h` and the keymaps were already byte-identical to what split72 dictates (no drift there). Data that can't come from a 72-key variant — the `LAYOUT_crkbd` layout, keymaps, and the 128×32 `status_oled.c` — was preserved.

The remaining split42-only changes are the ones its hardware requires:

- **4×6 matrix, 3 shift registers, no RGB matrix, no Cirque trackpad**, 128×32 status OLED (`OLED_ENABLE=yes`; harmless while unconnected).
- **`key_display[]` is now 6-wide** (`MATRIX_COLS = 6`). The old table was an 8-wide copy of split72's, so `LAYOUT_TO_INDEX = row*6+col` drifted every row past row 0 by 2 and keys inverted the wrong keycap display.
- **Encoder pins → GP2/GP3** (`ENC_A`/`ENC_B` per schematic; GP25/GP29 are Exp-header pads on this board). Frees GP2 (split72 drives WS2812 there).
- **`invert_display` uses direct indexing** (no split72 `c--` fold): the CRKBD right half carries all 6 columns.
- **`GET_ID` reports the real variant name** via `POLY_KB_NAME` (`"Split42"`). The shared `hid_com.c` fallback stays `"Split72"`, so split72 — which does not define it — emits the identical GET_ID string it always has. `split72/config.h` is unchanged from the default branch.

Not included on purpose: any split-UART / `SPI_MISO_PIN` change. If this baseline works on hardware, the old split42 had firmware drift; if it fails the same way split72 wouldn't, the cause is shared and gets investigated against evidence rather than pre-emptively "fixed" here.

Files changed: `split42/*` (config.h, rules.mk, split42.c, split42.h, keyboard.json) + a behavior-preserving fallback in the shared `hid_com.c`. `split72/config.h` has **zero** diff.

## Version bump label

*(none)* — new variant bring-up / config fixes, no protocol or feature change → patch bump.

## Testing
- [x] Compiled successfully — both `qmk compile -kb polykybd/split42 -km default` and `-kb polykybd/split72 -km default` (clean `.elf` + `.uf2`)
- [x] GET_ID verified in the built images: `Split42 … HW0x0100` and `Split72 … HW0x0320` (split72 unchanged)
- [ ] Flashed and tested on hardware
- [ ] If protocol changed: host updated and tested together — n/a (no protocol change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWppFnAZRMzrcYdMQTErup)_

## Summary by Sourcery

Rebuild the split42 keyboard variant from the working split72 baseline, configuring its 4x6 CRKBD matrix, shift-register-driven keycap displays, encoder, and OLED while keeping split72’s behavior and protocol unchanged.

New Features:
- Expose the Split42 variant name via GET_ID using a per-variant POLY_KB_NAME, while preserving Split72’s existing ID string.

Bug Fixes:
- Correct split42’s keycap display mapping to a 6-wide layout so matrix indices invert the intended key displays.
- Remove the right-half column offset in split42’s display inversion so CRKBD rows index all six columns symmetrically.

Enhancements:
- Align split42’s matrix, SPI, and encoder configuration with its hardware schematic and the split72 baseline, including clarified comments on pins and shift-register usage.
- Simplify split42’s source set and feature flags to match its actual hardware (no RGB matrix or pointing device, 128×32 status OLED only).

Build:
- Adjust split42 rules.mk source list and feature options to exclude RGB/pointing-related units and clean up feature flag formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Split42 devices now identify themselves with the correct keyboard name.
  - Rotary encoder inputs are mapped to the updated hardware pins.

- **Bug Fixes**
  - Corrected Split42 display-selection mapping for the six-column-per-side layout.
  - Updated display inversion handling to match the Split42 matrix layout.

- **Documentation**
  - Clarified display wiring, encoder configuration, OLED support, and hardware layout details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->