### PR TITLE
perf(overlay): only refresh on an actual overlay-flag transition (cmd 12)

### DIFF
--- a/keyboards/polykybd/hid_com.c
+++ b/keyboards/polykybd/hid_com.c
@@ -495,8 +495,19 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
             case 12: //overlays flags off
                 {
                     uint8_t flags_to_clear = data[HID_DATA_IDX];
-                    local_state->overlay_flags = flag_off(local_state->overlay_flags, flags_to_clear);
-                    if(flags_to_clear & OVERLAY_SYNCED_STATE_FLAGS) {
+                    uint8_t old_flags = local_state->overlay_flags;
+                    local_state->overlay_flags = flag_off(old_flags, flags_to_clear);
+                    // Only sync + full-refresh when a synced-state bit (MIRROR /
+                    // DISPLAY overlays) actually TRANSITIONED set->clear. Re-clearing
+                    // an already-clear bit changes nothing on screen, so gating on the
+                    // real transition avoids a blocking slave bridge-sync + full
+                    // 72-keycap re-render for a no-op. A host that re-asserts
+                    // "overlays off" on every active-window poll — e.g. a focused
+                    // window with no overlays whose TITLE keeps changing (a terminal
+                    // animating a spinner in its title) — would otherwise force one
+                    // full render per poll. (The host now dedups this too; this is the
+                    // firmware-side backstop for any client that re-asserts state.)
+                    if(old_flags & flags_to_clear & OVERLAY_SYNCED_STATE_FLAGS) {
                         send_to_bridge(USER_SYNC_POLY_DATA, (void *)local_state, sizeof(poly_sync_t), 10);
                         request_disp_refresh();
                     }


### PR DESCRIPTION
## Summary

`hid_com.c` case 12 (`OVERLAY_FLAGS_OFF`) triggered a slave bridge-sync + a **full 72-keycap re-render** whenever the cleared set intersected `OVERLAY_SYNCED_STATE_FLAGS` (`MIRROR_OVERLAYS` / `DISPLAY_OVERLAYS`) — **even when those bits were already clear**, i.e. the clear was a no-op. So a host that re-asserts "overlays off" on every active-window poll forced one full render per poll for no visible change.

That is exactly what happens with a focused window that has **no overlays but whose title keeps changing** — observed over the forwarder: a terminal running an AI-agent CLI that animates a **braille spinner in its title bar** (~1/s) → a full keyboard re-render every second. Confirmed with the loop profiler.

Fix: gate the sync+refresh on the real `set→clear` transition —

```c
if (old_flags & flags_to_clear & OVERLAY_SYNCED_STATE_FLAGS) { … }
```

A genuine on→off still syncs + refreshes; a redundant clear becomes a true no-op. **Wire format is unchanged** (same cmd, same payload).

The host also dedups this now ([PolyKybdHost#122](https://github.com/thpoll83/PolyKybdHost/pull/122) downgrades a redundant `DISABLE` to `NONE`); this is the firmware-side backstop so any client re-asserting state can't thrash the render.

## Version bump label

*(none)* — patch. No wire/protocol change, so **no `PROTOCOL_VERSION` / `__protocol__` bump**; pure redundant-work elimination with identical rendered output.

## Testing
- [x] Compiled — `qmk compile` for `polykybd/split72:default` **and** `polykybd/split42:default` (both → `.uf2`, exit 0)
- [ ] Flashed and used on hardware — pending
- [ ] If protocol changed: host updated and tested together *(n/a — no protocol change)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016uRCFoK5V77VF6bYqWzJ2i)_

## Summary by Sourcery

Gate overlay flag “off” handling on actual state transitions to eliminate redundant syncs and full keyboard re-renders.

Bug Fixes:
- Prevent unnecessary overlay sync and full keyboard refresh when clearing overlay flags that are already unset.

Enhancements:
- Improve overlay handling performance by avoiding slave bridge syncs and 72-keycap re-renders for no-op overlay state clears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved overlay flag handling to refresh the display and synchronize bridge state only when synced overlay flags actually change.
  - Prevented unnecessary display refreshes and synchronization when clearing flags that were already disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->