### PR TITLE
status OLED: diff-only flush + defer DISPLAY_ON to kill boot noise

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,6 +233,56 @@ new ISO codes append at the next free slot; private pseudo-codes with no ISO
   verifier is committed as `doom/tools/keycap_dispmap.py` (run it after any
   placement change); full write-up in `doom/README.md` § anti-burn-in placement.
 
+### Status OLED (128×64 split72 / 128×32 split42, SSD1306 over **I2C**)
+The status OLED is the QMK `ssd1306` driver (`OLED_DRIVER = ssd1306`, no
+`OLED_TRANSPORT` → QMK defaults to **I2C**) on `I2CD0` (GP0/GP1) at **400 kHz**
+(`config.h`). ⚠️ It is a **different bus** from the per-keycap displays (those are
+the SPI SSD1306s driven by `disp_array.c`) — don't conflate them. Each half drives
+its **own** status OLED locally. Rendering lives in `oled_helper.c` (`oled_task_user`
+dispatch) + `<variant>/status_oled.c` (`oled_update_buffer*` composers): everything
+is composed into the 1024-byte kdisp scratch buffer (`get_scratch_buffer()`,
+`128×8`, cleared by `kdisp_set_buffer(0)`) then blitted to the QMK framebuffer with
+`oled_write_raw`.
+
+**The "updates in multiple passes" flicker (2026-07):** QMK's driver splits the
+frame into **16 blocks** and `oled_render()` flushes only `OLED_UPDATE_PROCESS_LIMIT`
+(default **1**) block per call. `oled_render()` runs every main-loop iteration, so a
+static screen normally paints fast — but two things made a full repaint dribble out
+band-by-band:
+- Each screen composer used to call **`oled_clear()`** before `oled_write_raw`, which
+  marks **all 16 blocks dirty every 66 ms tick** even when only a digit moved.
+  `oled_write_raw` already diffs byte-for-byte and dirties only changed blocks, so the
+  `oled_clear()` was **dropped** from `oled_status_screen()` and `oled_fw_update_screen()`
+  — a static screen now costs nothing on the bus and an incremental change touches 1–2
+  blocks. (The scratch is a full-frame black background, so no stale pixels result.)
+- When the main loop is **saturated** (a firmware/font-pack flash streaming HID chunks
+  + driving the deferred sector erase, or a boot-time busy window), the 1-block-per-call
+  flush can't finish a full-screen transition before the loop starves it — the classic
+  symptom was the **status→"Firmware Update" screen transition tearing**, bottom rows
+  still showing the old status. Fix: both `oled_status_screen()` and
+  `oled_fw_update_screen()` end with **`oled_render_dirty(true)`** to push all changed
+  blocks in **one** synchronous pass. It is a **no-op when nothing changed** (early-returns
+  on `!oled_dirty`), so it only pays the ~26 ms full-frame I2C cost on an actual full
+  swap, never per idle tick. ⚠️ Don't reintroduce a per-frame `oled_clear()` — it defeats
+  the diffing and makes `oled_render_dirty(true)` re-push the whole frame every tick.
+- The other `oled_clear()` (`poly_keymap.c` `oled_init_user`) is harmless: QMK calls
+  `oled_init_user` at the **top** of `oled_init`, before `oled_initialized = true`, so
+  the `oled_off/render/on` around it are early-return no-ops (it only touches RAM).
+- The logos + DOOM status paths use diff-based `oled_write_raw` (no `oled_clear`) and
+  hardware scroll; they can still dribble on a busy transition but are non-critical, so
+  they were left as-is.
+
+**Boot noise (deferred `DISPLAY_ON`)** — the SSD1306 powers up with random GDDRAM, and
+stock `oled_init()` sent `DISPLAY_ON` before any content was flushed, so boot flashed
+RAM noise before the splash. Patched in QMK core (`drivers/oled/oled_driver.c`, tracked
+in `UPSTREAM_PATCHES.md`): the panel stays off through init, an all-black GDDRAM is
+flushed, **then** `DISPLAY_ON` — boot shows black → splash.
+
+**Speed levers not yet pulled** (were unnecessary once the diffing + one-shot flush
+landed; revisit only if a full swap still looks slow on hardware): raise
+`OLED_UPDATE_PROCESS_LIMIT`, or bump I2C to Fast-Mode+ 1 MHz (`I2C1_CLOCK_SPEED`,
+above SSD1306 spec — A/B on real hardware).
+
 ### Split synchronisation
 Seven custom QMK transaction IDs (`USER_SYNC_POLY_DATA`, `USER_SYNC_OVERLAY_DATA`, `USER_SYNC_COMPRESSED_DATA`, `USER_SYNC_ROI_DATA`, etc.) carry state and overlay data to the slave half over UART with CRC32 validation and up to 10 retries.
 

