### PR TITLE
docs(split42): bring-up notes + split-link diagnostics (issue identified)

### DIFF
--- a/keyboards/polykybd/split42/BRINGUP.md
+++ b/keyboards/polykybd/split42/BRINGUP.md
@@ -1,194 +1,83 @@
 # split42 hardware bring-up — handoff notes
 
-**Status: brought up and working.** The first physical split42 (42-key CRKBD
-footprint) is up. The variant was rebuilt transparently from the working split72 —
-one commit per step, every pin re-derived from the authoritative KiCad schematic —
-and merged in **PR #143**; the confirmed full-subsystem working config is captured in
-**PR #144**. The one bring-up bug that resisted the obvious theories (a dead inter-half
-split link) turned out to be a **firmware** dependency, not a board fault — see §9 and
-[`SPLIT_LINK_DIAGNOSTICS.md`](SPLIT_LINK_DIAGNOSTICS.md).
+split42 (42-key CRKBD footprint) was rebuilt from split72 one commit per step, every
+pin re-derived from the KiCad schematic, and merged in **#143**; a confirmed working
+config is in **#144**. The split-link investigation lives in the top-level **`CLAUDE.md`**
+(§ "Troubleshooting principle" + the split-link notes) — this file is the hardware
+reference and defers the firmware detail there.
 
-> **Living source of truth for the split-link investigation is the top-level
-> `CLAUDE.md`** (§ "Troubleshooting principle: don't take shortcuts" and the split-link
-> investigation notes). The split42 code config is still being narrowed there (the exact
-> resting config + the remaining root-mechanism discrimination), so this file records the
-> durable *hardware* facts and defers the evolving firmware detail to `CLAUDE.md`.
-
-**Hardware source of truth:** `thpoll83/PolyKybd` (the KiCad repo), schematic
-`poly_kybd/variations/poly_corne/poly_corne_split42_left.kicad_sch`. The MCU pins are
-exposed as hierarchical labels GP0–GP29 from the `RpPico` sub-sheet
-(`poly_kybd/rp_pico.kicad_sch`); the net each GPIO carries is defined on the parent
-sheet above.
+**Hardware source of truth:** `thpoll83/PolyKybd` (KiCad), schematic
+`poly_kybd/variations/poly_corne/poly_corne_split42_left.kicad_sch`.
 
 ---
 
-## 1. Definitive GPIO map (from the LEFT-half KiCad schematic)
+## GPIO map (from the LEFT-half KiCad schematic)
 
-| GPIO | Net (schematic) | Role | Firmware config | OK? |
-|------|-----------------|------|-----------------|-----|
-| GP0  | I2C_SDA | *intended* status-OLED SDA (I2C0) | shared `config.h` I2C0 | ⚠️ **not broken out to a pad on this rev** |
-| GP1  | I2C_SCL | *intended* status-OLED SCL (I2C0) | shared `config.h` I2C0 | ⚠️ **not broken out on this rev** |
-| GP2  | ENC_A | rotary encoder A | `keyboard.json` `pin_a` | ✅ |
-| GP3  | ENC_B | rotary encoder B | `keyboard.json` `pin_b` | ✅ |
-| GP4  | SERIAL_COM1 | **split UART RX** | shared `SERIAL_USART_RX_PIN` | ✅ |
-| GP5  | SERIAL_COM2 | **split UART TX** | shared `SERIAL_USART_TX_PIN` | ✅ |
-| GP6  | SPI SCK | keycap-display SPI clock | `SPI_SCK_PIN` | ✅ |
-| GP7  | SPI MOSI | keycap-display SPI data | `SPI_MOSI_PIN` | ✅ |
-| GP8  | D-C | keycap-display SPI D/C | `SPI_DC_PIN` | ✅ |
-| GP9  | RESET | keycap-display HW reset | `HW_RST_PIN` | ✅ |
-| GP10–15 | Col1–Col6 | key-matrix columns | `MATRIX_COL_PINS` | ✅ |
-| GP16 | E2 | Exp0 header pad | (free) | — |
-| GP17 | SPI CS | keycap-display SPI CS | `SPI_SS_PIN` | ✅ |
-| GP18–21 | Row1–Row4 | key-matrix rows | `MATRIX_ROW_PINS` | ✅ |
-| GP22 | E4 | Exp0 header pad → status-OLED SDA (current wiring) | see §4 | ⚠️ v2 workaround |
-| GP23 | E3 | Exp0 header pad → status-OLED SCL (current wiring) | see §4 | ⚠️ open joint, §4 |
-| GP25 | E0 | Exp0 header pad | (free) | — |
-| GP26 | SR_DATA | shift-register data | `SR_DATA_PIN` | ✅ |
-| GP27 | SR_CLOCK | shift-register clock | `SR_CLK_PIN` | ✅ |
-| GP28 | SR_LATCH | shift-register latch | `SR_LATCH_PIN` | ✅ |
-| GP29 | E1 | Exp0 header pad | (free) | — |
+| GPIO | Net | Role | Firmware config |
+|------|-----|------|-----------------|
+| GP0/GP1 | I2C_SDA/SCL | intended status-OLED bus (I2C0), not broken out to a pad on this rev | shared `config.h` I2C0 |
+| GP2/GP3 | ENC_A/ENC_B | rotary encoder | `keyboard.json` `pin_a`/`pin_b` |
+| GP4/GP5 | SERIAL_COM1/COM2 | split UART RX / TX | shared `SERIAL_USART_RX_PIN`/`_TX_PIN` |
+| GP6/GP7 | SPI SCK / MOSI | keycap-display SPI | `SPI_SCK_PIN` / `SPI_MOSI_PIN` |
+| GP8/GP9 | D-C / RESET | keycap-display SPI D/C, HW reset | `SPI_DC_PIN` / `HW_RST_PIN` |
+| GP10–15 | Col1–Col6 | key-matrix columns | `MATRIX_COL_PINS` |
+| GP17 | SPI CS | keycap-display SPI CS | `SPI_SS_PIN` |
+| GP18–21 | Row1–Row4 | key-matrix rows | `MATRIX_ROW_PINS` |
+| GP22/GP23 | E4/E3 (Exp0) | status-OLED SDA/SCL as wired on this rev (I2C1) | see status-OLED note |
+| GP26/27/28 | SR_DATA/CLOCK/LATCH | shift-register control | `SR_DATA_PIN` / `SR_CLK_PIN` / `SR_LATCH_PIN` |
+| GP16, GP25, GP29 | E2/E0/E1 (Exp0) | free header pads | — |
 
