### PR TITLE
split42: restore working split link on the default branch (config + boot delay)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -996,6 +996,74 @@ failure, and the transaction COUNT is ruled out.**
   LTR-559, confirmed working) captures the working split42 while this root-cause work
   continues on `claude/split42-literal-split72-copy`.
 
+**⚠️ The DEFAULT branch (`PolyKybd`) regressed split42 again — TWO unreverted
+experiment commits (found + FIXED 2026-07-15, confirmed on hardware).** After the
+above work, the split42 on the `PolyKybd` tip was itself broken (a fresh build from
+the default branch didn't come up). The working commit **`5de77192`** (FW 0.9.51,
+`SPLIT_POINTING_ENABLE` + no-op `custom` driver) *is an ancestor* of the tip, so a
+`git diff 5de77192..PolyKybd` restricted to split-relevant code isolated it — the
+entire split **transport** (`serial_vendor.c`, `serial_protocol.c`, `split_sync.c`,
+`bridge_helper.c`, `base/`) is **byte-identical** working↔tip, so it was neither a
+transport nor a hardware regression. Two breaks, both from root-cause EXPERIMENT
+commits committed straight onto `PolyKybd` and never reverted:
+- **Break #1 (config):** `SPLIT_POINTING_ENABLE` was removed from
+  `split42/config.h` by `01cb83d0` (heartbeat experiment) and only
+  `POINTING_DEVICE_ENABLE` was re-added by `0e04469d` — leaving the exact broken
+  **(c)** state the bisect condemned (pointing code linked, **no split transaction
+  registered**). The whole `01cb83d0…0e04469d` experiment series (heartbeat, boot
+  traces, `SERIAL_DEBUG`, 3 dummy transactions, pointing-code-only) landed on the
+  default branch; only the final one's config state survived, and it was the broken
+  one. **Lesson: revert experiment commits, or run them on a throwaway branch — do
+  NOT commit a discriminator series onto the release branch and walk away.**
+- **Break #2 (boot timing):** the progressive boot-splash rework (PR #138 + merges
+  #143/#144: `show_splash_screen()` → `splash_progress()`, `boot_diag.c`) **removed
+  the pre-init `wait_ms(400)` delay** the old blocking splash had (where it was
+  purely a **logo dwell**, now served by the progressive reveal), deferring the
+  dwell to the *end* of `post_init` and adding ~7 per-`post_init` keycap renders +
+  a boot banner. Fine on split72 (real trackpad → robust link) but split42's marginal
+  link (the dead PIO1 RX-IRQ) does not come up without that pre-init delay. This is
+  the only live shared-code delta working↔tip (the other two diffs are inert: a
+  `POLY_DUMMY_TXN` macro gated off, and a `POLY_KB_NAME` GET_ID string).
+  - ⚠️ **The delay is EMPIRICALLY load-bearing but its MECHANISM is unknown — do NOT
+    invent one.** A clean single-variable A/B on hardware (2026-07-15 eve) settled it:
+    the working restore with **only** the `wait_ms(400)` removed (identical config,
+    `SPLIT_POINTING_ENABLE` on) **fails** — the slave runs just its own local scan
+    (keypress display inversion works) while the rest of the split link never
+    establishes. So the delay genuinely fixes something on the link; *why* a boot
+    delay affects it is not understood. An earlier version of this note (and the
+    in-code comment) claimed a "settle window so the slave comes up before the master
+    hammers transactions" — that was a **fabricated mechanism**, corrected here. The
+    value 400 is inherited from the old splash (known-good, not a measured minimum).
+  - **RULED OUT — it is NOT the pointing driver / per-cycle I2C (2026-07-15 eve).**
+    Follow-up A/B: split42 built with the **real `cirque_pinnacle_i2c` driver** (like
+    split72, so each pointing cycle does a real I2C read — GP0/GP1 aren't broken out so
+    it just times out ~20 ms) **and no delay** → **still broken**, same symptom (no
+    split link, slave only doing its autonomous local invert). So split42 needs the
+    delay **regardless of pointing driver** (no-op `custom` and real Cirque both fail
+    without it), and split72 needs no delay — the split72↔split42 difference that
+    requires the delay is therefore **not** the pointing driver and **not** the
+    per-cycle I2C activity. ⚠️ This also means the earlier bisect's "the fix is the
+    split transaction, not the I2C stall" was tested *with the delay present*, which
+    masked this — the I2C stall is now cleanly ruled out on its own. Leading remaining
+    hypothesis (UNPROVEN): split72 simply **boots slower** (36 vs 21 keycap OLEDs/side,
+    real RGB, bigger status OLED), and with the dead PIO1 RX-IRQ making establishment a
+    *polling race*, a slower master boot wins the race — the 400 ms stands in for that.
+    The proper fix is the IRQ-independent pre-poll (`claude/split42-link-diag-minimal`),
+    not more delay tuning.
+- **Fix (branch `claude/split42-fresh-rebuild-4m3vip`, restarted from the tip; one
+  restore commit — PR #141 on it was closed unmerged, so the stale rebuild history
+  was discarded per the restart-from-default procedure):**
+  (1) restore the Cirque/pointing block + `SPLIT_POINTING_ENABLE` in
+  `split42/config.h`; (2) restore the pre-init `wait_ms(400)` delay in
+  `show_splash_screen()`, **split42-only** (`#if defined(KEYBOARD_polykybd_split42)`)
+  so the progressive reveal is kept and split72 is untouched. Confirmed working on
+  hardware 2026-07-15. The delay is a **stopgap** (empirically needed, mechanism
+  unknown — see the ⚠️ above) — drop it once the IRQ-independent link fix lands (the
+  deeper "why does the marginal link need the pointing transaction *and* a boot
+  delay" root cause is still open; see the `claude/split42-link-diag-minimal`
+  pre-poll work, where `poll_miss` — pointing OFF ≈500, pointing ON ≈2 — is the
+  definitive probe of the dead RX-IRQ).
+
 ### Bug: second half of keyboard becomes unresponsive (slave stops sending key events)
 
 **Symptom**: Intermittently, the right/slave half stops recognising keystrokes. Only keys on the master (USB) side still work. Reconnecting (replugging) or reflashing restores it. Happens "once in a while", not on every boot.

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -2809,6 +2809,21 @@ void post_process_record_user(uint16_t keycode, keyrecord_t* record) {
 // call site; later reveal steps are driven from keyboard_post_init_user().
 void show_splash_screen(void) {
     splash_progress(1);
+#if defined(KEYBOARD_polykybd_split42)
+    // split42 needs this pre-init delay to bring up its split link — EMPIRICAL,
+    // mechanism NOT understood. This wait was inherited from the old blocking
+    // splash, where it was purely a logo dwell (now served by the progressive
+    // reveal), so it does not "belong" here on its own terms — but a clean
+    // single-variable A/B on hardware (2026-07-15) showed it is load-bearing:
+    // the identical build (SPLIT_POINTING_ENABLE on) with ONLY this wait removed
+    // leaves split42 broken — the slave runs just its own local scan (keypress
+    // display inversion works) while the rest of the split link never comes up.
+    // WHY a boot delay affects split42's marginal link (the dead PIO1 RX-IRQ) is
+    // unknown; do NOT infer a "settle window" or any other mechanism from it (an
+    // earlier comment did, wrongly). Stopgap until the IRQ-independent link fix
+    // lands. split72 is unaffected (real trackpad -> robust link) and untouched.
+    wait_ms(400);
+#endif
 }
 
 // Configures all displays with contrast level; shows idle pulsating animation if enabled.

--- a/keyboards/polykybd/split42/config.h
+++ b/keyboards/polykybd/split42/config.h
@@ -71,14 +71,33 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define ENCODER_RESOLUTION 2
 
 /* -------------------------------------------------------------------------
-   ROOT-CAUSE EXPERIMENT (2026-07-14): pointing device DISABLED again, replaced
-   by a custom every-cycle master->slave heartbeat pull (see the
-   POLY_SPLIT_HEARTBEAT_EXPERIMENT block in poly_keymap.c housekeeping, enabled
-   from rules.mk). This tests whether split42's dependency is simply "a frequent
-   every-cycle slave pull" (which SPLIT_POINTING_ENABLE happened to provide) or
-   something structural to the pointing feature. The whole Cirque/pointing block
-   is omitted here for the test; if the heartbeat fixes split42 the proper fix is
-   in the poly transport and this block never comes back. */
+   Pointing device (Cirque trackpad) — REQUIRED for the split link to establish.
+   Bisect (2026-07-14) confirmed: SPLIT_POINTING_ENABLE is the ONE re-enabled
+   subsystem that touches the split link, and split42's marginal link only comes
+   up with it set. It was accidentally dropped on the default branch by the
+   root-cause EXPERIMENT commits `01cb83d0` (heartbeat — removed
+   SPLIT_POINTING_ENABLE) and `0e04469d` (rules re-enabled POINTING_DEVICE_ENABLE
+   but not SPLIT_POINTING), which left split42 broken (pointing code linked, but
+   no split transaction registered). Restored here to the confirmed-working
+   `5de77192` state. No trackpad is populated and the I2C0 bus (GP0/GP1) isn't
+   broken out on this rev, so the Cirque probe just fails and the driver idles
+   (rules.mk uses the no-op `custom` driver — zero I2C). Do NOT drop this block
+   again until the IRQ-independent link fix lands and is confirmed on hardware. */
+#define CIRQUE_PINNACLE_DIAMETER_MM 35
+#define CIRQUE_PINNACLE_TAP_ENABLE
+#define CIRQUE_PINNACLE_TAPPING_TERM 100
+#define CIRQUE_PINNACLE_TOUCH_DEBOUNCE 300
+#define CIRQUE_PINNACLE_POSITION_MODE  CIRQUE_PINNACLE_RELATIVE_MODE
+#define POINTING_DEVICE_GESTURES_CURSOR_GLIDE_ENABLE
+#define CIRQUE_PINNACLE_ATTENUATION EXTREG__TRACK_ADCCONFIG__ADC_ATTENUATE_2X
+
+// Enable use of pointing device on the slave split (registers the split transaction).
+#define SPLIT_POINTING_ENABLE
+// Pointing device is on the right split (split72 puts the trackpad there too).
+#define POINTING_DEVICE_RIGHT
+// Limit the frequency the sensor is polled for motion.
+#define POINTING_DEVICE_TASK_THROTTLE_MS 1
+#define POINTING_DEVICE_ROTATION_90
 
 /* RGB matrix: RE-ENABLED. split42 has no WS2812 LEDs populated, but
    we keep the RGB subsystem in the build (WS2812 PIO driver + the shared RGB code


### PR DESCRIPTION
## Summary

split42 on the current `PolyKybd` tip does not come up — a fresh build from the default branch fails to establish the split link. This restores it. The confirmed-working commit `5de77192` (FW 0.9.51, `SPLIT_POINTING_ENABLE` + no-op `custom` pointing driver) is an ancestor of the tip, so a `git diff 5de77192..PolyKybd` restricted to split-relevant code isolated the regression: the entire split **transport** (`serial_vendor.c`, `serial_protocol.c`, `split_sync.c`, `bridge_helper.c`, `base/`) is **byte-identical** working↔tip, so it is neither a transport nor a hardware change. Two breaks, both from root-cause **experiment** commits that landed straight on `PolyKybd` and were never reverted:

- **Break #1 (config):** `SPLIT_POINTING_ENABLE` was removed from `split42/config.h` by `01cb83d0` (a heartbeat experiment) and only `POINTING_DEVICE_ENABLE` was re-added by `0e04469d` — leaving the exact broken state an earlier bisect condemned: pointing code linked and running, but **no split transaction registered**. This PR restores the Cirque/pointing block + `SPLIT_POINTING_ENABLE`, mirroring `5de77192`. `rules.mk` keeps the no-op `custom` driver (zero I2C), so no trackpad or I2C bus is required.

- **Break #2 (boot delay):** the progressive boot-splash rework (PR #138 + merges #143/#144) removed the pre-init `wait_ms(400)` the old blocking splash had (there it was purely a **logo dwell**, now served by the progressive reveal). split42 does **not** bring up its split link without that pre-init delay. This PR restores it, **split42-only** (`#if defined(KEYBOARD_polykybd_split42)`), so the progressive reveal is kept and **split72 is untouched**.

### ⚠️ On Break #2: the delay is empirically load-bearing, mechanism unknown

I do not have a mechanism for *why* a boot delay affects the split link, and the code comment deliberately says so (an earlier draft invented a "settle window" story — that was wrong and is removed). What I *do* have is a clean single-variable A/B on hardware: the **identical** build (`SPLIT_POINTING_ENABLE` on, same config) with **only** the `wait_ms(400)` removed **fails** — the slave runs just its own local scan (keypress display inversion works) while the rest of the split link never establishes. So the delay genuinely fixes something on split42's marginal link (a dead PIO1 RX-IRQ, tracked separately). The value `400` is inherited from the old splash (known-good, not a measured minimum).

This is a **stopgap** — the delay and the `SPLIT_POINTING` workaround can both come out once the IRQ-independent link fix lands. The two other shared diffs between working and tip are inert (a `POLY_DUMMY_TXN` macro gated off, and a `POLY_KB_NAME` GET_ID string).

Files changed: `keyboards/polykybd/split42/config.h`, `keyboards/polykybd/poly_keymap.c` (split42-guarded), and a write-up of both breaks + the A/B result in `CLAUDE.md`. Built on the current tip, so all other 0.9.61 improvements are retained.

## Version bump label

*(none)* — bug fix / config restore, no protocol or feature change → patch bump.

## Testing
- [x] Compiled successfully — both `qmk compile -kb polykybd/split42 -km default` and `-kb polykybd/split72 -km default` (clean `.elf` + `.uf2`)
- [x] Flashed and tested on hardware — split42 split link comes up and both halves work
- [x] A/B verified the boot delay is load-bearing — same build minus the `wait_ms(400)` fails
- [ ] If protocol changed: host updated and tested together — n/a (no protocol change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWppFnAZRMzrcYdMQTErup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored split42-only startup timing for more reliable boot behavior.
  * Re-enabled split42 split-side trackpad/pointing support, including split-side communication and cursor-glide gestures.
  * Restored split42 trackpad configuration (placement, 90° rotation, polling/task behavior, and touch/tap parameters).
  * Confirmed the corrected behavior on hardware.
* **Documentation**
  * Updated investigation notes with the identified split42 regressions and the applied resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->