### PR TITLE
Record two CI-triage learnings from the wincompose release work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,10 +110,18 @@ inherited-upstream noise:
   (`!keyboards/polykybd/**/*.png`) — all three verified to make `qmk lint --strict`
   pass. **This contradicts the "lint passes green on every normal commit" line
   above** — that holds only while no such file exists.
+- ⚠️ **A PR has TWO check runs per workflow — one for the `push` event, one for
+  `pull_request` — and re-running one does NOT touch the other.** Both build the
+  same commit, so a code fix clears both; but a fix that lives **outside the
+  commit** (a branch/tag/repo-state change) needs each run re-run separately.
+  `rerun_failed_jobs` takes a **run id**, so it only ever fixes the run you named:
+  on wincompose#3 (2026-08-01) re-running one turned that check green and the PR
+  was reported green off it, while the other check run — same commit, same failure
+  — stayed red until it was re-run too. **Before calling a PR green, look at every
+  check run, not the one you just acted on.**
 - **Reproduce the whole `lint` job locally instead of reading the CI log** — it is
-  ~5 s and definitive, whereas the GitHub MCP `get_job_logs` caps its response at
-  ~2 KB *regardless of `tail_lines`*, so you often cannot scroll back far enough to
-  see the actual error:
+  ~5 s and definitive. (The GitHub MCP `get_job_logs` *does* work — see the
+  tail-size note below — but a local run is faster and gives the whole picture):
   ```bash
   export QMK_HOME=$PWD
   qmk lint --strict --keyboard polykybd/split42     # and split72
@@ -124,6 +132,17 @@ inherited-upstream noise:
   ```
   ⚠️ Drop `keyboards/polykybd/tools/__pycache__` first or it shows up as a false
   positive in the ignored-files list (CI checks out clean, so it never sees it).
+- **`get_job_logs` works — ask for 150–350 `tail_lines`.** An earlier version of
+  this file claimed it "caps its response at ~2 KB *regardless of `tail_lines`*";
+  that is **wrong** (`tail_lines: 330` returned ~15 KB, 2026-08). The real problem
+  is *what fills the tail*: every job ends with **post-job cleanup** — on a
+  submodule-heavy repo that is ~60 lines of `git config`/`submodule foreach`
+  spam — and a failing tool often dumps diagnostics **after** its own error
+  (GitVersion prints a 100-commit graph, so its exception sat ~150 lines above the
+  end). `tail_lines: 40` and `125` both landed squarely in that noise and cost
+  four wasted calls before 330 reached the actual message. Prefer
+  `failed_only: true` with a **run** id to find the job, then a generous
+  `tail_lines` on the **job** id.
 - The CodeRabbit **Docstring-Coverage** check is ignored per "Code review conventions"
   above.
 - ⚠️ **PR CI does NOT build the monolith.** `qmk-test.yml` builds only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,15 +110,20 @@ inherited-upstream noise:
   (`!keyboards/polykybd/**/*.png`) — all three verified to make `qmk lint --strict`
   pass. **This contradicts the "lint passes green on every normal commit" line
   above** — that holds only while no such file exists.
-- ⚠️ **A PR has TWO check runs per workflow — one for the `push` event, one for
-  `pull_request` — and re-running one does NOT touch the other.** Both build the
-  same commit, so a code fix clears both; but a fix that lives **outside the
-  commit** (a branch/tag/repo-state change) needs each run re-run separately.
-  `rerun_failed_jobs` takes a **run id**, so it only ever fixes the run you named:
-  on wincompose#3 (2026-08-01) re-running one turned that check green and the PR
-  was reported green off it, while the other check run — same commit, same failure
-  — stayed red until it was re-run too. **Before calling a PR green, look at every
-  check run, not the one you just acted on.**
+- ⚠️ **A workflow yields TWO check runs — `push` and `pull_request` — whenever the
+  branch matches BOTH triggers, and re-running one does NOT touch the other.**
+  Here that mostly doesn't happen: `qmk-test.yml` pushes only on `PolyKybd`/
+  `PolyKybd/**`, `unit_test.yml` only on `master`/`develop`, and `lint`/`labeler`
+  are PR-only — so a `claude/**` PR gets a single run per workflow. **The sibling
+  repos differ**: wincompose's `build.yml` pushes on `main` *and* `claude/**` on
+  top of `pull_request`, so every branch PR there carries two, and that is where
+  this bit (2026-08-01). Both runs build the same commit, so a code fix clears
+  both — but a fix that lives **outside the commit** (a branch/tag/repo-state
+  change) has to be re-run per run, and `rerun_failed_jobs` takes a **run id**, so
+  it only ever fixes the one you named. On wincompose#3 re-running one turned that
+  check green and the PR was reported green off it while the other — same commit,
+  same failure — stayed red. **Before calling a PR green, look at every check run,
+  not the one you just acted on.**
 - **Reproduce the whole `lint` job locally instead of reading the CI log** — it is
   ~5 s and definitive. (The GitHub MCP `get_job_logs` *does* work — see the
   tail-size note below — but a local run is faster and gives the whole picture):


### PR DESCRIPTION
## Summary

Two additions to **§ Continuous integration (PR checks)**, both from mistakes made today while driving the wincompose release pipeline to green. Docs only — no firmware code touched.

### 1. A PR has two check runs per workflow, and re-running one doesn't touch the other

`push` and `pull_request` each produce their own run of the same workflow, on the same commit. `rerun_failed_jobs` takes a **run id**, so it only ever fixes the run you name.

This bit on [wincompose#3](https://github.com/thpoll83/wincompose/pull/3): the failure was caused by repo state *outside* the commit (an orphan branch breaking GitVersion), I re-ran one run, saw it go green and reported the PR as green — while the other check run, same commit and same failure, was still red. The user caught it.

It sits next to the existing "just re-run the two jobs" advice for the lint/triage cancellation case, which has exactly the same trap.

### 2. Correct the `get_job_logs` claim

The current bullet says it "caps its response at ~2 KB *regardless of `tail_lines`*". **That's wrong** — `tail_lines: 330` returned ~15 KB today.

What actually hides the error is *what fills the tail*: every job ends with post-job cleanup (on a submodule-heavy repo, ~60 lines of `git config` / `submodule foreach` spam), and a failing tool often dumps diagnostics **after** its own exception — GitVersion prints a 100-commit graph, putting its message ~150 lines from the end. `tail_lines: 40` and `125` both landed in that noise and cost four wasted calls before `330` reached the message.

Worth correcting rather than leaving: the old wording tells the next session the tool is useless, when the fix is just a bigger tail. The local-reproduction advice above it stands on its own merits (faster, whole picture) and is kept.

## Testing

Nothing under `keyboards/` changes, so the build and HIL checks are unaffected by the diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_011PNCWo57UmMMfaNWyfJMBG)_

## Summary by Sourcery

Document CI triage learnings around GitHub workflow runs and log retrieval behaviour in CLAUDE.md.

Documentation:
- Clarify that each workflow has separate push and pull_request check runs and both must be verified or re-run when fixing non-commit-related failures.
- Correct and expand guidance on using the GitHub MCP get_job_logs tool, emphasizing effective tail_lines values and typical log noise patterns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI troubleshooting guidance to clarify how push and pull request checks are handled.
  * Added recommendations for reviewing failed jobs, retrieving more useful logs, and accounting for delayed diagnostic output.
  * Removed outdated information about log-size limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->