### PR TITLE
docs: record the first rig perf measurement + a skill to repeat it

### DIFF
--- a/.claude/skills/measure-firmware-perf/SKILL.md
+++ b/.claude/skills/measure-firmware-perf/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: measure-firmware-perf
+description: Measure PolyKybd firmware performance on the HIL rig and interpret the result — main-loop iteration timing, overlay-burst cost split into bridge/render/rest, HID round-trip latency, and boot-to-responsive. Drives the opt-in perf CI job (or a manual workflow_dispatch), waits for it, downloads and decodes the perf-report artifact, checks the run was clean, compares against the committed baseline, and explains what the numbers mean. Use when asked "how fast is this", "did this change cost time", "get me the firmware timings", "measure the overlay/app-switch cost", "is this a regression", or when a timing question would otherwise be answered by flashing a build by hand and reading the console log. Also use to record a new baseline.
+---
+
+# Measure firmware performance on the rig
+
+Replaces the old loop of "deploy a build by hand, poke the keyboard, paste the
+`LoopProf:` block". The rig flashes a profiling firmware, drives defined workloads
+inside **bounded profiler windows**, and emits a JSON + markdown report.
+
+**You do not measure anything yourself** — CI and the rig do. This skill's job is
+to *trigger*, *fetch*, *validate*, and *interpret*, because each of those has traps
+that produce confident-sounding nonsense (see **Pitfalls**).
+
+Repos: `qmk_firmware` (firmware + CI job), `polykybd-ctnd` (the harness + baselines).
+
+## What gets measured
+
+| Workload | Answers |
+|---|---|
+| **idle baseline** | Is the loop healthy at rest? (`iters_per_s`, worst iteration). The *control* — a burst number is meaningless without it. |
+| **overlay burst, plain (cmd 10)** | Where app-switch time goes: `bridge` (master→slave UART) vs `render` (`update_displays`) vs `rest`. |
+| **overlay burst, RLE/core1 (cmd 16)** | Same, for the compressed path. ⚠️ see Pitfalls. |
+| **HID round-trip latency** | What a user feels as responsiveness (p50/p95/p99/max, misses). |
+| **boot to first stable HID** | Cold-flash readiness. |
+
+## Procedure
+
+### 1. Trigger a run
+
+Three ways; pick by context.
+
+- **On an open PR** — add the `perf` label. This is the normal path for "did my
+  change cost time". The label persists, so later pushes to that PR keep measuring.
+- **On the default branch** — manual dispatch:
+  ```
+  mcp__github__actions_run_trigger  method=run_workflow
+      owner=thpoll83 repo=qmk_firmware workflow_id=qmk-test.yml ref=PolyKybd
+  ```
+- **`[perf]` in a commit message** — push events only (see Pitfalls).
+
+### 2. Wait for it, then find the run
+
+```
+mcp__github__actions_list  method=list_workflow_runs owner=thpoll83 repo=qmk_firmware
+    resource_id=qmk-test.yml  workflow_runs_filter={"event":"workflow_dispatch"}
+```
+A full run is ~20–30 min (two docker builds, then the rig). Do not poll tightly;
+prefer a scheduled check-in. Confirm the `Performance measurement (split72)` job
+actually ran — if `build-perf` was skipped, the trigger did not take.
+
+### 3. Download and decode the report
+
+```
+mcp__github__actions_list method=list_workflow_run_artifacts owner=… repo=… resource_id=<run_id>
+mcp__github__actions_get  method=download_workflow_run_artifact owner=… repo=… resource_id=<artifact_id>
+# then fetch the temporary URL it returns:
+cd /tmp && rm -rf perfart && mkdir perfart && cd perfart \
+  && curl -sSL -o perf.zip "<download_url>" && unzip -q perf.zip
+python3 -m json.tool perf-report.json | head -60
+```
+The zip holds `perf-report.json` (machine-readable), `perf-report.md` (the posted
+table) and `perf-run.log`.
+
+### 4. Validate the run BEFORE reading any number
+
+```bash
+python3 -c "
+import json; d=json.load(open('perf-report.json'))
+t=d['timing']; print('gates:', t.get('ready_gate_ok'), t.get('settled'))
+for k in ('overlay_plain','overlay_compressed'):
+    s=d[k]; print(k, 'ovl_iters', s['ovl_iters'], 'reports', s['reports'])
+print('console_tail:', d['console_tail'][:3])
+"
+```
+Reject the run if any of these fail:
+- **`ready_gate_ok` or `settled` is false** → it measured the master's boot-time
+  busy window, not the workload. Re-run; never baseline it.
+- **`ovl_iters != reports`** → the instrumentation is broken (one bulk overlay
+  report must produce exactly one tagged iteration). No timing from that window is
+  trustworthy.
+- **Truncated `console_tail`** (lines ending mid-word) → the rig is running a
+  station build older than the console-reassembly fix; the numbers are still valid
+  but the rig is stale, so check what else it is missing.
+
+### 5. Interpret
+
+Compare against `polykybd-ctnd/perf/baselines/<board>.json` (the report does this
+automatically when a baseline exists). Then read the **overlay attribution**, which
+is the part that actually drives decisions:
+
+- **`render` dominant** ⇒ render-bound. The fix is in the render path (coalesce
+  redundant renders, chunk a render across passes). A keyboard-side resource
+  pack / baked overlays would **not** help.
+- **`bridge` dominant** ⇒ transfer-bound. Fewer/smaller relayed bytes would help;
+  this is what makes a resource-pack approach worth building.
+- **`rest` dominant** ⇒ look at the HID copy / RLE kick / core1 wait.
+
+Also report `long_iters_ge_10ms` — iterations long enough to swallow a fast key
+tap, i.e. the missed-keystroke risk.
+
+### 6. Recording a baseline (only when asked, or when none exists)
+
+Commit the run's **exact** `perf-report.json` to
+`polykybd-ctnd/perf/baselines/<label>.json` on a fresh branch cut from `main`, with
+a message saying *why* the numbers moved. There is deliberately no automatic
+update — a self-rewriting baseline ratchets a slow regression in silently. See
+`perf/baselines/README.md`.
+
+## Output format
+
+Lead with the decision-relevant number, not the table:
+
+```
+<workload> is <render|bridge|rest>-bound: <X> ms of <Y> ms (<Z>%).
+<what that implies for the change/design under discussion>
+
+vs baseline: <metric> <±N%> (or "no baseline recorded yet")
+Run was clean (gates passed, ovl_iters == reports).
+<caveats that stop the number meaning more than it does>
+```
+
+## Pitfalls
+
+- **A regression never fails the check, by design.** These are wall-clock numbers
+  on shared hardware; a flaky red check is one people learn to ignore. Only a
+  *measurement* failure (wrong build flashed, device dead) exits non-zero. So a
+  green job does **not** mean "no regression" — you must read the comparison.
+- **`render = 0.0 ms` on the RLE/core1 path is an artefact, not a result.** Both
+  paths redraw the same keycaps; the core1-deferred render lands *after* the window
+  closes, because the harness ends a window when the master answers HID again — not
+  when the render finished. **Never quote a plain-vs-RLE ratio from one report.**
+- **The default workload is synthetic**: blank overlays to 8 keycodes, no reconnect
+  in the loop. That understates bridge cost (which scales with relayed bytes) versus
+  a real ~90-keycap cold app switch. State this whenever the number is used to argue
+  about architecture.
+- **"cmd 32 NACKed / not a POLYKYBD_LOOP_PROFILE build"** means the wrong images
+  were flashed — the profiler is compiled out of normal builds and that NACK is the
+  deliberate capability signal. It is *not* the same error as the device not
+  answering at all; the harness distinguishes them.
+- **`[perf]` in a commit message does nothing on a PR** — `github.event.head_commit`
+  exists only on push events. And `workflow_dispatch` is only available once the
+  workflow is on the default branch. On a PR, use the label.
+- **The rig runs the *installed* `/opt/polykybd-ctnd`.** CI force-syncs it to
+  `origin/main` first, so a harness fix must be merged to ctnd `main` before it
+  affects a run.
+- **GitHub MCP quirks**: `actions_get`/`actions_list` take `resource_id` (not
+  `run_id`), and `list_workflow_runs`' `branch` filter is **not applied** — filter by
+  `head_sha` yourself or you will read another branch's run.

