### PR TITLE
Resync publish_release.py with the wincompose copy

### DIFF
--- a/scripts/publish_release.py
+++ b/scripts/publish_release.py
@@ -7,21 +7,24 @@ Run from anywhere inside either repo checkout:
     python scripts/publish_release.py --dry-run  # show what it would do
 
 What it does (no bash-isms, no extra pip installs — Python 3.7+ stdlib only):
-  1. Auto-detects the repo (firmware qmk_firmware vs host PolyKybdHost) and the
-     current version from the DEFAULT branch (config.h / polyhost/_version.py),
-     so it is independent of whatever branch you have checked out.
+  1. Auto-detects the repo (firmware qmk_firmware / host PolyKybdHost /
+     wincompose) and the current version from the DEFAULT branch (config.h /
+     polyhost/_version.py / wincompose.csproj), so it is independent of
+     whatever branch you have checked out.
   2. Reads the prepared release notes for that tag from the unprotected
      `release-notes` branch (`<TAG>.md`, first line `# <title>`, rest = body).
   3. Creates + publishes the GitHub Release (or updates it if it already exists).
-     Firmware: publishing fires the `release: published` workflow, which builds
-     and attaches the .bin/.uf2 — you do NOT attach anything by hand.
+     Firmware and wincompose: publishing fires the `release: published`
+     workflow, which builds and attaches the assets (.bin/.uf2 / the installer
+     + portable zip + SHA256SUMS) — you do NOT attach anything by hand.
 
 Auth: uses `GH_TOKEN` / `GITHUB_TOKEN` if set, else `gh auth token`. No token and
 no `gh` -> it tells you how to fix it. `gh` is optional; a token alone is enough.
 
 Tags:
-  firmware  PolyKybd-fw-v<version>   (target branch: PolyKybd)
-  host      v<version>               (target branch: main)
+  firmware    PolyKybd-fw-v<version>   (target branch: PolyKybd)
+  host        v<version>               (target branch: main)
+  wincompose  PK-<version>             (target branch: main)
 """
 import argparse
 import json
@@ -58,7 +61,12 @@ def detect(root):
         return ("firmware", "keyboards/polykybd/config.h", "PolyKybd", "PolyKybd-fw-v")
     if os.path.exists(os.path.join(root, "polyhost", "_version.py")):
         return ("host", "polyhost/_version.py", "main", "v")
-    die("can't tell which repo this is (no keyboards/polykybd/config.h or polyhost/_version.py).")
+    # The fork tags PK-<version> (GitVersion.yml tag-prefix), and the shipped
+    # version is the csproj AssemblyVersion that iscc reads off the built exe.
+    if os.path.exists(os.path.join(root, "src", "wincompose", "wincompose.csproj")):
+        return ("wincompose", "src/wincompose/wincompose.csproj", "main", "PK-")
+    die("can't tell which repo this is (no keyboards/polykybd/config.h, "
+        "polyhost/_version.py or src/wincompose/wincompose.csproj).")
 
 
 def show(ref_path):
@@ -73,6 +81,11 @@ def parse_version(kind, text):
         if not m:
             die("couldn't find FW_VERSION in config.h.")
         return m.group(1)
+    if kind == "wincompose":
+        m = re.search(r'<AssemblyVersion>(\d+)\.(\d+)\.(\d+)', text)
+        if not m:
+            die("couldn't find <AssemblyVersion> in wincompose.csproj.")
+        return f"{m.group(1)}.{m.group(2)}.{m.group(3)}"
     maj = re.search(r'__major__\s*=\s*(\d+)', text)
     mnr = re.search(r'__minor__\s*=\s*(\d+)', text)
     pat = re.search(r'__patch__\s*=\s*(\d+)', text)
@@ -237,6 +250,9 @@ def main():
     print(res.get("html_url"))
     if kind == "firmware":
         print("firmware CI (release: published) will now build and attach the .bin/.uf2.")
+    elif kind == "wincompose":
+        print("wincompose CI (release: published) will now build and attach the "
+              "installer .exe, the portable .zip and SHA256SUMS.txt.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`scripts/publish_release.py` is meant to be byte-identical across the repos it serves. [thpoll83/wincompose#2](https://github.com/thpoll83/wincompose/pull/2) moved that repo's copy ahead by teaching it a third repo; this brings the firmware copy back in line. **No behaviour change here** — only `detect()` gains a wincompose branch, `parse_version()` gains a wincompose case, and the docstring/closing hint mention it.

The wincompose branch resolves version from the csproj `<AssemblyVersion>`, tag prefix `PK-` (per its `GitVersion.yml`), target branch `main`.

Verified byte-identical to `wincompose/scripts/publish_release.py` (`cmp`), and the firmware path still resolves exactly as before:

```
repo    : thpoll83/qmk_firmware  (firmware)
tag     : PolyKybd-fw-v0.9.86   target: PolyKybd
title   : PolyKybd v0.9.86 — All nine modifier overlays
```

The matching PR for `PolyKybdHost` is on the same branch name there.

## Testing

No firmware code is touched — nothing under `keyboards/` changes, so the build and HIL checks are unaffected. Exercised via `python scripts/publish_release.py --dry-run` in this checkout (output above), which reads the `release-notes` branch and the default-branch `FW_VERSION` without changing anything.

---
_Generated by [Claude Code](https://claude.ai/code/session_011PNCWo57UmMMfaNWyfJMBG)_

## Summary by Sourcery

Extend the shared publish_release script to support the wincompose repository alongside firmware and host.

New Features:
- Add auto-detection and tagging support for the wincompose repo using its csproj AssemblyVersion and PK- tag prefix.
- Update user-facing guidance in the script docstring and completion messages to describe wincompose release behavior and assets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated WinCompose repository detection and version parsing.
  * Added standardized `PK-<version>` release tagging.
  * Improved messaging for release assets.
  * Expanded documentation covering WinCompose publishing and firmware asset outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->