### PR TITLE
fix: don't let the unattended auto-brightness push re-light dark displays

### DIFF
--- a/keyboards/polykybd/state.c
+++ b/keyboards/polykybd/state.c
@@ -5,6 +5,7 @@
 
 #include <string.h>
 #include "eeconfig.h"
+#include "base/com.h"   // enum poly_flag — the display-state bits guarding the auto push
 
 static poly_layer_t l_layer;
 static poly_layer_t g_layer;
@@ -291,12 +292,34 @@ bool get_brightness_auto_mode(void) {
     return g_auto_brightness;
 }
 
+// True only while the panels are actually showing the awake brightness. False
+// once they are dark (USB suspend, or the TURN_OFF_TIME branch) and while the
+// idle fade/pulse owns the contrast.
+//
+// ⚠️ The host-auto (daylight) and LTR-559 pushes below are UNATTENDED — they fire
+// on a timer with no user in the loop — so they must not write l_state.contrast in
+// those states. Writing it after TURN_OFF_TIME is what re-lit the whole keyboard:
+// the turn-off branch calls disable_idle_tracking(), so the housekeeping idle
+// ladder no longer runs, and the contrast diff switched every keycap OLED back on
+// with nothing left to ever switch them off again (field 2026-07-30: 10-min
+// daylight push six minutes after "Turning off" → both halves lit until the next
+// keypress). The value is still remembered in g_last_auto_brightness, and every
+// wake path restores through get_active_brightness(), so it lands on the next
+// real wake instead.
+static bool displays_awake(void) {
+    return l_state.contrast != DISP_OFF &&
+           (l_state.flags & (uint8_t)STATUS_DISP_ON) != 0 &&
+           (l_state.flags & ((uint8_t)DISP_IDLE | (uint8_t)IDLE_TRANSITION)) == 0;
+}
+
 // Engage/disengage host-driven brightness, applying the resulting active
 // brightness to the display. The mode (and last value, below) is persisted so a
 // reboot in auto mode restores the auto brightness, not the stale manual value.
 void set_brightness_auto_mode(bool on) {
     g_auto_brightness = on;
-    l_state.contrast  = get_active_brightness();
+    if (displays_awake()) {
+        l_state.contrast = get_active_brightness();
+    }
     g_brightness_dirty = true;   // persist the new auto-mode state (flushed at suspend/store)
 }
 
@@ -312,7 +335,9 @@ void set_auto_brightness_value(uint8_t value) {
     g_last_auto_brightness = value;
     g_auto_value_known     = true;
     if (g_auto_brightness) {
-        l_state.contrast = value;
+        if (displays_awake()) {      // never light dark/idling panels — see displays_awake()
+            l_state.contrast = value;
+        }
         g_brightness_dirty = true;   // remember the latest auto value for the next boot
     }
 }


### PR DESCRIPTION
## The bug

After the idle ladder reaches `TURN_OFF_TIME` and switches the keycap OLEDs off, the next host daylight push switches them all back on — and nothing is left to ever switch them off again, so the keyboard sits fully lit until the user presses a key.

Field trace (2026-07-30), master HID console:

```
19:19:07.610  Stop idle.                                  <- last activity reset
19:21:17.210  Transition to idle [style=pulse] - pulsing  <- +130 s (FADE_OUT + FADE_TRANSITION)
19:25:43      Set brightness to: 32 (flags 0x1, auto 1)   <- host daylight, every 10 min
19:35:43      Set brightness to: 32 (flags 0x1, auto 1)
19:39:07.627  Turning off                                 <- +1200.017 s = TURN_OFF_TIME
19:45:43      (next daylight push)                        <- displays come back on here
```

No `Wake by keypress` anywhere after the turn-off — the user returned to a fully lit keyboard.

## Root cause

`set_auto_brightness_value()` wrote `l_state.contrast` unconditionally while host-auto mode was engaged, with no check that the panels were actually awake:

```c
if (g_auto_brightness) {
    l_state.contrast = value;      // no display-state check
    g_brightness_dirty = true;
}
```