-**Exp0 header (2×3, `Conn_02x03`):** E0=GP25, E1=GP29, E2=GP16, E3=GP23, E4=GP22.
-Valid RP2040 hardware-I2C pairs on that header: **I2C1 = E4(GP22 SDA)+E3(GP23 SCL)**,
-or I2C0 = E2(GP16 SDA)+E0(GP25 SCL)/E1(GP29 SCL).
-
-**`SPI_MISO_PIN` is left at GP4** (mirrors split72). GP4 also carries `SERIAL_COM1`
-(the split-serial RX) and there is no dedicated MISO net — the keycap SSD1306s are
-**write-only**, so MISO is never read. This is deliberately unchanged from split72
-(baseline-first). It is *not* the cause of the split-link bug in §9 — that was tracked
-to a firmware dependency (`SPLIT_POINTING_ENABLE`), not SPI stealing the pin.
+`SPI_MISO_PIN` is left at GP4 (mirrors split72); MISO is never read (the keycap
+SSD1306s are write-only), so it shares GP4 with the split-serial RX.
 
 ---
 
-## 2. What the rebuild established (merged in #143)
+## Merged config (from #143)
 
-split42 was reconstructed from split72 with one commit per step so every difference is
-auditable (see `CLAUDE.md` § "Troubleshooting principle" for why this mechanical path
-was the productive one). Merged facts:
-
-- **Encoder** GP2/GP3 (ENC_A/ENC_B per schematic; GP25/GP29 were Exp-header pads).
-- **Matrix** `MATRIX_COLS = 6`, rows GP18–21, cols GP10–15; `NUM_SHIFT_REGISTERS = 3`.
-- **Status OLED** 128×32 (vs split72's 128×64); **PID `0x2008`**; layout `LAYOUT_lr_stacked42`.
-- **`GET_ID` still reports `Split72`** — the per-variant name (`POLY_KB_NAME` /
-  cmd-6 string) was **not** merged (`hid_com.c` hardcodes `"Split72"`), so the host
-  currently shows the wrong board name for a split42. Cosmetic (PID `0x2008` already
-  distinguishes the variant to the host); a follow-up can wire `POLY_KB_NAME`.
-- **Keycap display map** — `split42.c key_display[]` is **6-wide** to match the 6-col
-  matrix (split72's was 8-wide). Row 0 is hardware-verified; the thumb entries and the
-  right-half fold are flagged TODO in `split42.c` (verify per §8).
+- Matrix `MATRIX_COLS = 6`, rows GP18–21, cols GP10–15; `NUM_SHIFT_REGISTERS = 3`.
+- Encoder GP2/GP3; status OLED 128×32; PID `0x2008`; layout `LAYOUT_lr_stacked42`.
+- No RGB matrix, no pointing hardware. The split link needs `SPLIT_POINTING_ENABLE`
+  (see the split-link note below and `CLAUDE.md`).
+- Keycap display map `split42.c key_display[]` is 6-wide (matches the 6-col matrix).
 
 ---
 
-## 3. Building & flashing
-
-QMK pulls 5 deps as git submodules (`lib/chibios`, `lib/chibios-contrib`,
-`lib/pico-sdk`, `lib/printf`, `lib/lufa`) — empty in a fresh clone. The ARM toolchain
-builds this fork end-to-end (verified; see the top-level `CLAUDE.md` "Building &
-flashing" for the container caveats, incl. the `codeload.github.com` tarball route when
-the git proxy blocks the `qmk/*` submodules).
+## Building & flashing
 
 ```bash
-sudo apt-get install -y gcc-arm-none-eabi binutils-arm-none-eabi   # arm-none-eabi-gcc 13.2.x
-make git-submodule                                                  # or per-SHA codeload (see CLAUDE.md)
-qmk compile -kb polykybd/split42 -km default                        # or: make polykybd/split42:default
-# raw image for HID flashing (the .bin is the deliverable, not the .uf2):
+sudo apt-get install -y gcc-arm-none-eabi binutils-arm-none-eabi
+make git-submodule                                    # or per-SHA codeload (see CLAUDE.md)
+qmk compile -kb polykybd/split42 -km default
 arm-none-eabi-objcopy -O binary .build/polykybd_split42_default.elf .build/polykybd_split42_default.bin
 ```
 
-Flash **both halves** with the same image; the USB half becomes master (VBUS detection).
+Flash **both halves** with the same image; the USB half becomes master.
 
 ---
 
-## 4. RESOLVED — status OLED dark on this rev: open SCL joint (deferred to next hardware rev)
+## Status OLED
 
-**Root cause (2026-07-10): an open solder joint on the SCL line — the RP2040 GP23 pad
-(U10.35) to the Exp0 E3 pad — so the status OLED never gets a clock and never ACKs.**
-Not a firmware, config, module, or design problem. Chased end-to-end:
-
-- **SDA (GP22 → E4) is fine.** A boot-time GPIO toggle (drive the pins as plain
-  push-pull outputs) showed E4 swinging cleanly, but **E3 (SCL) stayed stuck at 3.3 V**
-  even while GP23 was driving low at 1 Hz — a push-pull output beats any pull-up, so the
-  drive was **not reaching E3**.
-- **The 3.3 V came from the display, not the board:** unsoldering the display made it
-  disappear → it was the module's own SCL pull-up holding an otherwise-floating pad high.
-  Two different displays behaved identically; internal pull-ups + 100 kHz didn't help.
-- **Not a short:** the netlist has E3 on exactly two pads — `U10` pad 35 (GP23) and
-  `Exp0` pin 3 — with no connection to VDD/VBUS; removing the display killed the 3.3 V
-  (a real short would persist).
-
-**Decision: not fixing this hardware rev.** The next revision breaks out the board's
-*intended* status-OLED bus — **I2C0 on GP0/GP1** — so the GP22/GP23 (I2C1) Exp0
-workaround goes away. On the v2 board, drop the I2C1 override (split42 inherits the
-shared `config.h` I2C0/GP0/GP1 defaults) and use `RP_I2C_USE_I2C0`. Until then the
-status OLED is non-functional on this board; the **key displays and `qmk console` logs**
-cover bring-up needs.
-
-> The I2C1 status-OLED move (GP22/GP23) is **intentionally not in the shipped config** —
-> it never worked on this rev (this open joint). It lived only on the bring-up branch.
+On this rev the status OLED is wired to the Exp0 header (GP22/GP23, I2C1); the intended
+GP0/GP1 (I2C0) bus is not broken out to a pad. It does not display on this rev and is
+not needed for bring-up — the keycap displays and `qmk console` cover it. Revisit on a
+hardware rev that exposes GP0/GP1.
 
 ---
 
-## 5. Single-half quirk — "keystrokes only after a boot delay" (expected, not a fault)
-
-At boot the master arms a **forced layer-resync** to push the default layer to the slave
-(`g_force_layer_resync` in `keyboard_post_init_user`, spun in `sync_and_refresh_displays()`).
-With no slave connected, each pass burns ~3× the bridge timeout until the budget is
-exhausted, briefly stalling the USB/main loop → keystrokes appear after a delay, then
-clear. Harmless once the slave half is present. (Optional hardening: gate the forced
-push on `is_transport_connected()` — see the CLAUDE.md "HIL get current language" note.)
-
----
-
-## 6. Stale hardcoded encoder pins in shared code (low priority)
-
-`keyboard_post_init_user` (shared `poly_keymap.c`) still pokes
-`gpio_set_pin_input_high(GP25/GP29)` under an `//encoder pins` comment — those are the
-**split72** encoder pins. On split42 the encoder is GP2/GP3; GP25/GP29 are just Exp pads
-there (harmless), but the poke is dead for split42. Since `poly_keymap.c` compiles for
-both variants, a real fix needs a per-variant `POLY_ENC_*` macro rather than editing the
-shared literal. The QMK encoder driver already uses the correct GP2/GP3 from
-`keyboard.json`, so the encoder scans regardless — verify on hardware.
-
----
-
-## 7. Keycap-display mapping — remaining hardware verification
+## Keycap display map — verification status
 
 `split42.c key_display[]` maps `LAYOUT_TO_INDEX(row,col)` → shift-register bitmask.
-**Row 0 is verified** (matrix row 0 → `BITMASK1(0..5)` inverts the right displays).
-Still to verify on the bench: rows 1–2, the thumb row (only 3 of 6 col slots are
-wired), and the right-half fold in `invert_display()`. Fast procedure: press each key in
-turn and note which display inverts; fill the row/col → BITMASK table. The KiCad
-`poly_corne/shift_registers.kicad_sch` exposes 24 select nets `Out{1,2,3}_{1..8}`;
-`BITMASK{n}(x)` drives `Out{n}_{x+1}` (byte order: `bitmask[2]`=first chip=`BITMASK1`,
-`bitmask[0]`=last chip=`BITMASK3`; bit `x` → output `x`, MSB-first).
+Matrix **row 0 is verified** (inverts the correct displays). Rows 1–2, the thumb row
+(only 3 of 6 col slots are wired), and the right-half fold in `invert_display()` are
+not yet verified — press each key and note which display inverts to fill the table.
 
 ---
 
-## 8. Verification checklist for a fresh split42 board
+## Split link
 
-- [ ] `qmk compile -kb polykybd/split42 -km default` builds clean.
-- [ ] `qmk compile -kb polykybd/split72 -km default` builds clean (shared code guard).
-- [x] Key matrix scans; keycap-display shift-register chain drives the OLEDs.
-- [x] Keycap-display **row 0** inverts on the correct key; **split link comes up** with
-      the resting config (§9). Remaining: keycap rows 1–2 + thumb map (§7).
-- [ ] Status OLED — non-functional this rev (§4); expected. Bitmap logos in
-      `status_oled.c` are still placeholder zeros (cosmetic).
-
----
-
-## 9. Split link — was dead, now identified (firmware dependency, not a board fault)
-
-On the first physical split42 pair the inter-half UART was dead (master typed, slave
-`S 0`, `transport_fail=100%`). It looked like a hardware problem — and multiple hardware
-theories were floated — but the transparent split72→split42 rebuild + a per-subsystem
-bisect showed it is a **split-link *establishment* failure in firmware**, fixed by
-enabling **`SPLIT_POINTING_ENABLE`** (the split72 hardware always had the trackpad, which
-hid the dependency). The trackpad hardware/I2C is *not* required — a no-op `custom`
-pointing driver works too.
-
-The full corrected record — every hypothesis that was ruled out, the localisation that
-turned out to be a *wrong turn*, the bench toolkit, and the key learning that the
-"physical build / bench-scope" conclusion was wrong — is in
-[`SPLIT_LINK_DIAGNOSTICS.md`](SPLIT_LINK_DIAGNOSTICS.md). The authoritative, still-evolving
-narrative (the exact resting config and the remaining `(b)` shmem-layout vs `(c)`
-code-linkage discrimination) is in the top-level **`CLAUDE.md`**.
+The inter-half UART was initially dead on split42 (master typed; slave received nothing,
+`transport_fail=100%`). The transparent rebuild + per-subsystem bisect (#143) established
+that enabling **`SPLIT_POINTING_ENABLE`** brings the link up — the trackpad hardware is
+not needed (a no-op `custom` driver suffices). The ongoing analysis of *why* is in
+`CLAUDE.md`; the reusable bench toolkit is in
+[`SPLIT_LINK_DIAGNOSTICS.md`](SPLIT_LINK_DIAGNOSTICS.md).

--- a/keyboards/polykybd/split42/BRINGUP.md
+++ b/keyboards/polykybd/split42/BRINGUP.md
@@ -1,0 +1,191 @@
+# split42 hardware bring-up — handoff notes
+
+**Status: brought up and working.** The first physical split42 (42-key CRKBD
+footprint) is up. The variant was rebuilt transparently from the working split72 —
+one commit per step, every pin re-derived from the authoritative KiCad schematic —
+and merged in **PR #143**; the confirmed full-subsystem working config is captured in
+**PR #144**. The one bring-up bug that resisted the obvious theories (a dead inter-half
+split link) turned out to be a **firmware** dependency, not a board fault — see §9 and
+[`SPLIT_LINK_DIAGNOSTICS.md`](SPLIT_LINK_DIAGNOSTICS.md).
+
+> **Living source of truth for the split-link investigation is the top-level
+> `CLAUDE.md`** (§ "Troubleshooting principle: don't take shortcuts" and the split-link
+> investigation notes). The split42 code config is still being narrowed there (the exact
+> resting config + the remaining root-mechanism discrimination), so this file records the
+> durable *hardware* facts and defers the evolving firmware detail to `CLAUDE.md`.
+
+**Hardware source of truth:** `thpoll83/PolyKybd` (the KiCad repo), schematic
+`poly_kybd/variations/poly_corne/poly_corne_split42_left.kicad_sch`. The MCU pins are
+exposed as hierarchical labels GP0–GP29 from the `RpPico` sub-sheet
+(`poly_kybd/rp_pico.kicad_sch`); the net each GPIO carries is defined on the parent
+sheet above.
+
+---
+
+## 1. Definitive GPIO map (from the LEFT-half KiCad schematic)
+
+| GPIO | Net (schematic) | Role | Firmware config | OK? |
+|------|-----------------|------|-----------------|-----|
+| GP0  | I2C_SDA | *intended* status-OLED SDA (I2C0) | shared `config.h` I2C0 | ⚠️ **not broken out to a pad on this rev** |
+| GP1  | I2C_SCL | *intended* status-OLED SCL (I2C0) | shared `config.h` I2C0 | ⚠️ **not broken out on this rev** |
+| GP2  | ENC_A | rotary encoder A | `keyboard.json` `pin_a` | ✅ |
+| GP3  | ENC_B | rotary encoder B | `keyboard.json` `pin_b` | ✅ |
+| GP4  | SERIAL_COM1 | **split UART RX** | shared `SERIAL_USART_RX_PIN` | ✅ |
+| GP5  | SERIAL_COM2 | **split UART TX** | shared `SERIAL_USART_TX_PIN` | ✅ |
+| GP6  | SPI SCK | keycap-display SPI clock | `SPI_SCK_PIN` | ✅ |
+| GP7  | SPI MOSI | keycap-display SPI data | `SPI_MOSI_PIN` | ✅ |
+| GP8  | D-C | keycap-display SPI D/C | `SPI_DC_PIN` | ✅ |
+| GP9  | RESET | keycap-display HW reset | `HW_RST_PIN` | ✅ |
+| GP10–15 | Col1–Col6 | key-matrix columns | `MATRIX_COL_PINS` | ✅ |
+| GP16 | E2 | Exp0 header pad | (free) | — |
+| GP17 | SPI CS | keycap-display SPI CS | `SPI_SS_PIN` | ✅ |
+| GP18–21 | Row1–Row4 | key-matrix rows | `MATRIX_ROW_PINS` | ✅ |
+| GP22 | E4 | Exp0 header pad → status-OLED SDA (current wiring) | see §4 | ⚠️ v2 workaround |
+| GP23 | E3 | Exp0 header pad → status-OLED SCL (current wiring) | see §4 | ⚠️ open joint, §4 |
+| GP25 | E0 | Exp0 header pad | (free) | — |
+| GP26 | SR_DATA | shift-register data | `SR_DATA_PIN` | ✅ |
+| GP27 | SR_CLOCK | shift-register clock | `SR_CLK_PIN` | ✅ |
+| GP28 | SR_LATCH | shift-register latch | `SR_LATCH_PIN` | ✅ |
+| GP29 | E1 | Exp0 header pad | (free) | — |
+
+**Exp0 header (2×3, `Conn_02x03`):** E0=GP25, E1=GP29, E2=GP16, E3=GP23, E4=GP22.
+Valid RP2040 hardware-I2C pairs on that header: **I2C1 = E4(GP22 SDA)+E3(GP23 SCL)**,
+or I2C0 = E2(GP16 SDA)+E0(GP25 SCL)/E1(GP29 SCL).
+
+**`SPI_MISO_PIN` is left at GP4** (mirrors split72). GP4 also carries `SERIAL_COM1`
+(the split-serial RX) and there is no dedicated MISO net — the keycap SSD1306s are
+**write-only**, so MISO is never read. This is deliberately unchanged from split72
+(baseline-first). It is *not* the cause of the split-link bug in §9 — that was tracked
+to a firmware dependency (`SPLIT_POINTING_ENABLE`), not SPI stealing the pin.
+
+---
+
+## 2. What the rebuild established (merged in #143)
+
+split42 was reconstructed from split72 with one commit per step so every difference is
+auditable (see `CLAUDE.md` § "Troubleshooting principle" for why this mechanical path
+was the productive one). Merged facts:
+
+- **Encoder** GP2/GP3 (ENC_A/ENC_B per schematic; GP25/GP29 were Exp-header pads).
+- **Matrix** `MATRIX_COLS = 6`, rows GP18–21, cols GP10–15; `NUM_SHIFT_REGISTERS = 3`.
+- **Status OLED** 128×32 (vs split72's 128×64); **PID `0x2008`**; layout `LAYOUT_lr_stacked42`.
+- **`GET_ID` reports `Split42`** (via `POLY_KB_NAME`) so the host shows the right board.
+- **Keycap display map** — `split42.c key_display[]` is **6-wide** to match the 6-col
+  matrix (split72's was 8-wide). Row 0 is hardware-verified; the thumb entries and the
+  right-half fold are flagged TODO in `split42.c` (verify per §8).
+
+---
+
+## 3. Building & flashing
+
+QMK pulls 5 deps as git submodules (`lib/chibios`, `lib/chibios-contrib`,
+`lib/pico-sdk`, `lib/printf`, `lib/lufa`) — empty in a fresh clone. The ARM toolchain
+builds this fork end-to-end (verified; see the top-level `CLAUDE.md` "Building &
+flashing" for the container caveats, incl. the `codeload.github.com` tarball route when
+the git proxy blocks the `qmk/*` submodules).
+
+```bash
+sudo apt-get install -y gcc-arm-none-eabi binutils-arm-none-eabi   # arm-none-eabi-gcc 13.2.x
+make git-submodule                                                  # or per-SHA codeload (see CLAUDE.md)
+qmk compile -kb polykybd/split42 -km default                        # or: make polykybd/split42:default
+# raw image for HID flashing (the .bin is the deliverable, not the .uf2):
+arm-none-eabi-objcopy -O binary .build/polykybd_split42_default.elf .build/polykybd_split42_default.bin
+```
+
+Flash **both halves** with the same image; the USB half becomes master (VBUS detection).
+
+---
+
+## 4. RESOLVED — status OLED dark on this rev: open SCL joint (deferred to next hardware rev)
+
+**Root cause (2026-07-10): an open solder joint on the SCL line — the RP2040 GP23 pad
+(U10.35) to the Exp0 E3 pad — so the status OLED never gets a clock and never ACKs.**
+Not a firmware, config, module, or design problem. Chased end-to-end:
+
+- **SDA (GP22 → E4) is fine.** A boot-time GPIO toggle (drive the pins as plain
+  push-pull outputs) showed E4 swinging cleanly, but **E3 (SCL) stayed stuck at 3.3 V**
+  even while GP23 was driving low at 1 Hz — a push-pull output beats any pull-up, so the
+  drive was **not reaching E3**.
+- **The 3.3 V came from the display, not the board:** unsoldering the display made it
+  disappear → it was the module's own SCL pull-up holding an otherwise-floating pad high.
+  Two different displays behaved identically; internal pull-ups + 100 kHz didn't help.
+- **Not a short:** the netlist has E3 on exactly two pads — `U10` pad 35 (GP23) and
+  `Exp0` pin 3 — with no connection to VDD/VBUS; removing the display killed the 3.3 V
+  (a real short would persist).
+
+**Decision: not fixing this hardware rev.** The next revision breaks out the board's
+*intended* status-OLED bus — **I2C0 on GP0/GP1** — so the GP22/GP23 (I2C1) Exp0
+workaround goes away. On the v2 board, drop the I2C1 override (split42 inherits the
+shared `config.h` I2C0/GP0/GP1 defaults) and use `RP_I2C_USE_I2C0`. Until then the
+status OLED is non-functional on this board; the **key displays and `qmk console` logs**
+cover bring-up needs.
+
+> The I2C1 status-OLED move (GP22/GP23) is **intentionally not in the shipped config** —
+> it never worked on this rev (this open joint). It lived only on the bring-up branch.
+
+---
+
+## 5. Single-half quirk — "keystrokes only after a boot delay" (expected, not a fault)
+
+At boot the master arms a **forced layer-resync** to push the default layer to the slave
+(`g_force_layer_resync` in `keyboard_post_init_user`, spun in `sync_and_refresh_displays()`).
+With no slave connected, each pass burns ~3× the bridge timeout until the budget is
+exhausted, briefly stalling the USB/main loop → keystrokes appear after a delay, then
+clear. Harmless once the slave half is present. (Optional hardening: gate the forced
+push on `is_transport_connected()` — see the CLAUDE.md "HIL get current language" note.)
+
+---
+
+## 6. Stale hardcoded encoder pins in shared code (low priority)
+
+`keyboard_post_init_user` (shared `poly_keymap.c`) still pokes
+`gpio_set_pin_input_high(GP25/GP29)` under an `//encoder pins` comment — those are the
+**split72** encoder pins. On split42 the encoder is GP2/GP3; GP25/GP29 are just Exp pads
+there (harmless), but the poke is dead for split42. Since `poly_keymap.c` compiles for
+both variants, a real fix needs a per-variant `POLY_ENC_*` macro rather than editing the
+shared literal. The QMK encoder driver already uses the correct GP2/GP3 from
+`keyboard.json`, so the encoder scans regardless — verify on hardware.
+
+---
+
+## 7. Keycap-display mapping — remaining hardware verification
+
+`split42.c key_display[]` maps `LAYOUT_TO_INDEX(row,col)` → shift-register bitmask.
+**Row 0 is verified** (matrix row 0 → `BITMASK1(0..5)` inverts the right displays).
+Still to verify on the bench: rows 1–2, the thumb row (only 3 of 6 col slots are
+wired), and the right-half fold in `invert_display()`. Fast procedure: press each key in
+turn and note which display inverts; fill the row/col → BITMASK table. The KiCad
+`poly_corne/shift_registers.kicad_sch` exposes 24 select nets `Out{1,2,3}_{1..8}`;
+`BITMASK{n}(x)` drives `Out{n}_{x+1}` (byte order: `bitmask[2]`=first chip=`BITMASK1`,
+`bitmask[0]`=last chip=`BITMASK3`; bit `x` → output `x`, MSB-first).
+
+---
+
+## 8. Verification checklist for a fresh split42 board
+
+- [ ] `qmk compile -kb polykybd/split42 -km default` builds clean.
+- [ ] `qmk compile -kb polykybd/split72 -km default` builds clean (shared code guard).
+- [x] Key matrix scans; keycap-display shift-register chain drives the OLEDs.
+- [x] Keycap-display **row 0** inverts on the correct key; **split link comes up** with
+      the resting config (§9). Remaining: keycap rows 1–2 + thumb map (§7).
+- [ ] Status OLED — non-functional this rev (§4); expected. Bitmap logos in
+      `status_oled.c` are still placeholder zeros (cosmetic).
+
+---
+
+## 9. Split link — was dead, now identified (firmware dependency, not a board fault)
+
+On the first physical split42 pair the inter-half UART was dead (master typed, slave
+`S 0`, `transport_fail=100%`). It looked like a hardware problem — and multiple hardware
+theories were floated — but the transparent split72→split42 rebuild + a per-subsystem
+bisect showed it is a **split-link *establishment* failure in firmware**, fixed by
+enabling **`SPLIT_POINTING_ENABLE`** (the split72 hardware always had the trackpad, which
+hid the dependency). The trackpad hardware/I2C is *not* required — a no-op `custom`
+pointing driver works too.
+
+The full corrected record — every hypothesis that was ruled out, the localisation that
+turned out to be a *wrong turn*, the bench toolkit, and the key learning that the
+"physical build / bench-scope" conclusion was wrong — is in
+[`SPLIT_LINK_DIAGNOSTICS.md`](SPLIT_LINK_DIAGNOSTICS.md). The authoritative, still-evolving
+narrative (the exact resting config and the remaining `(b)` shmem-layout vs `(c)`
+code-linkage discrimination) is in the top-level **`CLAUDE.md`**.

--- a/keyboards/polykybd/split42/BRINGUP.md
+++ b/keyboards/polykybd/split42/BRINGUP.md
@@ -69,7 +69,10 @@ was the productive one). Merged facts:
 - **Encoder** GP2/GP3 (ENC_A/ENC_B per schematic; GP25/GP29 were Exp-header pads).
 - **Matrix** `MATRIX_COLS = 6`, rows GP18–21, cols GP10–15; `NUM_SHIFT_REGISTERS = 3`.
 - **Status OLED** 128×32 (vs split72's 128×64); **PID `0x2008`**; layout `LAYOUT_lr_stacked42`.
-- **`GET_ID` reports `Split42`** (via `POLY_KB_NAME`) so the host shows the right board.
+- **`GET_ID` still reports `Split72`** — the per-variant name (`POLY_KB_NAME` /
+  cmd-6 string) was **not** merged (`hid_com.c` hardcodes `"Split72"`), so the host
+  currently shows the wrong board name for a split42. Cosmetic (PID `0x2008` already
+  distinguishes the variant to the host); a follow-up can wire `POLY_KB_NAME`.
 - **Keycap display map** — `split42.c key_display[]` is **6-wide** to match the 6-col
   matrix (split72's was 8-wide). Row 0 is hardware-verified; the thumb entries and the
   right-half fold are flagged TODO in `split42.c` (verify per §8).

--- a/keyboards/polykybd/split42/SPLIT_LINK_DIAGNOSTICS.md
+++ b/keyboards/polykybd/split42/SPLIT_LINK_DIAGNOSTICS.md
@@ -1,0 +1,133 @@
+# split42 split-link diagnostics — investigation record + bench toolkit
+
+The first physical split42 pair had a **dead inter-half UART**: the master (USB half)
+typed fine, but the slave received nothing (`transport_fail=100%`, `crc_err=0`, slave RX
+counter `S 0`). This doc is the standalone record of that investigation, its **corrected
+outcome**, and the opt-in diagnostic firmware written to chase it.
+
+> **Authoritative, still-evolving narrative lives in the top-level `CLAUDE.md`** —
+> § "Troubleshooting principle: don't take shortcuts" and the split-link investigation
+> notes (the exact resting config, the transport-establishment analysis, and the
+> remaining `(b)` shmem-layout vs `(c)` code-linkage discrimination). This file is the
+> bring-up-side summary + the bench toolkit; defer to `CLAUDE.md` for the live detail.
+
+---
+
+## Outcome — IDENTIFIED (firmware dependency), and the big correction
+
+**It was never a board fault.** The productive path was **not** more bench probing of
+GP4/GP5 — it was the transparent split72→split42 rebuild + a per-subsystem bisect
+(merged in #143; confirmed-working config in #144). Result:
+
+- **The symptom is a split-link *establishment* failure** at boot, not a wire/PCB
+  problem and not the "slave hangs mid-render / core1 hang" originally framed here. With
+  the failing config the two halves (same image on both) can't establish the link: the
+  master retries split transactions, exhausts `SPLIT_MAX_CONNECTION_ERRORS` (200), times
+  out, and runs **solo** — the display sits on the boot splash until a keypress forces a
+  refresh. It follows the **master role** (swap USB → the behaviour moves), not a
+  physical half.
+- **The fix is enabling `SPLIT_POINTING_ENABLE`** (split72 always had the Cirque
+  trackpad, which hid the dependency). The trackpad *hardware*/I2C is **not** needed — a
+  no-op `custom` pointing driver works too, so it is the pointing feature's split
+  machinery, not the sensor, that matters.
+- **The exact mechanism is still being narrowed** in `CLAUDE.md` (transaction count and
+  gross memory layout are ruled out; it's down to the `split_shared_memory_t` `pointing`
+  member shifting the RPC buffer offsets, vs merely linking `pointing_device.c`).
+
+### ⚠️ Key learning — the earlier conclusion in this very file was WRONG
+
+The original version of this doc concluded *"UNRESOLVED — every firmware avenue is
+exhausted; the residual is the physical build of the split42 boards; pick up at the
+bench scope."* **That was a wrong turn.** Nothing on the bench was needed; the cause was
+a **disabled subsystem** in the firmware. Two lessons (both now in `CLAUDE.md`):
+
+- **Suspect what's *absent/disabled*, not only what's present.** Reading the *enabled*
+  code paths can never find a bug caused by a *missing* one. Diff a broken variant
+  against a working one for **removed** config, and re-add it to test.
+- **Don't upgrade a plausible hardware theory into a verdict.** "Copper-plane short",
+  "cracked QFN joint", "physical build fault" were all floated for this and **none was
+  real** — exactly the trap the `investigate-kicad-pcb` skill and the CLAUDE.md
+  methodology note warn about. A layout/DC check that exonerates the design is a
+  *result*; it is not a licence to invent a physical mechanism the instruments haven't
+  shown.
+
+---
+
+## What was ruled out (all correct — the fault was in none of these)
+
+These checks were sound; the mistake was the *conclusion drawn from them* (that the
+residual must be hardware), not the checks themselves.
+
+- **Firmware / serial config** — `diff`'d `halconf.h` / `mcuconf.h` / `config.h` split42
+  vs split72: identical apart from the OLED/trackpad I2C bus. The `SERIAL_USART_*` /
+  `SPLIT_TRANSACTION_IDS_USER` / `EE_HANDS` defines all live in the **shared** `config.h`;
+  the vendor/PIO transport is the *same code* that runs split72.
+- **Role / handshake** — forcing roles (`POLYKYBD_MASTER_LEFT`, `POLYKYBD_HIL=left/right`)
+  still failed; `PIN_SWAP` is applied by `is_keyboard_master()`, same path both variants.
+- **Baud** — failed at 230400, 115200, and 19200.
+- **PIO vs bitbang** — failed on PIO full-duplex, PIO half-duplex, AND bitbang.
+- **Cable** — the same bridge cable works on the split72 pair and for HID firmware
+  transfer.
+- **GP4↔GP5 short** — the phased loopback showed all four level combinations
+  `00/01/10/11` ⇒ the two conductors are independent (a bridge would only show `00`/`11`).
+- **Schematic + PCB layout** — via the `investigate-kicad-pcb` skill: the COM1/COM2 net
+  is equivalent between variants (same passives, same
+  `U10.6/7 (GP4/GP5) → U26 → USB2` path, right half byte-identical).
+
+> The one thing the "ruled out" list got *right* and important: because every hardware
+> avenue truly was equivalent to the working split72, the fault **had** to be in the
+> firmware config difference — which is precisely what the rebuild-and-bisect then found.
+> The list pointed at the answer; the old prose pointed away from it.
+
+---
+
+## Diagnostic build flags (bench toolkit — code on the bring-up branches)
+
+These opt-in `-e` flags were the instruments used during the investigation. They are
+**deliberately not in the shipped tree** (bring-up scaffolding, not features); they live
+on the bring-up branches at the SHAs below, to cherry-pick back for the next hard
+split-link bug. All OFF by default; the normal split42/split72 builds are untouched.
+
+| Flag | Commit(s) | What it does / proves |
+|------|-----------|-----------------------|
+| `POLYKYBD_LINK_DIAG=yes` | `0f208611`, `460bf1b6` | Draws role glyph + TX/transport-fail/RX-frame counters on the top keycap row (no console needed); `update_displays()` early-returns under it. Adds `get_split_rx_frames()` + the link getters. **This is the readout that showed `S 0` / `transport_fail=100%`.** |
+| `POLYKYBD_SERIAL_SPEED=N` | `c8b7f2b6` | Overrides `SELECT_SOFT_SERIAL_SPEED` for **any** driver (`=5` → 19200 on the proven vendor/PIO transport). |
+| `POLYKYBD_SERIAL_BITBANG=yes\|slow` | `6a330469`, `72745bc0` | Swaps `SERIAL_DRIVER` to QMK's software bitbang on GP5 (no PIO). ⚠️ Weak evidence — QMK bitbang is essentially unexercised on RP2040. |
+| `POLYKYBD_HALF_DUPLEX=yes` / `POLYKYBD_NO_PIN_SWAP=yes` | `d5b3f93c` | Single-wire half-duplex on GP5 / full-duplex without the firmware crossover. |
+| `POLYKYBD_PIN_LOOPBACK=drive\|read` | `dcf0bae3`, `5f7b353f` | Two-board GPIO loopback; driver toggles GP4/GP5 at **different** rates so a GP4↔GP5 short is visible (`00/11` only) vs independent (`00/01/10/11`). |
+| `POLYKYBD_NO_STATUS_OLED=yes` | `177ef5eb` | Disables the status OLED + its I2C1 bring-up entirely (removes I2C1 as a variable; clean cross-flash). |
+
+The most reusable of these is the **phased GP4/GP5 loopback** — driving the two pins to
+the *same* level can't distinguish two good independent conductors from a bridge (both
+read equal), so phase them apart:
+
+```c
+#ifdef POLYKYBD_PIN_LOOPBACK_DRIVE
+    gpio_set_pin_output(GP4);
+    gpio_set_pin_output(GP5);
+    uint32_t drv_now = timer_read32();
+    gpio_write_pin(GP4, (drv_now / 700)  & 1);   // toggles every 700 ms
+    gpio_write_pin(GP5, (drv_now / 1100) & 1);   // toggles every 1100 ms
+#else /* READER */
+    gpio_set_pin_input_high(GP4);
+    gpio_set_pin_input_high(GP5);
+    int g4 = (int)gpio_read_pin(GP4), g5 = (int)gpio_read_pin(GP5);
+    // show '0'+g4, '0'+g5 on the top keycap; all of 00/01/10/11 = independent & live,
+    // always-equal (only 00/11) = GP4/GP5 shorted, stuck 0 = short to GND, stuck 1 = open.
+#endif
+    return;   // own the pins, skip the split transport
+```
+
+The PCB side of the toolkit is the **`investigate-kicad-pcb`** skill (now in the
+`thpoll83/PolyKybd` hardware repo) with `kicad_net_diff.py` for by-name net/variant diffs.
+
+---
+
+## If a split-link bug recurs — the order that actually worked
+
+1. **Cross-flash the other variant's firmware onto the suspect hardware first** (the
+   O(1) firmware-vs-board isolation — see the CLAUDE.md "cheap cross-checks" note).
+2. **Diff the broken variant's config/rules against the working one for what's
+   *removed/disabled*** — re-add it (one subsystem per commit) and bisect.
+3. Only reach for the scope/multimeter/kicad-tools once a cheap cross-check has
+   *justified* a hardware hypothesis. Here, it never did.

--- a/keyboards/polykybd/split42/SPLIT_LINK_DIAGNOSTICS.md
+++ b/keyboards/polykybd/split42/SPLIT_LINK_DIAGNOSTICS.md
@@ -1,133 +1,27 @@
-# split42 split-link diagnostics — investigation record + bench toolkit
+# split42 split-link diagnostics — bench toolkit
 
-The first physical split42 pair had a **dead inter-half UART**: the master (USB half)
-typed fine, but the slave received nothing (`transport_fail=100%`, `crc_err=0`, slave RX
-counter `S 0`). This doc is the standalone record of that investigation, its **corrected
-outcome**, and the opt-in diagnostic firmware written to chase it.
+The first physical split42 pair had a dead inter-half UART: the master typed, the slave
+received nothing (`transport_fail=100%`, `crc_err=0`, slave RX `S 0`).
 
-> **Authoritative, still-evolving narrative lives in the top-level `CLAUDE.md`** —
-> § "Troubleshooting principle: don't take shortcuts" and the split-link investigation
-> notes (the exact resting config, the transport-establishment analysis, and the
-> remaining `(b)` shmem-layout vs `(c)` code-linkage discrimination). This file is the
-> bring-up-side summary + the bench toolkit; defer to `CLAUDE.md` for the live detail.
+**Outcome:** identified via the transparent split72→split42 rebuild + a per-subsystem
+bisect (#143) as a firmware split-link *establishment* failure — enabling
+**`SPLIT_POINTING_ENABLE`** brings the link up (a no-op `custom` pointing driver
+suffices; the trackpad hardware is not needed). The authoritative, still-evolving
+analysis of *why* is in the top-level **`CLAUDE.md`** (split-link investigation notes).
 
----
+This file is just the reusable **bench toolkit** — opt-in diagnostic builds used to
+chase the link. They are **not in the shipped tree** (bring-up scaffolding); they live
+on the bring-up branches at the SHAs below. All OFF by default; flash both halves with
+the same flag.
 
-## Outcome — IDENTIFIED (firmware dependency), and the big correction
-
-**It was never a board fault.** The productive path was **not** more bench probing of
-GP4/GP5 — it was the transparent split72→split42 rebuild + a per-subsystem bisect
-(merged in #143; confirmed-working config in #144). Result:
-
-- **The symptom is a split-link *establishment* failure** at boot, not a wire/PCB
-  problem and not the "slave hangs mid-render / core1 hang" originally framed here. With
-  the failing config the two halves (same image on both) can't establish the link: the
-  master retries split transactions, exhausts `SPLIT_MAX_CONNECTION_ERRORS` (200), times
-  out, and runs **solo** — the display sits on the boot splash until a keypress forces a
-  refresh. It follows the **master role** (swap USB → the behaviour moves), not a
-  physical half.
-- **The fix is enabling `SPLIT_POINTING_ENABLE`** (split72 always had the Cirque
-  trackpad, which hid the dependency). The trackpad *hardware*/I2C is **not** needed — a
-  no-op `custom` pointing driver works too, so it is the pointing feature's split
-  machinery, not the sensor, that matters.
-- **The exact mechanism is still being narrowed** in `CLAUDE.md` (transaction count and
-  gross memory layout are ruled out; it's down to the `split_shared_memory_t` `pointing`
-  member shifting the RPC buffer offsets, vs merely linking `pointing_device.c`).
-
-### ⚠️ Key learning — the earlier conclusion in this very file was WRONG
-
-The original version of this doc concluded *"UNRESOLVED — every firmware avenue is
-exhausted; the residual is the physical build of the split42 boards; pick up at the
-bench scope."* **That was a wrong turn.** Nothing on the bench was needed; the cause was
-a **disabled subsystem** in the firmware. Two lessons (both now in `CLAUDE.md`):
-
-- **Suspect what's *absent/disabled*, not only what's present.** Reading the *enabled*
-  code paths can never find a bug caused by a *missing* one. Diff a broken variant
-  against a working one for **removed** config, and re-add it to test.
-- **Don't upgrade a plausible hardware theory into a verdict.** "Copper-plane short",
-  "cracked QFN joint", "physical build fault" were all floated for this and **none was
-  real** — exactly the trap the `investigate-kicad-pcb` skill and the CLAUDE.md
-  methodology note warn about. A layout/DC check that exonerates the design is a
-  *result*; it is not a licence to invent a physical mechanism the instruments haven't
-  shown.
-
----
-
-## What was ruled out (all correct — the fault was in none of these)
-
-These checks were sound; the mistake was the *conclusion drawn from them* (that the
-residual must be hardware), not the checks themselves.
-
-- **Firmware / serial config** — `diff`'d `halconf.h` / `mcuconf.h` / `config.h` split42
-  vs split72: identical apart from the OLED/trackpad I2C bus. The `SERIAL_USART_*` /
-  `SPLIT_TRANSACTION_IDS_USER` / `EE_HANDS` defines all live in the **shared** `config.h`;
-  the vendor/PIO transport is the *same code* that runs split72.
-- **Role / handshake** — forcing roles (`POLYKYBD_MASTER_LEFT`, `POLYKYBD_HIL=left/right`)
-  still failed; `PIN_SWAP` is applied by `is_keyboard_master()`, same path both variants.
-- **Baud** — failed at 230400, 115200, and 19200.
-- **PIO vs bitbang** — failed on PIO full-duplex, PIO half-duplex, AND bitbang.
-- **Cable** — the same bridge cable works on the split72 pair and for HID firmware
-  transfer.
-- **GP4↔GP5 short** — the phased loopback showed all four level combinations
-  `00/01/10/11` ⇒ the two conductors are independent (a bridge would only show `00`/`11`).
-- **Schematic + PCB layout** — via the `investigate-kicad-pcb` skill: the COM1/COM2 net
-  is equivalent between variants (same passives, same
-  `U10.6/7 (GP4/GP5) → U26 → USB2` path, right half byte-identical).
-
-> The one thing the "ruled out" list got *right* and important: because every hardware
-> avenue truly was equivalent to the working split72, the fault **had** to be in the
-> firmware config difference — which is precisely what the rebuild-and-bisect then found.
-> The list pointed at the answer; the old prose pointed away from it.
-
----
-
-## Diagnostic build flags (bench toolkit — code on the bring-up branches)
-
-These opt-in `-e` flags were the instruments used during the investigation. They are
-**deliberately not in the shipped tree** (bring-up scaffolding, not features); they live
-on the bring-up branches at the SHAs below, to cherry-pick back for the next hard
-split-link bug. All OFF by default; the normal split42/split72 builds are untouched.
-
-| Flag | Commit(s) | What it does / proves |
-|------|-----------|-----------------------|
-| `POLYKYBD_LINK_DIAG=yes` | `0f208611`, `460bf1b6` | Draws role glyph + TX/transport-fail/RX-frame counters on the top keycap row (no console needed); `update_displays()` early-returns under it. Adds `get_split_rx_frames()` + the link getters. **This is the readout that showed `S 0` / `transport_fail=100%`.** |
-| `POLYKYBD_SERIAL_SPEED=N` | `c8b7f2b6` | Overrides `SELECT_SOFT_SERIAL_SPEED` for **any** driver (`=5` → 19200 on the proven vendor/PIO transport). |
-| `POLYKYBD_SERIAL_BITBANG=yes\|slow` | `6a330469`, `72745bc0` | Swaps `SERIAL_DRIVER` to QMK's software bitbang on GP5 (no PIO). ⚠️ Weak evidence — QMK bitbang is essentially unexercised on RP2040. |
+| Flag | Commit(s) | What it does |
+|------|-----------|--------------|
+| `POLYKYBD_LINK_DIAG=yes` | `0f208611`, `460bf1b6` | Draws role glyph + TX/transport-fail/RX-frame counters on the top keycap row (no console needed); `update_displays()` early-returns under it. |
+| `POLYKYBD_SERIAL_SPEED=N` | `c8b7f2b6` | Overrides `SELECT_SOFT_SERIAL_SPEED` for any driver (`=5` → 19200 on the vendor/PIO transport). |
+| `POLYKYBD_SERIAL_BITBANG=yes\|slow` | `6a330469`, `72745bc0` | Swaps `SERIAL_DRIVER` to QMK's software bitbang on GP5 (no PIO). |
 | `POLYKYBD_HALF_DUPLEX=yes` / `POLYKYBD_NO_PIN_SWAP=yes` | `d5b3f93c` | Single-wire half-duplex on GP5 / full-duplex without the firmware crossover. |
-| `POLYKYBD_PIN_LOOPBACK=drive\|read` | `dcf0bae3`, `5f7b353f` | Two-board GPIO loopback; driver toggles GP4/GP5 at **different** rates so a GP4↔GP5 short is visible (`00/11` only) vs independent (`00/01/10/11`). |
-| `POLYKYBD_NO_STATUS_OLED=yes` | `177ef5eb` | Disables the status OLED + its I2C1 bring-up entirely (removes I2C1 as a variable; clean cross-flash). |
+| `POLYKYBD_PIN_LOOPBACK=drive\|read` | `dcf0bae3`, `5f7b353f` | Two-board GPIO loopback; drives GP4/GP5 at different rates so a GP4↔GP5 short shows as `00/11` only vs `00/01/10/11` for independent lines. |
+| `POLYKYBD_NO_STATUS_OLED=yes` | `177ef5eb` | Disables the status OLED + its I2C1 bring-up (removes I2C1 as a variable). |
 
-The most reusable of these is the **phased GP4/GP5 loopback** — driving the two pins to
-the *same* level can't distinguish two good independent conductors from a bridge (both
-read equal), so phase them apart:
-
-```c
-#ifdef POLYKYBD_PIN_LOOPBACK_DRIVE
-    gpio_set_pin_output(GP4);
-    gpio_set_pin_output(GP5);
-    uint32_t drv_now = timer_read32();
-    gpio_write_pin(GP4, (drv_now / 700)  & 1);   // toggles every 700 ms
-    gpio_write_pin(GP5, (drv_now / 1100) & 1);   // toggles every 1100 ms
-#else /* READER */
-    gpio_set_pin_input_high(GP4);
-    gpio_set_pin_input_high(GP5);
-    int g4 = (int)gpio_read_pin(GP4), g5 = (int)gpio_read_pin(GP5);
-    // show '0'+g4, '0'+g5 on the top keycap; all of 00/01/10/11 = independent & live,
-    // always-equal (only 00/11) = GP4/GP5 shorted, stuck 0 = short to GND, stuck 1 = open.
-#endif
-    return;   // own the pins, skip the split transport
-```
-
-The PCB side of the toolkit is the **`investigate-kicad-pcb`** skill (now in the
+The PCB side of the toolkit is the **`investigate-kicad-pcb`** skill (in the
 `thpoll83/PolyKybd` hardware repo) with `kicad_net_diff.py` for by-name net/variant diffs.
-
----
-
-## If a split-link bug recurs — the order that actually worked
-
-1. **Cross-flash the other variant's firmware onto the suspect hardware first** (the
-   O(1) firmware-vs-board isolation — see the CLAUDE.md "cheap cross-checks" note).
-2. **Diff the broken variant's config/rules against the working one for what's
-   *removed/disabled*** — re-add it (one subsystem per commit) and bisect.
-3. Only reach for the scope/multimeter/kicad-tools once a cheap cross-check has
-   *justified* a hardware hypothesis. Here, it never did.


### PR DESCRIPTION
## Summary

Adds the two split42 bring-up docs as a **clean, docs-only** change against current
`PolyKybd`, updated to reflect that the inter-half split-link failure is now
**identified** (the transparent rebuild merged in #143; the confirmed-working
full-subsystem config in #144). These docs were first drafted under the open-mystery
framing; this rewrites them to the resolved state.

- **`keyboards/polykybd/split42/BRINGUP.md`** — the definitive GPIO map from the KiCad
  schematic, build/flash steps, the RESOLVED status-OLED open-SCL-joint finding
  (deferred to v2 hardware), the keycap display-map verification, and a split-link
  section that now points at the identified **firmware** dependency
  (`SPLIT_POINTING_ENABLE`), not a board fault.
- **`keyboards/polykybd/split42/SPLIT_LINK_DIAGNOSTICS.md`** — the corrected outcome: a
  split-link **establishment** failure (`transport_fail=100%`, transport dead), fixed by
  enabling the pointing feature's split machinery (a no-op `custom` driver works — the
  trackpad hardware isn't needed). It records the **key learning** that this file's
  earlier *"residual is the physical build, needs a bench scope"* conclusion was a wrong
  turn (suspect what's *disabled*; don't upgrade a plausible hardware theory into a
  verdict), keeps the bench toolkit + diagnostic-flag reference, and defers the
  still-evolving root-mechanism narrowing to the top-level `CLAUDE.md`.

The authoritative, live investigation stays in `CLAUDE.md` (§ "Troubleshooting principle:
don't take shortcuts" + the split-link notes); these files are the bring-up-side
reference and point to it rather than duplicate it.

Supersedes the docs that were bundled into the now-conflicted #140 (whose code fixes
landed via #143). The other bring-up branches / diagnostic-flag PRs are being closed.

## Version bump label

*(none)* — documentation only, no firmware change.

## Testing
- [x] Docs only — no code compiled or changed. Internal links (`BRINGUP.md` ↔
      `SPLIT_LINK_DIAGNOSTICS.md`) and referenced PRs (#143/#144) verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QeEo7SamJAXEykbNebEdvL)_

## Summary by Sourcery

Add hardware bring-up and split-link diagnostic documentation for the split42 variant, capturing the resolved status of the inter-half link issue and deferring ongoing investigation details to CLAUDE.md.

Documentation:
- Document the split42 hardware GPIO mapping, build/flash steps, known OLED hardware limitation, and verification checklist in a new BRINGUP.md.
- Record the split42 split-link failure investigation, its firmware-based resolution, and reusable diagnostic flags/tooling in a new SPLIT_LINK_DIAGNOSTICS.md.