### PR TITLE
fix(release): don't traceback when the gh CLI isn't installed

### DIFF
--- a/scripts/publish_release.py
+++ b/scripts/publish_release.py
@@ -37,8 +37,18 @@ def run(cmd):
     # Force UTF-8: git output (release notes) is UTF-8, but on Windows the
     # default is the locale codec (cp1252), which raises UnicodeDecodeError on
     # emoji/em-dashes and silently drops the output.
-    return subprocess.run(cmd, capture_output=True, text=True,
-                          encoding="utf-8", errors="replace")
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True,
+                              encoding="utf-8", errors="replace")
+    except (FileNotFoundError, NotADirectoryError, PermissionError) as e:
+        # The executable isn't installed / isn't runnable. Report it as an
+        # ordinary non-zero result so callers can fall back, instead of letting
+        # it escape as a traceback. get_token() probes `gh`, which plenty of
+        # machines don't have — on Windows that surfaced as a raw
+        # "[WinError 2] The system cannot find the file specified" traceback
+        # instead of the "no GitHub token…" message that was already written
+        # for exactly this case.
+        return subprocess.CompletedProcess(cmd, 127, stdout="", stderr=str(e))
 
 
 def die(msg):


### PR DESCRIPTION
## Summary

Mirror of [thpoll83/PolyKybdHost#132](https://github.com/thpoll83/PolyKybdHost/pull/132) — `scripts/publish_release.py` is **byte-identical** across the two repos and must stay that way (verified with `cmp`).

`publish_release.py` crashed with a raw traceback on any machine without the `gh` CLI:

```
FileNotFoundError: [WinError 2] The system cannot find the file specified
```

`get_token()` checks `GH_TOKEN` / `GITHUB_TOKEN` and then falls back to probing `gh auth token`. That probe is **optional** — but `run()` let `FileNotFoundError` escape, so the fallback killed the script instead of falling through to the message already written for this case:

> `no GitHub token. Set GH_TOKEN / GITHUB_TOKEN, or install gh and run 'gh auth login'.`

The output was actively misleading: the script had already printed the resolved tag, title and body, so it looked like the publish had failed midway. Nothing was sent — it never reached the API call.

`run()` now maps a missing or unrunnable executable to an ordinary `rc=127`, also covering `NotADirectoryError` and `PermissionError`. A real command's return value is untouched, as is the UTF-8 forcing that keeps Windows from choking on the emoji in the notes.

Hit while publishing `PolyKybd-fw-v0.9.86` from a fresh Windows checkout (2026-08-01).

## Version bump label

*(none)* — patch. Tooling-only: no firmware code, no `PROTOCOL_VERSION` change, nothing that reaches the keyboard.

## Testing
- [x] Missing executable → `rc 127`, empty stdout, no exception
- [x] `get_token()` with no `gh` and no token env → returns `None`, so the intended "no GitHub token" message is reached
- [x] A real command (`git rev-parse`) still returns `rc 0` and its stdout unchanged
- [x] `cmp` against the PolyKybdHost copy — byte-identical
- [ ] Compiled successfully — N/A, no firmware source touched
- [ ] Flashed and tested on hardware — N/A, release tooling only
- [ ] If protocol changed: host updated and tested together — N/A, no protocol change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqfJiLJQRssiMG2Fc7jPc3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LqfJiLJQRssiMG2Fc7jPc3)_

## Summary by Sourcery

Bug Fixes:
- Prevent publish_release.py from raising a traceback when the gh CLI or other probed executables are missing or not runnable, returning a standard non-zero result instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unavailable or non-runnable release commands.
  * Prevented unexpected error traces by returning a clear failure status and message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->