--- a/keyboards/polykybd/OVERLAY_FLASH_CACHE_DESIGN.md
+++ b/keyboards/polykybd/OVERLAY_FLASH_CACHE_DESIGN.md
@@ -231,6 +231,53 @@ Do **not** build the full bake-manager first. Prove the win:
    If cold-switch is already acceptable in practice, shelve it — the complexity isn't
    free.
 
+### First measurement (2026-08-01) — this workload is RENDER-bound, not transfer-bound
+
+Step 3's numbers can now be produced automatically: the rig drives the firmware's
+main-loop profiler through its on-demand control command and reports a bounded
+window per workload (qmk `CLAUDE.md` → "Performance measurement (split72)";
+`polykybd-ctnd` `station/perf_runner.py`). The first run on real hardware:
+
+| | plain (cmd 10) | RLE/core1 (cmd 16) |
+|---|---:|---:|
+| overlay-iteration wall | 261.25 ms | 16.17 ms |
+| **render** (`update_displays`) | **166.4 ms (64%)** | 0.0 ms |
+| **bridge** (master→slave UART) | **12.17 ms (4.7%)** | 2.23 ms |
+| rest | 82.68 ms (32%) | 13.94 ms |
+| worst single iteration | 36.99 ms | 3.96 ms |
+
+⚠️ **This cuts against the parenthetical prediction in step 4 above.**
+`profiling/README.md`'s attribution rule is explicit: **render** dominant ⇒ the
+stall is render-bound and *a keyboard-side resource pack would not help*;
+**bridge** dominant ⇒ transfer-bound and it would. At 64% render vs 4.7% bridge,
+this workload is firmly the former — which puts a question mark over **win #2**
+("cuts the biggest remaining app-switch cost + split-link load"). It says nothing
+against **win #1** (the reconnect wipe-and-resend oscillation), which is about
+*not re-sending at all*, not about how fast a send is.
+
+**Do NOT treat this as settling the question — it does not.** The measured
+workload is a synthetic burst of **blank** overlays to **8 keycodes** driven from
+the rig, and every way it differs from a real cold app switch pushes the bridge
+share *down*:
+
+- **8 keycodes, not ~90.** Bridge cost scales with the bytes relayed to the slave;
+  a real switch relays roughly an order of magnitude more.
+- **Blank bitmaps** RLE to ~23 bytes, so the compressed path moves almost nothing.
+- **No reconnect in the loop**, so the deaf-window/oscillation cost that motivates
+  win #1 is not exercised at all.
+- The rig uses the same full-duplex link a shipping keyboard has, so the *link* is
+  representative — the *volume* is not.
+
+⚠️ The compressed column's `render = 0.0 ms` is a **measurement artefact, not a
+result.** Both paths ultimately redraw the same keycaps, so the core1-deferred
+render almost certainly landed after the window closed — the harness ends a window
+when the master answers HID again, which is not the same as "the render finished".
+Do not quote a plain-vs-RLE ratio from this table.
+
+**So step 3 still needs the same measurement at realistic volume**: a full-keycap
+set of *real* bitmaps, with a reconnect in the loop, comparing activate-by-id
+against `send_overlays_mru`. The harness now exists; only the workload is missing.
+
 ## 7. Risks
 - **Couples two flash budgets** (staging↔overlay, or font-pack↔overlay) — document
   the cap and keep the linker/region guards honest so an overflow *fails to build*

