### PR TITLE
Boot splash: instant dim preview + solidify-per-step reveal

### DIFF
--- a/keyboards/polykybd/base/disp_array.c
+++ b/keyboards/polykybd/base/disp_array.c
@@ -90,14 +90,33 @@ void kdisp_set_gfx_erase(bool erase) {
     s_gfx_erase = erase;
 }
 
-// When set, the glyph plotter only lights pixels on even buffer rows — a "scanline"
-// half-brightness look used by the Eden idle screensaver to make the lit legend read
-// lighter over the comet field. Absolute buffer y (not glyph-local) so the scanlines
-// stay aligned as the legend drifts. Restore to false after the draw.
-static bool s_gfx_scanline = false;
+// Scanline dimming mode for the glyph plotter — a half-brightness "present but
+// dim" look. 0 = off, 1 = fine (light even buffer rows only, 1-on/1-off), 2 =
+// coarse (light rows in 2-on/2-off bands). Gated on ABSOLUTE buffer y (not
+// glyph-local) so the bands stay aligned as a legend drifts / across glyphs.
+// The Eden idle screensaver uses the fine mode; the boot splash uses the coarse
+// mode, which on the big 24pt letters reads as an intentional dim rather than a
+// fine shimmer. Restore to 0 after the draw.
+static uint8_t s_gfx_scanline = 0;
+
+// Returns true if absolute buffer row `abs_y` must stay dark in the active
+// scanline mode.
+static inline bool scanline_skip_row(int abs_y) {
+    switch (s_gfx_scanline) {
+        case 1:  return (abs_y & 1);   // 1-on/1-off: skip odd rows
+        case 2:  return (abs_y & 2);   // 2-on/2-off: skip rows 2,3 of each 4
+        default: return false;
+    }
+}
 
 void kdisp_set_gfx_scanline(bool scanline) {
-    s_gfx_scanline = scanline;
+    s_gfx_scanline = scanline ? 1 : 0;
+}
+
+// Coarse 2-on/2-off variant — a better fit than the fine scanline for large
+// glyphs (the boot-splash logo), where 1-on/1-off stripes read as flicker.
+void kdisp_set_gfx_scanline2(bool scanline) {
+    s_gfx_scanline = scanline ? 2 : 0;
 }
 
 uint8_t* get_scratch_buffer(void) {
@@ -391,7 +410,7 @@ int8_t kdisp_write_gfx_char(const GFXfont *const *fonts, uint8_t num_fonts, int8
             if (bits & 0x80) {
                 if (s_gfx_erase) {
                     CLEAR_PIXEL_CLIPPED(x + xo + xx, y + yo + yy);
-                } else if (!(s_gfx_scanline && ((y + yo + yy) & 1))) {
+                } else if (!scanline_skip_row(y + yo + yy)) {
                     SET_PIXEL_CLIPPED(x + xo + xx, y + yo + yy);
                 }
             }

--- a/keyboards/polykybd/base/disp_array.h
+++ b/keyboards/polykybd/base/disp_array.h
@@ -33,6 +33,11 @@ void kdisp_set_gfx_erase(bool erase);
 // false after the draw.
 void kdisp_set_gfx_scanline(bool scanline);
 
+// Coarser 2-on/2-off scanline band (vs the 1-on/1-off of kdisp_set_gfx_scanline).
+// Reads as a cleaner intentional dim on large glyphs (the boot-splash logo), where
+// the fine scanline looks like flicker. Restore to false after the draw.
+void kdisp_set_gfx_scanline2(bool scanline);
+
 // Glyph for codepoint `c` in a font set, or NULL if no font covers it (skips
 // empty gap glyphs, no '!' fallback). For coverage tests + metric reads.
 const GFXglyph *kdisp_gfx_glyph(const GFXfont *const *fonts, uint8_t num_fonts, uint32_t c);

--- a/keyboards/polykybd/boot_diag.c
+++ b/keyboards/polykybd/boot_diag.c
@@ -89,40 +89,43 @@ void boot_banner_housekeeping_tick(void) {
 //   step 7       post_init, after EEPROM config load
 //   SPLASH_DONE  post_init end                      boot complete -> legends
 //
-// Each step advances the splash by one distinguishable frame, so a hang freezes
-// it at the exact milestone it reached (see readme.md "Boot splash progress"):
+// Reveal model: the WHOLE word is drawn from step 1, but every letter starts
+// DIM (scanline / half-density) and solidifies one-by-one as boot advances. So
+// the splash appears instantly (no "slow" letter-by-letter typing wait — the
+// user sees the full logo immediately) while still doubling as a boot-progress
+// indicator: the number of SOLID letters is how far boot got. Step 1 solidifies
+// none (whole word dim); each further step solidifies one more; DONE solidifies
+// all. Because step 1 shows the full word, the reveal has 7 solidify frames
+// (steps 2..DONE):
 //
-//   step  left "POLY KYBD"   right "SPLIT 72"
-//   ----  ----------------   ----------------
-//    1    P                  S           <- pre_init: split/USB-init hang here =
-//    2    PO                 SP             the fw-apply "slave not rebooted" case
-//    3    POL                SPL
-//    4    POLY               SPLI
-//    5    POLY K             SPLII       <- right "types in" its last letter over
-//    6    POLY KY            SPLIT          two steps (SPLII -> SPLIT) so the
-//    7    POLY KYB           SPLIT 7        leading space in " 7 2" doesn't cost
-//   DONE  POLY KYBD          SPLIT 72       it a frame — both halves get 8 steps
+//   step  left "POLY KYBD" (8)   right "SPLIT 72" (7)   solid
+//   ----  -------------------   -------------------   -----
+//    1    (all dim)             (all dim)               0
+//    2    P                     S                       1
+//    3    PO                    SP                      2
+//    4    POL                   SPL                     3
+//    5    POLY                  SPLI                     4
+//    6    POLY K                SPLIT                    5
+//    7    POLY KY               SPLIT 7                  6
+//   DONE  POLY KYBD             SPLIT 72              all (8 / 7)
 //
-// A frozen SINGLE letter ("P" / "S") is the split/USB-init hang; the more letters
-// are lit, the later boot stalled; only a fully booted keyboard replaces the
-// splash with real legends. is_left_side() must be resolved (set_side()) before
-// any call — it is, at every call site.
+// (letters shown solid; the remainder are present but dim.) The right half has
+// exactly 7 visible glyphs, so it solidifies one per step with no placeholder
+// trick — the old " 7 2" leading-space "SPLII -> SPLIT" two-step reveal is gone.
+// The left half has 8, one more than the 7 solidify frames, so DONE solidifies
+// its last TWO letters (B D) at once. Alignment spaces in " 7 2" occupy their
+// keycap but never consume a solidify step. is_left_side() must be resolved
+// (set_side()) before any call — it is, at every call site.
 
-static uint8_t utext_len(const uint32_t* s) {
+// Count of visible (non-space, non-NUL) glyphs in a splash word.
+static uint8_t utext_visible_len(const uint32_t* s) {
     uint8_t n = 0;
-    while (n < 15 && s[n] != 0) {
-        n++;
+    for (uint8_t i = 0; i < 15 && s[i] != 0; ++i) {
+        if (s[i] != U' ') {
+            n++;
+        }
     }
     return n;
-}
-
-// NUL-terminated copy of the first `n` glyphs of `src` into `dst` (>= 16 words).
-static void utext_prefix(uint32_t* dst, const uint32_t* src, uint8_t n) {
-    uint8_t i = 0;
-    for (; i < n && i < 15 && src[i] != 0; ++i) {
-        dst[i] = src[i];
-    }
-    dst[i] = 0;
 }
 
 void splash_progress(uint8_t step) {
@@ -131,52 +134,20 @@ void splash_progress(uint8_t step) {
     const uint32_t* r1_word = left ? U"POLY" : POLY_SPLASH_R1;
     const uint32_t* r2_word = left ? U"KYBD" : POLY_SPLASH_R2;
     const uint8_t   r2_row  = left ? 2 : POLY_SPLASH_R2_ROW;
-    const uint8_t   r1_len  = utext_len(r1_word);
-    const uint8_t   r2_len  = utext_len(r2_word);
+    const uint8_t   r1_vis  = utext_visible_len(r1_word);
+    const uint8_t   total_vis = r1_vis + utext_visible_len(r2_word);
 
-    uint32_t r1buf[16];
-    uint32_t r2buf[16];
-    r1buf[0] = 0;
-    r2buf[0] = 0;
-
-    if (final) {                                  // whole splash
-        utext_prefix(r1buf, r1_word, r1_len);
-        utext_prefix(r2buf, r2_word, r2_len);
-    } else if (left) {
-        // Left "POLY KYBD" = 8 glyphs, one revealed per step -> 8 clean frames.
-        utext_prefix(r1buf, r1_word, step < r1_len ? step : r1_len);
-        if (step > r1_len) {
-            utext_prefix(r2buf, r2_word, step - r1_len);
-        }
-    } else {
-        // Right "SPLIT 72": the leading space in " 7 2" would otherwise hide the
-        // first row-2 reveal (two consecutive steps both showing "SPLIT"). So the
-        // LAST row-1 letter is "typed in" over two steps — step r1_len shows a
-        // placeholder ("SPLII", last glyph = the penultimate one), step r1_len+1
-        // corrects it ("SPLIT") — reclaiming the lost frame so the right half also
-        // gets 8 distinct steps.
-        if (step < r1_len) {                      // S, SP, SPL, SPLI
-            utext_prefix(r1buf, r1_word, step);
-        } else if (step == r1_len) {              // SPLII (placeholder last glyph)
-            utext_prefix(r1buf, r1_word, r1_len);
-            if (r1_len >= 2) {
-                r1buf[r1_len - 1] = r1_word[r1_len - 2];
-            }
-        } else {                                  // full row 1, then row 2
-            utext_prefix(r1buf, r1_word, r1_len);
-            uint8_t r2_show = step - r1_len - 1;  // 0 at the "SPLIT" correction step
-            if (r2_show > 0) {
-                // +1 so the leading space is included (the visible digit is next).
-                utext_prefix(r2buf, r2_word, r2_show + 1);
-            }
-        }
+    // How many visible glyphs render SOLID; the rest render dim (scanline). Step
+    // 1 -> 0 (whole word present but dim), each further step +1, DONE -> all.
+    uint8_t solid_count = final ? total_vis : (step >= 1 ? (uint8_t)(step - 1) : 0);
+    if (solid_count > total_vis) {
+        solid_count = total_vis;
     }
 
     clear_all_displays();
-    display_message(1, 1, r1buf, &FreeSansBold24pt7b);
-    if (r2buf[0] != 0) {
-        display_message(r2_row, 1, r2buf, &FreeSansBold24pt7b);
-    }
+    display_message_progressive(1, 1, r1_word, &FreeSansBold24pt7b, 0, solid_count);
+    display_message_progressive(r2_row, 1, r2_word, &FreeSansBold24pt7b, r1_vis, solid_count);
+
     if (final) {
         // Boot complete: dwell on the finished splash, then hand the keycaps
         // over to the real legends — the same tail show_splash_screen() always

--- a/keyboards/polykybd/boot_diag.c
+++ b/keyboards/polykybd/boot_diag.c
@@ -152,7 +152,7 @@ void splash_progress(uint8_t step) {
         // Hold the all-dim preview briefly so the eye registers the whole logo
         // before letters begin solidifying — the reveal otherwise starts the
         // instant boot leaves pre_init, too quick to read the dim frame.
-        wait_ms(300);
+        wait_ms(400);
     }
     if (final) {
         // Boot complete: dwell on the finished splash, then hand the keycaps

--- a/keyboards/polykybd/boot_diag.c
+++ b/keyboards/polykybd/boot_diag.c
@@ -148,6 +148,12 @@ void splash_progress(uint8_t step) {
     display_message_progressive(1, 1, r1_word, &FreeSansBold24pt7b, 0, solid_count);
     display_message_progressive(r2_row, 1, r2_word, &FreeSansBold24pt7b, r1_vis, solid_count);
 
+    if (step == 1) {
+        // Hold the all-dim preview briefly so the eye registers the whole logo
+        // before letters begin solidifying — the reveal otherwise starts the
+        // instant boot leaves pre_init, too quick to read the dim frame.
+        wait_ms(300);
+    }
     if (final) {
         // Boot complete: dwell on the finished splash, then hand the keycaps
         // over to the real legends — the same tail show_splash_screen() always

--- a/keyboards/polykybd/poly_util.c
+++ b/keyboards/polykybd/poly_util.c
@@ -130,9 +130,12 @@ void display_message_progressive(uint8_t row, uint8_t col, const uint32_t* messa
                 const uint32_t cp = message[index];
                 if (cp != U' ') {
                     const uint32_t text[2] = { cp, 0 };
-                    kdisp_set_gfx_scanline(visible >= solid_count);
+                    // Not-yet-solid letters render dim via the coarse 2-on/2-off
+                    // scanline — cleaner than the fine 1-on/1-off on the big
+                    // 24pt splash glyphs, which flickered.
+                    kdisp_set_gfx_scanline2(visible >= solid_count);
                     kdisp_write_gfx_text(displayFont, 1, 49, 38, text);
-                    kdisp_set_gfx_scanline(false);
+                    kdisp_set_gfx_scanline2(false);
                     visible++;
                 }
                 index++;

--- a/keyboards/polykybd/poly_util.c
+++ b/keyboards/polykybd/poly_util.c
@@ -102,3 +102,42 @@ void display_message(uint8_t row, uint8_t col, const uint32_t* message, const GF
         }
     }
 }
+
+// Like display_message(), but each visible glyph is drawn either SOLID or DIM
+// (scanline, half-density) depending on its position in the reveal sequence:
+// the first `solid_count` visible glyphs (counting from `base_visible`, i.e.
+// including glyphs already drawn on a previous row) render solid, the rest
+// render scanline-dimmed. Spaces occupy their keycap (drawn as nothing) but do
+// not advance the visible counter, so alignment spaces never cost a reveal step.
+// Used by the progressive boot splash: the whole word is present from the first
+// frame (dim), then solidifies letter-by-letter as boot advances.
+void display_message_progressive(uint8_t row, uint8_t col, const uint32_t* message,
+                                 const GFXfont* font, uint8_t base_visible, uint8_t solid_count) {
+
+    const GFXfont* displayFont[] = { font };
+    uint8_t index   = 0;
+    uint8_t visible = base_visible;
+    for (uint8_t c = 0; c < MATRIX_COLS; ++c) {
+
+        uint8_t disp_idx = LAYOUT_TO_INDEX(row, c);
+
+        if (disp_idx != 255) {
+
+            sr_shift_out_buffer_latch(get_key_disp_bitmask(disp_idx), get_disp_bitmask_size());
+            kdisp_set_buffer(0x00);
+
+            if (c >= col && message[index] != 0) {
+                const uint32_t cp = message[index];
+                if (cp != U' ') {
+                    const uint32_t text[2] = { cp, 0 };
+                    kdisp_set_gfx_scanline(visible >= solid_count);
+                    kdisp_write_gfx_text(displayFont, 1, 49, 38, text);
+                    kdisp_set_gfx_scanline(false);
+                    visible++;
+                }
+                index++;
+            }
+            kdisp_send_buffer();
+        }
+    }
+}

--- a/keyboards/polykybd/poly_util.h
+++ b/keyboards/polykybd/poly_util.h
@@ -14,6 +14,9 @@ void clear_all_displays(void);
 
 void display_message(uint8_t row, uint8_t col, const uint32_t* message, const GFXfont* font);
 
+void display_message_progressive(uint8_t row, uint8_t col, const uint32_t* message,
+                                 const GFXfont* font, uint8_t base_visible, uint8_t solid_count);
+
 void display_bootloader_message(void);
 
 void poly_announce_bootloader(void);

--- a/keyboards/polykybd/readme.md
+++ b/keyboards/polykybd/readme.md
@@ -112,33 +112,40 @@ keyboards/polykybd/create_fonts.sh     # invoke fontconvert per range; writes ba
 ### Boot splash progress (always on)
 
 The boot splash (`POLY KYBD` on the left half, `SPLIT 72` / `SPLIT 42` on the
-right) fills in **one glyph at a time** as boot advances, instead of appearing
-complete at once. Because each keycap OLED holds the last frame it was sent, a
-boot that **hangs** freezes the reveal at the exact glyph it reached — so you read
-how far boot got by **counting the lit letters**. No compile flag: this is always
-on (`splash_progress()` in `poly_keymap.c`, driven from `keyboard_pre_init_user()`
-+ several points in `keyboard_post_init_user()`).
+right) shows the **whole word from the first frame**, but every letter starts
+**dim** (a scanline / half-density render) and **solidifies one letter at a time**
+as boot advances. This appears instantly — no "slow", letter-by-letter typing wait
+— while still doubling as a progress indicator: because each keycap OLED holds the
+last frame it was sent, a boot that **hangs** freezes the reveal at the exact
+letter it reached, so you read how far boot got by **counting the SOLID (bright)
+letters** (the rest are present but dim). No compile flag: this is always on
+(`splash_progress()` in `boot_diag.c`, driven from `keyboard_pre_init_user()` +
+several points in `keyboard_post_init_user()`).
 
-Each lit letter maps to a boot milestone (read the **hung half** — in the
-firmware-apply hang that's the master/USB half):
+Each solid letter maps to a boot milestone (read the **hung half** — in the
+firmware-apply hang that's the master/USB half; letters shown below are the ones
+rendered **solid**, the remainder are dim):
 
 | Step | Milestone reached | Left (`POLY KYBD`) | Right (`SPLIT 72`) |
 |---|---|---|---|
-| 1 | `pre_init` (before split/USB init) | `P` | `S` |
-| 2 | after `set_side()` (**split/USB init passed**) | `PO` | `SP` |
-| 3 | language/emoji/MRU init done | `POL` | `SPL` |
-| 4 | before core 1 launch | `POLY` | `SPLI` |
-| 5 | after core 1 launch | `POLY K` | `SPLII` \* |
-| 6 | split RPCs + fw-staging up | `POLY KY` | `SPLIT` |
-| 7 | EEPROM config loaded | `POLY KYB` | `SPLIT 7` |
+| 1 | `pre_init` (before split/USB init) | *(all dim)* | *(all dim)* |
+| 2 | after `set_side()` (**split/USB init passed**) | `P` | `S` |
+| 3 | language/emoji/MRU init done | `PO` | `SP` |
+| 4 | before core 1 launch | `POL` | `SPL` |
+| 5 | after core 1 launch | `POLY` | `SPLI` |
+| 6 | split RPCs + fw-staging up | `POLY K` | `SPLIT` |
+| 7 | EEPROM config loaded | `POLY KY` | `SPLIT 7` |
 | all | boot complete → real key legends | `POLY KYBD` | `SPLIT 72` |
 
-\* The right half "types in" its last letter over two steps — step 5 shows a
-placeholder `SPLII` (last glyph repeated), step 6 corrects it to `SPLIT` — so the
-leading space in `" 7 2"` doesn't cost the right half a distinguishable frame.
-Both halves therefore give 8 distinct steps.
+The whole word being present from step 1 frees a frame (the old scheme spent step
+1 on a single letter), so the reveal now has 7 solidify frames. The right half has
+exactly 7 visible glyphs → one solidifies per step, retiring the old `" 7 2"`
+leading-space placeholder trick (there used to be a `SPLII → SPLIT` two-step
+reveal). The left half has 8, one more than the frames, so the final step
+solidifies its **last two letters** (`B D`) at once.
 
-So a frozen **single letter** (`P` / `S`) is the split/USB-init hang — the
+So a frozen frame with **no solid letter** (whole word dim) is the split/USB-init
+hang — the
 **"hangs on the boot splash after a firmware apply"** case (`hid_fw_up.c`
 `CMD_FW_UP_APPLY`: the slave never rebooted, so the master waits for a split
 handshake that never comes; recovery = replug/reset or re-run Apply). The more


### PR DESCRIPTION
## Summary

Rework the progressive boot splash so the whole logo appears **instantly** instead of typing in one letter at a time (which made the keyboard look slow to boot).

- The full word (`POLY KYBD` / `SPLIT 72` / `SPLIT 42`) is drawn from the very first frame, but every letter starts **dim** (a coarse 2-on/2-off scanline render). Each boot milestone then solidifies one more letter; the final step solidifies the rest.
- Because the full word shows from step 1, the reveal gains a frame:
  - The right half has exactly 7 visible glyphs and solidifies one per step, so the old `" 7 2"` leading-space placeholder trick (`SPLII → SPLIT`) is **removed**.
  - The left half has 8 glyphs, one more than the solidify frames, so the last step fills its final two letters (`B D`) at once.
- The progress-indicator purpose is preserved: the number of **solid** letters still tells how far boot got, and a hang freezes the frame at that point (a fully-dim frame = the pre_init / split-USB-init hang).
- A **400 ms dwell** holds the all-dim preview before letters begin solidifying, so the eye registers the whole logo first.

Implementation:
- `poly_util.c/.h` — new `display_message_progressive()`: draws each visible glyph solid or scanline-dimmed by its position in the reveal sequence; alignment spaces occupy their keycap but never consume a reveal step.
- `base/disp_array.c/.h` — the scanline plotter state becomes a level (0 off / 1 fine / 2 coarse); new `kdisp_set_gfx_scanline2()` for the coarse 2-on/2-off band, which reads as a steady dim on the big 24 pt splash glyphs rather than the fine 1-on/1-off shimmer. The Eden idle legend keeps the fine scanline (unchanged).
- `boot_diag.c` — `splash_progress()` draws the whole word every step with a `solid_count` threshold instead of prefix words + the placeholder trick, plus the 400 ms preview dwell.
- `readme.md` — updated the "Boot splash progress" table/description.

No protocol or wire-format change; shared code, lands on both variants.

## Version bump label

Cosmetic UX change to an existing feature — default (patch) bump is fine.

## Testing
- [x] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`; split42 too)
- [x] Flashed and tested on hardware (split42) — pacing/legibility tuned to the 400 ms dwell + coarse scanline over a couple of iterations
- [ ] If protocol changed: host updated and tested together — n/a, no protocol change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsZ6o1j4i5f5aNFjswGkcw)_