### PR TITLE
FW-2: enforce image signatures, with a physical-presence override

### DIFF
--- a/keyboards/polykybd/base/fw_staging.c
+++ b/keyboards/polykybd/base/fw_staging.c
@@ -467,6 +467,36 @@ void fw_staging_set_signature(const uint8_t sig[FW_SIG_LEN]) {
     s_signature_present = true;
 }
 
+// FW-2 physical-presence override. Under FW_REQUIRE_SIGNATURE an unsigned or badly
+// signed image is refused — but a developer flashing their own build needs a way
+// through that malware cannot take. An acknowledgement carried over HID would be
+// worthless: the HID flash surface is exactly what signing defends, so anything a
+// host can send, an attacker can send too. A KEYPRESS cannot be forged remotely,
+// so arming is a physical act on the keyboard and nothing else can do it.
+//
+// RAM-only and time-limited on purpose: it must not survive a reboot or sit armed
+// indefinitely, or it degrades into a permanently disabled check.
+static bool     s_unsigned_armed    = false;
+static uint32_t s_unsigned_armed_at = 0;
+
+void fw_staging_arm_unsigned(void) {
+    s_unsigned_armed    = true;
+    s_unsigned_armed_at = timer_read32();
+    uprintf("FW_UP: unsigned-image override ARMED for %lus\n",
+            (unsigned long)(FW_UNSIGNED_ARM_WINDOW_MS / 1000));
+}
+
+bool fw_staging_unsigned_armed(void) {
+    // timer_elapsed32() is modular, so this stays correct across the 49.7-day
+    // timer wrap — the same trap that once disabled idle for a 25-day window
+    // (see the update.c signed-timestamp bug).
+    return s_unsigned_armed && timer_elapsed32(s_unsigned_armed_at) < FW_UNSIGNED_ARM_WINDOW_MS;
+}
+
+void fw_staging_disarm_unsigned(void) {
+    s_unsigned_armed = false;
+}
+
 // FW-2: verify the staged FIRMWARE image's Ed25519 signature against the embedded
 // public key. The image is read straight from XIP flash (memory-mapped), so no RAM
 // copy of the (up to ~2 MB) image is needed. Returns:
@@ -570,13 +600,23 @@ static bool fw_staging_finalize_impl(bool defer_fontpack_reload) {
                 uprintf("FW_UP: image UNSIGNED (no signature supplied)\n");
             }
 #ifdef FW_REQUIRE_SIGNATURE
-            // Enforcement (flip on once a real key is provisioned and releases are
-            // signed): reject anything but a valid signature. Phase A leaves this
-            // undefined → verify-and-warn only, so flashing keeps working today.
+            // Enforcement: reject anything but a valid signature, UNLESS the user
+            // physically armed the override on the keyboard (KC_ALLOW_UNSIGNED)
+            // within the last FW_UNSIGNED_ARM_WINDOW_MS. See fw_staging_arm_unsigned.
             if (sig != 1) {
-                uprintf("FW_UP: REJECTED — FW_REQUIRE_SIGNATURE and image not validly signed\n");
-                ok = false;
+                if (fw_staging_unsigned_armed()) {
+                    uprintf("FW_UP: unsigned/invalid image ALLOWED — physical override armed\n");
+                } else {
+                    uprintf("FW_UP: REJECTED — image not validly signed. Press the "
+                            "'allow unsigned firmware' key on the keyboard, then flash "
+                            "again within %lus.\n",
+                            (unsigned long)(FW_UNSIGNED_ARM_WINDOW_MS / 1000));
+                    ok = false;
+                }
             }
+            // One flash per arming: consume it either way, so a single keypress can
+            // never authorise a second image the user did not intend.
+            fw_staging_disarm_unsigned();
 #endif
         }
         // FIRMWARE: stamp the staging header {magic,size,crc} so the staged image

--- a/keyboards/polykybd/base/fw_staging.h
+++ b/keyboards/polykybd/base/fw_staging.h
@@ -35,6 +35,18 @@
 #define FW_UP_CHUNK_SIZE 56
 
 // Must be called once before any other fw_staging_* function.
+// FW-2 physical-presence override: how long an arming keypress stays valid.
+// Long enough to arm, alt-tab and start a flash; short enough that it cannot be
+// left armed by accident. RAM-only — a reboot always disarms.
+#define FW_UNSIGNED_ARM_WINDOW_MS 120000u
+
+// Arm/query/consume the override. Arming is deliberately reachable ONLY from a
+// keycode (KC_ALLOW_UNSIGNED): an acknowledgement sent over HID would be
+// forgeable by the very surface signing defends, so it must be a physical act.
+void fw_staging_arm_unsigned(void);
+bool fw_staging_unsigned_armed(void);
+void fw_staging_disarm_unsigned(void);
+
 void fw_staging_init(void);
 
 // Staging target: which flash region a begin/chunk/finalize sequence writes to,

