### PR TITLE
profiling: on-demand profiler control (HID cmd 32) + opt-in perf CI job

### DIFF
--- a/.github/workflows/qmk-test.yml
+++ b/.github/workflows/qmk-test.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [PolyKybd, "PolyKybd/**"]
   pull_request:
+  # Manual trigger for the opt-in performance measurement below (the normal
+  # build + HIL test always run; perf does not). No inputs: the baseline is moved
+  # by committing the run's JSON to polykybd-ctnd, not by a workflow switch — the
+  # rig's checkout is force-synced to origin/main before every run, so anything
+  # written there would be discarded on the next one.
+  workflow_dispatch:
 
 jobs:
   build:
@@ -212,6 +218,161 @@ jobs:
             let diag = '(diagnostics file not found — the test step failed before producing output)';
             try { diag = fs.readFileSync('/tmp/hil-diagnostics.md', 'utf8'); } catch (e) {}
             let body = '<!-- hil-diagnostics -->\n' + diag;
+            const MAX = 65000;
+            if (body.length > MAX) body = body.slice(0, MAX) + '\n\n…(truncated)';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+
+  # --- Performance measurement (OPT-IN) ---------------------------------------
+  #
+  # Not part of the normal PR gate: it flashes a *different* firmware (the
+  # profiler build) and occupies the rig for a few more minutes, so it only runs
+  # when asked for. Three ways to ask:
+  #   * run the workflow manually (Actions -> Run workflow),
+  #   * add the `perf` label to a PR,
+  #   * put `[perf]` in a commit message on a PolyKybd branch.
+  #
+  # It reports numbers and compares them against the baseline committed in the
+  # polykybd-ctnd repo (perf/baselines/<board>.json). It deliberately NEVER fails
+  # the check on a regression — these are wall-clock measurements on shared
+  # hardware, and a flaky red check is a check people learn to ignore. Only a
+  # measurement failure (wrong build flashed, device unresponsive) fails the job.
+  build-perf:
+    name: Build firmware (profiling)
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'perf') ||
+      contains(github.event.head_commit.message, '[perf]')
+    runs-on: ubuntu-latest
+    outputs:
+      hil_left: ${{ steps.names.outputs.hil_left }}
+      hil_right: ${{ steps.names.outputs.hil_right }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      # Same flags as the graded HIL build (so the measurement reflects the
+      # shipping shape) PLUS POLYKYBD_LOOP_PROFILE, which compiles in the
+      # main-loop profiler and its on-demand HID control command (32). Without
+      # that flag the command NACKs and the perf run fails fast with a clear
+      # "not a POLYKYBD_LOOP_PROFILE build" message rather than reporting zeros.
+      - name: Build split72 (profiling, HIL left/master)
+        uses: docker://qmkfm/qmk_cli
+        with:
+          args: qmk compile -kb polykybd/split72 -km default -e POLYKYBD_DOOM_PACK=yes -e POLYKYBD_LOOP_PROFILE=yes -e POLYKYBD_HIL=left -e TARGET=polykybd_split72_perf_hil_left
+
+      - name: Build split72 (profiling, HIL right/slave)
+        uses: docker://qmkfm/qmk_cli
+        with:
+          args: qmk compile -kb polykybd/split72 -km default -e POLYKYBD_DOOM_PACK=yes -e POLYKYBD_LOOP_PROFILE=yes -e POLYKYBD_HIL=right -e TARGET=polykybd_split72_perf_hil_right
+
+      - id: names
+        run: |
+          echo "hil_left=$(ls polykybd_split72_perf_hil_left*.uf2 2>/dev/null | head -1)" >> "$GITHUB_OUTPUT"
+          echo "hil_right=$(ls polykybd_split72_perf_hil_right*.uf2 2>/dev/null | head -1)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: firmware-perf
+          path: "*_perf_hil_*.uf2"
+          retention-days: 7
+
+  perf-test:
+    name: Performance measurement (split72)
+    # Ordered after hil-test so the two rig jobs can't interleave their flashes.
+    # `always()` so a red HIL suite doesn't skip the measurement — a perf number
+    # is often exactly what explains a timing-related HIL failure. It still needs
+    # its own build to have succeeded.
+    needs: [build-perf, hil-test]
+    if: always() && needs.build-perf.result == 'success'
+    runs-on: [self-hosted, polykybd-ctnd]
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+    steps:
+      - name: Locate station directory
+        id: ctnd
+        run: |
+          dir="${CTND_DIR:-}"
+          if [ -z "$dir" ]; then
+            for candidate in /opt/polykybd-ctnd "$HOME/polykybd-ctnd"; do
+              if [ -f "$candidate/venv/bin/python" ]; then
+                dir="$candidate"
+                break
+              fi
+            done
+          fi
+          if [ -z "$dir" ]; then
+            echo "ERROR: could not find a polykybd-ctnd install with a venv." >&2
+            exit 1
+          fi
+          echo "dir=$dir" >> "$GITHUB_OUTPUT"
+
+      # Same reason as the HIL job: CI runs the *installed* station copy, so pull
+      # it to origin/main first or a lagging self-update timer silently measures
+      # with stale harness code (and a stale baseline).
+      - name: Sync station to current ctnd main
+        run: |
+          dir="${{ steps.ctnd.outputs.dir }}"
+          if [ ! -d "$dir/.git" ]; then
+            echo "WARNING: $dir is not a git checkout — running the installed station as-is" >&2
+            exit 0
+          fi
+          git -C "$dir" fetch --quiet origin main \
+            && git -C "$dir" checkout -q -f -B main origin/main \
+            && echo "station synced to $(git -C "$dir" rev-parse --short HEAD)" \
+            || echo "WARNING: could not sync $dir to origin/main" >&2
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: firmware-perf
+          path: ${{ steps.ctnd.outputs.dir }}/firmware
+
+      - name: Measure
+        run: |
+          cd ${{ steps.ctnd.outputs.dir }}
+          set -o pipefail
+          venv/bin/python -u -m station.perf_runner \
+            --left  "firmware/${{ needs.build-perf.outputs.hil_left }}" \
+            --right "firmware/${{ needs.build-perf.outputs.hil_right }}" \
+            --label split72 \
+            --json /tmp/perf-report.json \
+            --markdown /tmp/perf-report.md \
+            2>&1 | tee /tmp/perf-run.log
+
+      # The JSON is what you commit to polykybd-ctnd's perf/baselines/split72.json
+      # to move the baseline — there is deliberately no automatic baseline update
+      # (an auto-updating baseline ratchets a slow regression in silently).
+      - name: Upload perf report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-report
+          path: |
+            /tmp/perf-report.json
+            /tmp/perf-report.md
+            /tmp/perf-run.log
+          retention-days: 30
+
+      - name: Post perf report as PR comment
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let body;
+            try {
+              body = fs.readFileSync('/tmp/perf-report.md', 'utf8');
+            } catch (e) {
+              body = '## ⏱️ Firmware performance\n\n> ❌ The perf run produced no report — see the job log.';
+            }
+            body = '<!-- perf-report -->\n' + body;
             const MAX = 65000;
             if (body.length > MAX) body = body.slice(0, MAX) + '\n\n…(truncated)';
             await github.rest.issues.createComment({

--- a/.github/workflows/qmk-test.yml
+++ b/.github/workflows/qmk-test.yml
@@ -4,16 +4,30 @@ on:
   push:
     branches: [PolyKybd, "PolyKybd/**"]
   pull_request:
+    # `labeled` is NOT in GitHub's default set (opened/synchronize/reopened), and
+    # without it adding the `perf` label to an open PR fires no run at all — the
+    # label condition below would only ever be evaluated on the next push. The
+    # normal build + HIL jobs opt out of label events (`github.event.action !=
+    # 'labeled'`) so the repo's auto-labeler can't re-run the whole expensive
+    # pipeline every time it tags a PR by path.
+    types: [opened, synchronize, reopened, labeled]
   # Manual trigger for the opt-in performance measurement below (the normal
   # build + HIL test always run; perf does not). No inputs: the baseline is moved
   # by committing the run's JSON to polykybd-ctnd, not by a workflow switch — the
   # rig's checkout is force-synced to origin/main before every run, so anything
   # written there would be discarded on the next one.
+  # ⚠️ workflow_dispatch only becomes available once this file is on the DEFAULT
+  # branch — it cannot be used to try the perf job out from an unmerged PR.
   workflow_dispatch:
 
 jobs:
   build:
     name: Build firmware
+    # A `labeled` event means someone (or the auto-labeler) tagged the PR; it is
+    # not a code change, so there is nothing new to build or HIL-test. Only the
+    # opt-in perf jobs below act on it. `github.event.action` is null for push /
+    # workflow_dispatch, so those still run normally.
+    if: github.event.action != 'labeled'
     runs-on: ubuntu-latest
     outputs:
       split72: ${{ steps.names.outputs.split72 }}
@@ -231,10 +245,15 @@ jobs:
   #
   # Not part of the normal PR gate: it flashes a *different* firmware (the
   # profiler build) and occupies the rig for a few more minutes, so it only runs
-  # when asked for. Three ways to ask:
-  #   * run the workflow manually (Actions -> Run workflow),
-  #   * add the `perf` label to a PR,
-  #   * put `[perf]` in a commit message on a PolyKybd branch.
+  # when asked for. Three ways to ask, each with its own scope:
+  #   * add the `perf` label to a PR — the way to measure a PR (needs the
+  #     `labeled` event type above; the label stays on, so later pushes to that
+  #     PR keep measuring),
+  #   * put `[perf]` in a commit message — PUSH events only. `head_commit` does
+  #     not exist on a pull_request event, so this does nothing on a PR; it
+  #     applies to pushes to PolyKybd branches (i.e. after merge),
+  #   * run the workflow manually (Actions -> Run workflow) — only available
+  #     once this file is on the default branch.
   #
   # It reports numbers and compares them against the baseline committed in the
   # polykybd-ctnd repo (perf/baselines/<board>.json). It deliberately NEVER fails

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,21 @@ inherited-upstream noise:
   positive in the ignored-files list (CI checks out clean, so it never sees it).
 - The CodeRabbit **Docstring-Coverage** check is ignored per "Code review conventions"
   above.
+- **`Performance measurement (split72)` is OPT-IN and never gates.** It builds a
+  second pair of HIL images with `-e POLYKYBD_LOOP_PROFILE=yes` and has the rig
+  measure main-loop timing, overlay cost (bridge/render/rest) and HID latency, then
+  posts a table to the job summary + a PR comment and compares against the baseline
+  committed in `polykybd-ctnd` (`perf/baselines/split72.json`). Trigger it with the
+  **`perf` PR label**, **`[perf]` in a commit message**, or a manual
+  `workflow_dispatch`. ⚠️ It **never fails on a regression** (wall-clock numbers on
+  shared hardware — a flaky red check is one people learn to ignore); only a
+  *measurement* failure (wrong build flashed, device dead) fails the job. Ordered
+  `needs: [build-perf, hil-test]` + `always()` so the two rig jobs can't interleave
+  flashes, but a red HIL suite still yields a perf number — often exactly what
+  explains a timing-related HIL failure. **Use this instead of asking the user to
+  flash a build and paste the console log.** See
+  `keyboards/polykybd/profiling/README.md` (§ on-demand control, HID cmd 32) and the
+  `polykybd-ctnd` CLAUDE.md § Performance measurement.
 
 ## Releases
 
@@ -233,6 +248,14 @@ extraction fixed: `corne42` had silently fallen ~98 languages behind split72).
   paths are untouched** (their headers already fit). **Bump `FW_VERSION` +
   `PROTOCOL_VERSION` (config.h) and `__protocol__` (PolyKybdHost `_version.py`) in
   lockstep** — the host connect gate is exact-match.
+- **Cmd `32` = main-loop profiler control — present ONLY in a
+  `POLYKYBD_LOOP_PROFILE` build, and bumps NO `PROTOCOL_VERSION`** (dispatched
+  independently like cmd 31 / the fontpack commands). Sub-commands `0` RESET / `1`
+  READ (binary snapshot, `data[3]` = page) / `2` LOG. ⚠️ The whole `case 32` is
+  inside `#ifdef POLYKYBD_LOOP_PROFILE`, so a normal build **NACKs** it — that
+  NACK is the deliberate capability signal telling a host "no profiler here"
+  instead of handing back a page of zeros. Consumed by the rig's automated perf
+  run; see `keyboards/polykybd/profiling/README.md`.
 - Overlay transmission: each keycap overlay (360 bytes) is split into 6 × 60-byte segments (cmd `0x0A`, protocol 11+: modifier+segment packed into one header byte), or sent RLE-compressed in 1–2 packets (cmds `0x10`/`0x11`)
 - ROI updates (cmds `0x12`/`0x13`) allow partial refresh of a keycap's display area
 - Overlay index = `keycode_slot + 90 * modifier_variant` (9 variants: bare, Ctrl, Shift, Ctrl+Shift, Alt, Ctrl+Alt, Alt+Shift, Ctrl+Alt+Shift, GUI)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,8 +98,14 @@ inherited-upstream noise:
   measure main-loop timing, overlay cost (bridge/render/rest) and HID latency, then
   posts a table to the job summary + a PR comment and compares against the baseline
   committed in `polykybd-ctnd` (`perf/baselines/split72.json`). Trigger it with the
-  **`perf` PR label**, **`[perf]` in a commit message**, or a manual
-  `workflow_dispatch`. ⚠️ It **never fails on a regression** (wall-clock numbers on
+  **`perf` PR label** (the way to measure a PR), **`[perf]` in a commit message**
+  (PUSH events only — `head_commit` doesn't exist on a `pull_request` event, so it
+  does nothing on a PR), or a manual **`workflow_dispatch`** (only available once
+  the workflow is on the default branch). ⚠️ The label needs `labeled` in the
+  workflow's `pull_request` `types:` — it is **not** in GitHub's default set, so
+  without it labelling an open PR fires no run at all; `build`/`hil-test` opt out
+  of label events so the auto-labeler can't re-run the whole pipeline.
+  ⚠️ It **never fails on a regression** (wall-clock numbers on
   shared hardware — a flaky red check is one people learn to ignore); only a
   *measurement* failure (wrong build flashed, device dead) fails the job. Ordered
   `needs: [build-perf, hil-test]` + `always()` so the two rig jobs can't interleave

--- a/keyboards/polykybd/hid_com.c
+++ b/keyboards/polykybd/hid_com.c
@@ -902,6 +902,66 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                     uprint("Replaying startup animation.\n");
                 }
                 break;
+#ifdef POLYKYBD_LOOP_PROFILE
+            case 32: //main-loop profiler control (POLYKYBD_LOOP_PROFILE builds only)
+                {
+                    // Lets an automated harness (the polykybd-ctnd rig) bound ONE
+                    // measurement: reset the counters, drive a workload, read the
+                    // window back as binary. Without it the only readout is the
+                    // periodic console block, whose counters are cumulative from
+                    // boot and whose `worst` is an all-time maximum — impossible to
+                    // attribute to a specific workload.
+                    //
+                    // NOT protocol-gated and bumps NO PROTOCOL_VERSION — like cmd 31
+                    // (REPLAY_ANIM) and the fontpack commands, it is dispatched
+                    // independently. On a normal (non-profiling) build the whole case
+                    // is compiled out, so the command NACKs via the default branch;
+                    // that NACK is how the rig distinguishes "no profiler in this
+                    // firmware" from a real answer.
+                    //
+                    // data[2] = sub-command, data[3] = page (READ only).
+                    const uint8_t sub  = hid_payload_avail(length, 2) > 0 ? data[2] : 0xFFu;
+                    const uint8_t page = hid_payload_avail(length, 3) > 0 ? data[3] : 0;
+                    switch (sub) {
+                        case 0: // RESET — zero the counters and start a fresh window
+                            loop_profile_reset();
+                            memset(data, 0, length);
+                            hid_reply(data, 32, true);
+                            raw_hid_send(data, length);
+                            break;
+                        case 1: { // READ — binary snapshot of the current window
+                            uint8_t body[64];
+                            uint8_t n = loop_profile_snapshot(page, body, (uint8_t)sizeof(body));
+                            memset(data, 0, length);
+                            hid_reply(data, 32, n > 0);
+                            if (n > 0) {
+                                data[3] = page;
+                                // Header is 4 bytes (P, cmd, status, page), so the
+                                // body is bounded by whatever the report holds after
+                                // it — via the shared helper, so a short report can
+                                // never underflow into a huge memcpy.
+                                const uint16_t room = hid_payload_avail(length, 4);
+                                if ((uint16_t)n > room) n = (uint8_t)room;
+                                memcpy(&data[4], body, n);
+                            }
+                            raw_hid_send(data, length);
+                            break;
+                        }
+                        case 2: // LOG — dump the console summary block immediately
+                            loop_profile_log_now();
+                            memset(data, 0, length);
+                            hid_reply(data, 32, true);
+                            raw_hid_send(data, length);
+                            break;
+                        default:
+                            memset(data, 0, length);
+                            hid_reply(data, 32, false);
+                            raw_hid_send(data, length);
+                            break;
+                    }
+                }
+                break;
+#endif
             default:
                 if (hid_fw_up_receive(data, length)) {
                     break;

--- a/keyboards/polykybd/profiling/README.md
+++ b/keyboards/polykybd/profiling/README.md
@@ -108,6 +108,51 @@ ms-rounding loses the sub-millisecond-per-iteration render slices. `bridge` is c
 to the iteration wall and `render` into the remaining wall, so the derived `rest` can
 never underflow on a measurement artefact.
 
+## On-demand control (HID command 32) — how the rig automates this
+
+The periodic block above is fine for a human watching the console, but it cannot
+*bound* a measurement: the counters are cumulative from boot and `worst` is an
+all-time maximum, so there is no way to attribute a number to one workload. HID
+command **32** fixes that. It exists **only in a `POLYKYBD_LOOP_PROFILE` build** —
+the whole `case 32` in `hid_com.c` is inside `#ifdef POLYKYBD_LOOP_PROFILE`, so a
+normal build falls through to the dispatcher's default branch and **NACKs**. That
+NACK is the contract: it is how a host tells "this firmware has no profiler" apart
+from "the profiler answered", instead of silently reading back a page of zeros.
+
+Like cmd 31 (`REPLAY_ANIM`) and the fontpack commands it is dispatched
+independently and bumps **no `PROTOCOL_VERSION`**.
+
+Request: `data[0]='P'`, `data[1]=32`, `data[2]=sub-command`, `data[3]=page`.
+
+| sub | name | effect |
+|-----|------|--------|
+| 0 | `RESET` | Zero every counter and re-arm. The in-flight iteration (the one dispatching this command) is **dropped**, not counted — its cost is HID plumbing, not the workload. |
+| 1 | `READ` | Reply with one binary snapshot page (`data[3]` selects it). |
+| 2 | `LOG` | Emit the console summary block immediately. |
+
+`READ` replies `P<32><status><page>` followed by the little-endian body:
+
+* **page 0** — `[version][flags][2 reserved]` then `u32`: `iters`, `ovl_iters`,
+  `max_us`, `max_bridge_us`, `max_render_us`, `ovl_wall_us`, `ovl_bridge_us`,
+  `ovl_render_us`. `flags` bit 0 = the worst iteration was overlay-handling.
+* **page 1** — `u32 bkt_norm[7]` then `u32 bkt_ovl[7]`.
+
+`version` is `LOOP_PROFILE_SNAPSHOT_VERSION` (`loop_profile.h`). **Bump it if the
+field layout ever changes** — the reader refuses an unknown version rather than
+mis-decoding a reordered struct.
+
+So one bounded measurement is: `RESET` → run the workload → `READ` page 0 + 1.
+
+**The rig does all of this for you.** In `polykybd-ctnd`,
+`station/perf.py` + `station/perf_runner.py` flash a profiling HIL pair, wait out
+the boot window using the same settle gates as the HIL suite, drive the overlay /
+latency / idle workloads each inside its own window, and publish a JSON + markdown
+report with a comparison against a committed baseline. It runs as the **opt-in**
+`Performance measurement (split72)` CI job (`qmk-test.yml`): trigger it with the
+`perf` PR label, `[perf]` in a commit message, or a manual workflow run. Build the
+images with `-e POLYKYBD_LOOP_PROFILE=yes` or the run fails fast with a clear
+"not a POLYKYBD_LOOP_PROFILE build" message.
+
 ## How to take a clean measurement
 
 - **Type / switch programs while watching the console.** The counters are all-time
@@ -131,6 +176,7 @@ All are no-ops unless `POLYKYBD_LOOP_PROFILE` is defined:
 | `loop_profile_note_overlay_cmd()` | `hid_com.c` `raw_hid_receive()`, the classifier `switch` | Tags this iteration as overlay-handling (cmds 10/11/12/16/17/18/19/21). |
 | `loop_profile_add_bridge_us(us)` | `bridge_helper.c` `send_to_bridge()`, around `transaction_rpc_exec()` | Accumulates blocking bridge microseconds for this iteration. |
 | `loop_profile_add_render_us(us)` | `poly_keymap.c` `sync_and_refresh_displays()`, around the `update_displays()` calls | Accumulates render microseconds for this iteration. |
+| `loop_profile_reset()` / `_snapshot()` / `_log_now()` | `hid_com.c` `raw_hid_receive()` case 32 | The on-demand control API above. ⚠️ Unlike the four hooks, these have **no `#else` stubs** — the call site itself is `#ifdef`-guarded so the command NACKs on a normal build. |
 
 ## Tuning the profiler itself
 

--- a/keyboards/polykybd/profiling/loop_profile.c
+++ b/keyboards/polykybd/profiling/loop_profile.c
@@ -5,6 +5,7 @@
 #ifdef POLYKYBD_LOOP_PROFILE
 
 #include <print.h>
+#include <string.h>
 #include "hardware/structs/timer.h"   // timer_hw->timerawl — raw 1 MHz us counter
                                       // (lightweight struct header; avoids the pico
                                       // alarm API inlines that trip QMK's -Werror)
@@ -26,7 +27,7 @@ static bool     s_have_start    = false;  // false until the first boundary is s
 
 // Iteration-time buckets (microseconds), split overlay vs normal:
 //   0:<1ms 1:1-2 2:2-5 3:5-10 4:10-20 5:20-50 6:>=50ms
-#define NBUCKET 7
+#define NBUCKET LOOP_PROFILE_NBUCKET
 static uint32_t s_bkt_norm[NBUCKET];
 static uint32_t s_bkt_ovl[NBUCKET];
 
@@ -50,6 +51,9 @@ static uint32_t s_ovl_render_us = 0;
 static uint32_t s_iters     = 0;  // total iterations measured
 static uint32_t s_ovl_iters = 0;  // of those, iterations that handled an overlay cmd
 static uint32_t s_last_log  = 0;  // s_iters at the last emitted summary
+
+// Defined below, next to the on-demand control API it shares.
+static void emit_summary(void);
 
 static uint8_t bucket_of(uint32_t us) {
     if (us <  1000u) return 0;
@@ -106,32 +110,7 @@ void loop_profile_tick(void) {
 
         if ((s_iters - s_last_log) >= LOOP_PROFILE_LOG_EVERY) {
             s_last_log = s_iters;
-            uprintf("LoopProf: iters=%lu ovl=%lu worst=%lums(%s br=%lums rn=%lums)\n",
-                    (unsigned long)s_iters, (unsigned long)s_ovl_iters,
-                    (unsigned long)(s_max_us / 1000u),
-                    s_max_overlay ? "ovl" : "norm",
-                    (unsigned long)(s_max_bridge_us / 1000u),
-                    (unsigned long)(s_max_render_us / 1000u));
-            uprintf("  norm  <1=%lu 1-2=%lu 2-5=%lu 5-10=%lu 10-20=%lu 20-50=%lu 50+=%lu\n",
-                    (unsigned long)s_bkt_norm[0], (unsigned long)s_bkt_norm[1],
-                    (unsigned long)s_bkt_norm[2], (unsigned long)s_bkt_norm[3],
-                    (unsigned long)s_bkt_norm[4], (unsigned long)s_bkt_norm[5],
-                    (unsigned long)s_bkt_norm[6]);
-            uprintf("  ovl   <1=%lu 1-2=%lu 2-5=%lu 5-10=%lu 10-20=%lu 20-50=%lu 50+=%lu\n",
-                    (unsigned long)s_bkt_ovl[0], (unsigned long)s_bkt_ovl[1],
-                    (unsigned long)s_bkt_ovl[2], (unsigned long)s_bkt_ovl[3],
-                    (unsigned long)s_bkt_ovl[4], (unsigned long)s_bkt_ovl[5],
-                    (unsigned long)s_bkt_ovl[6]);
-            // Where the OVERLAY-iteration wall time goes, in aggregate (ms totals).
-            // rest = wall - bridge - render. This is the line that settles bridge-vs-
-            // render: a big render share points at update_displays (baked resources
-            // would not help); a big bridge share points at the master->slave relay.
-            uint32_t rest_us = s_ovl_wall_us - s_ovl_bridge_us - s_ovl_render_us;
-            uprintf("  ovltot wall=%lums bridge=%lums render=%lums rest=%lums\n",
-                    (unsigned long)(s_ovl_wall_us   / 1000u),
-                    (unsigned long)(s_ovl_bridge_us / 1000u),
-                    (unsigned long)(s_ovl_render_us / 1000u),
-                    (unsigned long)(rest_us         / 1000u));
+            emit_summary();
         }
     }
 
@@ -141,6 +120,108 @@ void loop_profile_tick(void) {
     s_render_us     = 0;
     s_overlay_iter  = false;
     s_have_start    = true;
+}
+
+// Emit the human-readable summary block. Shared by the periodic path in
+// loop_profile_tick() and the on-demand loop_profile_log_now() so the console
+// readout can never drift between the two.
+static void emit_summary(void) {
+    uprintf("LoopProf: iters=%lu ovl=%lu worst=%lums(%s br=%lums rn=%lums)\n",
+            (unsigned long)s_iters, (unsigned long)s_ovl_iters,
+            (unsigned long)(s_max_us / 1000u),
+            s_max_overlay ? "ovl" : "norm",
+            (unsigned long)(s_max_bridge_us / 1000u),
+            (unsigned long)(s_max_render_us / 1000u));
+    uprintf("  norm  <1=%lu 1-2=%lu 2-5=%lu 5-10=%lu 10-20=%lu 20-50=%lu 50+=%lu\n",
+            (unsigned long)s_bkt_norm[0], (unsigned long)s_bkt_norm[1],
+            (unsigned long)s_bkt_norm[2], (unsigned long)s_bkt_norm[3],
+            (unsigned long)s_bkt_norm[4], (unsigned long)s_bkt_norm[5],
+            (unsigned long)s_bkt_norm[6]);
+    uprintf("  ovl   <1=%lu 1-2=%lu 2-5=%lu 5-10=%lu 10-20=%lu 20-50=%lu 50+=%lu\n",
+            (unsigned long)s_bkt_ovl[0], (unsigned long)s_bkt_ovl[1],
+            (unsigned long)s_bkt_ovl[2], (unsigned long)s_bkt_ovl[3],
+            (unsigned long)s_bkt_ovl[4], (unsigned long)s_bkt_ovl[5],
+            (unsigned long)s_bkt_ovl[6]);
+    // Where the OVERLAY-iteration wall time goes, in aggregate (ms totals).
+    // rest = wall - bridge - render. This is the line that settles bridge-vs-
+    // render: a big render share points at update_displays (baked resources
+    // would not help); a big bridge share points at the master->slave relay.
+    uint32_t rest_us = s_ovl_wall_us - s_ovl_bridge_us - s_ovl_render_us;
+    uprintf("  ovltot wall=%lums bridge=%lums render=%lums rest=%lums\n",
+            (unsigned long)(s_ovl_wall_us   / 1000u),
+            (unsigned long)(s_ovl_bridge_us / 1000u),
+            (unsigned long)(s_ovl_render_us / 1000u),
+            (unsigned long)(rest_us         / 1000u));
+}
+
+void loop_profile_log_now(void) {
+    // Keep the periodic cadence anchored to "now" so an on-demand dump does not
+    // leave the next automatic block due immediately after it.
+    s_last_log = s_iters;
+    emit_summary();
+}
+
+void loop_profile_reset(void) {
+    memset(s_bkt_norm, 0, sizeof(s_bkt_norm));
+    memset(s_bkt_ovl,  0, sizeof(s_bkt_ovl));
+    s_max_us        = 0;
+    s_max_bridge_us = 0;
+    s_max_render_us = 0;
+    s_max_overlay   = false;
+    s_ovl_wall_us   = 0;
+    s_ovl_bridge_us = 0;
+    s_ovl_render_us = 0;
+    s_iters         = 0;
+    s_ovl_iters     = 0;
+    s_last_log      = 0;
+    // Drop the in-flight iteration instead of counting it into the fresh window:
+    // it is the one dispatching this very HID command, so its cost is host
+    // plumbing rather than the workload about to be measured. Clearing
+    // s_have_start makes the next tick() re-arm without recording, which also
+    // means the reset itself can never land in the worst-iteration slot.
+    s_have_start    = false;
+    s_bridge_us     = 0;
+    s_render_us     = 0;
+    s_overlay_iter  = false;
+}
+
+// Little-endian u32 store — the snapshot is decoded by Python (struct '<I'), so
+// pin the byte order explicitly rather than memcpy'ing the native layout.
+static uint8_t put_u32(uint8_t *out, uint32_t v) {
+    out[0] = (uint8_t)(v & 0xFFu);
+    out[1] = (uint8_t)((v >> 8) & 0xFFu);
+    out[2] = (uint8_t)((v >> 16) & 0xFFu);
+    out[3] = (uint8_t)((v >> 24) & 0xFFu);
+    return 4;
+}
+
+uint8_t loop_profile_snapshot(uint8_t page, uint8_t *out, uint8_t cap) {
+    uint8_t n = 0;
+    if (page == 0) {
+        // 4 header bytes + 8 u32 = 36
+        if (cap < 36) return 0;
+        out[n++] = (uint8_t)LOOP_PROFILE_SNAPSHOT_VERSION;
+        out[n++] = (uint8_t)(s_max_overlay ? 0x01u : 0x00u);
+        out[n++] = 0;  // reserved
+        out[n++] = 0;  // reserved
+        n += put_u32(&out[n], s_iters);
+        n += put_u32(&out[n], s_ovl_iters);
+        n += put_u32(&out[n], s_max_us);
+        n += put_u32(&out[n], s_max_bridge_us);
+        n += put_u32(&out[n], s_max_render_us);
+        n += put_u32(&out[n], s_ovl_wall_us);
+        n += put_u32(&out[n], s_ovl_bridge_us);
+        n += put_u32(&out[n], s_ovl_render_us);
+        return n;
+    }
+    if (page == 1) {
+        // 2 histograms x 7 u32 = 56
+        if (cap < (uint8_t)(NBUCKET * 8)) return 0;
+        for (uint8_t i = 0; i < NBUCKET; ++i) n += put_u32(&out[n], s_bkt_norm[i]);
+        for (uint8_t i = 0; i < NBUCKET; ++i) n += put_u32(&out[n], s_bkt_ovl[i]);
+        return n;
+    }
+    return 0;
 }
 
 #endif // POLYKYBD_LOOP_PROFILE

--- a/keyboards/polykybd/profiling/loop_profile.h
+++ b/keyboards/polykybd/profiling/loop_profile.h
@@ -30,6 +30,18 @@
 // sites can stay unconditional (no #ifdef clutter in poly_keymap.c / hid_com.c).
 
 #include <stdint.h>
+#include <stdbool.h>
+
+// Wire format of the binary snapshot read over HID cmd 32 (see loop_profile.c
+// loop_profile_snapshot). Bumped only if the field layout changes; the reader
+// (polykybd-ctnd station/perf.py) refuses a version it does not know rather than
+// mis-decoding a reordered struct.
+#define LOOP_PROFILE_SNAPSHOT_VERSION 1u
+// Number of snapshot pages a full read returns (page 0 = scalars, page 1 = the
+// two histograms).
+#define LOOP_PROFILE_SNAPSHOT_PAGES   2u
+// Iteration-time buckets: <1ms, 1-2, 2-5, 5-10, 10-20, 20-50, >=50ms.
+#define LOOP_PROFILE_NBUCKET          7
 
 #ifdef POLYKYBD_LOOP_PROFILE
 
@@ -51,11 +63,47 @@ void loop_profile_add_bridge_us(uint32_t us);
 // update_displays() calls).
 void loop_profile_add_render_us(uint32_t us);
 
+// --- On-demand control (HID cmd 32), so a host/rig can measure ONE workload ---
+//
+// The periodic LOOP_PROFILE_LOG_EVERY summary is fine for a human watching the
+// console, but it cannot bound a measurement: the counters are cumulative from
+// boot and `worst` is an all-time maximum, so an automated run could only diff
+// two blocks and would never get a windowed worst-iteration. These let a caller
+// zero the counters, run a defined workload, then read the window back exactly.
+
+// Zero every counter and re-arm the iteration boundary. The iteration that is in
+// flight when this runs (i.e. the one handling the reset command itself) is
+// deliberately DROPPED rather than attributed to the new window — its cost is HID
+// dispatch, not the workload under test.
+void loop_profile_reset(void);
+
+// Fill one page of the binary snapshot at `out` (a 64-byte HID report body, with
+// the 3-byte "P<cmd><status>" reply header already written and `out` pointing at
+// data[3]). Returns the number of bytes written, or 0 for an unknown page.
+// Page 0: [version][flags][2 reserved] then u32 LE: iters, ovl_iters, max_us,
+//         max_bridge_us, max_render_us, ovl_wall_us, ovl_bridge_us, ovl_render_us.
+//         flags bit0 = the worst iteration was an overlay-handling one.
+// Page 1: u32 LE bkt_norm[7] then bkt_ovl[7].
+uint8_t loop_profile_snapshot(uint8_t page, uint8_t *out, uint8_t cap);
+
+// Emit the periodic summary block to the HID console immediately, without waiting
+// for the next LOOP_PROFILE_LOG_EVERY boundary.
+void loop_profile_log_now(void);
+
 #else
 
 static inline void loop_profile_tick(void) {}
 static inline void loop_profile_note_overlay_cmd(void) {}
 static inline void loop_profile_add_bridge_us(uint32_t us) { (void)us; }
 static inline void loop_profile_add_render_us(uint32_t us) { (void)us; }
+
+// NOTE: loop_profile_reset/_snapshot/_log_now deliberately have NO stubs here.
+// The four hooks above are stubbed because their call sites are unconditional in
+// poly_keymap.c / hid_com.c / bridge_helper.c and must compile to nothing. The
+// control API is different: hid_com.c guards command 32 with
+// `#ifdef POLYKYBD_LOOP_PROFILE`, so on a normal build the command falls through
+// to the dispatcher's default branch and NACKs. That NACK is the contract — it is
+// how the rig tells "this firmware has no profiler" apart from "the profiler
+// answered", instead of silently reading back a page of zeros.
 
 #endif


### PR DESCRIPTION
## Summary

Makes the main-loop profiler usable by an automated harness, so getting firmware timings no longer means "deploy a build by hand and paste the console log".

The profiler could only be read from its **periodic** console block, whose counters are cumulative from boot and whose `worst` is an all-time maximum. That makes a measurement impossible to attribute to any particular workload. This adds a control command so a harness can bracket exactly one:

```
RESET  ->  run the workload  ->  READ the window back
```

**HID cmd 32** (`hid_com.c`), sub-commands:

| sub | name | effect |
|-----|------|--------|
| 0 | `RESET` | Zero the counters and re-arm. The in-flight iteration — the one dispatching this very command — is **dropped**, not counted: its cost is HID plumbing, not the workload under test. |
| 1 | `READ` | One binary snapshot page (`data[3]` selects it): page 0 = scalars, page 1 = the two iteration-time histograms. Little-endian, with a version byte so a reader refuses an unknown layout rather than mis-decoding a reordered struct. |
| 2 | `LOG` | Emit the console summary block immediately. |

The periodic path and `LOG` now share one `emit_summary()`, so the console readout can't drift between them.

**No `PROTOCOL_VERSION` bump.** The command is dispatched independently, like cmd 31 (`REPLAY_ANIM`) and the fontpack commands. The whole `case 32` sits inside `#ifdef POLYKYBD_LOOP_PROFILE`, so a **normal build falls through to the dispatcher's default branch and NACKs** — and that NACK is the contract: it tells a host "no profiler in this firmware" instead of handing back a page of zeros.

Also adds the opt-in **`Performance measurement (split72)`** CI job. It builds a second HIL pair with `-e POLYKYBD_LOOP_PROFILE=yes` and has the rig measure main-loop timing, overlay cost (bridge/render/rest) and HID latency, posting a table to the job summary and a PR comment.

- Triggered by the **`perf` PR label**, **`[perf]` in a commit message**, or `workflow_dispatch`.
- **Never fails on a regression** — wall-clock numbers on shared hardware, and a flaky red check is one people learn to ignore. Only a measurement failure (wrong build flashed, device dead) fails the job.
- Ordered `needs: [build-perf, hil-test]` with `always()`, so the two rig jobs can't interleave flashes, but a red HIL suite still yields a perf number — often exactly what explains a timing-related HIL failure.

The rig-side harness is thpoll83/polykybd-ctnd#47, which should merge first (`qmk-test.yml` force-syncs the rig's checkout to `origin/main` before every run).

## Version bump label

`bump:minor` — new feature, backwards-compatible. **Not** `bump:protocol`: cmd 32 is dispatched independently of `PROTOCOL_VERSION` and only exists in a profiling build, so no host `__protocol__` change is needed.

## Testing

- [x] Compiled successfully — verified all three flavours: normal (`-e POLYKYBD_DOOM_PACK=yes`), profiling, and the exact profiling HIL image CI builds. Also `qmk lint --strict` on split72 + split42, the tracked-but-ignored file check, and the `format-text` half of the lint job: all clean.
- [ ] Flashed and tested on hardware — **not done**; no rig access from this session. Mitigated by the rig-side `FakeProfilerDevice`, which re-implements these cmd-32 replies byte for byte as a contract test of the wire format, but the first real run is still the first real run.
- [x] If protocol changed: host updated and tested together — n/a, no protocol change.

## Note on shipping cost

Zero for a normal build: `POLYKYBD_LOOP_PROFILE` is undefined, `loop_profile.c` isn't compiled, and the new `case 32` is preprocessed out. The four existing hooks remain empty `static inline`s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNwwz1QxACZwfqWcYBG8L2)_

## Summary by Sourcery

Add automated, on-demand firmware loop profiling and an opt-in CI perf measurement job for PolyKybd.

New Features:
- Expose main-loop profiler control over HID command 32 with reset, snapshot, and log sub-commands, available only in POLYKYBD_LOOP_PROFILE builds.
- Provide a binary snapshot wire format for profiler metrics, including scalar counters and iteration-time histograms, for consumption by the rig harness.
- Introduce an opt-in Performance measurement (split72) CI job that builds profiling firmware images, runs automated perf measurements on the rig, and posts reports to PRs.

Enhancements:
- Refactor profiler console output into a shared emit_summary helper used by both periodic and on-demand logging.
- Document the on-demand profiler control API, snapshot format, and CI perf workflow usage in profiling README and CLAUDE guidelines.

CI:
- Extend qmk-test workflow with workflow_dispatch and new build-perf and perf-test jobs to support profiling builds and automated performance measurement without gating normal PR checks.