### PR TITLE
idle: name the style in every log line, log sensor brightness, stop overlays deferring idle

### DIFF
--- a/keyboards/polykybd/base/update.h
+++ b/keyboards/polykybd/base/update.h
@@ -7,6 +7,20 @@ enum refresh_mode { START_FIRST_HALF, START_SECOND_HALF, DONE_ALL, ALL_AT_ONCE }
 
 // Records current timestamp for idle timeout tracking and idle display animation.
 // Marks idle tracking active. Global variables: last_update, idle_tracking
+//
+// ⚠️ Call this ONLY for real USER activity on the keyboard — a keypress, a wake
+// (key / proximity / host stop-idle), or a deliberate host command. It is NOT a
+// generic "something changed, redraw" hook; use request_disp_refresh() for that.
+//
+// In particular the overlay-upload completion paths must NOT call it. An overlay
+// push is the HOST reacting to a window switch on the computer, which says nothing
+// about whether the user is at the keyboard — and because the host re-pushes
+// overlays on every focus change, a keyboard attached to a busy machine had its
+// idle countdown restarted indefinitely and never reached the fade. Worse, it is
+// silent: update_performed() does not clear DISP_IDLE, so it never produced a wake
+// log line, it just reset the pulse phase and pushed the TURN_OFF deadline back.
+// It also re-enabled idle_tracking after a deliberate disable_idle_tracking()
+// (turn-off reached / host display-off cmd 24), quietly re-arming STATUS_DISP_ON.
 void update_performed(void);
 
 uint32_t get_last_update(void);

--- a/keyboards/polykybd/boot_diag.c
+++ b/keyboards/polykybd/boot_diag.c
@@ -8,6 +8,7 @@
 #include "split_util.h"   // is_transport_connected()
 #include "side.h"         // is_left_side()
 #include "poly_util.h"    // clear_all_displays(), display_message()
+#include "state.h"        // get_idle_style(), idle_style_name()
 #include "base/update.h"       // enum refresh_mode / ALL_AT_ONCE
 #include "base/disp_array.h"   // GFXfont type
 // Only the single splash font is needed. Don't pull in gfx_used_fonts.h — the
@@ -57,6 +58,19 @@ void emit_boot_banner(void) {
 #endif
 }
 
