### PR TITLE
split: raise split-link baud 230400 → 460800

### DIFF
--- a/keyboards/polykybd/config.h
+++ b/keyboards/polykybd/config.h
@@ -30,6 +30,8 @@
 #define SERIAL_USART_RX_PIN GP4
 #define SERIAL_USART_FULL_DUPLEX
 #define SERIAL_USART_PIN_SWAP
+// Split-link baud is set per variant via SELECT_SOFT_SERIAL_SPEED in halconf.h
+// (0 = 460800). See platforms/chibios/drivers/serial_usart.h for the mapping.
 
 #define SPLIT_TRANSPORT_MIRROR
 // #define SPLIT_LAYER_STATE_ENABLE

--- a/keyboards/polykybd/split42/halconf.h
+++ b/keyboards/polykybd/split42/halconf.h
@@ -39,7 +39,11 @@
 //3	57600 baud
 //4	38400 baud
 //5	19200 baud
-#define SELECT_SOFT_SERIAL_SPEED 1
+// 460800 (was 230400): halves the duration of every overlay transfer — the bulk
+// of split-UART traffic — shortening the master->slave bridge window on each app
+// switch. Safe: the full-duplex two-wire link measured zero steady-state errors at
+// 230400 (split-link health counter, bridge_helper.c). Validate err% on hardware.
+#define SELECT_SOFT_SERIAL_SPEED 0
 
 #define PICO_FLASH_SIZE_BYTES (8 * 1024 * 1024)
 //for split keyboard setup

--- a/keyboards/polykybd/split72/halconf.h
+++ b/keyboards/polykybd/split72/halconf.h
@@ -39,7 +39,11 @@
 //3	57600 baud
 //4	38400 baud
 //5	19200 baud
-#define SELECT_SOFT_SERIAL_SPEED 1
+// 460800 (was 230400): halves the duration of every overlay transfer — the bulk
+// of split-UART traffic — shortening the master->slave bridge window on each app
+// switch. Safe: the full-duplex two-wire link measured zero steady-state errors at
+// 230400 (split-link health counter, bridge_helper.c). Validate err% on hardware.
+#define SELECT_SOFT_SERIAL_SPEED 0
 
 #define PICO_FLASH_SIZE_BYTES (8 * 1024 * 1024)
 //for split keyboard setup


### PR DESCRIPTION
## Summary

Sets `SELECT_SOFT_SERIAL_SPEED 0` (= **460800 baud**) in both variants' `halconf.h` — the idiomatic QMK baud knob, in its natural home — up from `1` (230400). (An earlier revision of this PR overrode `SERIAL_USART_SPEED` from `config.h`; switched to the standard preset per review.)

Doubling the baud **halves the duration of every overlay transfer** (the bulk of split-UART traffic), shortening the blocking master→slave bridge window on each app switch.

**Safe headroom:** the full-duplex two-wire link measured **zero steady-state errors** at 230400 (the split-link health counter in `bridge_helper.c`), and the RP2040 PIO driver has ample margin above 460800.

**Validate on hardware** by watching the counter's `err%` (`Split link: … err=…%`) before going higher. Note 460800 is the **top of the `SELECT_SOFT_SERIAL_SPEED` table** — pushing past it (921600 / 1e6) would need a direct `SERIAL_USART_SPEED` define instead.

## Version bump label

*(none)* — patch. Config-only tweak, no protocol change.

## Testing
- [x] Compiled successfully — `split72` **and** `split42` (`qmk compile … → .uf2`, exit 0)
- [ ] Flashed and tested on hardware
- [ ] If protocol changed: host updated and tested together *(n/a — no protocol change)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)