### PR TITLE
chore: allow read-only tooling prompts via .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__Claude_Code_Remote__send_later",
+      "mcp__github__pull_request_read",
+      "mcp__github__subscribe_pr_activity",
+      "mcp__github__unsubscribe_pr_activity",
+      "mcp__github__get_file_contents",
+      "mcp__github__list_branches",
+      "mcp__github__get_job_logs",
+      "mcp__github__actions_get",
+      "mcp__github__actions_list"
+    ]
+  }
+}


### PR DESCRIPTION
Adds a project-level `.claude/settings.json` pre-allowing a small set of **read-only / session-local** tools, so routine PR-watching stops interrupting with permission prompts.

## What

| Tool | Why it is safe |
|---|---|
| `mcp__Claude_Code_Remote__send_later` | Schedules a message back into this session. Session-local, no external effect. |
| `mcp__github__pull_request_read` | Read-only. |
| `mcp__github__subscribe_pr_activity` / `unsubscribe_pr_activity` | Session-local event subscription; changes nothing on GitHub. |
| `mcp__github__get_file_contents`, `list_branches` | Read-only. |
| `mcp__github__get_job_logs`, `actions_get`, `actions_list` | Read-only CI inspection. |

## Deliberately NOT included

Anything that writes or triggers: `create_pull_request`, `add_issue_comment`, `pull_request_review_write`, `merge_pull_request`, `push_files`, `create_or_update_file`, `actions_run_trigger`. Those keep prompting.

Checked: the file is valid JSON and **not** matched by the root `.gitignore` — a tracked-but-ignored file under this repo would fail `qmk lint --strict` (it only scans `keyboards/`, but verified regardless).

---
_Generated by [Claude Code](https://claude.ai/code/session_016T7dyL8E4h8WH11oWwmBGS)_

## Summary by Sourcery

Build:
- Add .claude/settings.json to define pre-allowed read-only GitHub and CI inspection tools for Claude-based automation.