--- a/keyboards/polykybd/keycode_helper.h
+++ b/keyboards/polykybd/keycode_helper.h
@@ -169,6 +169,13 @@ enum my_keycodes {
     // Settings-layer key: replay the one-time startup ("Eden") animation on demand.
     // Appended at the very end (QK_USER range) so no existing keycode is renumbered.
     KC_EDEN,
+
+    // FW-2: arm the physical-presence override that lets ONE unsigned/invalid
+    // firmware image through under FW_REQUIRE_SIGNATURE. Must be a keycode rather
+    // than a HID command — the HID flash path is precisely what signing defends,
+    // so an acknowledgement sent over it would be forgeable. Appended at the end,
+    // same reason as KC_EDEN.
+    KC_ALLOW_UNSIGNED,
 };
 static_assert((int)KC_DAUTO <= (int)QK_KB_31, "Too many custom QK key codes");
 static_assert((int)KC_DAUTO < (int)KCL_ENUS, "Overlap detected");

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -3122,6 +3122,16 @@ void post_process_record_user(uint16_t keycode, keyrecord_t* record) {
             request_disp_refresh();
             break;
         }
+        case KC_ALLOW_UNSIGNED:
+            // FW-2: arm the physical-presence override for one unsigned/invalid
+            // firmware image (see fw_staging_arm_unsigned). Master-only — the
+            // master is what verifies the signature and gates the apply, so
+            // arming on the slave would have nothing to authorise.
+            if (is_keyboard_master()) {
+                fw_staging_arm_unsigned();
+            }
+            break;
+
         case KC_STORE_EE:
             // Manual "commit everything to EEPROM" — for users who want to be
             // sure their changes survive a hard power-cut without suspending.

--- a/keyboards/polykybd/rules.mk
+++ b/keyboards/polykybd/rules.mk
@@ -277,3 +277,18 @@ ifneq ($(strip $(POLYKYBD_DOOM_PACK)), yes)
            lib/pico-sdk/src/rp2_common/hardware_sync/sync.c
 endif
 endif
+
+# FW-2: enforce firmware image signatures. Only an image carrying a valid Ed25519
+# signature over the project key (base/fw_pubkey.h) is applied.
+#
+# Enabled 2026-08-04, after the full chain was verified on hardware: a signed
+# release produced "image signature OK" and a byte-flipped signature produced
+# "INVALID", so the check is known to discriminate rather than rubber-stamp.
+#
+# There is a deliberate escape hatch for unsigned developer builds:
+# KC_ALLOW_UNSIGNED arms a 2-minute, single-use, RAM-only override ON THE
+# KEYBOARD. It is a keycode and not a HID command because the HID flash surface
+# is exactly what this defends — an acknowledgement sent over HID would be
+# forgeable by an attacker. BOOTSEL/UF2 also remains unaffected (it bypasses
+# fw_staging entirely), so this can never brick a board.
+OPT_DEFS += -DFW_REQUIRE_SIGNATURE

--- a/keyboards/polykybd/split42/keymaps/default/keymap.c
+++ b/keyboards/polykybd/split42/keymaps/default/keymap.c
@@ -167,7 +167,7 @@ const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         KC_BASE, LBL_TEXT,KC_TOGMODS,
         KC_NO,   KC_NO,   KC_NO,   KC_NO,   QK_MAKE, QK_BOOT,
         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   QK_RBT,
-        EE_CLR,  KC_STORE_EE, KC_NO, KC_NO, KC_NO,   KC_NO,
+        EE_CLR,  KC_STORE_EE, KC_ALLOW_UNSIGNED, KC_NO, KC_NO,   KC_NO,
         DB_TOGG, KC_DEADKEY, KC_BASE
     ),
     // Language selection layer — mirrors the emoji picker. LEFT half: row 0 = the

--- a/keyboards/polykybd/split72/keymaps/default/keymap.c
+++ b/keyboards/polykybd/split72/keymaps/default/keymap.c
@@ -236,7 +236,7 @@ const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                     RM_PREV,   RGB_M_SW,   RGB_M_R,    KC_RGB_TOG, RGB_M_P,    RGB_M_B,    RM_NEXT,
                     KC_NO,      RM_SPDD,    RM_SPDU,    KC_NO,      RM_HUED,    RM_HUEU,    KC_NO,
         _______,    KC_NO,      RM_VALD,    RM_VALU,    KC_NO,      RM_SATD,    RM_SATU,    KC_NO,