--- a/keyboards/polykybd/profiling/README.md
+++ b/keyboards/polykybd/profiling/README.md
@@ -153,6 +153,25 @@ report with a comparison against a committed baseline. It runs as the **opt-in**
 images with `-e POLYKYBD_LOOP_PROFILE=yes` or the run fails fast with a clear
 "not a POLYKYBD_LOOP_PROFILE build" message.
 
+### Sanity check: `ovl_iters` must equal the overlay reports sent
+
+The cheapest check that the instrumentation is working at all — independent of any
+timing — is that a bounded window's `ovl_iters` equals the number of bulk overlay
+reports the host sent inside it. One report ⇒ one tagged iteration. The first rig
+run measured 48 and 8 against 48 and 8 reports, which is what actually established
+that the C encoder and the Python decoder agree on real silicon. If they diverge,
+the `loop_profile_note_overlay_cmd()` tagging (or the snapshot decode) is broken
+and **no timing number from that window should be trusted**.
+
+### First measured result (2026-08-01)
+
+A plain overlay burst came out **render-bound**: render 166.4 ms of 261.25 ms
+(64%) against bridge 12.17 ms (4.7%). By the attribution rule above, that argues
+*against* a keyboard-side resource pack being the fix. See
+[`../OVERLAY_FLASH_CACHE_DESIGN.md`](../OVERLAY_FLASH_CACHE_DESIGN.md) §6 for the
+full table, the caveats that stop it settling the question (synthetic 8-keycode
+blank-overlay workload, no reconnect in the loop) and what still needs measuring.
+
 ## How to take a clean measurement
 
 - **Type / switch programs while watching the console.** The counters are all-time


