### PR TITLE
CLAUDE.md: two CodeRabbit behaviours that cost a review cycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,18 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
     comment **`@coderabbitai review`** on the final commit for a single full-diff
     review; **`@coderabbitai resume`** turns automatic reviews back on. Both
     commands are listed in the paused comment itself.
+  - ⚠️ **A push while a review is in flight ABORTS it** — "Review failed: The head
+    commit changed during the review from `<a>` to `<b>`". The run is lost, not
+    resumed, and re-triggering costs another slot against the rate limit. So once
+    a review starts, **hold pushes until it reports** (2026-08, cost a full cycle).
+  - ⚠️ **Order matters: `resume` BEFORE `review` makes the review a no-op.**
+    CodeRabbit is incremental and "does not re-review already reviewed commits";
+    that guard is only relaxed *while reviews are paused*. Resuming first
+    un-pauses, so the following `review` finds nothing to do and silently reviews
+    nothing. Either `review` first and `resume` after, or use **`@coderabbitai
+    full review`**, which re-reviews the whole diff regardless of state — that is
+    also the command to reach for after an aborted run, since the failed run
+    recorded nothing but the head has already moved.
 
 ## Branching (all PolyKybd repos)
 


### PR DESCRIPTION
## Summary

Documentation only — 12 lines added to the CodeRabbit section of `CLAUDE.md`. No firmware change.

The auto-pause and the per-developer rate limit were already written up there; these two behaviours were not, and between them they burned a full review plus a rate-limit wait during PolyKybd#19.

**A push while a review is IN FLIGHT aborts it** — *"Review failed: The head commit changed during the review from `<a>` to `<b>`"*. The run is lost rather than resumed, and re-triggering spends another slot against the rate limit. So once a review starts, hold pushes until it reports.

**`resume` before `review` makes the review a no-op.** CodeRabbit is incremental and "does not re-review already reviewed commits" — and that guard is relaxed *only while reviews are paused*. Resuming first un-pauses, so the following `review` finds nothing to do and silently reviews nothing while reporting success. Either `review` first and `resume` after, or use `@coderabbitai full review`, which re-reviews the whole diff regardless of state. `full review` is also the right command after an *aborted* run, since the failed run recorded nothing but the head has already moved.

Both were hit in the same session, in that order, which is how the second one was found: the recovery from the first (a `resume`) is what made the retry silently do nothing.

## Version bump label

*(none)* — patch. Documentation only; no code, no protocol change.

## Testing

- [ ] Compiled successfully — n/a, no source file touched (`CLAUDE.md` only)
- [ ] Flashed and tested on hardware — n/a
- [ ] If protocol changed: host updated and tested together — n/a, no protocol change

---
_Generated by [Claude Code](https://claude.ai/code/session_01JUbhQNpubfrBdkMVDV7cS4)_

## Summary by Sourcery

Documentation:
- Expand CodeRabbit section in CLAUDE.md with guidance on in-flight push abort behavior and resume/review ordering, including use of full review after aborted runs.