-        EE_CLR,     KC_STORE_EE, KC_EDEN,   KC_NO,      KC_NO,      KC_NO,      KC_NO,      KC_NO,
+        EE_CLR,     KC_STORE_EE, KC_EDEN,   KC_ALLOW_UNSIGNED, KC_NO, KC_NO,   KC_NO,      KC_NO,
         DB_TOGG,    KC_DEADKEY, KC_NO,                  KC_NO,      KC_NO,      KC_NO,      KC_BASE
         ),
     // Language Selection Layer — mirrors the emoji picker. TOP row of the LEFT

--- a/keyboards/polykybd/tools/SIGNING.md
+++ b/keyboards/polykybd/tools/SIGNING.md
@@ -26,10 +26,41 @@ pipeline are put in place. The serial/HID console shows one of:
     FW_UP: image signature INVALID
     FW_UP: image UNSIGNED (no signature supplied)
 
-To **enforce** later (reject anything but a valid signature), define
-`FW_REQUIRE_SIGNATURE` (e.g. in `rules.mk`: `OPT_DEFS += -DFW_REQUIRE_SIGNATURE`)
-and flash that build — but only **after** the steps below, and after adding
-slave-side verification (see "Not yet done" at the bottom).
+**ENFORCEMENT IS NOW ON** (2026-08-04, `rules.mk`: `OPT_DEFS += -DFW_REQUIRE_SIGNATURE`).
+An image without a valid signature is refused at COMMIT. Enabled only after the
+whole chain was demonstrated on hardware: a signed release logged `image signature
+OK`, and a byte-flipped signature logged `INVALID` — the second test is the one that
+matters, since it proves the check discriminates rather than rubber-stamps, and a
+passing flash alone cannot show that.
+
+## Flashing an UNSIGNED build (developer escape hatch)
+
+Your own `qmk compile` output is unsigned, so under enforcement it will be refused
+over HID. Two ways through:
+
+1. **Sign it** (preferred — same path releases take):
+
+   ```bash
+   arm-none-eabi-objcopy -O binary .build/polykybd_split72_default.elf out.bin
+   python3 keyboards/polykybd/tools/sign_firmware.py --privkey fw_signing_key.bin out.bin
+   ```
+
+2. **Arm the physical override**: press **`KC_ALLOW_UNSIGNED`** on the keyboard
+   (settings layer, next to the Eden key), then start the flash within
+   **`FW_UNSIGNED_ARM_WINDOW_MS`** (2 minutes). It is **single-use** — consumed by
+   the next COMMIT whether or not that image was signed — and **RAM-only**, so a
+   reboot disarms it.
+
+⚠️ **Why a keycode and not a host dialog / HID command.** The threat FW-2 addresses
+is *any process that can talk the HID flash protocol*. An acknowledgement carried
+over that same channel is forgeable by exactly the attacker it is meant to stop:
+malware would set the flag and flash whatever it liked. A keypress cannot be
+produced remotely, so the override is worth something. Do not "improve" this into a
+host-side confirmation.
+
+**BOOTSEL/UF2 is unaffected** — it bypasses `fw_staging` entirely, so it remains an
+unconditional recovery path and enforcement cannot brick a board. That also means
+the HIL rig is untouched: `polykybd-ctnd` flashes with `picotool`, not over HID.
 
 ## One-time setup
 

