### PR TITLE
skills: add update-polykybd-docs and run it from session-retro

### DIFF
--- a/.claude/skills/session-retro/SKILL.md
+++ b/.claude/skills/session-retro/SKILL.md
@@ -7,12 +7,15 @@ description: Scan the current (or a past) Claude Code session for things worth k
 
 A session often discovers things that took real iteration to find, and runs
 workflows that will recur. Both are cheap to lose and valuable to keep. This
-skill turns a session into two concrete outputs:
+skill turns a session into three concrete outputs:
 
 1. **Learnings** → appended to the right `CLAUDE.md` / `docs/*.md` (or saved as
    memory) so the next session starts knowing them.
 2. **New skills** → scaffolded `SKILL.md`s for repeatable workflows that were
    done by hand this time.
+3. **Docs gaps** → user-facing features added/changed this session that the
+   public docs (the `polykybd-docs` site) don't yet describe. Run the
+   **`update-polykybd-docs`** skill to close them (a separate PR in that repo).
 
 The deliverable is a *ranked proposal you approve*, then the files. Don't write
 anything until the user picks what to keep.
@@ -75,12 +78,26 @@ for f in $(find . /root/.claude/skills ~/.claude/skills -name SKILL.md 2>/dev/nu
   awk -F': ' '/^name:/{n=$2} /^description:/{print "  "n": "substr($2,1,80)}' "$f"; done
 ```
 
+## 3b. What counts as a DOCS gap (document-worthy)
+
+A **user-facing** change this session that would make the public docs wrong or
+leave a new capability undocumented — a new/changed HID command or
+`PROTOCOL_VERSION`, a new `polyctl` subcommand, a host setting or tray entry, a
+keyboard feature (glyph script, idle style, brightness, font pack), or a new
+language. These belong on the `polykybd-docs` **site**, not in a `CLAUDE.md`.
+
+Don't flag internal refactors, bug fixes with no visible effect, or dev plumbing.
+For each gap, name the change and the likely target page, then hand it to the
+**`update-polykybd-docs`** skill (it owns the page map, the build/verify, and the
+separate-PR flow). The retro's job is only to *notice* the gap and trigger that
+skill — it does not itself edit the docs site.
+
 ## 4. Procedure
 
 1. **Map the session** into its main threads/tasks (2–6 of them). For each, note
    what was *figured out* and what *workflow* was executed.
-2. **Extract candidates** — learnings (§2) and skills (§3) — citing the evidence
-   (what happened, ideally which step/message).
+2. **Extract candidates** — learnings (§2), skills (§3), and docs gaps (§3b) —
+   citing the evidence (what happened, ideally which step/message).
 3. **Dedup**: grep the relevant `CLAUDE.md`/docs for each learning; list existing
    skills for each workflow. Drop anything already captured (or propose an *edit*
    to the existing item instead of a new one).
@@ -95,6 +112,9 @@ for f in $(find . /root/.claude/skills ~/.claude/skills -name SKILL.md 2>/dev/nu
      procedural body with concrete commands, an output format, and a
      **Pitfalls** section). Put reusable helper scripts beside it. Model the
      depth on `qmk_firmware/.claude/skills/firmware-size-diff/SKILL.md`.
+   - Docs gaps → invoke the **`update-polykybd-docs`** skill for each (it edits
+     the `polykybd-docs` site on its own branch + PR). This retro only surfaces
+     them; that skill does the writing.
    - Offer to commit + push the new/edited files (don't unless asked, per repo
      rules).
 
@@ -111,6 +131,10 @@ SKILL CANDIDATES (codify)
      steps: <3–6 word outline>; done <N>× this session
      location: <repo>/.claude/skills/  (or ~/.claude/skills for cross-repo)
   B. ...
+
+DOCS GAPS (→ update-polykybd-docs)
+  i. <feature added/changed> → <likely polykybd-docs page>
+  ii. ...
 
 ALREADY COVERED (skipped): <item> → <existing doc/skill>
 

--- a/.claude/skills/update-polykybd-docs/SKILL.md
+++ b/.claude/skills/update-polykybd-docs/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: update-polykybd-docs
+description: When you add or change a USER-FACING feature in the firmware or host — a new HID command / PROTOCOL_VERSION, a polyctl subcommand, a host setting or tray menu item, a keyboard feature (glyph script, idle style, brightness, font pack), or a language/layout — also extend the public documentation site (the polykybd-docs repo). Use whenever a change would make an existing docs page wrong or leave a new capability undocumented, at the end of feature work, or when the session-retro skill flags a docs gap. NOT for internal-only refactors, bug fixes with no user-visible change, or the firmware/host code change itself.
+---
+
+# Extend the PolyKybd docs when a feature lands
+
+PolyKybd's user documentation is a **separate Astro Starlight site** in the
+`polykybd-docs` repo (published at https://www.polykybd.org). A feature is not
+"done" until the docs describe it — otherwise the site silently drifts (e.g. the
+HID reference sat at PROTOCOL_VERSION 3 while the firmware was at 11, and glyph
+scripts / font packs shipped undocumented for months).
+
+This skill is the checklist for keeping the docs in lockstep. It is **cross-repo**:
+the docs change is its **own branch + PR in `polykybd-docs`**, never part of the
+firmware/host PR.
+
+## When it applies (and when it doesn't)
+
+Update the docs when the change is **user-visible**:
+
+- A new / changed **HID command** or a **PROTOCOL_VERSION** bump.
+- A new **`polyctl`** subcommand or flag.
+- A new **host setting**, tray menu entry, daemon behaviour, or install/startup step.
+- A new **keyboard feature** (idle style, glyph script, brightness/sensor, font pack,
+  overlay behaviour, multi-machine).
+- A new **language / layout** (the `add-polykybd-language` skill covers the firmware
+  side; this covers the docs mention).
+- Any change that makes an existing docs statement **wrong** (renamed thing, changed
+  default, removed option).
+
+Skip it for internal refactors, bug fixes with no user-visible effect, or
+firmware/host build-plumbing.
+
+## Where the docs live
+
+Sibling checkout `../polykybd-docs` (clone `thpoll83/polykybd-docs` if absent).
+Default branch **`main`**. Astro Starlight; pages are Markdown/MDX under
+`src/content/docs/<section>/<page>.{md,mdx}`. The URL is the file path
+(`using/glyph-scripts.mdx` → `/using/glyph-scripts/`).
+
+Sections (nav order): **Introduction · Assembly · Setup · Using the Keyboard ·
+Host Software · Firmware · Development · Reference**. The sidebar is **hand-curated**
+in `astro.config.mjs` (`sidebar: [...]`, `slug`-based) — a new page must be added
+there or it won't appear in the nav.
+
+## Feature → page map (where to write)
+
+| You changed… | Update these pages |
+|---|---|
+| HID command / `PROTOCOL_VERSION` | `reference/hid-protocol.mdx` — the command table **and** the per-version history list. Bump the "current" version. |
+| A `polyctl` subcommand | `software/cli.mdx` (subcommand table) |
+| Host setting / daemon / startup | `software/usage.mdx`, `software/architecture.mdx`, or `setup/installation.mdx` |
+| Keyboard feature (glyph script, idle, brightness, font pack, overlays) | the matching page under `using/` or `firmware/` (add a new page if it's a new feature area) |
+| A new language / layout | `using/languages.mdx` |
+| New term worth defining | `reference/glossary.mdx` |
+| Anything genuinely new | add a page **and** a sidebar entry in `astro.config.mjs`; consider a cross-link from a related page so it's discoverable |
+
+Match the site's voice: **user-facing**, friendly, `<Aside>` callouts and tables,
+no internal debugging detail. If you move/rename a page, add a `redirects` entry in
+`astro.config.mjs` for the old URL.
+
+## Procedure
+
+1. **Get the docs repo current**: `git -C ../polykybd-docs fetch origin main &&
+   git -C ../polykybd-docs checkout -B claude/docs-<feature-slug> origin/main`.
+   (Docs are their own PR — do this even mid-firmware-work.)
+2. **Find the affected page(s)** from the map above; grep the docs for the old
+   fact if you're correcting drift (`grep -rn "PROTOCOL_VERSION 3" src/`).
+3. **Edit / add** the page(s). For a new page, add the `slug` to the sidebar in
+   `astro.config.mjs`; add a cross-link from a related page.
+4. **Verify** (see below).
+5. **Commit + push** the docs branch and open a PR **in `polykybd-docs`** (base
+   `main`). Keep it separate from the firmware/host PR; note the companion PR in
+   both descriptions.
+
+## Verify
+
+Cheap checks first (no build needed):
+
+```bash
+cd ../polykybd-docs
+# every internal /section/page link resolves to a file:
+grep -rhoE '\]\(/[a-z0-9-]+/[a-z0-9-]+' src/content/docs --include='*.md' --include='*.mdx' \
+  | sed -E 's/^\]\(//' | sort -u \
+  | while read -r l; do [ -f "src/content/docs$l.mdx" ] || [ -f "src/content/docs$l.md" ] || echo "BROKEN: $l"; done
+```
+
+Then a full build. ⚠️ **`npm ci` fails in the sandbox because `sharp` can't fetch
+its prebuilt binary through the proxy (HTTP 403)** — this is an environment limit,
+not your change. Work around it:
+
+```bash
+npm ci --ignore-scripts            # installs deps, skips sharp's postinstall
+# temporarily swap in a passthrough image service so the build needs no sharp:
+cp astro.config.mjs /tmp/ac.bak
+node -e 'let s=require("fs").readFileSync("astro.config.mjs","utf8");
+ s=s.replace("import mermaid from \x27astro-mermaid\x27;","import mermaid from \x27astro-mermaid\x27;\nimport { passthroughImageService } from \x27astro/config\x27;");
+ s=s.replace("export default defineConfig({","export default defineConfig({\n  image: { service: passthroughImageService() },");
+ require("fs").writeFileSync("astro.config.mjs",s);'
+node_modules/.bin/astro build      # expect "N page(s) built", no errors
+cp /tmp/ac.bak astro.config.mjs    # RESTORE — never commit the passthrough tweak
+```
+
+If you added heading anchors in links, confirm each target heading exists (Starlight
+slugs headings as lowercase, non-alphanumerics dropped, spaces→`-`; an em-dash "—"
+between words yields a double hyphen).
+
+## Pitfalls
+
+- **Keep the HID protocol reference authoritative.** On any command / version
+  change, update BOTH the command table and the version history, and the "current
+  version" wording. This is the page most prone to silent drift.
+- **A new page needs a sidebar entry** in `astro.config.mjs` — Starlight won't
+  auto-add it, and an orphan page is invisible.
+- **Docs are a separate PR** in `polykybd-docs` (base `main`) — do not bury a docs
+  edit inside a firmware/host PR; they merge on different branches.
+- **Never commit the passthrough image-service tweak** — it's only to let the build
+  run in the sandbox; restore `astro.config.mjs` before committing.
+- **User voice, not dev notes.** These pages are for keyboard owners; put deep
+  mechanism in the firmware/host `CLAUDE.md` or the `development/` section, not the
+  user pages.
+- Add a **redirect** when you move/rename a page (old bookmarks are live).


### PR DESCRIPTION
## What

Adds a dev skill that keeps the **public docs** (the `polykybd-docs` Starlight site) in lockstep whenever a **user-facing** feature lands, and makes `session-retro` trigger it.

### New skill: `update-polykybd-docs`
A checklist for "a feature shipped — update the docs": when you add/change a HID command or `PROTOCOL_VERSION`, a `polyctl` subcommand, a host setting/tray entry, a keyboard feature (glyph script, idle style, brightness, font pack), or a language. It owns:
- the **feature → docs-page map**,
- the sandbox **build/verify** (including the `sharp`-download workaround via a temporary passthrough image service),
- the **separate-PR-in-`polykybd-docs`** flow (docs are their own repo/branch).

It explicitly excludes internal refactors and no-op bug fixes.

### `session-retro` now has a third output: **DOCS GAPS**
The retro already harvests LEARNINGS and new SKILLS; it now also **notices** user-facing changes the docs don't yet describe and hands each to `update-polykybd-docs` (the retro only surfaces the gap; that skill does the writing, on its own PR).

## Why

The docs drifted before — the HID reference sat at `PROTOCOL_VERSION 3` while firmware was at 11, and glyph scripts / font packs shipped undocumented. This makes "extend the docs" a standing, triggerable step rather than a thing we remember by luck.

## Files

- `.claude/skills/update-polykybd-docs/SKILL.md` (new)
- `.claude/skills/session-retro/SKILL.md` (adds the DOCS GAPS pass)

Docs-tooling only — no firmware code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018BWdUyY8GU9oqGjedCBeKP

---
_Generated by [Claude Code](https://claude.ai/code/session_018BWdUyY8GU9oqGjedCBeKP)_