### PR DESCRIPTION
## Summary

Docs + skill only — **no firmware or CI change**. Session retro from the perf-harness work (#175).

`OVERLAY_FLASH_CACHE_DESIGN.md` §6 ("Rollout — measure first") asks, at step 3, for exactly one number before committing to the design: where cold-app-switch time actually goes. The rig can now produce it, and the first run on real hardware says this workload is **render-bound**:

| | plain (cmd 10) | RLE/core1 (cmd 16) |
|---|---:|---:|
| overlay-iteration wall | 261.25 ms | 16.17 ms |
| **render** (`update_displays`) | **166.4 ms (64%)** | 0.0 ms |
| **bridge** (master→slave UART) | **12.17 ms (4.7%)** | 2.23 ms |
| rest | 82.68 ms (32%) | 13.94 ms |

By `profiling/README.md`'s own attribution rule that argues *against* a keyboard-side resource pack being the fix — which cuts against step 4's parenthetical ("they should, given the deaf-window cost") and puts a question mark over **win #2**. It says nothing against **win #1** (the reconnect wipe-and-resend oscillation), which is about *not re-sending at all* rather than about how fast a send is.

**Recorded with the caveats that stop it settling anything**, because on its own the number is easy to over-read:

- The workload is a synthetic burst of **blank** overlays to **8 keycodes**, not a real ~90-keycap cold switch — and every way it differs pushes the bridge share *down* (bridge cost scales with relayed bytes; blank bitmaps RLE to ~23 bytes).
- No reconnect in the loop, so the deaf-window cost motivating win #1 isn't exercised at all.
- The compressed column's `render = 0.0 ms` is flagged as a **measurement artefact**: both paths redraw the same keycaps, so the core1-deferred render lands after the window closes (the harness ends a window when the master answers HID again, not when the render finished). The doc explicitly says not to quote a plain-vs-RLE ratio from it.

So §6 step 3 still needs the same measurement at realistic volume. The harness exists now; only the workload is missing.

## Also

- `profiling/README.md` gains a pointer plus the **cheapest correctness check on the profiler**: `ovl_iters` must equal the number of overlay reports sent — one report ⇒ one tagged iteration. That identity (48==48, 8==8) is what actually established the C encoder and the Python decoder agree on real silicon; if it ever diverges, no timing from that window is trustworthy.
- New **`measure-firmware-perf` skill** codifying the trigger → wait → fetch artifact → validate → interpret loop, with the traps that produce confident-sounding nonsense: reading a run whose readiness gates failed, over-reading the RLE `render=0.0ms` artefact, assuming a green job means no regression (it never fails on one, by design), and the `[perf]`-does-nothing-on-a-PR / `resource_id` / unapplied-`branch`-filter gotchas.

## Version bump label

No label needed — docs and a `.claude/skills/` entry only; no compiled change.

## Testing

- [x] `qmk lint --strict` on split72 clean; tracked-but-ignored file check empty.
- [x] No source or workflow files touched, so nothing to build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNwwz1QxACZwfqWcYBG8L2)_

## Summary by Sourcery

Document the first rig-based firmware performance measurement and add a supporting skill for triggering, validating, and interpreting future runs.

Documentation:
- Record initial overlay-burst timing results in the overlay flash cache design doc, including attribution, caveats, and remaining measurement gaps.
- Extend profiling documentation with a sanity check for profiler correctness and a summary of the first measured result.

Chores:
- Add a measure-firmware-perf skill file describing how to run CI-based firmware perf measurements on the rig and interpret their output.