### PR TITLE
feat(split42): report the real variant name in GET_ID

### DIFF
--- a/keyboards/polykybd/hid_com.c
+++ b/keyboards/polykybd/hid_com.c
@@ -163,7 +163,13 @@ bool legacy_command_kb(uint8_t *data, uint8_t length) {
 // Handles HID commands: device ID, language change, overlay reception, mapping, and display control.
 // Global variables: hid_keycode, hid_modifier, hid_roi, hid_bit_index, hid_bit_index_bridge
 void raw_hid_receive(uint8_t *data, uint8_t length) {
-    const char * name = "P\x06.Split72 " FW_VERSION " P" STR(PROTOCOL_VERSION) " HW" STR(DEVICE_VER) " ";
+    // Board name in the GET_ID reply — each variant header (QMK_KEYBOARD_H) may
+    // define POLY_KB_NAME; default to "Split72" so split72 (which doesn't define
+    // it) emits the exact same string as before.
+#ifndef POLY_KB_NAME
+#    define POLY_KB_NAME "Split72"
+#endif
+    const char * name = "P\x06." POLY_KB_NAME " " FW_VERSION " P" STR(PROTOCOL_VERSION) " HW" STR(DEVICE_VER) " ";
 
     if (length<1) {
         return;

--- a/keyboards/polykybd/split42/split42.h
+++ b/keyboards/polykybd/split42/split42.h
@@ -56,6 +56,11 @@ struct display_info {
 #define POLY_SPLASH_R2     U" 4 2"
 #define POLY_SPLASH_R2_ROW 2
 
+// Board name reported in the GET_ID (cmd 6) string, so the host shows the right
+// variant. hid_com.c falls back to "Split72" when a variant doesn't define this,
+// so split72's GET_ID stays byte-identical (it relies on that fallback).
+#define POLY_KB_NAME "Split42"
+
 void invert_display(uint8_t r, uint8_t c, bool state);
 
 const uint8_t* get_key_disp_bitmask(uint8_t index);


### PR DESCRIPTION
## Summary

GET_ID (cmd 6) hardcoded `"Split72"` for every variant, so the host (and `polyctl`) showed the **wrong board name** for a split42. This makes the name a per-variant `POLY_KB_NAME` macro:

- `split42/split42.h` defines `POLY_KB_NAME "Split42"`.
- `hid_com.c` falls back to `"Split72"` when a variant doesn't define it, so **split72 (which doesn't) emits a byte-identical GET_ID string** — the shipping board is untouched.

Verified in the built ELFs:
- split42 → `.Split42 0.9.54 P11 HW0x0100`
- split72 → `.Split72 0.9.54 P11 HW0x0320` (unchanged)

This is the one genuinely-missing piece from the old #140 branch (its code otherwise landed via #143); the variant name never actually made it in. PID `0x2008` already distinguishes the variant to the host, so this is the cosmetic name shown in the UI.

## Version bump label

*(none)* — the GET_ID *string* content changes but the format/protocol does not; no host update required (the host parses the version/protocol tokens, not the name). Patch bump is fine.

## Testing
- [x] `qmk compile -kb polykybd/split72 -km default` — clean; GET_ID string byte-identical (`Split72 … HW0x0320`)
- [x] `qmk compile -kb polykybd/split42 -km default` — clean; GET_ID now `Split42 … HW0x0100`
- [ ] Flashed and confirmed the host shows "Split42" — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QeEo7SamJAXEykbNebEdvL)_

## Summary by Sourcery

Report the correct per-variant board name in the HID GET_ID response while preserving the existing Split72 behavior.

New Features:
- Introduce a per-variant POLY_KB_NAME macro to control the board name reported in GET_ID responses.

Bug Fixes:
- Fix GET_ID for the Split42 variant so the host displays the correct board name instead of always showing Split72.

Enhancements:
- Add a default POLY_KB_NAME fallback in the HID communication code so Split72 continues to emit an identical GET_ID string as before.