### PR TITLE
Teach the release skill about WinCompose

### DIFF
--- a/.claude/skills/polykybd-github-release/SKILL.md
+++ b/.claude/skills/polykybd-github-release/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: polykybd-github-release
-description: Cut a GitHub Release for the PolyKybd firmware (qmk_firmware) or the host app (PolyKybdHost) — draft customer-facing release notes (newest version first, maintenance-only bumps skipped, concise, informative-over-funny), get the user's review, then publish with the correct tag, title, "latest" flag and (firmware) CI-built .bin/.uf2/.plyx assets. Use when asked to "cut/create/make/publish a release", "release the firmware/host", "release vX.Y.Z", "draft the release for …".
+description: Cut a GitHub Release for the PolyKybd firmware (qmk_firmware), the host app (PolyKybdHost) or WinCompose (wincompose) — draft customer-facing release notes (newest version first, maintenance-only bumps skipped, concise, informative-over-funny), get the user's review, then publish with the correct tag, title, "latest" flag and CI-built assets (firmware .bin/.uf2/.plyx; wincompose installer/portable/SHA256SUMS). Use when asked to "cut/create/make/publish a release", "release the firmware/host/wincompose", "release vX.Y.Z", "draft the release for …".
 ---
 
 # PolyKybd GitHub release
 
-Prepare and hand off a **GitHub Release** for one of the two shipping artifacts:
+Prepare and hand off a **GitHub Release** for one of the three shipping artifacts:
 
 | Target | Repo | Default branch | Version source | Release tag |
 |--------|------|----------------|----------------|-------------|
 | **Firmware** | `thpoll83/qmk_firmware` | `PolyKybd` | `FW_VERSION` in `keyboards/polykybd/config.h` | `PolyKybd-fw-vX.Y.Z` |
 | **Host** | `thpoll83/PolyKybdHost` | `main` | `polyhost/_version.py` (`__major/minor/patch__`) | `vX.Y.Z` |
+| **WinCompose** | `thpoll83/wincompose` | `main` | `<AssemblyVersion>` in `src/wincompose/wincompose.csproj` | `PK-X.Y.Z` |
+
+> The `PK-` prefix is not arbitrary — `GitVersion.yml` sets `tag-prefix: 'PK-'`, so the
+> build derives its version from tags of exactly that shape. Don't tag wincompose `vX.Y.Z`.
 
 This skill **builds on `polykybd-release-notes`** for gathering commits per version,
 but applies a **release-specific voice** (below) and adds two things the plain
@@ -33,6 +37,12 @@ exactly as `polykybd-release-notes` does:
   (bumped-but-unreleased), so always anchor on the release, not the newest bump commit.
 - **High end = current tree** — read the version source above.
 - If they're equal there's nothing to release — say so.
