### PR TITLE
Let GUI (Cmd) combine with other modifiers for overlays (protocol 12)

### DIFF
--- a/keyboards/polykybd/base/com.h
+++ b/keyboards/polykybd/base/com.h
@@ -56,7 +56,7 @@ enum overlay_flag {
 // be force-synced from master to slave at the moment the host changes them,
 // not deferred to the next housekeeping cycle.
 // MIRROR_OVERLAYS: upload bridge handlers use it immediately to decide whether
-//   set_overlay_usage_post_upload is a no-op — must arrive before any upload.
+//   mark_display_has_overlay_post_upload is a no-op — must arrive before any upload.
 // DISPLAY_OVERLAYS: adding it here makes enable_overlays() force-sync to slave
 //   via case 11, triggering a state_diff refresh on slave after all mapping
 //   chunks are guaranteed delivered — fixes ESC (and any key in a later chunk)

--- a/keyboards/polykybd/base/overlay.c
+++ b/keyboards/polykybd/base/overlay.c
@@ -12,8 +12,8 @@
 // correct if the display geometry ever changes.
 #define OVERLAY_BIT_CAPACITY (SCREEN_WIDTH * SCREEN_HEIGHT)
 
-static volatile uint8_t use_overlay[(NUM_OVERLAYS*NUM_VARIATIONS_WITH_MAP/8)+1];
-// ⚠️ overlays[] IS the doom easter-egg's entire game arena (borrowed as RAM). Its
+static volatile uint8_t display_has_overlay_bits[(NUM_OVERLAYS*NUM_VARIATIONS_WITH_MAP/8)+1];
+// ⚠️ overlay_pool[] IS the doom easter-egg's entire game arena (borrowed as RAM). Its
 // size = NUM_OVERLAY_SLOTS*360 = 216,000 B today. If you SHRINK the pool
 // to reclaim RAM, keep it >= ~205 KB or the doom build won't fit: the engine floor
 // is ~144 KB of fixed structure (frame buffer 53,760 + pd_render 58,880 + statics
@@ -30,8 +30,8 @@ static volatile uint8_t use_overlay[(NUM_OVERLAYS*NUM_VARIATIONS_WITH_MAP/8)+1];
 // (The DoomPack flavour keeps the plain array below: the flashed pack links
 // its statics AT the array's measured address instead — doom/PACK_DESIGN.md.)
 extern uint8_t __doom_shared_base__[];
-#define overlays ((uint8_t (*)[72*40/8])__doom_shared_base__)
-#define OVERLAYS_SIZE (NUM_OVERLAY_SLOTS*(72*40/8))
+#define overlay_pool ((uint8_t (*)[72*40/8])__doom_shared_base__)
+#define OVERLAY_POOL_SIZE (NUM_OVERLAY_SLOTS*(72*40/8))
 #elif defined(POLYKYBD_DOOM_PACK)
 // DoomPack flavour: the pool is PINNED at the RAM origin (0x20000000) via
 // the dedicated .overlay_pool section (ld/RP2040_FLASH_TIMECRIT_DOOMPACK.ld)
@@ -39,13 +39,13 @@ extern uint8_t __doom_shared_base__[];
 // Like the monolith's .doom_shared the section is NOLOAD (crt0 does not
 // zero it) — the usage bits above gate every read and the reset/refill
 // paths memset it, so boot behaviour is unchanged.
-static uint8_t overlays [NUM_OVERLAY_SLOTS][72*40/8] __attribute__((section(".overlay_pool")));
-#define OVERLAYS_SIZE sizeof(overlays)
+static uint8_t overlay_pool [NUM_OVERLAY_SLOTS][72*40/8] __attribute__((section(".overlay_pool")));
+#define OVERLAY_POOL_SIZE sizeof(overlay_pool)
 #else
-static /*volatile*/ uint8_t overlays [NUM_OVERLAY_SLOTS][72*40/8]; // ResX*ResY/PixelPerByte
-#define OVERLAYS_SIZE sizeof(overlays)
+static /*volatile*/ uint8_t overlay_pool [NUM_OVERLAY_SLOTS][72*40/8]; // ResX*ResY/PixelPerByte
+#define OVERLAY_POOL_SIZE sizeof(overlay_pool)
 #endif
-static uint16_t overlay_map [NUM_OVERLAYS*NUM_VARIATIONS_WITH_MAP];
+static uint16_t display_to_pool [NUM_OVERLAYS*NUM_VARIATIONS_WITH_MAP];
 
 static overlay_fragment_context_t g_fragment_context = {0};
 
@@ -75,7 +75,7 @@ roi_bounds_t set_fragment_context_from_buffer(const uint8_t *buffer) {
     // SECURITY: the ROI bounds are raw host bytes (y/yy up to 63, x up to 255,
     // xx up to 127) but the keycap is only 72x40. Unclamped, copy_rectangle_to_overlay_xy
     // would index a 360-byte overlay row well past its end (OOB write into adjacent
-    // overlays[]). Clip to the visible window so x/y are valid start coords and
+    // overlay_pool[]). Clip to the visible window so x/y are valid start coords and
     // xx/yy are valid exclusive ends. (A second backstop lives in the copy loop.)
     // NOTE: x/y are INCLUSIVE start pixels (max SCREEN_-1) while xx/yy are
     // EXCLUSIVE ends (max SCREEN_); width = xx-x, so a 1px ROI (xx==x+1) is valid
@@ -120,8 +120,8 @@ void set_fragment_context_roi(uint8_t x, uint8_t y, uint8_t xx, uint8_t yy, bool
 }
 
 
-uint8_t (* get_overlays(void))[72*40/8] {
-    return overlays;
+uint8_t (* get_overlay_pool(void))[72*40/8] {
+    return overlay_pool;
 }
 
 // Throwaway row returned for an out-of-range overlay index — so an OOB access
@@ -130,8 +130,8 @@ uint8_t (* get_overlays(void))[72*40/8] {
 static uint8_t s_overlay_discard[72*40/8];
 
 uint8_t* get_overlay(uint16_t overlay_idx) {
-    // SECURITY: this is the single place overlays[] is dereferenced. The index
-    // arrives from the host-programmed mapping (get_overlay_mapping -> overlay_map[],
+    // SECURITY: this is the single place overlay_pool[] is dereferenced. The index
+    // arrives from the host-programmed mapping (get_display_pool_slot -> display_to_pool[],
     // cmd 21) and is only validated at write time today, so an out-of-range value
     // here would read/write past the pool. Route it to a discard row instead —
     // memory-safe AND non-destructive (no real slot is read or overwritten; slot 0
@@ -146,38 +146,38 @@ uint8_t* get_overlay(uint16_t overlay_idx) {
         }
         return s_overlay_discard;
     }
-    return overlays[overlay_idx];
+    return overlay_pool[overlay_idx];
 }
 
-uint16_t get_overlay_mapping(uint16_t overlay_idx) {
-    return overlay_map[overlay_idx];
+uint16_t get_display_pool_slot(uint16_t overlay_idx) {
+    return display_to_pool[overlay_idx];
 }
 
-void set_overlay_mapping(uint16_t overlay_idx, uint16_t val) {
-    overlay_map[overlay_idx] = val;
+void set_display_pool_slot(uint16_t overlay_idx, uint16_t val) {
+    display_to_pool[overlay_idx] = val;
 }
 
-void set_overlay_usage(uint16_t overlay_idx) {
-    use_overlay[overlay_idx/8] |= (1<<(overlay_idx%8));
+void mark_display_has_overlay(uint16_t overlay_idx) {
+    display_has_overlay_bits[overlay_idx/8] |= (1<<(overlay_idx%8));
 }
 
-bool is_overlay_used(uint16_t overlay_idx) {
-    return (use_overlay[overlay_idx/8] & (1<<(overlay_idx%8))) != 0;
+bool display_has_overlay(uint16_t overlay_idx) {
+    return (display_has_overlay_bits[overlay_idx/8] & (1<<(overlay_idx%8))) != 0;
 }
 
-void reset_overlay_buffers(void) {
-    memset(overlays, 0, OVERLAYS_SIZE);
+void reset_overlay_pool(void) {
+    memset(overlay_pool, 0, OVERLAY_POOL_SIZE);
 }
 
-void reset_overlay_usage(void) {
-    for(int16_t i = 0; i < sizeof(use_overlay); ++i) {
-        use_overlay[i] = 0;
+void clear_display_has_overlay(void) {
+    for(int16_t i = 0; i < sizeof(display_has_overlay_bits); ++i) {
+        display_has_overlay_bits[i] = 0;
     }
 }
 
-void set_all_overlay_mapping(void) {
-    for(int16_t i = 0; i < sizeof(use_overlay); ++i) {
-        use_overlay[i] = 0xff;
+void set_all_display_has_overlay(void) {
+    for(int16_t i = 0; i < sizeof(display_has_overlay_bits); ++i) {
+        display_has_overlay_bits[i] = 0xff;
     }
 }
 
@@ -189,10 +189,10 @@ void set_all_overlay_mapping(void) {
 // via cmd 21 — but the flat (slot, variant) index is still the only ADDRESS the
 // upload wire format has, so the identity is what makes "write pool slot N"
 // expressible. See the warning in the body before changing anything here.
-void reset_overlay_mapping(void) {
+void reset_display_to_pool(void) {
     // ⚠️ IDENTITY IS LOAD-BEARING FOR UPLOADS — do not "simplify" this to a zero
     // fill. Every upload path resolves its destination THROUGH this table
-    // (fill_overlay.c: adjust_overlay_idx_to_mod() then get_overlay_mapping()),
+    // (fill_overlay.c: adjust_overlay_idx_to_mod() then get_display_pool_slot()),
     // and an MRU upload addresses pool slot N by sending the (keycode, modifier)
     // pair whose flat index IS N — host OverlayMRUCache.pool_slot_to_firmware_address:
     //     keycode_slot = N % 90 ; modifier_var = N / 90
@@ -202,13 +202,13 @@ void reset_overlay_mapping(void) {
     // sent all of them to slot 0: nearly every keycap went blank and the Esc
     // position (which maps to slot 0) showed the pile-up (field, 2026-08-01).
     for(int16_t i = 0; i < NUM_OVERLAY_SLOTS; ++i) {
-        overlay_map[i] = i;
+        display_to_pool[i] = i;
     }
     // Flat indices past the pool can never be an upload destination (the host only
     // ever addresses slots < capacity), so they just need to be in range. Rendering
     // is gated on the usage bits, which every caller clears alongside this.
     for(int16_t i = NUM_OVERLAY_SLOTS; i < OVERLAY_MAP_IDX_CNT; ++i) {
-        overlay_map[i] = 0;
+        display_to_pool[i] = 0;
     }
 }
 

--- a/keyboards/polykybd/base/overlay.h
+++ b/keyboards/polykybd/base/overlay.h
@@ -1,5 +1,39 @@
 #pragma once
 
+// Overlay vocabulary — three distinct things that all used to be called "overlay
+// something", which was the main source of confusion when reading this code:
+//
+//   overlay_pool[NUM_OVERLAY_SLOTS][360]  the physical bank of keycap IMAGES.
+//                                         Addressed by a "pool slot" (0..599).
+//   display_to_pool[OVERLAY_MAP_IDX_CNT]  "display position" -> pool slot. A
+//                                         display position is a flat index
+//                                         (keycode slot 0..89) + 90*(modifier
+//                                         variant 0..15), i.e. WHICH KEY under
+//                                         WHICH modifier state.
+//   display_has_overlay_bits[]            1 bit per display position: does it
+//                                         have an image assigned at all? This is
+//                                         the render gate.
+//
+// The indirection is what lets several modifier variants that share the same
+// artwork share ONE pool slot — which is why the pool (600) is much smaller than
+// the position space (1440).
+//
+// The host uses the same two words: PolyKybdHost's OverlayMRUCache has
+// display_flat_idx() and pool_slot_to_firmware_address(). Keep them aligned.
+//
+// LEGACY NAMES (renamed 2026-08, may still appear in older commits/comments/docs):
+//   overlays              -> overlay_pool
+//   overlay_map           -> display_to_pool
+//   get/set_overlay_mapping -> get/set_display_pool_slot
+//   reset_overlay_mapping -> reset_display_to_pool
+//   use_overlay           -> display_has_overlay_bits
+//   is_overlay_used       -> display_has_overlay
+//   set_overlay_usage     -> mark_display_has_overlay
+//   reset_overlay_usage   -> clear_display_has_overlay
+//   set_all_overlay_mapping -> set_all_display_has_overlay
+//   reset_overlay_buffers -> reset_overlay_pool
+// get_overlay(pool_slot) kept its name — it already reads as a pool accessor.
+
 #include <stdint.h>
 #include <stdbool.h>
 
@@ -42,35 +76,35 @@ void set_fragment_context_byte_len(uint8_t byte_len);
 void set_fragment_context_msg_count(uint8_t msg_count);
 void set_fragment_context_roi(uint8_t x, uint8_t y, uint8_t xx, uint8_t yy, bool compressed);
 
-uint8_t (*get_overlays(void))[72*40/8];
+uint8_t (*get_overlay_pool(void))[72*40/8];
 
 uint8_t* get_overlay(uint16_t overlay_idx);
 
-uint16_t get_overlay_mapping(uint16_t overlay_idx);
+uint16_t get_display_pool_slot(uint16_t overlay_idx);
 
-void set_overlay_mapping(uint16_t overlay_idx, uint16_t val);
+void set_display_pool_slot(uint16_t overlay_idx, uint16_t val);
 
-void set_overlay_usage(uint16_t overlay_idx);
+void mark_display_has_overlay(uint16_t overlay_idx);
 
 // Checks if the specified overlay is marked as being used.
-// Global variables: use_overlay
-bool is_overlay_used(uint16_t overlay_idx);
+// Global variables: display_has_overlay_bits
+bool display_has_overlay(uint16_t overlay_idx);
 
 // Clears all overlay buffer data by setting it to zero.
 // Global variables: overlays
-void reset_overlay_buffers(void);
+void reset_overlay_pool(void);
 
 // Resets all overlay usage flags by clearing the entire usage array.
-// Global variables: use_overlay
-void reset_overlay_usage(void);
+// Global variables: display_has_overlay_bits
+void clear_display_has_overlay(void);
 
-// Marks every overlay slot as used (inverse of reset_overlay_usage).
-// Global variables: use_overlay
-void set_all_overlay_mapping(void);
+// Marks every overlay slot as used (inverse of clear_display_has_overlay).
+// Global variables: display_has_overlay_bits
+void set_all_display_has_overlay(void);
 
 // Initializes the overlay mapping indices: standard entries map 1:1, followed by modifier combinations.
-// Global variables: overlay_map
-void reset_overlay_mapping(void);
+// Global variables: display_to_pool
+void reset_display_to_pool(void);
 
 // Copies rectangle region of overlay data handling both compressed and uncompressed formats.
 // Global variables: (none - uses passed parameters only)

--- a/keyboards/polykybd/config.h
+++ b/keyboards/polykybd/config.h
@@ -287,15 +287,38 @@
 // must move together, and the pack's .plyx carries the size in its header.
 #define NUM_OVERLAY_SLOTS 600
 #define OVERLAY_MAP_IDX_CNT (NUM_OVERLAYS*NUM_VARIATIONS_WITH_MAP)
-// Bit width of ONE packed value in a SEND_OVERLAY_MAPPING (cmd 21) report. Both
-// halves of a pair use it: `from` (a flat (slot, variant) index, 0..1439) and `to`
-// (a pool slot, 0..NUM_OVERLAY_SLOTS-1). ⚠️ It must hold OVERLAY_MAP_IDX_CNT
-// itself, not just CNT-1 — that value is the host's / the repair's noop padding
-// sentinel. 11 bits covers 1440; it was 10 while the index space was 810. Widening
-// it is a WIRE CHANGE (fewer pairs per report, different bit offsets) and needs a
-// PROTOCOL_VERSION bump plus a matching host encode branch.
-#define OVERLAY_MAP_IDX_BITS 11
+// --- overlay-mapping wire widths -------------------------------------------
+// A mapping report is a flat LSB-first bit stream of equal-width values read as
+// alternating `from, to, from, to, …`. `from` is a display position (a flat
+// (slot, variant) index, 0..OVERLAY_MAP_IDX_CNT-1) and `to` is a pool slot
+// (0..NUM_OVERLAY_SLOTS-1), so the width a given pair NEEDS is
+// max(bits(from), bits(to)).
+//
+// Two commands carry that stream:
+//   cmd 21 SEND_OVERLAY_MAPPING    — fixed 10 bits. Unchanged since forever, and
+//                                    the only one a pre-v12 keyboard understands.
+//   cmd 33 SEND_OVERLAY_MAPPING_W  — v12+. data[2] is the WIDTH, data[3..] the
+//                                    stream, so the host can pick the narrowest
+//                                    width each group of pairs fits in.
+// Pairs are order-independent (each is a standalone assignment), so the host
+// partitions them BY REQUIRED WIDTH rather than by index order: variants 0..10
+// stay in the 10-bit form (24 pairs/report, no regression), only the high GUI
+// combos need 11, and low-index pairs can ride at 9 or even 8 (27 / 30 pairs).
+// 11 is the ceiling — max `from` is 1439 < 2048 — so 12+ is never needed today.
+#define OVERLAY_MAP_IDX_BITS 10                 // cmd 21's fixed width
 #define OVERLAY_MAP_IDX_CNT_PER_REPORT (HID_DATA_MAX*8/OVERLAY_MAP_IDX_BITS)
+// cmd 33: one extra header byte for the width, so one fewer data byte.
+#define OVERLAY_MAP_W_HDR   3                   // report id + cmd + width
+#define OVERLAY_MAP_W_BYTES (HID_REPORT_SIZE-OVERLAY_MAP_W_HDR)
+#define OVERLAY_MAP_WIDTH_MIN 8
+#define OVERLAY_MAP_WIDTH_MAX 16
+// Values a stream of `bytes` bytes holds at `width` bits — the ONE definition
+// host and firmware must agree on, since there is no count field: the host fills
+// every value (padding by repeating the last pair, which is idempotent) so a
+// disagreement would decode trailing junk as real mappings.
+#define OVERLAY_MAP_VALUES(bytes, width) ((uint16_t)((bytes)*8/(width)))
+// Width the master's own repair packer uses — the widest, so any index fits.
+#define OVERLAY_MAP_REPAIR_WIDTH 11
 #define UNSET_OVERLAY_MAPPING 0xffff
 
 #define PICO_FLASH_SIZE_BYTES (8 * 1024 * 1024)

--- a/keyboards/polykybd/config.h
+++ b/keyboards/polykybd/config.h
@@ -195,10 +195,15 @@
 //      variant 8 (see adjust_overlay_idx_to_mod in fill_overlay.c). The upload
 //      commands are UNCHANGED (all three already carry the modifier in a 4-bit
 //      field), but the flat (slot, variant) index space grows 810 -> 1440, which
-//      no longer fits the 10-bit fields of SEND_OVERLAY_MAPPING (cmd 21) — so its
-//      packed indices widen to OVERLAY_MAP_IDX_BITS 11 (22 pairs/report, was 24).
-//      That is the only wire change; the host encodes cmd 21 at 10 or 11 bits by
-//      the device's protocol and never sends a variant > 8 to a pre-v12 keyboard.
+//      no longer fits the 10-bit fields of SEND_OVERLAY_MAPPING (cmd 21).
+//      cmd 21 STAYS FIXED AT 10 BITS — unchanged, and still the only mapping
+//      command a pre-v12 keyboard understands. The wider space rides a NEW
+//      command, SEND_OVERLAY_MAPPING_W (cmd 33), whose data[2] carries the value
+//      width: the host groups mapping pairs by the width they need (8/9/10/11 ->
+//      30/27/24/22 pairs per report) and sends each group at its own width. Since
+//      variants 0..10 still fit 10 bits, the common case keeps cmd 21's density;
+//      only indices >= 1024 need 11. A pre-v12 keyboard gets cmd 21 only, and
+//      never a variant > 8 (it has no index space for one).
 #define PROTOCOL_VERSION 12
 
 #define FULL_BRIGHT 50
@@ -310,6 +315,16 @@
 // cmd 33: one extra header byte for the width, so one fewer data byte.
 #define OVERLAY_MAP_W_HDR   3                   // report id + cmd + width
 #define OVERLAY_MAP_W_BYTES (HID_REPORT_SIZE-OVERLAY_MAP_W_HDR)
+// Widths the DECODER accepts. Deliberately wider than the 8..11 the host emits
+// today: the decoder is width-generic, and every value it produces is still
+// range-checked against OVERLAY_MAP_IDX_CNT / NUM_OVERLAY_SLOTS before it can
+// touch a table, so a stream at 12..16 can only ever be rejected pair-by-pair —
+// it cannot address anything a narrower one couldn't. Accepting them keeps
+// headroom for a future index-space growth without a second command, in the same
+// spirit as the open-ended glyph-script index (v10). ⚠️ The bound that actually
+// protects memory is the per-value range check, NOT this range; both the read and
+// the write side touch a byte only when the value truly extends into it, verified
+// by round-tripping the packer through the decoder across all of 8..16.
 #define OVERLAY_MAP_WIDTH_MIN 8
 #define OVERLAY_MAP_WIDTH_MAX 16
 // Values a stream of `bytes` bytes holds at `width` bits — the ONE definition

--- a/keyboards/polykybd/config.h
+++ b/keyboards/polykybd/config.h
@@ -274,7 +274,7 @@
 
 // Physical overlay pool: how many DISTINCT 360-byte keycap images can be resident
 // at once. Deliberately DECOUPLED from NUM_OVERLAYS*variants — overlay mapping is
-// mandatory, so overlay_map[] (810 entries, every keycode-slot x variant pair)
+// mandatory, so display_to_pool[] (810 entries, every keycode-slot x variant pair)
 // points each pair at any pool slot. Variants that share artwork therefore cost
 // ONE slot, not one each: measured across the 24 shipped app templates, the
 // heaviest app needs 62 distinct images and the median 31, so 600 holds ~10 apps

--- a/keyboards/polykybd/config.h
+++ b/keyboards/polykybd/config.h
@@ -188,7 +188,18 @@
 //      firmware read 1 byte past the report (harmless on a no-MMU MCU, but the
 //      last data byte of each segment was undefined). Compressed/ROI paths are
 //      unchanged. Host must match v11 to connect (exact-match gate).
-#define PROTOCOL_VERSION 11
+// v12: GUI (Cmd) COMBINES with the other modifiers for overlays. The modifier
+//      variant is now simply the L/R-folded QMK modifier bitmask 0..15 (bit0 Ctrl,
+//      bit1 Shift, bit2 Alt, bit3 GUI), so Cmd+Shift, Cmd+Alt, Cmd+Shift+Alt, ...
+//      each address their own overlay instead of collapsing onto the bare-GUI
+//      variant 8 (see adjust_overlay_idx_to_mod in fill_overlay.c). The upload
+//      commands are UNCHANGED (all three already carry the modifier in a 4-bit
+//      field), but the flat (slot, variant) index space grows 810 -> 1440, which
+//      no longer fits the 10-bit fields of SEND_OVERLAY_MAPPING (cmd 21) — so its
+//      packed indices widen to OVERLAY_MAP_IDX_BITS 11 (22 pairs/report, was 24).
+//      That is the only wire change; the host encodes cmd 21 at 10 or 11 bits by
+//      the device's protocol and never sends a variant > 8 to a pre-v12 keyboard.
+#define PROTOCOL_VERSION 12
 
 #define FULL_BRIGHT 50
 #define MIN_BRIGHT 1
@@ -251,7 +262,15 @@
 #define ROI_START (HID_REPORT_SIZE-7) // additional minus keycode and 4 bytes compressed roi header -> -7
 
 #define NUM_OVERLAYS 90
-#define NUM_VARIATIONS_WITH_MAP 9 // ALL modifier variants are addressable: NO_MOD(0), CTRL(1), SHIFT(2), CTRL_SHIFT(3), ALT(4), CTRL_ALT(5), ALT_SHIFT(6), CTRL_ALT_SHIFT(7), GUI_KEY(8) (maximum would be 14, maybe later support GUI+CTL/ALT/SHIFT -> 12)
+// The modifier variant IS the L/R-folded QMK modifier bitmask (bit0 Ctrl, bit1
+// Shift, bit2 Alt, bit3 GUI), so all 16 combinations are addressable and the
+// numbering is self-describing: 0 = none, 1 = Ctrl, 2 = Shift, 3 = Ctrl+Shift,
+// 4 = Alt, ... 8 = GUI, 9 = GUI+Ctrl, 10 = GUI+Shift, ... 15 = GUI+Ctrl+Alt+Shift.
+// Protocol v12 grew this from 9 (GUI could not be combined — every GUI+x chord
+// collapsed onto the bare-GUI variant 8, so e.g. a Mac Cmd+Shift+P shortcut drew
+// the Cmd image). ⚠️ Growing it further would need OVERLAY_MAP_IDX_BITS to grow
+// too — see the note there.
+#define NUM_VARIATIONS_WITH_MAP 16
 
 // Physical overlay pool: how many DISTINCT 360-byte keycap images can be resident
 // at once. Deliberately DECOUPLED from NUM_OVERLAYS*variants — overlay mapping is
@@ -268,7 +287,14 @@
 // must move together, and the pack's .plyx carries the size in its header.
 #define NUM_OVERLAY_SLOTS 600
 #define OVERLAY_MAP_IDX_CNT (NUM_OVERLAYS*NUM_VARIATIONS_WITH_MAP)
-#define OVERLAY_MAP_IDX_BITS 10
+// Bit width of ONE packed value in a SEND_OVERLAY_MAPPING (cmd 21) report. Both
+// halves of a pair use it: `from` (a flat (slot, variant) index, 0..1439) and `to`
+// (a pool slot, 0..NUM_OVERLAY_SLOTS-1). ⚠️ It must hold OVERLAY_MAP_IDX_CNT
+// itself, not just CNT-1 — that value is the host's / the repair's noop padding
+// sentinel. 11 bits covers 1440; it was 10 while the index space was 810. Widening
+// it is a WIRE CHANGE (fewer pairs per report, different bit offsets) and needs a
+// PROTOCOL_VERSION bump plus a matching host encode branch.
+#define OVERLAY_MAP_IDX_BITS 11
 #define OVERLAY_MAP_IDX_CNT_PER_REPORT (HID_DATA_MAX*8/OVERLAY_MAP_IDX_BITS)
 #define UNSET_OVERLAY_MAPPING 0xffff
 

--- a/keyboards/polykybd/doom/doom_mode.c
+++ b/keyboards/polykybd/doom/doom_mode.c
@@ -1617,6 +1617,7 @@ bool doom_hid_frozen(uint8_t cmd) {
         case 18: // start ROI overlay          (0x12)
         case 19: // ROI overlay data           (0x13)
         case 21: // overlay mapping            (0x15)
+        case 33: // overlay mapping, sized      (0x21)
             // All ACKless bulk writes into the borrowed pool / fragment
             // context — the dispatcher drops them without a reply.
             return true;

--- a/keyboards/polykybd/doom/doom_mode.c
+++ b/keyboards/polykybd/doom/doom_mode.c
@@ -57,7 +57,7 @@ extern uint8_t __doom_shared_end__[];
 #else
 // DoomPack flavour (PACK_DESIGN.md): no engine in the image, no custom
 // linker script. The pool is base/overlay.c's plain array (borrowed via
-// get_overlays() as always) and the engine-statics/arena split inside it
+// get_overlay_pool() as always) and the engine-statics/arena split inside it
 // comes from the loaded pack's header (doom_pack_arena_off()).
 #define DOOM_POOL_BYTES ((uint32_t)NUM_OVERLAY_SLOTS * (72 * 40 / 8))
 #endif
@@ -419,7 +419,7 @@ static bool doom_session_start(void) {
     // The runtime handoff: the overlay pool becomes the game arena. The pool
     // is entirely reconstructible — the host re-sends overlays on every app
     // switch, so nothing is lost (see DOOM_FEASIBILITY.md, Challenge 2).
-    s_fb = (uint8_t *)get_overlays();
+    s_fb = (uint8_t *)get_overlay_pool();
 #ifdef POLYKYBD_DOOM_PACK
     // Zero the whole pool, then bring up the flashed engine pack: its init
     // re-runs the pack crt0 (.data copy + .bss zero inside the pool), so
@@ -533,9 +533,9 @@ static void doom_exit(void) {
     s_fb = NULL;
     // Hand the pool back in the same state a fresh boot / font-pack wipe leaves
     // it: blank buffers, no usage bits, identity mapping.
-    reset_overlay_buffers();
-    reset_overlay_usage();
-    reset_overlay_mapping();
+    reset_overlay_pool();
+    clear_display_has_overlay();
+    reset_display_to_pool();
     reset_fragment_context();
     // Actively tell the host its overlays are gone: re-raise the GET_ID fresh-boot
     // marker so the next reconnect probe (~1 s) resets the host MRU cache and
@@ -1188,9 +1188,9 @@ static void doom_slave_stop(void) {
 #endif
     s_fb = NULL;
     // Same pool hand-back contract as doom_exit: blank + reconstructible.
-    reset_overlay_buffers();
-    reset_overlay_usage();
-    reset_overlay_mapping();
+    reset_overlay_pool();
+    clear_display_has_overlay();
+    reset_display_to_pool();
     reset_fragment_context();
     // The game blitter owned these panels with untracked full-window sends and the
     // slave never drove s_disp_render_active false (doom_mode_active() is the

--- a/keyboards/polykybd/fill_overlay.c
+++ b/keyboards/polykybd/fill_overlay.c
@@ -281,9 +281,11 @@ void fill_roi_overlay_buffer(uint8_t* data, bool first) {
     }
 }
 
-// Unpacks 10-bit overlay mapping pairs from buffer and updates display_to_pool array.
+// Unpacks `width`-bit overlay mapping pairs from `bytes` bytes of buffer and
+// updates the display_to_pool array. Both values of a pair share the width; the
+// caller supplies it (cmd 21 is always OVERLAY_MAP_IDX_BITS, cmd 33 carries it).
 // `from` indexes display_to_pool[] (0..OVERLAY_MAP_IDX_CNT-1, currently 1440).
-// `to` indexes overlays[] (0..NUM_OVERLAY_SLOTS-1, currently 600) — the
+// `to` indexes overlay_pool[] (0..NUM_OVERLAY_SLOTS-1, currently 600) — the
 // physical pool. A `to` >= NUM_OVERLAY_SLOTS is an out-of-pool value
 // and would cause an OOB read in copy_overlay_to_buffer / fill_overlay_buffer.
 // Returns true if any mapping in this chunk lands on a currently-displayed position

--- a/keyboards/polykybd/fill_overlay.c
+++ b/keyboards/polykybd/fill_overlay.c
@@ -129,7 +129,7 @@ void fill_overlay_buffer(uint8_t segment_index, uint8_t* buffer) {
 
     uint8_t mods = get_fragment_context()->modifier;
     idx = adjust_overlay_idx_to_mod(idx, mods);
-    idx = get_overlay_mapping(idx);
+    idx = get_display_pool_slot(idx);
 
     enum key_split_pos pos = resolve_upload_side(keycode);
     if (is_on_current_side(pos)) {
@@ -153,7 +153,7 @@ void fill_overlay_buffer(uint8_t segment_index, uint8_t* buffer) {
     }
 
     if (segment_index == NUM_SEGMENTS_PER_OVERLAY - 1) {
-        set_overlay_usage_post_upload(idx);
+        mark_display_has_overlay_post_upload(idx);
         uprintf("Received overlay for keycode 0x%x (modifiers: 0x%x): %d bytes, index %d, side: %s.\n",
                 keycode, mods, (segment_index+1)*BYTES_PER_SEGMENT, idx, pos_to_str(pos));
     }
@@ -176,7 +176,7 @@ void decompress_overlay_buffer(uint8_t* compressed, bool first) {
     uint16_t base_slot = idx;   // 0..89, before the modifier/mapping resolve — for the visibility gate
     bool visible = overlay_visible(base_slot, ctx_mod);
     idx = adjust_overlay_idx_to_mod(idx, ctx_mod);
-    idx = get_overlay_mapping(idx);
+    idx = get_display_pool_slot(idx);
 
     enum key_split_pos pos = resolve_upload_side(keycode);
     uint16_t bit_index = get_fragment_context()->bit_index;
@@ -190,7 +190,7 @@ void decompress_overlay_buffer(uint8_t* compressed, bool first) {
         bit_index += rle_decompress(get_overlay(idx)+bit_index/8, PK_MAX(0,maxlen), compressed, compressed_len, bit_index);
 
         if (bit_index >= 360*8 -1) {
-            set_overlay_usage_post_upload(idx);
+            mark_display_has_overlay_post_upload(idx);
             uprintf("--> Finished keycode 0x%x (mod 0x%x): side %s, total bytes %d.\n",
                 keycode, ctx_mod, pos_to_str(pos), bit_index/8);
             // No update_performed() — a host overlay push is not user activity and
@@ -237,7 +237,7 @@ void fill_roi_overlay_buffer(uint8_t* data, bool first) {
     uint16_t base_slot = idx;   // 0..89, before the modifier/mapping resolve — for the visibility gate
     bool visible = overlay_visible(base_slot, ctx_mod);
     idx = adjust_overlay_idx_to_mod(idx, ctx_mod);
-    idx = get_overlay_mapping(idx);
+    idx = get_display_pool_slot(idx);
 
     enum key_split_pos pos = resolve_upload_side(keycode);
 
@@ -256,7 +256,7 @@ void fill_roi_overlay_buffer(uint8_t* data, bool first) {
             }
             bit_index = copy_rectangle_to_overlay(bit_index, get_overlay(idx), first?(&(data[5])):data, &ctx_roi, data_len);
             if(bit_index >= 2880) {
-                set_overlay_usage_post_upload(idx);
+                mark_display_has_overlay_post_upload(idx);
                 // No update_performed() — see base/update.h.
                 // Only refresh if this overlay is on screen (see overlay_visible).
                 if (visible) {
@@ -281,8 +281,8 @@ void fill_roi_overlay_buffer(uint8_t* data, bool first) {
     }
 }
 
-// Unpacks 10-bit overlay mapping pairs from buffer and updates overlay_map array.
-// `from` indexes overlay_map[] (0..OVERLAY_MAP_IDX_CNT-1, currently 1440).
+// Unpacks 10-bit overlay mapping pairs from buffer and updates display_to_pool array.
+// `from` indexes display_to_pool[] (0..OVERLAY_MAP_IDX_CNT-1, currently 1440).
 // `to` indexes overlays[] (0..NUM_OVERLAY_SLOTS-1, currently 600) — the
 // physical pool. A `to` >= NUM_OVERLAY_SLOTS is an out-of-pool value
 // and would cause an OOB read in copy_overlay_to_buffer / fill_overlay_buffer.
@@ -321,11 +321,11 @@ bool set_packed_overlay_mapping(uint8_t* mapping) {
         } else {
             if(from < OVERLAY_MAP_IDX_CNT) {
                 if(to < NUM_OVERLAY_SLOTS) {
-                    set_overlay_mapping(from, to);
-                    // use_overlay[] is from-indexed: a display position is
+                    set_display_pool_slot(from, to);
+                    // display_has_overlay_bits[] is from-indexed: a display position is
                     // "in use" iff it has an overlay assigned. Establishing
                     // the mapping is exactly that act, so set the bit here.
-                    set_overlay_usage(from);
+                    mark_display_has_overlay(from);
                     if (overlay_from_index_visible(from)) {
                         any_visible = true;
                     }
@@ -430,9 +430,9 @@ void overlay_map_repair_tick(void) {
         memset(msg.mapping, 0, sizeof(msg.mapping));
         // Collect up to one report's worth of used entries from the cursor.
         while (s_repair_from < OVERLAY_MAP_IDX_CNT && slot < OVERLAY_MAP_IDX_CNT_PER_REPORT) {
-            if (is_overlay_used(s_repair_from)) {
+            if (display_has_overlay(s_repair_from)) {
                 pack_map_value(msg.mapping, slot++, s_repair_from);
-                pack_map_value(msg.mapping, slot++, get_overlay_mapping(s_repair_from));
+                pack_map_value(msg.mapping, slot++, get_display_pool_slot(s_repair_from));
                 ++s_repair_pairs;
             }
             ++s_repair_from;
@@ -463,14 +463,14 @@ void overlay_map_repair_tick(void) {
 }
 
 void apply_overlay_action_flags(uint8_t flags) {
-    if(test_flag(flags, RESET_BUFFERS))  reset_overlay_buffers();
-    if(test_flag(flags, USAGE_RESET))    reset_overlay_usage();
-    if(test_flag(flags, MAPPING_RESET))  reset_overlay_mapping();
-    if(test_flag(flags, MAPPING_ALLSET)) set_all_overlay_mapping();
+    if(test_flag(flags, RESET_BUFFERS))  reset_overlay_pool();
+    if(test_flag(flags, USAGE_RESET))    clear_display_has_overlay();
+    if(test_flag(flags, MAPPING_RESET))  reset_display_to_pool();
+    if(test_flag(flags, MAPPING_ALLSET)) set_all_display_has_overlay();
 }
 
-void set_overlay_usage_post_upload(uint16_t idx) {
+void mark_display_has_overlay_post_upload(uint16_t idx) {
     if (!test_flag(get_local_state()->overlay_flags, MIRROR_OVERLAYS)) {
-        set_overlay_usage(idx);
+        mark_display_has_overlay(idx);
     }
 }

--- a/keyboards/polykybd/fill_overlay.c
+++ b/keyboards/polykybd/fill_overlay.c
@@ -289,33 +289,41 @@ void fill_roi_overlay_buffer(uint8_t* data, bool first) {
 // Returns true if any mapping in this chunk lands on a currently-displayed position
 // (see overlay_from_index_visible) — the caller renders only then; an all-off-screen
 // chunk is staged silently and shown by the eventual layer/modifier/enable refresh.
-bool set_packed_overlay_mapping(uint8_t* mapping) {
+bool set_packed_overlay_mapping(const uint8_t* mapping, uint8_t bytes, uint8_t width) {
     bool any_visible = false;
     uint16_t from = UNSET_OVERLAY_MAPPING;
+    if (width < OVERLAY_MAP_WIDTH_MIN || width > OVERLAY_MAP_WIDTH_MAX) {
+        uprintf("REJECTED overlay mapping report: bad width %u\n", (unsigned)width);
+        return false;
+    }
     // Accumulate this report's mappings into ONE log line instead of one uprintf
-    // per pair (22 pairs/report flooded the console). "from>to" pairs, space-sep.
+    // per pair (20-30 pairs/report flooded the console). "from>to" pairs, space-sep.
     char    map_log[220];
     int     map_log_n  = 0;
     uint8_t map_count  = 0;   // pairs accepted (established) this report
     uint8_t map_shown  = 0;   // pairs actually rendered into map_log (may be fewer if it filled)
     map_log[0] = '\0';
-    for(uint8_t idx=0;idx<OVERLAY_MAP_IDX_CNT_PER_REPORT;++idx) {
-        // start_bit must be wide enough to hold idx*OVERLAY_MAP_IDX_BITS (up to ~484)
-        // — a uint8_t would wrap.
-        uint16_t start_bit = (uint16_t)idx*OVERLAY_MAP_IDX_BITS;
+    const uint16_t values = OVERLAY_MAP_VALUES(bytes, width);
+    for(uint16_t idx=0;idx<values;++idx) {
+        // start_bit must be wide enough to hold idx*width (up to ~488) — a uint8_t
+        // would wrap.
+        uint16_t start_bit = idx*(uint16_t)width;
         uint8_t start_byte = start_bit/8;
         uint8_t start_bit_in_byte = start_bit%8;
-        // ⚠️ An 11-bit value can span THREE bytes (offset 6 or 7 reaches bit 17),
-        // which a 10-bit one never did — 10 % 8 == 2 kept every offset in {0,2,4,6}.
-        // Read the third byte only when the value actually extends into it, so the
-        // load can never run past the report buffer.
-        uint32_t acc = (uint32_t)mapping[start_byte] |
-                       ((uint32_t)mapping[start_byte+1] << 8);
-        if (start_bit_in_byte + OVERLAY_MAP_IDX_BITS > 16) {
+        // ⚠️ How many bytes a value spans depends on the width, so BOTH the second
+        // and third byte are conditional — the load must never reach past the last
+        // data byte. At width 8 (gcd(8,8)==8) every value is one whole byte at
+        // offset 0; at 10 or 12 (gcd 2 / 4) the offset stays low enough for two;
+        // only the odd widths 9/11 (gcd 1) walk all eight offsets and reach a third.
+        uint32_t acc = (uint32_t)mapping[start_byte];
+        if (start_bit_in_byte + width > 8) {
+            acc |= (uint32_t)mapping[start_byte+1] << 8;
+        }
+        if (start_bit_in_byte + width > 16) {
             acc |= (uint32_t)mapping[start_byte+2] << 16;
         }
         uint16_t to = (uint16_t)((acc >> start_bit_in_byte) &
-                                 ((1u << OVERLAY_MAP_IDX_BITS) - 1u));
+                                 ((1u << width) - 1u));
         if(from==UNSET_OVERLAY_MAPPING) {
             from = to;
         } else {
@@ -374,22 +382,22 @@ void note_overlay_map_sync_lost(void) {
     s_map_sync_lost = true;
 }
 
-// Inverse of the unpacking in set_packed_overlay_mapping: write `v` as
-// OVERLAY_MAP_IDX_BITS bits at `idx`'s bit offset. `buf` must be zeroed first
-// (this ORs in). OVERLAY_MAP_IDX_CNT_PER_REPORT is derived from HID_DATA_MAX, so
-// the last value's bits always land inside the buffer.
-// ⚠️ Mirror of the decoder's three-byte span: an 11-bit value starting at bit
-// offset 6 or 7 reaches into the third byte. Write it only when the value really
-// extends there, so this can never touch a byte past the last one the decoder
-// reads. Verify any change by round-tripping through the decoder, not by eye.
-static void pack_map_value(uint8_t *buf, uint8_t idx, uint16_t v) {
-    uint16_t start_bit = (uint16_t)idx * OVERLAY_MAP_IDX_BITS;
+// Inverse of the unpacking in set_packed_overlay_mapping: write `v` as `width`
+// bits at `idx`'s bit offset. `buf` must be zeroed first (this ORs in).
+// ⚠️ Mirror the decoder's conditional byte reads exactly — write the second and
+// third byte only when the value really extends there, so this can never touch a
+// byte past the last one the decoder reads. Verify any change by round-tripping
+// through the decoder, not by eye.
+static void pack_map_value(uint8_t *buf, uint16_t idx, uint16_t v, uint8_t width) {
+    uint16_t start_bit = idx * (uint16_t)width;
     uint8_t  b         = (uint8_t)(start_bit / 8);
     uint8_t  s         = (uint8_t)(start_bit % 8);
     uint32_t shifted   = (uint32_t)v << s;
-    buf[b]     |= (uint8_t)(shifted & 0xff);
-    buf[b + 1] |= (uint8_t)((shifted >> 8) & 0xff);
-    if (s + OVERLAY_MAP_IDX_BITS > 16) {
+    buf[b] |= (uint8_t)(shifted & 0xff);
+    if (s + width > 8) {
+        buf[b + 1] |= (uint8_t)((shifted >> 8) & 0xff);
+    }
+    if (s + width > 16) {
         buf[b + 2] |= (uint8_t)((shifted >> 16) & 0xff);
     }
 }
@@ -425,14 +433,24 @@ void overlay_map_repair_tick(void) {
     overlay_map_sync_t msg;
     uint8_t sent_this_tick = 0;
 
+    // The repair packs at the WIDEST width so any display position fits — it walks
+    // the whole index space, unlike the host which partitions by required width.
+    const uint8_t  width  = OVERLAY_MAP_REPAIR_WIDTH;
+    const uint16_t values = OVERLAY_MAP_VALUES(sizeof(msg.mapping), width);
+
     while (sent_this_tick < MAP_REPAIR_REPORTS_PER_TICK) {
-        uint8_t slot = 0;       // value slot in this report (from,to,from,to,...)
+        uint16_t slot = 0;      // value slot in this report (from,to,from,to,...)
+        uint16_t last_from = 0, last_to = 0;
         memset(msg.mapping, 0, sizeof(msg.mapping));
+        msg.width = width;
+        msg.bytes = (uint8_t)sizeof(msg.mapping);
         // Collect up to one report's worth of used entries from the cursor.
-        while (s_repair_from < OVERLAY_MAP_IDX_CNT && slot < OVERLAY_MAP_IDX_CNT_PER_REPORT) {
+        while (s_repair_from < OVERLAY_MAP_IDX_CNT && slot + 1 < values) {
             if (display_has_overlay(s_repair_from)) {
-                pack_map_value(msg.mapping, slot++, s_repair_from);
-                pack_map_value(msg.mapping, slot++, get_display_pool_slot(s_repair_from));
+                last_from = s_repair_from;
+                last_to   = get_display_pool_slot(s_repair_from);
+                pack_map_value(msg.mapping, slot++, last_from, width);
+                pack_map_value(msg.mapping, slot++, last_to,   width);
                 ++s_repair_pairs;
             }
             ++s_repair_from;
@@ -443,10 +461,16 @@ void overlay_map_repair_tick(void) {
                     (unsigned)s_repair_pairs, (unsigned)s_repair_reports);
             return;
         }
-        // Pad with the host's noop convention: a `from` outside the map is
-        // ignored by set_packed_overlay_mapping on the far side.
-        while (slot < OVERLAY_MAP_IDX_CNT_PER_REPORT) {
-            pack_map_value(msg.mapping, slot++, OVERLAY_MAP_IDX_CNT);
+        // Pad by REPEATING THE LAST PAIR. Re-applying a mapping is idempotent
+        // (set_display_pool_slot + mark_display_has_overlay), so a duplicate is a
+        // semantic no-op and needs no reserved sentinel — which matters because a
+        // sentinel would have to exceed OVERLAY_MAP_IDX_CNT (1440) and so could not
+        // be expressed at the narrower widths at all. Every value must be written:
+        // there is no count field, so anything left zero would decode as the real
+        // pair 0>0 and wrongly light up display position 0.
+        while (slot + 1 < values) {
+            pack_map_value(msg.mapping, slot++, last_from, width);
+            pack_map_value(msg.mapping, slot++, last_to,   width);
         }
         if (!sync_succeeded(send_to_bridge(USER_SYNC_OVERLAY_MAP_DATA, (void *)&msg,
                                            sizeof(overlay_map_sync_t), 10))) {

--- a/keyboards/polykybd/fill_overlay.c
+++ b/keyboards/polykybd/fill_overlay.c
@@ -46,30 +46,23 @@ static enum key_split_pos resolve_upload_side(uint8_t keycode) {
 }
 
 
-// Maps overlay index to modifier combination offset
-// NO_MOD(0), CTRL(1), SHIFT(2), CTRL_SHIFT(3), ALT(4), CTRL_ALT(5),
-// ALT_SHIFT(6), CTRL_ALT_SHIFT(7) and GUI_KEY(8)
-uint16_t adjust_overlay_idx_to_mod(uint16_t idx, uint8_t mods) {
-    // GUI_KEY key cannot be combined with other modifiers in case of overlays
-    // for the moment, so GUI_KEY takes priority over all modifiers
-    if((mods&0x88) != 0) {
-        return idx + NUM_OVERLAYS * 8;
-    }
-    //no difference between r&l mods:
-    mods |= mods>>4;
-    mods &= 0x0f;
-    return idx + NUM_OVERLAYS * mods;
-}
-
-// Modifier-variant (0..8) of a modifier byte, mirroring adjust_overlay_idx_to_mod's
-// math: GUI is variant 8 (it doesn't combine with others for overlays); otherwise the
-// L/R-folded ctrl/shift/alt bitmask 0..7.
+// Modifier-variant (0..NUM_VARIATIONS_WITH_MAP-1) of a QMK modifier byte: fold the
+// right-hand mods onto the left-hand ones and keep the low nibble, so the variant IS
+// the modifier bitmask (bit0 Ctrl, bit1 Shift, bit2 Alt, bit3 GUI).
+//
+// ⚠️ Protocol v12 removed a GUI special case here: GUI used to short-circuit to
+// variant 8, i.e. Cmd+Shift / Cmd+Alt / Cmd+Shift+Alt all rendered the *bare Cmd*
+// overlay. Mac apps lean on those chords (Sublime Text's Cmd+Shift+P command
+// palette was the report), so all 16 combinations are addressable now. The upload
+// paths pass an already-4-bit value from the host, which this leaves untouched.
 static uint8_t overlay_mod_variant(uint8_t mods) {
-    if ((mods & 0x88) != 0) {
-        return 8;
-    }
     mods |= mods >> 4;
     return mods & 0x0f;
+}
+
+// Maps overlay index to modifier combination offset (see overlay_mod_variant).
+uint16_t adjust_overlay_idx_to_mod(uint16_t idx, uint8_t mods) {
+    return idx + NUM_OVERLAYS * overlay_mod_variant(mods);
 }
 
 // True if an overlay staged for keycode-slot `base_slot` (0..89) and modifier-variant
@@ -82,7 +75,7 @@ static uint8_t overlay_mod_variant(uint8_t mods) {
 //     is staged into memory but not shown.
 // Either way the overlay lands in overlay memory and is picked up by the eventual
 // layer/modifier-change refresh (both ungated), so completing it need not re-render now.
-// At rest a program switch pushes all 9 variants of every key incl. off-layer keys, and
+// At rest a program switch pushes every modifier variant of every key incl. off-layer keys, and
 // only the displayed variant-0 slots are visible — skipping the rest is the coalescing
 // win. Uses the same local_layer->mods + displayed-slot set the display resolves against,
 // so it never suppresses a render that is actually on screen.
@@ -289,31 +282,40 @@ void fill_roi_overlay_buffer(uint8_t* data, bool first) {
 }
 
 // Unpacks 10-bit overlay mapping pairs from buffer and updates overlay_map array.
-// `from` indexes overlay_map[] (0..OVERLAY_MAP_IDX_CNT-1, currently 810).
+// `from` indexes overlay_map[] (0..OVERLAY_MAP_IDX_CNT-1, currently 1440).
 // `to` indexes overlays[] (0..NUM_OVERLAY_SLOTS-1, currently 600) — the
 // physical pool. A `to` >= NUM_OVERLAY_SLOTS is an out-of-pool value
 // and would cause an OOB read in copy_overlay_to_buffer / fill_overlay_buffer.
 // Returns true if any mapping in this chunk lands on a currently-displayed position
 // (see overlay_from_index_visible) — the caller renders only then; an all-off-screen
 // chunk is staged silently and shown by the eventual layer/modifier/enable refresh.
-bool set_10bit_overlay_mapping(uint8_t* mapping) {
+bool set_packed_overlay_mapping(uint8_t* mapping) {
     bool any_visible = false;
     uint16_t from = UNSET_OVERLAY_MAPPING;
     // Accumulate this report's mappings into ONE log line instead of one uprintf
-    // per pair (24 pairs/report flooded the console). "from>to" pairs, space-sep.
+    // per pair (22 pairs/report flooded the console). "from>to" pairs, space-sep.
     char    map_log[220];
     int     map_log_n  = 0;
     uint8_t map_count  = 0;   // pairs accepted (established) this report
     uint8_t map_shown  = 0;   // pairs actually rendered into map_log (may be fewer if it filled)
     map_log[0] = '\0';
     for(uint8_t idx=0;idx<OVERLAY_MAP_IDX_CNT_PER_REPORT;++idx) {
-        // start_bit must be wide enough to hold idx*10 up to 480 — uint8_t wraps at idx=26.
+        // start_bit must be wide enough to hold idx*OVERLAY_MAP_IDX_BITS (up to ~484)
+        // — a uint8_t would wrap.
         uint16_t start_bit = (uint16_t)idx*OVERLAY_MAP_IDX_BITS;
         uint8_t start_byte = start_bit/8;
         uint8_t start_bit_in_byte = start_bit%8;
-        uint8_t num_bits_in_byte2 = OVERLAY_MAP_IDX_BITS-(8-start_bit_in_byte);
-        uint16_t to =   ((uint16_t)(mapping[start_byte]>>start_bit_in_byte)) |
-                        ((uint16_t)(0xff>>(8-num_bits_in_byte2))&mapping[start_byte+1])<<(8-start_bit_in_byte);
+        // ⚠️ An 11-bit value can span THREE bytes (offset 6 or 7 reaches bit 17),
+        // which a 10-bit one never did — 10 % 8 == 2 kept every offset in {0,2,4,6}.
+        // Read the third byte only when the value actually extends into it, so the
+        // load can never run past the report buffer.
+        uint32_t acc = (uint32_t)mapping[start_byte] |
+                       ((uint32_t)mapping[start_byte+1] << 8);
+        if (start_bit_in_byte + OVERLAY_MAP_IDX_BITS > 16) {
+            acc |= (uint32_t)mapping[start_byte+2] << 16;
+        }
+        uint16_t to = (uint16_t)((acc >> start_bit_in_byte) &
+                                 ((1u << OVERLAY_MAP_IDX_BITS) - 1u));
         if(from==UNSET_OVERLAY_MAPPING) {
             from = to;
         } else {
@@ -347,7 +349,7 @@ bool set_10bit_overlay_mapping(uint8_t* mapping) {
                             from, to, NUM_OVERLAY_SLOTS - 1);
                 }
             }
-            // from >= OVERLAY_MAP_IDX_CNT is the host's deliberate noop padding (e.g. 810/810); silent.
+            // from >= OVERLAY_MAP_IDX_CNT is the host's deliberate noop padding (e.g. 1440/1440); silent.
             from = UNSET_OVERLAY_MAPPING;
         }
     }
@@ -372,17 +374,24 @@ void note_overlay_map_sync_lost(void) {
     s_map_sync_lost = true;
 }
 
-// Inverse of the unpacking in set_10bit_overlay_mapping: write `v` as
+// Inverse of the unpacking in set_packed_overlay_mapping: write `v` as
 // OVERLAY_MAP_IDX_BITS bits at `idx`'s bit offset. `buf` must be zeroed first
-// (this ORs in). The highest index touches buf[58]/buf[59], so a HID_DATA_MAX
-// (60 B) buffer holds the full OVERLAY_MAP_IDX_CNT_PER_REPORT values.
-static void pack_10bit_map_value(uint8_t *buf, uint8_t idx, uint16_t v) {
+// (this ORs in). OVERLAY_MAP_IDX_CNT_PER_REPORT is derived from HID_DATA_MAX, so
+// the last value's bits always land inside the buffer.
+// ⚠️ Mirror of the decoder's three-byte span: an 11-bit value starting at bit
+// offset 6 or 7 reaches into the third byte. Write it only when the value really
+// extends there, so this can never touch a byte past the last one the decoder
+// reads. Verify any change by round-tripping through the decoder, not by eye.
+static void pack_map_value(uint8_t *buf, uint8_t idx, uint16_t v) {
     uint16_t start_bit = (uint16_t)idx * OVERLAY_MAP_IDX_BITS;
     uint8_t  b         = (uint8_t)(start_bit / 8);
     uint8_t  s         = (uint8_t)(start_bit % 8);
-    uint8_t  low       = (uint8_t)(8 - s);          // bits landing in buf[b]
-    buf[b]     |= (uint8_t)((v & ((1u << low) - 1u)) << s);
-    buf[b + 1] |= (uint8_t)(v >> low);
+    uint32_t shifted   = (uint32_t)v << s;
+    buf[b]     |= (uint8_t)(shifted & 0xff);
+    buf[b + 1] |= (uint8_t)((shifted >> 8) & 0xff);
+    if (s + OVERLAY_MAP_IDX_BITS > 16) {
+        buf[b + 2] |= (uint8_t)((shifted >> 16) & 0xff);
+    }
 }
 
 // Repair cursor. The walk is SPLIT ACROSS HOUSEKEEPING TICKS rather than run in
@@ -422,8 +431,8 @@ void overlay_map_repair_tick(void) {
         // Collect up to one report's worth of used entries from the cursor.
         while (s_repair_from < OVERLAY_MAP_IDX_CNT && slot < OVERLAY_MAP_IDX_CNT_PER_REPORT) {
             if (is_overlay_used(s_repair_from)) {
-                pack_10bit_map_value(msg.mapping, slot++, s_repair_from);
-                pack_10bit_map_value(msg.mapping, slot++, get_overlay_mapping(s_repair_from));
+                pack_map_value(msg.mapping, slot++, s_repair_from);
+                pack_map_value(msg.mapping, slot++, get_overlay_mapping(s_repair_from));
                 ++s_repair_pairs;
             }
             ++s_repair_from;
@@ -435,9 +444,9 @@ void overlay_map_repair_tick(void) {
             return;
         }
         // Pad with the host's noop convention: a `from` outside the map is
-        // ignored by set_10bit_overlay_mapping on the far side.
+        // ignored by set_packed_overlay_mapping on the far side.
         while (slot < OVERLAY_MAP_IDX_CNT_PER_REPORT) {
-            pack_10bit_map_value(msg.mapping, slot++, OVERLAY_MAP_IDX_CNT);
+            pack_map_value(msg.mapping, slot++, OVERLAY_MAP_IDX_CNT);
         }
         if (!sync_succeeded(send_to_bridge(USER_SYNC_OVERLAY_MAP_DATA, (void *)&msg,
                                            sizeof(overlay_map_sync_t), 10))) {

--- a/keyboards/polykybd/fill_overlay.h
+++ b/keyboards/polykybd/fill_overlay.h
@@ -19,7 +19,7 @@ void fill_roi_overlay_buffer(uint8_t* data, bool first);
 // the display_to_pool array.
 // Returns true if any pair maps a currently-displayed position, so the caller can
 // skip the display refresh for an all-off-screen chunk (see fill_overlay.c).
-bool set_packed_overlay_mapping(uint8_t* mapping);
+bool set_packed_overlay_mapping(const uint8_t* mapping, uint8_t bytes, uint8_t width);
 
 // Runs the four overlay self-actions (RESET_BUFFERS / USAGE_RESET /
 // MAPPING_RESET / MAPPING_ALLSET) for whichever bits are set in `flags`.

--- a/keyboards/polykybd/fill_overlay.h
+++ b/keyboards/polykybd/fill_overlay.h
@@ -15,10 +15,11 @@ void decompress_overlay_buffer(uint8_t* compressed, bool first);
 // Fills region-of-interest of overlay buffer with data and syncs to bridge when needed.
 void fill_roi_overlay_buffer(uint8_t* data, bool first);
 
-// Unpacks 10-bit overlay mapping pairs from buffer and updates overlay_map array.
+// Unpacks OVERLAY_MAP_IDX_BITS-wide overlay mapping pairs from buffer and updates
+// the overlay_map array.
 // Returns true if any pair maps a currently-displayed position, so the caller can
 // skip the display refresh for an all-off-screen chunk (see fill_overlay.c).
-bool set_10bit_overlay_mapping(uint8_t* mapping);
+bool set_packed_overlay_mapping(uint8_t* mapping);
 
 // Runs the four overlay self-actions (RESET_BUFFERS / USAGE_RESET /
 // MAPPING_RESET / MAPPING_ALLSET) for whichever bits are set in `flags`.
@@ -32,7 +33,7 @@ void apply_overlay_action_flags(uint8_t flags);
 // so setting the bit here would cause the wrong display position (the one
 // whose firmware address happens to coincide with the pool slot) to render
 // at every press. In MRU mode use_overlay is exclusively set by
-// set_10bit_overlay_mapping for from-indices in the host's mapping.
+// set_packed_overlay_mapping for from-indices in the host's mapping.
 void set_overlay_usage_post_upload(uint16_t idx);
 
 uint16_t adjust_overlay_idx_to_mod(uint16_t idx, uint8_t mods);
@@ -44,7 +45,7 @@ uint16_t adjust_overlay_idx_to_mod(uint16_t idx, uint8_t mods);
 // host happened to re-send the whole mapping on the next app switch. Symptom:
 // one keycap on the link-side half falls back to its plain legend while the
 // rest of the overlay set renders (the slave's render gate is the usage bit,
-// which set_10bit_overlay_mapping is what sets).
+// which set_packed_overlay_mapping is what sets).
 //
 // The master holds the authoritative overlay_map[] + use_overlay[] (it applies
 // every chunk locally regardless of the bridge), so it can rebuild the slave's

--- a/keyboards/polykybd/fill_overlay.h
+++ b/keyboards/polykybd/fill_overlay.h
@@ -15,8 +15,9 @@ void decompress_overlay_buffer(uint8_t* compressed, bool first);
 // Fills region-of-interest of overlay buffer with data and syncs to bridge when needed.
 void fill_roi_overlay_buffer(uint8_t* data, bool first);
 
-// Unpacks OVERLAY_MAP_IDX_BITS-wide overlay mapping pairs from buffer and updates
-// the display_to_pool array.
+// Unpacks `width`-wide overlay mapping pairs from `bytes` bytes of buffer and
+// updates the display_to_pool array. `bytes`/`width` come from the command that
+// carried the stream — they are NOT globals, since cmd 21 and cmd 33 differ.
 // Returns true if any pair maps a currently-displayed position, so the caller can
 // skip the display refresh for an all-off-screen chunk (see fill_overlay.c).
 bool set_packed_overlay_mapping(const uint8_t* mapping, uint8_t bytes, uint8_t width);

--- a/keyboards/polykybd/fill_overlay.h
+++ b/keyboards/polykybd/fill_overlay.h
@@ -16,7 +16,7 @@ void decompress_overlay_buffer(uint8_t* compressed, bool first);
 void fill_roi_overlay_buffer(uint8_t* data, bool first);
 
 // Unpacks OVERLAY_MAP_IDX_BITS-wide overlay mapping pairs from buffer and updates
-// the overlay_map array.
+// the display_to_pool array.
 // Returns true if any pair maps a currently-displayed position, so the caller can
 // skip the display refresh for an all-off-screen chunk (see fill_overlay.c).
 bool set_packed_overlay_mapping(uint8_t* mapping);
@@ -27,14 +27,14 @@ bool set_packed_overlay_mapping(uint8_t* mapping);
 // post-action state is in place before subsequent commands can race ahead.
 void apply_overlay_action_flags(uint8_t flags);
 
-// Sets use_overlay[idx] only when MIRROR_OVERLAYS is *off* (i.e. legacy
+// Sets display_has_overlay_bits[idx] only when MIRROR_OVERLAYS is *off* (i.e. legacy
 // non-MRU mode where uploads use display-addresses and pool_idx == display_idx).
 // In MRU mode the upload's HID address is a pool slot, not a display position,
 // so setting the bit here would cause the wrong display position (the one
 // whose firmware address happens to coincide with the pool slot) to render
-// at every press. In MRU mode use_overlay is exclusively set by
+// at every press. In MRU mode display_has_overlay_bits is exclusively set by
 // set_packed_overlay_mapping for from-indices in the host's mapping.
-void set_overlay_usage_post_upload(uint16_t idx);
+void mark_display_has_overlay_post_upload(uint16_t idx);
 
 uint16_t adjust_overlay_idx_to_mod(uint16_t idx, uint8_t mods);
 
@@ -47,7 +47,7 @@ uint16_t adjust_overlay_idx_to_mod(uint16_t idx, uint8_t mods);
 // rest of the overlay set renders (the slave's render gate is the usage bit,
 // which set_packed_overlay_mapping is what sets).
 //
-// The master holds the authoritative overlay_map[] + use_overlay[] (it applies
+// The master holds the authoritative display_to_pool[] + display_has_overlay_bits[] (it applies
 // every chunk locally regardless of the bridge), so it can rebuild the slave's
 // view from its own tables. note_..._lost() latches the failure;
 // arm_...() starts a repair at the end of the app switch (enable_overlays,

--- a/keyboards/polykybd/hid_com.c
+++ b/keyboards/polykybd/hid_com.c
@@ -730,10 +730,10 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                     // Render only if this chunk remapped a position that is on screen;
                     // an all-off-screen chunk (non-held variants, off-layer keys) is
                     // staged silently and shown by the enable-overlays refresh.
-                    if (set_10bit_overlay_mapping(&data[HID_DATA_IDX])) {
+                    if (set_packed_overlay_mapping(&data[HID_DATA_IDX])) {
                         request_disp_refresh();
                     }
-                    // Routine per-chunk chatter — set_10bit_overlay_mapping already
+                    // Routine per-chunk chatter — set_packed_overlay_mapping already
                     // logs the decoded pairs under the same gate.
                     if (debug_enable) {
                         uprint("Overlay mapping data received.\n");

--- a/keyboards/polykybd/hid_com.c
+++ b/keyboards/polykybd/hid_com.c
@@ -194,7 +194,7 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
         //  - loop_profile_note_overlay_cmd() tags the iteration for the timing profiler
         //    (no-op unless POLYKYBD_LOOP_PROFILE).
         switch (data[1]) {
-            case 10: case 11: case 12: case 16: case 17: case 18: case 19: case 21:
+            case 10: case 11: case 12: case 16: case 17: case 18: case 19: case 21: case 33:
                 note_overlay_activity();
                 loop_profile_note_overlay_cmd();
                 break;
@@ -715,6 +715,8 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                     // (case 11) still holds: reports are dispatched sequentially
                     // and the bridge completes before this case returns.
                     overlay_map_sync_t map_sync;
+                    map_sync.width = OVERLAY_MAP_IDX_BITS;   // cmd 21 is fixed 10-bit
+                    map_sync.bytes = HID_DATA_MAX;
                     memcpy(map_sync.mapping, &data[HID_DATA_IDX], HID_DATA_MAX);
                     // A chunk is one-shot — nothing re-fires it (unlike the periodic
                     // state syncs, where the diff IS the retry queue). Losing one used
@@ -730,13 +732,42 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                     // Render only if this chunk remapped a position that is on screen;
                     // an all-off-screen chunk (non-held variants, off-layer keys) is
                     // staged silently and shown by the enable-overlays refresh.
-                    if (set_packed_overlay_mapping(&data[HID_DATA_IDX])) {
+                    if (set_packed_overlay_mapping(&data[HID_DATA_IDX], HID_DATA_MAX,
+                                                   OVERLAY_MAP_IDX_BITS)) {
                         request_disp_refresh();
                     }
                     // Routine per-chunk chatter — set_packed_overlay_mapping already
                     // logs the decoded pairs under the same gate.
                     if (debug_enable) {
                         uprint("Overlay mapping data received.\n");
+                    }
+                }
+                break;
+            case 33: // receive overlay mapping, host-chosen value width (v12+)
+                {
+                    // Same stream as cmd 21, but data[2] carries the WIDTH so the host
+                    // can send each group of pairs at the narrowest width it fits in:
+                    // 8 bits = 30 pairs/report, 9 = 27, 10 = 24, 11 = 22. Pairs are
+                    // order-independent (each is a standalone assignment), so the host
+                    // partitions them by required width rather than by index order —
+                    // variants 0..10 keep riding the dense 10-bit form and only the
+                    // high GUI combos pay for 11. Silent, like cmd 21.
+                    const uint8_t width = data[HID_DATA_IDX];
+                    overlay_map_sync_t map_sync;
+                    map_sync.width = width;
+                    map_sync.bytes = OVERLAY_MAP_W_BYTES;
+                    memcpy(map_sync.mapping, &data[OVERLAY_MAP_W_HDR], OVERLAY_MAP_W_BYTES);
+                    if (!sync_succeeded(send_to_bridge(USER_SYNC_OVERLAY_MAP_DATA, (void*)&map_sync,
+                                                       sizeof(overlay_map_sync_t), 10))) {
+                        note_overlay_map_sync_lost();
+                        uprint("Warning: overlay mapping chunk did not reach the slave; repairing at enable.\n");
+                    }
+                    if (set_packed_overlay_mapping(&data[OVERLAY_MAP_W_HDR],
+                                                   OVERLAY_MAP_W_BYTES, width)) {
+                        request_disp_refresh();
+                    }
+                    if (debug_enable) {
+                        uprintf("Overlay mapping data received (%u-bit).\n", (unsigned)width);
                     }
                 }
                 break;

--- a/keyboards/polykybd/multicore_exec.c
+++ b/keyboards/polykybd/multicore_exec.c
@@ -11,7 +11,7 @@
 #include "polymod_rle.h"
 #include "base/disp_array.h"
 #include "base/multicore/core1.h"
-#include "fill_overlay.h"   // for set_overlay_usage_post_upload
+#include "fill_overlay.h"   // for mark_display_has_overlay_post_upload
 
 #ifdef USE_CORE1
 static volatile uint16_t core1_bit_index = 0;
@@ -67,7 +67,7 @@ void core1_entry(void) {
                     core1_bit_index += rle_decompress(get_overlay(core1_idx)+core1_bit_index/8, PK_MAX(0,core1_max_bitlen), core1_buffer, data_len, core1_bit_index);
 
                     if (core1_bit_index >= 360*8 -1) {
-                        set_overlay_usage_post_upload(core1_idx);
+                        mark_display_has_overlay_post_upload(core1_idx);
                         // No update_performed() — a host overlay push is not user
                         // activity and must not restart the idle countdown (see
                         // base/update.h). Also keeps core1 out of the idle-timer
@@ -92,7 +92,7 @@ void core1_entry(void) {
                     }
                     core1_bit_index = copy_rectangle_to_overlay(core1_bit_index, get_overlay(core1_idx), core1_buffer, &core1_roi, data_len);
                     if(core1_bit_index >= 2880) {
-                        set_overlay_usage_post_upload(core1_idx);
+                        mark_display_has_overlay_post_upload(core1_idx);
                         // No update_performed() — see base/update.h.
                         // Only refresh a variant that is actually on screen (core1_visible).
                         if (core1_visible) {

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -2027,7 +2027,7 @@ bool copy_overlay_to_buffer(uint16_t keycode, uint8_t mods) {
     // Record that this keycode-slot is on screen (LAYER visibility for the render gate).
     s_displayed_slots[idx >> 3] |= (uint8_t)(1u << (idx & 7));
     idx = adjust_overlay_idx_to_mod(idx, mods);
-    // use_overlay[] is from-indexed (see set_10bit_overlay_mapping): check it
+    // use_overlay[] is from-indexed (see set_packed_overlay_mapping): check it
     // here on the display position, before resolving to the pool slot.
     if(!is_overlay_used(idx)) {
         return false;

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -2027,12 +2027,12 @@ bool copy_overlay_to_buffer(uint16_t keycode, uint8_t mods) {
     // Record that this keycode-slot is on screen (LAYER visibility for the render gate).
     s_displayed_slots[idx >> 3] |= (uint8_t)(1u << (idx & 7));
     idx = adjust_overlay_idx_to_mod(idx, mods);
-    // use_overlay[] is from-indexed (see set_packed_overlay_mapping): check it
+    // display_has_overlay_bits[] is from-indexed (see set_packed_overlay_mapping): check it
     // here on the display position, before resolving to the pool slot.
-    if(!is_overlay_used(idx)) {
+    if(!display_has_overlay(idx)) {
         return false;
     }
-    idx = get_overlay_mapping(idx);
+    idx = get_display_pool_slot(idx);
 
     // Overlay images are ROW-MAJOR MSB-first (host: np.packbits over the 40x72 mask),
     // which is what kdisp_draw_bitmap reads — so the courtyard must use the row-major
@@ -3382,10 +3382,10 @@ void keyboard_post_init_user(void) {
     mru_init();
     splash_progress(3);                 // language/emoji/MRU init done
 
-    reset_overlay_buffers();
-    reset_overlay_usage();
+    reset_overlay_pool();
+    clear_display_has_overlay();
     //standard mapping is 1:1
-    reset_overlay_mapping();
+    reset_display_to_pool();
 
 #ifdef FW_UP_BOOT_TRACE
     boot_trace(U"2");

--- a/keyboards/polykybd/split_sync.c
+++ b/keyboards/polykybd/split_sync.c
@@ -353,7 +353,7 @@ void user_sync_overlay_map_data_handler(uint8_t in_len, const void* in_data, uin
     // Render only if this chunk remapped an on-screen position (the slave has its own
     // displayed-slot set + synced mods); an all-off-screen chunk is shown by the
     // enable-overlays state sync (DISPLAY_OVERLAYS in OVERLAY_SYNCED_STATE_FLAGS).
-    if (set_10bit_overlay_mapping((uint8_t *)data->mapping)) {
+    if (set_packed_overlay_mapping((uint8_t *)data->mapping)) {
         request_disp_refresh();
     }
     ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK;

--- a/keyboards/polykybd/split_sync.c
+++ b/keyboards/polykybd/split_sync.c
@@ -353,7 +353,7 @@ void user_sync_overlay_map_data_handler(uint8_t in_len, const void* in_data, uin
     // Render only if this chunk remapped an on-screen position (the slave has its own
     // displayed-slot set + synced mods); an all-off-screen chunk is shown by the
     // enable-overlays state sync (DISPLAY_OVERLAYS in OVERLAY_SYNCED_STATE_FLAGS).
-    if (set_packed_overlay_mapping((uint8_t *)data->mapping)) {
+    if (set_packed_overlay_mapping(data->mapping, data->bytes, data->width)) {
         request_disp_refresh();
     }
     ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK;

--- a/keyboards/polykybd/split_sync.c
+++ b/keyboards/polykybd/split_sync.c
@@ -78,7 +78,7 @@ void user_sync_poly_data_handler(uint8_t in_len, const void* in_data, uint8_t ou
     // Detect action flags newly set in this sync and run them immediately,
     // mirroring the master's case-11 handling. Without this, a mapping
     // bridge transaction arriving before housekeeping runs would have its
-    // use_overlay bits wiped by a later deferred reset_overlay_usage().
+    // display_has_overlay_bits bits wiped by a later deferred clear_display_has_overlay().
     uint8_t newly_set     = (incoming->overlay_flags & ~current->overlay_flags);
 #ifdef RGB_MATRIX_ENABLE
     uint8_t newly_cleared = (current->overlay_flags  & ~incoming->overlay_flags);
@@ -184,7 +184,7 @@ void user_sync_overlay_data_handler(uint8_t in_len, const void* in_data, uint8_t
     // get_overlay()/FW-4.)
     memcpy(get_overlay(ov->adj_idx) + ov->segment*BYTES_PER_SEGMENT, ov->overlay, BYTES_PER_SEGMENT);
     if(ov->segment==NUM_SEGMENTS_PER_OVERLAY-1) {
-        set_overlay_usage_post_upload(ov->adj_idx);
+        mark_display_has_overlay_post_upload(ov->adj_idx);
         request_disp_refresh();
     }
     ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK;
@@ -210,7 +210,7 @@ void user_sync_compressed_overlay_data_handler(uint8_t in_len, const void* in_da
     int16_t maxlen = 360 - hid_bit_index/8;
     hid_bit_index += rle_decompress(get_overlay(ov->adj_idx)+hid_bit_index/8, PK_MAX(0,maxlen), ov->compressed, ov->len, hid_bit_index);
     if (hid_bit_index >= 360*8) {
-        set_overlay_usage_post_upload(ov->adj_idx);
+        mark_display_has_overlay_post_upload(ov->adj_idx);
         request_disp_refresh();
         hid_bit_index = 0;
     }
@@ -246,7 +246,7 @@ void user_sync_roi_data_handler(uint8_t in_len, const void* in_data, uint8_t out
         if(new_index >= 2880) {
             //finished roi update
             ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK_SIG;
-            set_overlay_usage_post_upload(roi_ov->adj_idx);
+            mark_display_has_overlay_post_upload(roi_ov->adj_idx);
             request_disp_refresh();
         } else {
             ((poly_sync_reply_t*)out_data)->ack = SYNC_ACK;

--- a/keyboards/polykybd/split_sync.h
+++ b/keyboards/polykybd/split_sync.h
@@ -55,8 +55,16 @@ typedef struct _dynamic_keymap_sync_t {
     uint8_t  commands[RAW_EPSIZE];
 } dynamic_keymap_sync_t;
 
+// A bridged overlay-mapping report. `width`/`bytes` describe the packed stream so
+// the slave decodes it exactly as the master did — they differ per source: cmd 21
+// is always (10, HID_DATA_MAX) while cmd 33 carries the host's chosen width over
+// OVERLAY_MAP_W_BYTES. There is no count field (the sender fills every value by
+// repeating the last pair), so getting these two wrong decodes trailing junk as
+// real mappings.
 typedef struct _overlay_map_sync_t {
     uint32_t crc32;
+    uint8_t  width;
+    uint8_t  bytes;
     uint8_t  mapping[HID_DATA_MAX];
 } overlay_map_sync_t;
 


### PR DESCRIPTION
## Summary

GUI could not be combined with another modifier for overlays. `adjust_overlay_idx_to_mod()` short-circuited any `mods & GUI` to variant 8, so **Cmd+Shift, Cmd+Alt and Cmd+Shift+Alt all rendered the bare Cmd overlay**.

Reported in [PolyKybdHost#131](https://github.com/thpoll83/PolyKybdHost/issues/131): Mac apps lean on those chords heavily — Sublime Text binds `Cmd+Shift+P` (command palette) and `Cmd+Shift+Alt+P`, and both drew the Cmd image.

Three commits, each independently reviewable:

### 1. `a0928604` — GUI combines with the other modifiers

The modifier variant is now just the L/R-folded QMK modifier bitmask (bit0 Ctrl, bit1 Shift, bit2 Alt, bit3 GUI), so all 16 combinations are addressable and the numbering is self-describing. That is what the existing 0..8 numbering already was, minus the GUI special case — the function reduces to one line.

`NUM_VARIATIONS_WITH_MAP` 9 → 16 grows the flat (slot, variant) index space 810 → 1440. **The three image-upload commands are unchanged** — they all already carry the modifier in a 4-bit field.

RAM: **+1336 B of `.bss`** (`display_to_pool` 1620 → 2880, the usage bitmap 102 → 181). The 216 kB image pool is untouched, since variants sharing artwork still share one pool slot — more variants cost address space, not pixels.

> ℹ️ `CLAUDE.md` says the monolith had **20 bytes** of `.heap` free at v0.9.82. That is stale — it measured **10,812 B** free on 0.9.89 before this change, and 9,476 B after. Worth correcting in the doc.

### 2. `f62bd734` — rename the mapping tables for what they map

Pure rename, no behaviour or wire change. Three different things all began with "overlay", and `overlay_map` said nothing about what maps to what:

| before | after |
|---|---|
| `overlays` | `overlay_pool` (bank of keycap images) |
| `overlay_map` | `display_to_pool` (display position → pool slot) |
| `get/set_overlay_mapping` | `get/set_display_pool_slot` |
| `use_overlay` | `display_has_overlay_bits` |
| `is_overlay_used` | `display_has_overlay` |

This adopts the vocabulary the host already uses (`display_flat_idx` / `pool_slot_to_firmware_address`). `base/overlay.h` gains a header comment defining the three concepts plus a legacy-name table, so older commits and docs stay searchable.

### 3. `6e1a2288` — variable-width mapping command

Widening every mapping report to 11 bits would have taxed every app switch forever to accommodate variants most templates never author. Instead cmd 21 keeps its original fixed 10 bits, and a new **cmd 33** carries a width byte.

Mapping pairs are order-independent, so the host partitions them by *required* width — `max(bits(from), bits(to))` — rather than by index order:

| width | pairs/report | covers `from` for |
|---|---|---|
| 8 | 30 | variants 0–1 fully |
| 9 | 27 | variants 0–4 fully |
| 10 | 24 | variants 0–10 fully |
| 11 | 22 | everything |

11 is the ceiling — max `from` is `90*15+89 = 1439 < 2048`, so 12+ is never needed. **Because variants 0..10 all fit in 10 bits, Cmd / Cmd+Ctrl / Cmd+Shift keep riding the dense 10-bit form at 24 pairs/report — no regression versus today** — and only Cmd+Alt and above pay for 11.

Two correctness points in the codec:

- Both the second **and** third byte reads are now conditional on the value actually extending there. At width 8 every value is one whole byte, so an unconditional `b+1` read could reach past the last data byte.
- The old fixed expression computed `0xff >> (8 - num_bits_in_byte2)`, which at offset 7 is a **shift by −2**. Unreachable at 10 bits (`gcd(10,8)=2` keeps offsets in {0,2,4,6}) but hit by the odd widths 9 and 11.

Padding now **repeats the last pair** rather than using an out-of-range sentinel. Re-applying a mapping is idempotent, so a duplicate is a semantic no-op — which matters because a sentinel would have to exceed `OVERLAY_MAP_IDX_CNT` (1440) and cannot be expressed at the narrower widths at all. This also fixes a latent bug commit 1 introduced on its own: the host pads with `from = 810`, which was out of range at 9 variants but is now the **real** index of variant 9, slot 0.

## Version bump label

**None** — `PROTOCOL_VERSION` is bumped 11 → 12 in-source, so a `bump:protocol` label would double-bump.

Matching host PR: **thpoll83/PolyKybdHost#134** (`__protocol__` → 12 in the same way).

## Testing

- [x] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`)
- [x] `POLYKYBD_DOOM=yes` monolith also links — the tightest RAM flavour, and not built by PR CI. `.heap` 9,476 B free.
- [ ] Flashed and tested on hardware — **not done, I have no device**
- [x] If protocol changed: host updated and tested together (host suite green, 1262 tests)

Codec verified by round-tripping the packer through the decoder rather than by eye, per the standing rule: the two functions were compiled verbatim into a host test and exercised at widths 8–16 over 60/62-byte buffers with a canary past the data area — no mismatches, no out-of-range writes.

⚠️ **Wants a hardware round before merge.** The overlay path is display-visible and has bitten before; what would exercise it best is a Mac template authoring a `Cmd+Shift` cell, plus an app switch on a split to confirm the mapping still lands on the slave half.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded overlay modifier combinations from 9 to 16, allowing GUI combinations with other modifiers.
  - Added support for variable-width packed overlay mappings, including wider repair mappings.
  - Improved overlay synchronization between split keyboard halves, with automatic repair and display refreshes.
  - Added activity tracking for overlay mapping updates and sized mapping commands.

- **Bug Fixes**
  - Improved handling of invalid overlay slots by safely redirecting them without repeated logging.
  - Ensured overlay state and mappings reset consistently during startup and mode transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->