### PR TITLE
split42: fix off-screen status OLED text (signed glyph offsets)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,49 @@ landed; revisit only if a full swap still looks slow on hardware): raise
 `OLED_UPDATE_PROCESS_LIMIT`, or bump I2C to Fast-Mode+ 1 MHz (`I2C1_CLOCK_SPEED`,
 above SSD1306 spec — A/B on real hardware).
 
+**split42: PORTRAIT status OLED (2026-07).** The split42 panel is 128×32 physical
+but **mounted rotated 90°**, so the user reads it as **32 wide × 128 tall**. The poly
+pipeline blits a **raw page-format buffer** via `oled_write_raw`, which **bypasses
+QMK's `OLED_ROTATION`** — setting `OLED_ROTATION_90` does nothing here. So
+`split42/status_oled.c` `oled_update_buffer()` composes the whole screen in a
+**logical 32×128 portrait space** and **software-rotates** each lit pixel into the
+128×32 scratch page buffer via a `pset()` mapping `(lx,ly) → (px=ly, py=31−lx)`
+(page offset `(py>>3)*128 + px`; `kdisp_set_buffer(0)` clears the full 1024 B first).
+It carries **self-contained portrait primitives** (`pdraw_glyph/_text/_text_center/
+_glyph_half/_text_center_half/_bitmap`) that reuse `kdisp_gfx_glyph_font()` for the
+lookup but plot through `pset` (the shared `kdisp_write_gfx_*` draw landscape into the
+128-wide buffer, unusable for portrait). Orientation is the **single compile switch
+`POLY42_STATUS_ROT_CW`** — flip it if the panel reads mirrored/upside-down (nothing
+else changes; everything composes in logical space). The flash/update + boot-logo
+screens are still landscape (deferred). Preview + clip check:
+`tools/status_oled42_preview.py` (`--diag`) mirrors the C coordinate-for-coordinate.
+
+- ⚠️ **Read glyph `xOffset`/`yOffset` through `int8_t`** in the portrait draw
+  helpers: `pgm_read_byte()` returns `uint8_t` and **zero-extends** the Adafruit-GFX
+  signed offsets, so `int yo = pgm_read_byte(&g->yOffset)` turns a text glyph's
+  `yOffset −8` into `248` and the glyph plots off-screen (silently clipped by
+  `pset`). Every text glyph has a negative `yOffset` (above baseline) and the icons
+  −15/−16, so this blanks **all** text + icons while bitmaps/globe/bars still draw.
+  Cast: `int xo = (int8_t)pgm_read_byte(&g->xOffset)` — the pattern `disp_array.c`
+  uses. ⚠️ The Python preview parses signed decimals directly, so it does **not**
+  reproduce this bug — it validates the *layout*, not the compiled C sign-handling
+  (this shipped once, PR #149, caught in review).
+- ⚠️ **Font-header DOUBLE-DEFINITION trap** (cost a full link cycle): `util_font.h`
+  (`NotoSans_Regular_Mid_10pt7b`) and `lang_label_font.h`
+  (`NotoSans_Regular_Tiny_6pt7b`) **define** the font *data* (non-`static`) and are
+  **already compiled into `poly_keymap.c`**. `#include`ing them in `status_oled.c` too
+  gives a `multiple definition of …` **link** error (compiles fine). **Declare them
+  `extern const GFXfont X;`** instead — the pattern `oled_helper.c` already uses.
+  (`NotoSans_Regular_Base_11pt.h`/`Medium_Base_8pt.h` are only included here, so those
+  `#include`s are safe.)
+- **32 px width budget:** at 32 px only ~5 chars fit even in the **Tiny 6 px** font
+  (the smallest compiled in); half-scaling (2×2-OR) any font reads **bold**, and the
+  decimation ("thin") downsample breaks strokes — **Mid 10 pt at half scale (~5 px)**
+  is the crispest small option (used for the layout name). split42 uses **short**
+  layout names via `layout_name_short()` in `status_oled.c` (`Qwrty/Stag!/ColDH/Neo/
+  Wkmn/Unkn`); split72 keeps the full names in the shared `oled_helper.c` array — keep
+  the two in sync when layouts change.
+
 ### Split synchronisation
 Seven custom QMK transaction IDs (`USER_SYNC_POLY_DATA`, `USER_SYNC_OVERLAY_DATA`, `USER_SYNC_COMPRESSED_DATA`, `USER_SYNC_ROI_DATA`, etc.) carry state and overlay data to the slave half over UART with CRC32 validation and up to 10 retries.
 

--- a/keyboards/polykybd/split42/status_oled.c
+++ b/keyboards/polykybd/split42/status_oled.c
@@ -89,7 +89,7 @@ static int pdraw_glyph(const GFXfont* const* fonts, uint8_t n, int x, int baseli
     if (!g) return 0;
     uint16_t bo = pgm_read_word(&g->bitmapOffset);
     int w = pgm_read_byte(&g->width),  h  = pgm_read_byte(&g->height);
-    int xo = pgm_read_byte(&g->xOffset), yo = pgm_read_byte(&g->yOffset);
+    int xo = (int8_t)pgm_read_byte(&g->xOffset), yo = (int8_t)pgm_read_byte(&g->yOffset);
     const uint8_t* bmp = (const uint8_t*)pgm_read_ptr(&f->bitmap);
     int bit = 0; uint8_t bits = 0;
     for (int gy = 0; gy < h; gy++)
@@ -155,7 +155,7 @@ static void pdraw_text_center_half(const GFXfont* const* fonts, uint8_t n, int t
         if (!g) { cx += 4; continue; }   // fallback advance (e.g. a space with no glyph)
         uint16_t bo = pgm_read_word(&g->bitmapOffset);
         int w = pgm_read_byte(&g->width),  h  = pgm_read_byte(&g->height);
-        int xo = pgm_read_byte(&g->xOffset), yo = pgm_read_byte(&g->yOffset);
+        int xo = (int8_t)pgm_read_byte(&g->xOffset), yo = (int8_t)pgm_read_byte(&g->yOffset);
         const uint8_t* bmp = (const uint8_t*)pgm_read_ptr(&f->bitmap);
         int bit = 0; uint8_t bits = 0;
         for (int gy = 0; gy < h; gy++)

--- a/keyboards/polykybd/tools/status_oled42_preview.py
+++ b/keyboards/polykybd/tools/status_oled42_preview.py
@@ -192,7 +192,7 @@ def draw_brightness(setpix, contrast, top_y):
 
 
 # ------------------------------- compose -----------------------------------
-def build(side, mid, tiny, icons, world, contrast=35):
+def build(side, mid, tiny, icons, world, contrast=35, layout_name=SHORT_NAMES[0]):
     """side 'L' (USB host, brightness+WPM) or 'R' (Link bridge, locks)."""
     pts = set()
     setp = lambda px, py: pts.add((px, py))
@@ -268,6 +268,16 @@ def main():
     R = build('R', mid, tiny, icons, world)
 
     if args.diag:
+        # Exercise EVERY short layout name — glyph widths differ, so a clip specific
+        # to e.g. "ColDH" would never surface if we only rendered "Qwrty". The R side
+        # carries a constant ~33 from the intentional half-off Link icon; a name that
+        # clips adds beyond the L=0 / R=33 baseline.
+        def clip_count(pts):
+            return sum(1 for (x, y) in pts if not (0 <= x < P_W and 0 <= y < P_H))
+        for nm in SHORT_NAMES + ["Unkn"]:
+            lc = clip_count(build('L', mid, tiny, icons, world, layout_name=nm))
+            rc = clip_count(build('R', mid, tiny, icons, world, layout_name=nm))
+            print(f"  {nm:6} clipped L={lc} R={rc}")
         Li, lc = render_diag(L, 'LEFT (brightness/WPM)  RED=clipped')
         Ri, rc = render_diag(R, 'RIGHT (Num/Caps lock)  RED=clipped')
         gap = 24
@@ -275,7 +285,7 @@ def main():
         c.paste(Li, (0, 0)); c.paste(Ri, (Li.width + gap, 0))
         out = args.out or '/tmp/status_oled42_diag.png'
         c.save(out)
-        print(f"{out}  clipped L={lc} R={rc}")
+        print(f"{out}  representative (Qwrty): L={lc} R={rc}")
     else:
         Li, Ri = render_plain(L), render_plain(R)
         pad, gap = 16, 40


### PR DESCRIPTION
## Summary

Follow-up bugfix to the split42 portrait status OLED from #149.

The portrait renderer read glyph offsets with `int xo = pgm_read_byte(&g->xOffset)`, but `pgm_read_byte()` **zero-extends** the Adafruit-GFX `int8_t` offsets — a text glyph's `yOffset` of `-8` became `248`, so every string and icon was plotted far off-screen and silently clipped by `pset()`. On the shipped image only the raw USB/Link bitmaps, the globe and the brightness bars would have drawn; **all text and the layer/lock icons were blank**.

Fix: read `xOffset`/`yOffset` through `int8_t` in both draw paths (`pdraw_glyph` and the `pdraw_text_center_half` inline copy), matching `disp_array.c`. `width`/`height`/`xAdvance` are always positive and left unchanged.

Why the clip diagnostic missed it: `tools/status_oled42_preview.py` parses signed decimals directly, so it validated the *layout* but never the compiled C's sign handling. Its `--diag` mode now also exercises **every** short layout name (glyph widths differ) so a name-specific clip can't hide behind `Qwrty`.

Also records both traps (signed-offset read + the font-header double-definition `extern`) in the qmk `CLAUDE.md` status-OLED section.

## Version bump label

None — patch bugfix.

## Testing
- [x] Compiled successfully (`qmk compile -kb polykybd/split42 -km default`)
- [ ] Flashed and tested on hardware — pending; the fix is code-verified (mirrors `disp_array.c`) and the preview `--diag` is clean (`L=0`, `R=33` = the intentional half-off Link icon) for all six names
- [ ] Protocol change: n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBmCVD3bcjRTeCb6ai8bzY)_