--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -345,7 +345,12 @@ bool oled_init(oled_rotation_t rotation) {
         }
     }
 
-    static const uint8_t PROGMEM display_setup2[] = {I2C_CMD, COM_PINS, OLED_COM_PINS, CONTRAST, OLED_BRIGHTNESS, PRE_CHARGE_PERIOD, OLED_PRE_CHARGE_PERIOD, VCOM_DETECT, OLED_VCOM_DETECT, DISPLAY_ALL_ON_RESUME, NORMAL_DISPLAY, DEACTIVATE_SCROLL, DISPLAY_ON};
+    // PolyKybd deviation: DISPLAY_ON intentionally NOT sent here. The panel's
+    // GDDRAM holds random data at power-on; turning the display on before the
+    // framebuffer has been pushed makes the boot flash a screenful of RAM noise.
+    // We keep the panel off, clear GDDRAM below, then enable it. See
+    // keyboards/polykybd/UPSTREAM_PATCHES.md.
+    static const uint8_t PROGMEM display_setup2[] = {I2C_CMD, COM_PINS, OLED_COM_PINS, CONTRAST, OLED_BRIGHTNESS, PRE_CHARGE_PERIOD, OLED_PRE_CHARGE_PERIOD, VCOM_DETECT, OLED_VCOM_DETECT, DISPLAY_ALL_ON_RESUME, NORMAL_DISPLAY, DEACTIVATE_SCROLL};
     if (!oled_send_cmd_P(display_setup2, ARRAY_SIZE(display_setup2))) {
         print("display_setup2 failed\n");
         return false;
@@ -360,8 +365,19 @@ bool oled_init(oled_rotation_t rotation) {
 
     oled_clear();
     oled_initialized = true;
-    oled_active      = true;
     oled_scrolling   = false;
+    // PolyKybd deviation (see UPSTREAM_PATCHES.md): the DISPLAY_ON in the init
+    // command list above was removed so the panel is still physically OFF here.
+    // Push the just-cleared (all-black) framebuffer to GDDRAM, THEN switch the
+    // panel on, so the first thing the eye sees is black -> boot splash rather
+    // than a flash of power-on RAM noise. oled_render_dirty() calls oled_on()
+    // internally, so we hold oled_active = true across the flush to suppress that
+    // (no DISPLAY_ON emitted), then clear it and call oled_on() to emit exactly
+    // one DISPLAY_ON with a clean GDDRAM already in place.
+    oled_active = true;
+    oled_render_dirty(true);
+    oled_active = false;
+    oled_on();
     return true;
 }
 

--- a/keyboards/polykybd/UPSTREAM_PATCHES.md
+++ b/keyboards/polykybd/UPSTREAM_PATCHES.md
@@ -44,3 +44,42 @@ The strong override of `raw_hid_pre_receive_kb` lives in
 
 If a future QMK upstream changes the signature or semantics of `raw_hid_task`,
 re-apply by hand: keep the weak hook, keep the `if`-not-`while`.
+
+## drivers/oled/oled_driver.c
+
+Defer the status-OLED `DISPLAY_ON` until the framebuffer has been pushed, so
+the boot no longer flashes the panel's random power-on GDDRAM before the splash
+appears (the SSD1306 status OLED is on I2C @ 400 kHz).
+
+Two hunks in `oled_init()`:
+
+1. Drop `DISPLAY_ON` from the `display_setup2[]` init command list so the panel
+   stays physically OFF after the init commands:
+
+   ```diff
+   -    static const uint8_t PROGMEM display_setup2[] = {…, DEACTIVATE_SCROLL, DISPLAY_ON};
+   +    static const uint8_t PROGMEM display_setup2[] = {…, DEACTIVATE_SCROLL};
+   ```
+
+2. At the tail of `oled_init()`, after `oled_clear()`, flush the cleared
+   (all-black) buffer to GDDRAM with the panel still off, then enable it:
+
+   ```diff
+        oled_clear();
+        oled_initialized = true;
+   -    oled_active      = true;
+        oled_scrolling   = false;
+   +    oled_active = true;          // suppress oled_render_dirty()'s internal oled_on()
+   +    oled_render_dirty(true);     // flush all-black GDDRAM while the panel is off
+   +    oled_active = false;         // make the next oled_on() actually emit DISPLAY_ON
+   +    oled_on();                   // light the panel — GDDRAM already black
+        return true;
+   ```
+
+`oled_render_dirty()` calls `oled_on()` at its top when there is dirty data;
+holding `oled_active = true` across the flush makes that a no-op, so exactly one
+`DISPLAY_ON` is emitted (by the final `oled_on()`) after GDDRAM is clean.
+
+If upstream restructures `oled_init()` / the init command list, re-apply by
+hand: no `DISPLAY_ON` in the command list; flush-then-enable at the tail. End
+state is unchanged (`oled_active == true`, panel on).

--- a/keyboards/polykybd/oled_helper.c
+++ b/keyboards/polykybd/oled_helper.c
@@ -135,8 +135,18 @@ uint8_t fw_update_percent(void) {
 void oled_fw_update_screen(void) {
     oled_on();
     oled_update_buffer_fw_update();
-    oled_clear();
+    // Same diff-only compose as the status screen (no oled_clear() — the scratch
+    // is a full 1024-byte frame with a black background from kdisp_set_buffer(0)).
     oled_write_raw((char*)get_scratch_buffer(), get_scratch_buffer_size());
+    // Then push the changed blocks synchronously in ONE pass. During a flash the
+    // main loop is saturated feeding HID chunks / driving the deferred sector
+    // erase, so the normal per-iteration oled_render() (1 block per call) can't
+    // keep up — the status->update transition dribbled out top-first and left the
+    // bottom rows still showing the old status screen for a visible moment. A full
+    // flush here lands the whole frame on the first tick it is drawn; afterwards
+    // the master's screen is static (slave's progress bar is the only churn), so
+    // diffing keeps this to just the bar's blocks.
+    oled_render_dirty(true);
 }
 
 bool oled_task_user(void) {

--- a/keyboards/polykybd/oled_helper.c
+++ b/keyboards/polykybd/oled_helper.c
@@ -76,7 +76,14 @@ void oled_status_screen(void) {
         oled_on();
     }
     oled_update_buffer();
-    oled_clear();
+    // No oled_clear() here: oled_update_buffer() already composes a full 1024-byte
+    // frame into the scratch buffer (it starts with kdisp_set_buffer(0), so the
+    // background is black), and oled_write_raw() diffs byte-for-byte and marks only
+    // the blocks that actually changed dirty. Calling oled_clear() first forced ALL
+    // 16 framebuffer blocks dirty every 66 ms tick, so the whole panel was re-pushed
+    // over I2C band-by-band even when only the WPM digit / brightness bar moved —
+    // that is the "updates in multiple passes" flicker. Diffing keeps a static screen
+    // silent and shrinks an incremental change to the one or two blocks it touches.
     oled_write_raw((char*)get_scratch_buffer(), get_scratch_buffer_size());
 }
 

--- a/keyboards/polykybd/oled_helper.c
+++ b/keyboards/polykybd/oled_helper.c
@@ -85,6 +85,12 @@ void oled_status_screen(void) {
     // that is the "updates in multiple passes" flicker. Diffing keeps a static screen
     // silent and shrinks an incremental change to the one or two blocks it touches.
     oled_write_raw((char*)get_scratch_buffer(), get_scratch_buffer_size());
+    // Push the changed blocks in ONE pass (see oled_fw_update_screen for the full
+    // rationale): the stock per-iteration oled_render() flushes only one block per
+    // main-loop pass, so a status change landing during a busy window (e.g. an
+    // overlay burst on an app switch) could tear top-first. This is a no-op when
+    // nothing changed, so a static screen still costs nothing on the bus.
+    oled_render_dirty(true);
 }
 
 void oled_render_logos(void) {


### PR DESCRIPTION
## Summary

Two independent improvements to the **status OLED** (SSD1306 on I2C `I2CD0` GP0/GP1 @ 400 kHz), addressing two field observations: the status screen appearing to redraw "in multiple passes", and boot flashing a screenful of noise before the splash.

**Fix A — diff-only flush** (`keyboards/polykybd/oled_helper.c`)
Dropped the per-frame `oled_clear()` in `oled_status_screen()`. `oled_update_buffer()` already composes a full 1024-byte frame into the scratch buffer (black background via `kdisp_set_buffer(0)`), and `oled_write_raw()` diffs byte-for-byte and marks only the blocks that actually changed dirty. The old `oled_clear()` forced **all 16** framebuffer blocks dirty on every 66 ms tick, so the whole panel was re-pushed over I2C band-by-band even when only the WPM digit / brightness bar moved — that is the "updates in multiple passes" flicker. Diffing keeps a static screen silent on the bus and shrinks an incremental change to the one or two blocks it touches.

**Fix C — defer `DISPLAY_ON`** (`drivers/oled/oled_driver.c`)
The SSD1306 powers up with random GDDRAM; the stock `oled_init()` sends `DISPLAY_ON` in its init command list *before* any content is flushed, so boot flashed the panel's power-on RAM contents before the splash. The init now leaves the panel off, flushes an all-black GDDRAM, then enables the panel — boot shows **black → splash**, never noise. `oled_render_dirty()` calls `oled_on()` internally, so `oled_active` is held `true` across the flush to suppress that, then cleared so exactly one `DISPLAY_ON` is emitted with a clean GDDRAM already in place. End state is unchanged (`oled_active == true`, panel on).

This touches QMK core (`drivers/oled/oled_driver.c`), so it is recorded in `keyboards/polykybd/UPSTREAM_PATCHES.md` with a re-apply recipe for future upstream merges.

Held back for a follow-up pending hardware A/B: raising `OLED_UPDATE_PROCESS_LIMIT` (whole frame in one render pass) and bumping I2C to Fast-Mode+ 1 MHz — Fix A likely makes the former unnecessary, and the latter is above SSD1306 spec.

## Version bump label

*(none)* — behavioural fix, patch bump. No protocol/wire change.

## Testing
- [x] Compiled successfully — both `polykybd/split72:default` and `polykybd/split42:default` link clean
- [ ] Flashed and tested on hardware
- [ ] If protocol changed: host updated and tested together — n/a, no protocol change

---
_Generated by [Claude Code](https://claude.ai/code/session_012EycH9XhG2Hohu9eL5JEZM)_

## Summary by Sourcery

Improve status OLED behavior by eliminating unnecessary full-frame clears and deferring display activation until after a clean framebuffer has been pushed.

Bug Fixes:
- Prevent status OLED from flashing random power-on RAM contents during boot by turning the display on only after an all-black frame is rendered.
- Remove multi-pass flicker on the status OLED by avoiding forced full-frame redraws when only small regions change.

Enhancements:
- Reduce I2C traffic and improve perceived smoothness of status OLED updates by relying on diff-based framebuffer flushing instead of clearing every frame.

Documentation:
- Record the local deviation from upstream OLED initialization behavior and re-apply instructions in UPSTREAM_PATCHES.md.