### PR TITLE
fix(doom): wake the DOOM attract screensaver on proximity

### DIFF
--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -712,6 +712,20 @@ static void user_sync_dummy_handler(uint8_t in_len, const void* in_data, uint8_t
 // second "Transition to idle" with nothing explaining the first one ending.
 static void poly_force_wake(void) {
     poly_sync_t* local_state = access_local_state();
+    // The DOOM attract screensaver (IDLE_STYLE_IDDQD) runs with STATUS_DISP_ON SET
+    // and DISP_IDLE CLEARED — it owns the keycaps at active brightness via
+    // doom_tick(), not through the DISP_IDLE pulse path. So it matches NEITHER
+    // branch below, and proximity would be a silent no-op over it while pulse /
+    // jitter / eden (all DISP_IDLE) and full suspend wake normally — the reported
+    // "doom idle doesn't react to the proximity sensor, the other idle modes do".
+    // Tear it down exactly like a keypress does (doom_exit restores the legends and
+    // stamps a fresh last_update); only the screensaver, never an active game.
+    if (doom_mode_screensaver()) {
+        uprint("Wake by proximity (from doom screensaver)\n");
+        doom_screensaver_stop();
+        update_performed();
+        return;
+    }
     if ((local_state->flags & (STATUS_DISP_ON | DISP_IDLE)) == 0) {
         uprint("Wake by proximity (from suspend)\n");
         suspend_wakeup_init_kb();   // fully suspended -> full wake


### PR DESCRIPTION
## Summary

The `IDLE_STYLE_IDDQD` DOOM attract screensaver runs with `STATUS_DISP_ON` set and `DISP_IDLE` **cleared** — it owns the keycaps at active brightness via `doom_tick()`, not through the pulse/`DISP_IDLE` path. As a result it matched **neither** branch of `poly_force_wake()`, so the LTR‑559 proximity sensor was a silent no‑op over it: pulse / jitter / eden (all `DISP_IDLE`) and full suspend woke on proximity, but the DOOM screensaver did not. This is the "doom idle mode doesn't react to the proximity sensor, the other idle modes do" report.

Fix: add a leading branch to `poly_force_wake()` — if the DOOM **screensaver** (never an active game) is running, tear it down exactly like a keypress does via `doom_screensaver_stop()` → `doom_exit()` (restores the legends, stamps a fresh `last_update`) + `update_performed()`. `doom_mode_screensaver()` / `doom_screensaver_stop()` are stubbed to no‑ops in non‑DOOM builds, so the shipping default image is byte‑unaffected past the stubbed call.

One file: `poly_keymap.c` (`poly_force_wake`).

## Version bump label

*(none)* — small bug fix, patch bump. No protocol/wire change.

## Testing
- [x] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`, plus `-e POLYKYBD_DOOM_PACK=yes` to exercise the DOOM path)
- [ ] Flashed and tested on hardware (pending)
- [x] Non‑DOOM default build unaffected (stubbed no‑ops)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uRCFoK5V77VF6bYqWzJ2i

---
_Generated by [Claude Code](https://claude.ai/code/session_016uRCFoK5V77VF6bYqWzJ2i)_

## Summary by Sourcery

Bug Fixes:
- Ensure the DOOM idle screensaver responds to proximity sensor wake events while leaving non-DOOM builds behavior unchanged.