+// The configured idle (anti-burn-in) style + the timings that drive the idle
+// state machine. Emitted separately from the identity banner because the style
+// is only known after the EEPROM config load, which happens well after the
+// one-shot emit_boot_banner() call — so a console can no longer see a fade/pulse
+// happen without also seeing which style was actually selected.
+void emit_idle_config(void) {
+    const uint8_t style = get_idle_style();
+    uprintf("   idle: style=%s (%u) fade_out=%ums fade=%ums turn_off=%ums\n",
+            idle_style_name(style), (unsigned int)style,
+            (unsigned int)FADE_OUT_TIME, (unsigned int)FADE_TRANSITION_TIME,
+            (unsigned int)TURN_OFF_TIME);
+}
+
 void boot_banner_housekeeping_tick(void) {
     // Re-emit the boot identification banner a few times after power-on so a
     // `qmk console` attached shortly after boot still catches it (the one-shot
@@ -68,6 +82,7 @@ void boot_banner_housekeeping_tick(void) {
             banner_timer = timer_read32();   // arm on the first housekeeping pass
         } else if (timer_elapsed32(banner_timer) >= BOOT_BANNER_INTERVAL_MS) {
             emit_boot_banner();
+            emit_idle_config();
             banner_timer = timer_read32();
             banner_repeats++;
         }

--- a/keyboards/polykybd/boot_diag.c
+++ b/keyboards/polykybd/boot_diag.c
@@ -1,3 +1,5 @@
+// Copyright 2025 thpoll83
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Boot diagnostics — HID-console identification banner + boot-splash progress.
 // Extracted from poly_keymap.c so the keymap file stays focused on keymap logic;
 // both features are self-contained boot instrumentation with no keymap state.

--- a/keyboards/polykybd/boot_diag.h
+++ b/keyboards/polykybd/boot_diag.h
@@ -14,6 +14,12 @@
 // shows which board, firmware and role a half is, plus its split-link state.
 void emit_boot_banner(void);
 
+// The configured idle (anti-burn-in) style and the timings driving the idle state
+// machine. Separate from the banner because the style is only known after the
+// EEPROM config load; call it once from post_init after that load (the banner tick
+// re-emits it alongside the banner for a late console).
+void emit_idle_config(void);
+
 // Throttled re-emit of the boot banner, called once per housekeeping pass. The
 // one-shot print in keyboard_post_init_user fires before a console is usually
 // attached, so this re-emits it a bounded number of times over the first ~half

--- a/keyboards/polykybd/boot_diag.h
+++ b/keyboards/polykybd/boot_diag.h
@@ -1,3 +1,5 @@
+// Copyright 2025 thpoll83
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Boot diagnostics — the HID-console identification banner and the per-milestone
 // boot-splash progress. Both live here (out of poly_keymap.c) because they are
 // self-contained boot instrumentation; poly_keymap.c just calls into them.

--- a/keyboards/polykybd/fill_overlay.c
+++ b/keyboards/polykybd/fill_overlay.c
@@ -142,7 +142,8 @@ void decompress_overlay_buffer(uint8_t* compressed, bool first) {
             set_overlay_usage_post_upload(idx);
             uprintf("--> Finished keycode 0x%x (mod 0x%x): side %s, total bytes %d.\n",
                 keycode, ctx_mod, pos_to_str(pos), bit_index/8);
-            update_performed();
+            // No update_performed() — a host overlay push is not user activity and
+            // must not restart the idle countdown (see base/update.h).
             request_disp_refresh();
         }
 #endif
@@ -194,7 +195,7 @@ void fill_roi_overlay_buffer(uint8_t* data, bool first) {
             bit_index = copy_rectangle_to_overlay(bit_index, get_overlay(idx), first?(&(data[5])):data, &ctx_roi, data_len);
             if(bit_index >= 2880) {
                 set_overlay_usage_post_upload(idx);
-                update_performed();
+                // No update_performed() — see base/update.h.
                 request_disp_refresh();
             }
             set_fragment_context_bit_index(bit_index);

--- a/keyboards/polykybd/hid_com.c
+++ b/keyboards/polykybd/hid_com.c
@@ -444,7 +444,13 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                     if(get_fragment_context()->keycode>=KC_A && get_fragment_context()->keycode<=KC_RIGHT_GUI && segment<NUM_SEGMENTS_PER_OVERLAY) {
                         fill_overlay_buffer(segment, &data[HID_DATA_IDX+2]);
                         if(segment==NUM_SEGMENTS_PER_OVERLAY-1) {
-                            update_performed();
+                            // Refresh only — deliberately NOT update_performed().
+                            // An overlay upload is the HOST reacting to a window
+                            // switch, not the user touching the keyboard; counting
+                            // it as activity restarted the whole idle countdown
+                            // every time the focused app changed (so a keyboard
+                            // watching a busy machine never idled) with nothing in
+                            // the log to explain it. See the note in base/update.h.
                             request_disp_refresh();
                         }
                     }

--- a/keyboards/polykybd/multicore_exec.c
+++ b/keyboards/polykybd/multicore_exec.c
@@ -61,7 +61,10 @@ void core1_entry(void) {
 
                     if (core1_bit_index >= 360*8 -1) {
                         set_overlay_usage_post_upload(core1_idx);
-                        update_performed();
+                        // No update_performed() — a host overlay push is not user
+                        // activity and must not restart the idle countdown (see
+                        // base/update.h). Also keeps core1 out of the idle-timer
+                        // state entirely; only core0 writes it now.
                         request_disp_refresh();
                         core1_bit_index = 0;
                     }
@@ -80,7 +83,7 @@ void core1_entry(void) {
                     core1_bit_index = copy_rectangle_to_overlay(core1_bit_index, get_overlay(core1_idx), core1_buffer, &core1_roi, data_len);
                     if(core1_bit_index >= 2880) {
                         set_overlay_usage_post_upload(core1_idx);
-                        update_performed();
+                        // No update_performed() — see base/update.h.
                         request_disp_refresh();
                         core1_bit_index = 0;
                     }

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -657,11 +657,16 @@ static void user_sync_dummy_handler(uint8_t in_len, const void* in_data, uint8_t
 #endif
 
 // Master-side: mirror the HID cmd-15 stop-idle path to force the displays awake.
+// Logged because this is the ONLY wake with no user-visible trigger — a proximity
+// wake used to restart the whole idle countdown silently, so the console showed a
+// second "Transition to idle" with nothing explaining the first one ending.
 static void poly_force_wake(void) {
     poly_sync_t* local_state = access_local_state();
     if ((local_state->flags & (STATUS_DISP_ON | DISP_IDLE)) == 0) {
+        uprint("Wake by proximity (from suspend)\n");
         suspend_wakeup_init_kb();   // fully suspended -> full wake
     } else if (local_state->flags & DISP_IDLE) {
+        uprint("Wake by proximity (from idle)\n");
         local_state->contrast = get_active_brightness();
         local_state->flags &= ~((uint8_t)DISP_IDLE);
         local_state->flags |= STATUS_DISP_ON;
@@ -699,8 +704,9 @@ static uint8_t lux_to_contrast(uint16_t lux) {
 }
 
 static void poly_ltr559_drive(void) {
-    static uint32_t last    = 0;
-    static bool     engaged = false;
+    static uint32_t last        = 0;
+    static bool     engaged     = false;
+    static uint8_t  last_logged = 0xFF;   // last brightness announced to the console
     if (!is_usb_host_side()) {
         return;   // decisions are master-only (the slave just serves reads)
     }
@@ -744,8 +750,20 @@ static void poly_ltr559_drive(void) {
         }
         set_brightness_auto_mode(true);
         engaged = true;
+        uprintf("LTR-559: auto-brightness engaged (avg lux %u)\n", lux);
     }
-    set_auto_brightness_value(lux_to_contrast(lux));
+
+    // Announce every brightness the sensor drives — but only when it actually
+    // changes: this runs every LTR559_DRIVE_MS (500 ms), so an unconditional print
+    // would drown the console. Without it a sensor-driven brightness move is
+    // indistinguishable from a key/host change (or from a bug) in the log.
+    const uint8_t target = lux_to_contrast(lux);
+    if (target != last_logged) {
+        last_logged = target;
+        uprintf("LTR-559: auto brightness -> %u (avg lux %u)%s\n", target, lux,
+                get_brightness_auto_mode() ? "" : " [auto off, not applied]");
+    }
+    set_auto_brightness_value(target);
 
     // Proximity: something is close -> defer idle (and wake if already idle).
     if (prox > LTR559_NEAR_THRESHOLD) {
@@ -957,7 +975,12 @@ void housekeeping_task_user(void) {
 
                 //transition to pulsing mode
                 if(brightness<=MIN_BRIGHT) {
-                    if (get_idle_style() == IDLE_STYLE_IDDQD && doom_screensaver_start()) {
+                    // Log the CONFIGURED style on every transition: three different
+                    // styles land in the pulse branch below (pulse, jitter, and an
+                    // iddqd that could not start its demo), so an unnamed
+                    // "Transition to pulsing" cannot tell you which one is active.
+                    const uint8_t style = get_idle_style();
+                    if (style == IDLE_STYLE_IDDQD && doom_screensaver_start()) {
                         // Doom attract screensaver instead of the pulse: the demo
                         // owns the keycaps at the user brightness — no DISP_IDLE,
                         // and IDLE_TRANSITION stays dropped (cleared above), which
@@ -967,8 +990,8 @@ void housekeeping_task_user(void) {
                         // deadline. Falls through to the pulse whenever the demo
                         // can't start (non-doom build, fw staging active).
                         contrast = get_active_brightness();
-                        uprint("Transition to doom screensaver\n");
-                    } else if (get_idle_style() == IDLE_STYLE_EDEN) {
+                        uprint("Transition to idle [style=iddqd] - doom screensaver\n");
+                    } else if (style == IDLE_STYLE_EDEN) {
                         // Eden screensaver: enter DISP_IDLE like the pulse (so the
                         // wake-on-key and TURN_OFF suspend paths work unchanged and
                         // the flag+idle_style tell the slave to loop too), but hold
@@ -977,12 +1000,18 @@ void housekeeping_task_user(void) {
                         // burn-in and no per-pass pulse contrast to fight.
                         contrast = EDEN_IDLE_BRIGHTNESS;
                         flags |= DISP_IDLE;
-                        uprint("Transition to eden screensaver\n");
+                        uprint("Transition to idle [style=eden] - eden screensaver\n");
                     } else {
                         contrast = DISP_OFF;
                         flags |= DISP_IDLE;
                         flags |= IDLE_TRANSITION;
-                        uprint("Transition to pulsing\n");
+                        // An IDDQD here means doom_screensaver_start() refused (no
+                        // doom build / fw staging active) and we silently degraded
+                        // to the legacy pulse — say so rather than reporting a plain
+                        // "pulsing" the user never selected.
+                        uprintf("Transition to idle [style=%s] - pulsing%s\n",
+                                idle_style_name(style),
+                                style == IDLE_STYLE_IDDQD ? " (doom unavailable)" : "");
                     }
                 } else if(brightness>FULL_BRIGHT) {
                     contrast = FULL_BRIGHT;
@@ -3101,6 +3130,7 @@ bool display_wakeup(keyrecord_t* record) {
         // Stop the looping Eden idle screensaver immediately so update_displays() (no
         // longer blocked by startup_anim_active()) can repaint the woken legends.
         startup_anim_stop();
+        uprint("Wake by keypress\n");
         local_state->contrast = get_active_brightness();
         local_state->flags &= ~((uint8_t)DISP_IDLE);
         local_state->flags |= STATUS_DISP_ON;
@@ -3267,6 +3297,7 @@ void keyboard_post_init_user(void) {
     // the host re-engages). Overrides local_state->contrast when auto was on.
     load_auto_brightness(ee.auto_brightness);
     note_idle_style(ee.idle_style);
+    emit_idle_config();   // the style is only known here — the banner tick re-emits it
     note_glyph_script(ee.glyph_script);
     // Restore the active-OS state (auto/manual + last known OS). Auto by default, so
     // a fresh EEPROM re-resolves per host via detection / host push; a manual pin

--- a/keyboards/polykybd/state.c
+++ b/keyboards/polykybd/state.c
@@ -399,6 +399,17 @@ void note_idle_style(uint8_t style) {
     g_idle_style = (style < IDLE_STYLE_COUNT) ? style : IDLE_STYLE_PULSE;
 }
 
+// Console-log name for an idle style. Keep in sync with enum poly_idle_style.
+const char* idle_style_name(uint8_t style) {
+    switch (style) {
+        case IDLE_STYLE_PULSE:  return "pulse";
+        case IDLE_STYLE_JITTER: return "jitter";
+        case IDLE_STYLE_IDDQD:  return "iddqd";
+        case IDLE_STYLE_EDEN:   return "eden";
+        default:                return "?";
+    }
+}
+
 // The active glyph-script override (GLYPH_STD = normal language legends).
 uint8_t get_glyph_script(void) {
     return g_glyph_script;

--- a/keyboards/polykybd/state.h
+++ b/keyboards/polykybd/state.h
@@ -309,6 +309,10 @@ void set_idle_style(uint8_t style);
 // Records the idle style without marking settings dirty (boot-time EEPROM load).
 void note_idle_style(uint8_t style);
 
+// Human-readable name of an idle style, for console logs ("pulse"/"jitter"/…).
+// Never NULL — an unknown value reads as "?".
+const char* idle_style_name(uint8_t style);
+
 // ---- Glyph-script override (enum poly_glyph_script) — see enum comment above. ----
 
 // The active glyph-script override (GLYPH_STD = normal language legends).


### PR DESCRIPTION
Three related changes, all driven by a 36-minute console log in which the idle pipeline behaved correctly but the log could not say which style produced it.

## 1. The log can now answer "which idle style was actually running?"

`uprint("Transition to pulsing")` was emitted by **three different configured styles**:

- `IDLE_STYLE_PULSE`
- `IDLE_STYLE_JITTER` (same branch — jitter happens later, inside `kdisp_idle()`)
- `IDLE_STYLE_IDDQD` **when `doom_screensaver_start()` returns false**

That third one is a real defect, not just a logging gap. Doom is opt-in (`rules.mk` `POLYKYBD_DOOM=yes`); on a normal build `doom_mode.h` stubs `doom_screensaver_start()` to `return false`, so IDDQD silently degrades to the legacy pulse. Meanwhile `hid_com.c` case 28 ACKs any value `< IDLE_STYLE_COUNT` with no build gate — so the tray radio button sticks on IDDQD, `polyctl idle-style` reports `iddqd`, and you get a plain pulse with nothing anywhere saying so.

Every transition line now names the configured style, and the IDDQD fall-through says why:

```
Transition to idle [style=jitter] - pulsing
Transition to idle [style=iddqd] - pulsing (doom unavailable)
Transition to idle [style=eden] - eden screensaver
Transition to idle [style=iddqd] - doom screensaver
```

Plus a boot line — `emit_idle_config()`, printed once after the EEPROM config load and re-emitted by the existing bounded banner tick so a late `qmk console` still catches it:

```
   idle: style=jitter (1) fade_out=120000ms fade=10000ms turn_off=1200000ms
```

It is deliberately **not** folded into `emit_boot_banner()`: the banner fires ~70 lines before `load_user_eeconf()`, so it would have printed the compile default rather than the configured style.

Both silent wake paths now log, since a wake that restarts the whole idle countdown with nothing in the console is what made the original log unreadable:

- `poly_force_wake()` → `Wake by proximity (from idle)` / `(from suspend)`
- `display_wakeup()` → `Wake by keypress`

Both sit behind the existing idle→awake edge guard, so neither repeats while awake.

## 2. The LTR-559 announces the brightness it drives

```
LTR-559: auto-brightness engaged (avg lux 41)
LTR-559: auto brightness -> 26 (avg lux 28)
LTR-559: auto brightness -> 4 (avg lux 3) [auto off, not applied]
```

Throttled to actual changes — the drive tick runs every `LTR559_DRIVE_MS` (500 ms), so an unconditional print would bury the console. The `[auto off, not applied]` marker matters because `set_auto_brightness_value()` still records the value after a manual override turns auto off; without it the log would claim a brightness that never reached the panel.

## 3. An overlay upload no longer counts as user activity

Five upload-completion sites called `update_performed()`:

| File | Path |
|---|---|
| `hid_com.c` case 10 | plain overlay, last segment |
| `fill_overlay.c` ×2 | compressed + ROI, core0 path |
| `multicore_exec.c` ×2 | compressed + ROI, core1 path |

The host pushes overlays on **every focused-window change**, so each one restarted the idle countdown — a keyboard watching a busy machine never reached the fade.

Two things made it worse than it looks:

- **It is invisible.** `update_performed()` does not clear `DISP_IDLE`, so it produced no wake line — it just reset the pulse phase and pushed the `TURN_OFF` deadline back.
- **It re-enabled `idle_tracking`** after a deliberate `disable_idle_tracking()` (turn-off reached, or host display-off cmd 24). The housekeeping idle block then re-runs and sets `STATUS_DISP_ON` unconditionally at the top — the "displays come back on when they shouldn't" family.

All five sites keep their `request_disp_refresh()`; only the activity stamp is dropped. `update_displays()` early-returns while `DISP_IDLE` is set and `display_wakeup()` re-requests a refresh on wake, so nothing is lost visually. Dropping the two core1 calls also means the idle timer is written by core0 only.

The contract is now documented on `update_performed()` in `base/update.h` so it does not get reintroduced as a generic "something changed, redraw" hook.

## Scope note

`hid_com.c` case 9 (change language) still calls `update_performed()`. It is arguably the same class — the host also switches language on window changes — but it is a more deliberate host command, so it is left alone here rather than widened without asking.

## Verification

- No wire-protocol change → no `PROTOCOL_VERSION` / `__protocol__` bump.
- `qmk compile -kb polykybd/split72 -km default` — clean, no warnings from the changed files (forced recompile of all six).
- `qmk compile -kb polykybd/split42 -km default` — clean.
- Not yet exercised on hardware; the log lines are what the next idle session should be read against.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQwvH6woVbrBLKmL8XKD3U)_

## Summary by Sourcery

Improve idle behavior observability and robustness, and ensure non-user-driven display updates no longer interfere with idle timing.

New Features:
- Log the configured idle style and related timing configuration at boot and on each idle transition.
- Log proximity- and keypress-driven wake events as explicit console messages.
- Log LTR-559-driven auto-brightness engagement and brightness changes, including when auto mode is disabled.

Bug Fixes:
- Prevent overlay upload completion from being treated as user activity so it no longer restarts idle countdowns or re-enables idle tracking.
- Avoid silent degradation of the IDDQD idle style to a generic pulse by clearly indicating when the doom screensaver is unavailable.

Enhancements:
- Add a human-readable idle style name helper for consistent logging of style identifiers.
- Document and constrain the contract of update_performed() so it is only used for real user activity.
- Ensure only the master core updates idle timer state by removing core1 calls that treated overlay uploads as activity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Boot and runtime diagnostics now report configured idle styles, fade and shutdown timing, wake sources, and automatic brightness changes.
  - Console output identifies selected idle effects, including pulsing, jitter, IDDQD, and Eden modes.

- **Bug Fixes**
  - Overlay uploads and region updates no longer count as user activity or restart the idle countdown.
  - Wake and idle transitions now provide clearer status information, including keypress and proximity wake events.

- **Documentation**
  - Clarified the correct use of activity tracking to prevent unintended idle-state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->