### PR TITLE
perf(display): push only the visible 72×40 window per keycap render

### DIFF
--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -2445,7 +2445,7 @@ void update_displays(enum refresh_mode mode) {
                             doom_handled = true;
                         } else {
                             kdisp_set_buffer(0x00);
-                            kdisp_send_buffer();
+                            kdisp_send_window();
                             doom_handled = true;
                         }
                     } else if (local_state->doom_ctl) {
@@ -2497,31 +2497,31 @@ void update_displays(enum refresh_mode mode) {
                                     kdisp_draw_bitmap(BUFFER_X, SCREEN_HEIGHT - 2, ready_bar, 72, 2);
                                 }
                             }
-                            kdisp_send_buffer();
+                            kdisp_send_window();
                             doom_handled = true;
                         } else if (pad == KC_ESC) {
                             // The shared exit-hint face — byte-identical to
                             // the master's HUD corner key (field rd 18).
                             doom_render_esc_key();
-                            kdisp_send_buffer();
+                            kdisp_send_window();
                             doom_handled = true;
                         } else if (keycode == KC_LCTL || keycode == KC_RCTL) {
                             // Ctrl fires in DOOM — show a crosshair reticle
                             // instead of the plain Ctrl legend (field rd 16).
                             kdisp_set_buffer(0x00);
                             doom_render_fire_key();
-                            kdisp_send_buffer();
+                            kdisp_send_window();
                             doom_handled = true;
                         } else if (keycode == KC_SPACE) {
                             // Space is DOOM's use/open — a door symbol
                             // instead of the space legend (field rd 17).
                             kdisp_set_buffer(0x00);
                             doom_render_use_key();
-                            kdisp_send_buffer();
+                            kdisp_send_window();
                             doom_handled = true;
                         } else if (!doom_key_is_control(keycode)) {
                             kdisp_set_buffer(0x00);
-                            kdisp_send_buffer();
+                            kdisp_send_window();
                             doom_handled = true;
                         }
                     }
@@ -2535,20 +2535,20 @@ void update_displays(enum refresh_mode mode) {
                             kdisp_set_buffer(0x00);
                             draw_mru_top_bar(keycode);
                             render_lang_flag_key((uint8_t)lang_idx, to_static_text((uint16_t)(KCL_ENUS + lang_idx), state), local_state->lang);
-                            kdisp_send_buffer();
+                            kdisp_send_window();
                         } else if (keycode == KC_EMJ_PRESET || keycode == KC_LANG_PRESET ||
                                    keycode == KC_EMJ_CLEAR  || keycode == KC_LANG_CLEAR) {
                             // Top-row MRU controls: "Preset" / "Clear".
                             kdisp_set_buffer(0x00);
                             render_mru_ctrl_key(keycode == KC_EMJ_PRESET || keycode == KC_LANG_PRESET);
-                            kdisp_send_buffer();
+                            kdisp_send_window();
                         } else if (keycode >= KC_LANG_CAT_BASE && keycode < KC_LANG_PAGE_PREV) {
                             // Language region tab — continent label + active frame.
                             kdisp_set_buffer(0x00);
                             lang_draw_tab_indicator(keycode);
                             lang_draw_tab_bottom(keycode);
                             render_lang_region_tab(keycode);
-                            kdisp_send_buffer();
+                            kdisp_send_window();
                         } else {
                         const uint32_t* text = to_static_text(keycode, state);
                         kdisp_set_buffer(0x00);
@@ -2596,7 +2596,7 @@ void update_displays(enum refresh_mode mode) {
                             // per-keycode special-case is needed here.
                             kdisp_write_gfx_text_cy(g_all_fonts, g_all_font_count, BUFFER_X, 23, text, KDISP_CY_DEFAULT);
                         }
-                        kdisp_send_buffer();
+                        kdisp_send_window();
                         }
                     }
                 }

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -2213,7 +2213,7 @@ static bool render_idle_key(uint16_t keycode, led_t state, uint32_t seed) {
     kdisp_set_draw_offset(dx, dy);
     kdisp_write_gfx_text(g_all_fonts, g_all_font_count, BUFFER_X, 23, text);
     kdisp_set_draw_offset(0, 0);
-    kdisp_send_buffer();
+    kdisp_send_window();   // idle jitter draws within the 72x40 window (roll_idle_offset clamps to it)
     return true;
 }
 


### PR DESCRIPTION
## Summary

Cuts the SPI cost of every per-keycap OLED redraw by pushing **only the visible 72×40 window (360 bytes)** to each panel instead of the full 1024-byte scratch buffer.

`kdisp_send_buffer()` pushes all 1024 bytes of the scratch; `kdisp_send_window()` pushes only pages 0–4 at column `BUFFER_X` — the exact 360-byte region the keycap actually shows — so it is **~2.9× less SPI per key**. The profiler work in #153 established that the awake program-switch stall is **render-bound**, not transfer-bound (the `ovltot` render total dominates), so shrinking the per-key SPI blit is the direct lever on how long a full 72-keycap re-render holds the main loop — and therefore on keystrokes missed during an application switch.

Two commits, both swapping `kdisp_send_buffer()` → `kdisp_send_window()`:
- **`update_displays()`** — all 10 per-keycap send sites (the awake render path that fires on every overlay/program switch).
- **`render_idle_key()`** — the idle-jitter per-key redraw. Its draw is already confined to the visible window (`roll_idle_offset()` clamps the relocated legend to `[BUFFER_X, BUFFER_X+SCREEN_WIDTH-1] × [0, SCREEN_HEIGHT-1]`), so the window send is exact there too.

Both are per-key redraws that only ever touch the visible window, which is exactly the case `kdisp_send_window()` is documented for. No pixels outside the window are written by these paths, so the output is identical — this is purely a reduction in bytes clocked out per key.

**Note on the dirty-key partial-render idea (dead end):** the other candidate for shortening a switch was to re-render only the keycaps whose overlay changed. That doesn't help this host: a program switch always begins with an overlay-state reset (`USAGE_RESET | MAPPING_RESET | MIRROR_OVERLAYS`) that invalidates every slot and forces a full render — there is nothing to partial-render when everything changed. The window-send is the render-duration win that survives that.

**Stacked on #153** (base is `claude/loop-timing-instrumentation`, which already carries the merged visibility-gate work). This PR auto-retargets to `PolyKybd` once #153 lands.

## Version bump label

*(none)* — patch. Pure per-key SPI-bytes reduction; identical rendered output, no wire/protocol change.

## Testing
- [x] Compiled successfully — `qmk compile` for `polykybd/split72:default` **and** `polykybd/split42:default` (both → `.uf2`, exit 0)
- [ ] Flashed and used on hardware — pending
- [ ] If protocol changed: host updated and tested together *(n/a — no protocol change)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016uRCFoK5V77VF6bYqWzJ2i)_

## Summary by Sourcery

Reduce per-key OLED render cost by sending only the visible 72×40 window instead of the full buffer for keycap updates.

Enhancements:
- Switch idle key jitter rendering to use windowed OLED updates confined to the visible keycap region.
- Update all per-key display refresh paths to use windowed OLED transfers during overlay/program changes for lower SPI bandwidth.