The `TURN_OFF_TIME` branch in `housekeeping_task_user()` (`poly_keymap.c:1072`) calls `poly_suspend()` **and** `disable_idle_tracking()`, so the whole idle ladder is skipped from then on. With nothing guarding the contrast, the next unattended push produced a `contrast_changed` diff, `sync_and_refresh_displays()` ran `set_displays(32, false)` → `kdisp_enable(true)`, and both halves lit up permanently (contrast rides the synced `poly_sync_t`). Every subsequent 10-minute push just rewrote the same value.

`set_brightness_auto_mode()` had the same unconditional `l_state.contrast = get_active_brightness()`.

Both are driven by timers with no user in the loop — the host daylight timer (~10 min) and, on a sensor-equipped split72, `poly_ltr559_drive()` (every `LTR559_DRIVE_MS` = 500 ms, which would re-light the panels within half a second of turning off).

## The fix

A `displays_awake()` helper in `state.c`, and both auto-brightness entry points gated on it:

```c
static bool displays_awake(void) {
    return l_state.contrast != DISP_OFF &&
           (l_state.flags & (uint8_t)STATUS_DISP_ON) != 0 &&
           (l_state.flags & ((uint8_t)DISP_IDLE | (uint8_t)IDLE_TRANSITION)) == 0;
}
```

Nothing is lost by skipping the write — the value is still recorded in `g_last_auto_brightness` / `g_auto_value_known` and still marks the state dirty, and **every** wake path already restores through `get_active_brightness()` (`display_wakeup`, `suspend_wakeup_init_kb`, cmd 15 stop-idle, `poly_prepare_for_flash`, the fade restore). So the latest daylight value lands on the next real wake instead of forcing one.

Notes on scope:

- **Deliberate sets are unchanged.** `set_user_brightness()` (the `KC_D*` preset keys, an explicit host slider / `polyctl brightness`) still lights the panels — that is a user action, not an unattended timer.
- **`KC_DAUTO` still applies immediately.** It is handled in `post_process_record_user`, which runs *after* `process_record_user` ends with `display_wakeup(record)`, so the toggle always sees an awake display.
- The idle/transition check is an explicit bitmask rather than `test_flag()`, which is `(flags & f) == f` (AND semantics) and would be wrong for a two-bit test.

## Verification

Both variants compile and link clean, no new warnings:

| target | text | data | bss | `.bin` |
|---|---|---|---|---|
| `polykybd/split72:default` | 118264 | 283752 | 262192 | 402016 B |
| `polykybd/split42:default` | 111400 | 265424 | 262232 | 376824 B |

On hardware, the check is that `Set brightness to: N (flags 0x1, auto 1)` still appears in the console after a `Turning off` but the displays stay dark, and come up at the latest auto value on the next keypress.

No wire-protocol change, so no `PROTOCOL_VERSION` / `__protocol__` bump.

## Not included

A related host-side issue found in the same investigation is deliberately left out of this PR: `PolyKybdHost` `poly_core.py:560` calls `set_idle(False)` at the end of *every* overlay-send job, so each active-window change resets the 130 s idle countdown (HID cmd 15 stop-idle calls `update_performed()`). On a machine with frequent focus changes the keyboard can never reach idle at all. That's a host-repo change and belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLDVsx8HMzsX1Fbv1ZSX6a

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLDVsx8HMzsX1Fbv1ZSX6a)_

## Summary by Sourcery

Prevent unattended auto-brightness updates from re-lighting displays after they have been turned off or are idling.

Bug Fixes:
- Guard host-driven and sensor-driven auto-brightness updates so they only apply when displays are awake, avoiding dark or idle panels being lit by background timers.

Enhancements:
- Introduce a displays_awake state helper to centralize display wake/idle checks and use it to gate auto-brightness contrast writes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic brightness handling when switching modes or updating host brightness values.
  * Prevented brightness changes from interrupting displays that are dimmed, suspended, fading, or pulsing.
  * Ensured brightness settings are restored appropriately when displays become active again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->