--- a/keyboards/polykybd/tools/sign_firmware.py
+++ b/keyboards/polykybd/tools/sign_firmware.py
@@ -21,6 +21,7 @@ Requires: ``pip install cryptography``.
 """
 import argparse
 import base64
+import binascii
 import os
 import sys
 from pathlib import Path
@@ -33,7 +34,27 @@ def _load_seed(privkey: Path | None) -> bytes:
         b64 = os.environ.get("FW_SIGNING_KEY")
         if not b64:
             raise SystemExit("error: pass --privkey or set FW_SIGNING_KEY (base64 seed)")
-        seed = base64.b64decode(b64)
+        # Strip surrounding whitespace, and diagnose rather than traceback. Getting
+        # this secret in by hand is error-prone in a way that is invisible from the
+        # raw exception: b64decode() SILENTLY DISCARDS characters outside the base64
+        # alphabet, but letters are inside it — so copying the tool's label along
+        # with the value ("FW_SIGNING_KEY (base64 ...):") absorbs those letters,
+        # breaks the length, and raises "Incorrect padding" while the trailing "="
+        # is still visibly present. That reads as "the padding is missing" and sends
+        # you looking in the wrong place (cost two release runs, 2026-08).
+        b64 = b64.strip()
+        try:
+            seed = base64.b64decode(b64, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise SystemExit(
+                f"error: FW_SIGNING_KEY is not valid base64 ({exc}).\n"
+                f"       got {len(b64)} characters; a 32-byte seed is exactly 44, "
+                f"ending in '='.\n"
+                "       Regenerate it from the key file rather than re-copying:\n"
+                "         python3 -c \"import base64,pathlib;"
+                "print(base64.b64encode(pathlib.Path('fw_signing_key.bin')"
+                ".read_bytes()).decode())\""
+            ) from None
     if len(seed) != 32:
         raise SystemExit(f"error: private seed must be 32 bytes, got {len(seed)}")
     return seed


### PR DESCRIPTION
Turns on signature enforcement and gives unsigned developer builds a way through that an attacker cannot take. Two commits — the second was already open here as the `FW_SIGNING_KEY` diagnostic fix; it rode the same branch, so it stays.

## Why this is safe to enable now

Enforcement was held back until the chain was demonstrated on real hardware, and both halves were:

| Test | Result |
|---|---|
| signed `v0.9.94` release flashed over HID | `FW_UP: image signature OK` |
| byte-flipped `.sig` | `FW_UP: image signature INVALID` |

The second is the one that licenses this change. Enforcement rejects on `sig != 1`, so a verifier that returned OK for a bad signature would make `FW_REQUIRE_SIGNATURE` pure theatre — and a passing flash alone can never show the difference. Verified OK *and* INVALID, so the check genuinely discriminates.

## The escape hatch, and why it's a keycode

A firmware you compiled yourself is unsigned, so under enforcement it is refused. `KC_ALLOW_UNSIGNED` arms a **single-use, RAM-only, 2-minute** window that lets one unsigned or invalid image through.

⚠️ **It is a keypress, not a host dialog or an HID command, and that is the whole point.** FW-2's threat model is *any process that can talk the HID flash protocol*. An acknowledgement carried over that same channel is forgeable by exactly the attacker it is meant to stop — malware would set the flag and flash whatever it liked. A keypress cannot be produced remotely. Please don't "improve" this into a checkbox in the host app; the comments in `rules.mk`, `fw_staging.c` and `SIGNING.md` all say so, because it is the obvious next suggestion.

Design details worth reviewing:

- **Consumed on every COMMIT**, signed or not — one keypress can never authorise a second image the user didn't intend.
- **`timer_elapsed32()`, not a subtraction**, so the window stays correct across the 49.7-day timer wrap. That is the exact trap that once disabled idle for a 25-day window (`base/update.c`).
- **Master-only arming** — the master is what verifies and gates the apply, so arming on the slave would have nothing to authorise.
- **Rejection is instructive**: the console names the key to press and the window, instead of only reporting refusal.
- **Wired into both default keymaps** (settings layer, beside the Eden key). An unreachable keycode would not be an escape hatch at all — this mattered as much as the mechanism.

## What can't break

- **BOOTSEL/UF2 bypasses `fw_staging` entirely**, so it stays an unconditional recovery path. Enforcement cannot brick a board.
- **The HIL rig is untouched** — `polykybd-ctnd`'s `flash.py` uses `sudo picotool load`, i.e. BOOTSEL, not the HID staging path.
- **Released firmware is signed automatically** by release CI, so normal user updates are unaffected.

One operational consequence worth noting: if `FW_SIGNING_KEY` is ever removed, releases silently go back to unsigned (a `::notice::`, green run) — and with enforcement on, those releases won't flash. The `.sig`-asset check stops being cosmetic.

## Builds

- `split72:default` ✅
- `split42:default` ✅
- **`split72 -e POLYKYBD_DOOM=yes` (monolith) ✅** — built because this adds statics and the monolith is the tightest RAM flavour, per the repo's own rule. Links with **9,340 bytes** of `.heap` free.

## Also in this PR (pre-existing commit)

`fix(tools): diagnose a bad FW_SIGNING_KEY instead of raising a traceback` — two release runs died on a bare `binascii.Error: Incorrect padding`, which reads as "the padding is missing" when the real cause was a value one character short (`b64decode` discards non-alphabet characters but keeps letters, so the trailing `=` was still visibly there). Now reports the character count against the expected 44 plus a regeneration one-liner.

## Docs

`SIGNING.md` rewritten for the enforced state, plus a matching update to the public docs site (polykybd-docs, separate PR) — its aside still told readers unsigned images always flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qc8ktXFoysiKAfTSSjpkB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added signature enforcement for staged firmware updates.
  * Added a physical, single-use override for unsigned firmware, available for two minutes.
  * Added settings-layer controls for authorized override access.

* **Bug Fixes**
  * Added stricter validation for firmware signing keys.
  * Malformed values now produce clear error messages and replacement-key guidance.
  * Leading and trailing whitespace is handled automatically.

* **Documentation**
  * Updated firmware signing and recovery guidance, including supported recovery workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->