### PR TITLE
FW-2: distinct COMMIT status for "refused: not validly signed"

### DIFF
--- a/keyboards/polykybd/base/fw_staging.c
+++ b/keyboards/polykybd/base/fw_staging.c
@@ -479,6 +479,13 @@ void fw_staging_set_signature(const uint8_t sig[FW_SIG_LEN]) {
 static bool     s_unsigned_armed    = false;
 static uint32_t s_unsigned_armed_at = 0;
 
+// Why the last COMMIT was refused. Without this the caller cannot tell a
+// signature refusal from a CRC mismatch — fw_staging_finalize() returns a bare
+// bool and the signature check sits behind the CRC result, so both surfaced as
+// the same NACK. The rig duly reported "staged CRC mismatch" for an image whose
+// CRC was perfect, and sent a diagnosis the wrong way (2026-08-05).
+static bool s_refused_unsigned = false;
+
 void fw_staging_arm_unsigned(void) {
     s_unsigned_armed    = true;
     s_unsigned_armed_at = timer_read32();
@@ -495,6 +502,10 @@ bool fw_staging_unsigned_armed(void) {
 
 void fw_staging_disarm_unsigned(void) {
     s_unsigned_armed = false;
+}
+
+bool fw_staging_refused_unsigned(void) {
+    return s_refused_unsigned;
 }
 
 // FW-2: verify the staged FIRMWARE image's Ed25519 signature against the embedded
@@ -538,6 +549,9 @@ bool fw_staging_process_fontpack_reload(void) {
 }
 
 static bool fw_staging_finalize_impl(bool defer_fontpack_reload) {
+    // Cleared per attempt: a stale reason would mislabel a later CRC failure as
+    // a signature refusal, which is the exact confusion this flag exists to end.
+    s_refused_unsigned = false;
     if (!s_initialized) return false;
 
     // Flush any partial final page (padded with 0xFF already from fw_staging_begin/flush_page)
@@ -607,6 +621,7 @@ static bool fw_staging_finalize_impl(bool defer_fontpack_reload) {
                 if (fw_staging_unsigned_armed()) {
                     uprintf("FW_UP: unsigned/invalid image ALLOWED — physical override armed\n");
                 } else {
+                    s_refused_unsigned = true;
                     uprintf("FW_UP: REJECTED — image not validly signed. Press the "
                             "'allow unsigned firmware' key on the keyboard, then flash "
                             "again within %lus.\n",

--- a/keyboards/polykybd/base/fw_staging.h
+++ b/keyboards/polykybd/base/fw_staging.h
@@ -47,6 +47,12 @@ void fw_staging_arm_unsigned(void);
 bool fw_staging_unsigned_armed(void);
 void fw_staging_disarm_unsigned(void);
 
+// True when the last fw_staging_finalize() refused the image because it was not
+// validly signed (as opposed to a CRC mismatch). Lets COMMIT answer with a
+// distinct status so the host and the HIL rig can report the real reason instead
+// of guessing — they are indistinguishable from the bool alone.
+bool fw_staging_refused_unsigned(void);
+
 void fw_staging_init(void);
 
 // Staging target: which flash region a begin/chunk/finalize sequence writes to,

--- a/keyboards/polykybd/hid_fw_up.c
+++ b/keyboards/polykybd/hid_fw_up.c
@@ -268,8 +268,17 @@ bool hid_fw_up_receive(uint8_t *data, uint8_t length) {
             bool master_ok = fw_staging_finalize();   // also clears fw_up_active + restarts master core1
             bool ok = (slave_ack == SYNC_ACK) && master_ok;
             memset(data, 0, length);
-            memcpy(data, ok ? "P\x42." : "P\x42!", 3);
-            uprintf("FW_UP_COMMIT: slave_ack=0x%02x master_finalize=%d\n", slave_ack, master_ok);
+            // Three outcomes, not two. 'S' distinguishes "refused: not validly
+            // signed" from '!' "staged CRC mismatch". They were the same byte
+            // until 2026-08-05, so the host and the HIL rig both reported a
+            // signature refusal as a CRC failure — a wrong answer at exactly the
+            // moment someone is trying to work out why a flash was rejected.
+            const char *status = ok ? "P\x42."
+                                    : (fw_staging_refused_unsigned() ? "P\x42S" : "P\x42!");
+            memcpy(data, status, 3);
+            uprintf("FW_UP_COMMIT: slave_ack=0x%02x master_finalize=%d%s\n",
+                    slave_ack, master_ok,
+                    fw_staging_refused_unsigned() ? " (refused: unsigned)" : "");
             raw_hid_send(data, length);
             return true;
         }

--- a/keyboards/polykybd/tools/SIGNING.md
+++ b/keyboards/polykybd/tools/SIGNING.md
@@ -33,6 +33,22 @@ OK`, and a byte-flipped signature logged `INVALID` — the second test is the on
 matters, since it proves the check discriminates rather than rubber-stamps, and a
 passing flash alone cannot show that.
 
+## Telling a refusal apart from a CRC failure
+
+`FW_UP_COMMIT` answers with three status bytes, not two:
+
+| byte | meaning |
+|---|---|
+| `.` | staged image accepted (CRC verified, signature valid or not required) |
+| `S` | **refused — image not validly signed** |
+| `!` | staged CRC mismatch (or another finalize failure) |
+
+`S` exists because the signature check sits behind the CRC result inside
+`fw_staging_finalize()`, so a bare bool cannot distinguish them. Until it was added
+the host and the HIL rig both printed "staged CRC mismatch" for images whose CRC was
+perfect — a wrong answer at precisely the moment someone is trying to find out why a
+flash was rejected.
+
 ## Flashing an UNSIGNED build (developer escape hatch)
 
 Your own `qmk compile` output is unsigned, so under enforcement it will be refused


### PR DESCRIPTION
Follow-up to #184. Fixes the ambiguity that enforcement introduced.

## The problem

`fw_staging_finalize()` returns a bare `bool`, and the signature check sits **behind** the CRC result inside it. So a signature refusal and a genuine staged-CRC mismatch arrived as the same `!` byte, and every consumer had to guess which it was. Both guessed wrong in the same direction:

- The **HIL rig** printed `FAIL: FW_UP_COMMIT NACK — staged CRC mismatch` for an image whose CRC was perfect — 7915/7915 chunks, 0 rewinds — and sent a real investigation the wrong way until the log was read closely enough to notice the image was simply unsigned.
- The **host** told users the same thing, with *"Try again"* advice that cannot possibly work: retrying an unsigned image produces an identical refusal.

## The change

`FW_UP_COMMIT` now has three status bytes:

| byte | meaning |
|---|---|
| `.` | accepted — CRC verified, signature valid or not required |
| **`S`** | **refused — image not validly signed** |
| `!` | staged CRC mismatch (or another finalize failure) |

`fw_staging_refused_unsigned()` exposes the reason. It is **cleared at the top of every finalize attempt**, so a stale value can never mislabel a later CRC failure as a signature refusal — which would be the same class of bug in reverse.

## Compatibility

- **Older firmware never sends `S`**, so nothing needs a version gate; consumers fall through to their existing behaviour.
- **The HIL rig needs no change** — polykybd-ctnd#60 already treats *any* refusal of an unsigned build as the expected outcome, so it stays green either way. It can be tightened to assert `S` specifically later.
- **PolyKybdHost** ([companion PR](https://github.com/thpoll83/PolyKybdHost/pull/138)) reports the real cause and both remedies: fetch the `.sig` that ships beside a released `.bin`, or arm the allow-unsigned key for a build you compiled yourself.

## Builds

`split72:default` ✅ · `split42:default` ✅ · `split72 -e POLYKYBD_DOOM=yes` ✅

## Docs

`SIGNING.md` gains the status-byte table and the reason `S` exists, so nobody collapses the two branches back together as redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qc8ktXFoysiKAfTSSjpkB

---
_Generated by [Claude Code](https://claude.ai/code/session_014qc8ktXFoysiKAfTSSjpkB)_

## Summary by Sourcery

Differentiate unsigned-image refusals from CRC failures in firmware updates and expose this reason through COMMIT status.

New Features:
- Add a distinct COMMIT status byte to indicate firmware images refused due to invalid or missing signatures.

Enhancements:
- Track and expose whether the last firmware finalize operation was refused for being unsigned, and propagate this to HID firmware update responses.
- Document the COMMIT status byte meanings and rationale in SIGNING.md so consumers can correctly interpret update outcomes.