+- **WinCompose has no bump commits to anchor on.** Firmware/host versions are
+  produced by `bump-version.yml` at PR-merge time, so their history is punctuated by
+  `chore: bump … version` commits. **wincompose has no such workflow** — the version is
+  simply whatever `<AssemblyVersion>` currently says, and it only changes when someone
+  edits it. So the range is "last published release → csproj", and the per-version
+  grouping the notes skill does collapses to a single set of commits.
 
 State the resolved range back before drafting (e.g. "Last firmware release is
 0.9.23, tree is 0.9.42 — release notes for 0.9.24 → 0.9.42").
@@ -77,6 +87,27 @@ Per-version shape:
 - <why you care / or "requires matching host+firmware — protocol vN" when a protocol bumped>
 ```
 
+## 2b. WinCompose only — three things to do BEFORE the review gate
+
+WinCompose needs manual prep the other two repos automate away. Do all three, then
+include them in what you show the user at the review gate.
+
+1. **Bump `<AssemblyVersion>` in `src/wincompose/wincompose.csproj`** if the release
+   should carry a new number. There is no `bump-version.yml` here, so nothing does it
+   for you. Everything downstream derives from it: `iscc` reads the built exe's version
+   resource, which names `WinCompose-Setup-<ver>.exe`, and the workflow derives the zip
+   name and the tag's expected assets from the same value. `AssemblyVersion` is 4-part
+   (`0.9.16.0`); the release uses MAJOR.MINOR.REV.
+2. **Bump `Latest:` in `status.txt`** to the version being released. ⚠️ **This fails
+   silently if you forget.** WinCompose's own updater (`src/wincompose/Updater.cs`)
+   fetches that file from `raw.githubusercontent.com/thpoll83/wincompose/main/status.txt`
+   and only offers a download when `Latest` is **greater** than the running version — so
+   a stale value means **every existing install never learns about the release**. It
+   costs nothing to check and cannot be noticed by testing the release itself.
+   (PolyKybdHost's "Install WinCompose…" tray entry is unaffected — it always resolves
+   `releases/latest` — so this breaks only for people who already have it installed.)
+3. **Stage `PK-<version>.md`** on the `release-notes` branch, as for the other repos.
+
 ## 3. REVIEW GATE — get sign-off before creating anything
 
 Present to the user, in chat:
@@ -99,6 +130,7 @@ headline number.
 - Firmware: `PolyKybd v0.9.23 Fantasy scripts` · `PolyKybd-fw-v0.9.18 OS Shortcuts` ·
   `PolyKybd-fw-v0.8.21: 143 New languages, Emoji/Lang layer unification`
 - Host: `v0.9.16 Glyph Script control` · `v0.8.47 Background service & snappier Windows tray`
+- WinCompose: `WinCompose 0.9.16 — the first PolyKybd build`
 
 Pick the theme from the **headline feature** of the newest/most significant version in
 the range; keep it to ~2–6 words. Confirm it in the review gate. Note: CI's fallback
@@ -227,4 +259,13 @@ note above).
   must tell users to update host + firmware together (exact-match connect gate).
 - **No git tags in the firmware tree** — releases are the GitHub Releases API; history
   boundaries are the `bump firmware/host version` commits (see `polykybd-release-notes`).
+- **WinCompose: a stale `status.txt` silently strands existing installs** — see step 2b.
+  The release itself looks perfect; only users who already run WinCompose are affected,
+  and they simply never see the update prompt.
+- **WinCompose: a published release whose build failed cannot be fixed by re-running it.**
+  A re-run of the `release` job replays the workflow file **from that tag's commit**, so
+  it reproduces the same failure. Fix the workflow on `main`, then **Actions → Release →
+  Run workflow with the `tag` input set** to the published tag — that builds and attaches
+  the assets to the existing release. (Its notes are unaffected either way:
+  `publish_release.py` sets title/body over the API, independent of CI.)
 - Keep the model identifier out of everything pushed (commit messages, release body).

--- a/.claude/skills/polykybd-github-release/SKILL.md
+++ b/.claude/skills/polykybd-github-release/SKILL.md
@@ -188,8 +188,30 @@ branch** (`gh api …/contents/<TAG>.md?ref=release-notes`). If present, CI appl
 `gh release create` when it doesn't. If absent, it leaves the user's notes / auto-generates.
 
 **Lifecycle: one file per tag, never overwritten or deleted.** `PolyKybd-fw-vX.Y.Z.md`
-(firmware) / `vX.Y.Z.md` (host) is written once; the next release adds a new file. The
-branch is an accumulating changelog archive — don't reuse or clear old files.
+(firmware) / `vX.Y.Z.md` (host) / `PK-X.Y.Z.md` (wincompose) is written once; the next
+release adds a new file. The branch is an accumulating changelog archive — don't reuse
+or clear old files.
+
+⚠️ **If you ever create the `release-notes` branch from scratch, do NOT make it an
+orphan.** It holds only `.md` files, so `git checkout --orphan` / a parentless
+`commit-tree` is the obvious move — and in **wincompose it breaks every build**.
+`language.csproj` runs GitVersion (MsBuild 5.6.10), which walks **every local branch**
+to infer a feature branch's parent; a branch sharing no ancestor makes `FindMergeBase`
+return null, which GitVersion dereferences:
+
+    ERROR An unexpected error occurred:
+    System.NullReferenceException: Object reference not set to an instance of an object.
+       at GitVersion.Commit..ctor(Commit innerCommit)
+       at GitVersion.GitRepository.<FindMergeBase>b__0()
+
+⚠️ **`main` keeps building green**, because a branch that matches a GitVersion branch
+config never takes the inherit-from-parent path — so this looks like "PR builds are
+broken" and hides its own cause (cost a full debug round, 2026-08). Root the branch on
+the repo's initial commit instead, which costs nothing and leaves the content identical:
+
+    ROOT=$(git rev-list --max-parents=0 origin/<default>)
+    NEW=$(git commit-tree <tree> -p "$ROOT" -m "…")
+    git branch -f release-notes "$NEW" && git push --force-with-lease origin release-notes
 
 ### Recommended flow (near hands-off)
 1. Write the approved notes to a file whose **first line is `# <crafted title>`** and the


### PR DESCRIPTION
## Summary

Mirror of the PolyKybdHost copy — the two are kept byte-identical (`cmp`-verified). Matching PR: [PolyKybdHost#130](https://github.com/thpoll83/PolyKybdHost/pull/130).

`thpoll83/wincompose` now has the same release pipeline as the firmware and the host, but **three steps it does not automate**, so they need writing down:

- **Target table** gains a WinCompose row: version from the csproj `<AssemblyVersion>`, tag prefix `PK-` (set by its `GitVersion.yml` — tagging it `vX.Y.Z` would leave the build unable to derive its version).
- **New step 2b — manual prep before the review gate.** The dangerous one is `status.txt`: WinCompose's own updater only offers a download when its `Latest:` exceeds the running version, so forgetting to bump it means existing installs never learn about the release, and testing the release itself never reveals it.
- **Version-range anchoring**: wincompose has no `bump-version.yml`, so there are no `chore: bump …` commits to use as boundaries the way this repo's `FW_VERSION` history does.
- **Pitfall**: a published release whose build failed can't be repaired by re-running it — the re-run replays the workflow file from that tag's commit. Fix the default branch, then dispatch with a tag input.

## Testing

No firmware code is touched — `.claude/skills/` only, so the build and HIL checks are unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_011PNCWo57UmMMfaNWyfJMBG)_

## Summary by Sourcery

Extend the PolyKybd GitHub release skill to support WinCompose alongside firmware and host releases, including documenting its specific versioning, manual pre-release steps, and failure modes.

New Features:
- Add WinCompose as a supported release target with repository, version source, and tag format documented.

Enhancements:
- Clarify release range anchoring rules for WinCompose given the absence of automated bump-version commits.
- Document WinCompose-specific manual preparation required before the release review gate, including version and status file updates.
- Add WinCompose examples and notes to the review gate and release pitfalls sections to guide correct usage.