### PR TITLE
FW-2: confirm an unsigned image on the keycaps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -606,6 +606,49 @@ touching at a **0px** gap, while 4 rows sat unused under the bottom row.
 ### Split synchronisation
 Seven custom QMK transaction IDs (`USER_SYNC_POLY_DATA`, `USER_SYNC_OVERLAY_DATA`, `USER_SYNC_COMPRESSED_DATA`, `USER_SYNC_ROI_DATA`, etc.) carry state and overlay data to the slave half over UART with CRC32 validation and up to 10 retries.
 
+### Firmware signing enforcement & the on-keycap confirmation (FW-2)
+
+`rules.mk` sets `-DFW_REQUIRE_SIGNATURE`, so `fw_staging_finalize()` only stamps the
+staging header for an image carrying a valid Ed25519 signature over `base/fw_pubkey.h`.
+An image that fails that check is **not refused outright** — the keyboard asks:
+
+- **The board becomes the dialog.** `poly_sync_t.fw_confirm` (synced, so both halves
+  render) makes `update_displays()` blank every keycap except one per half: a 2×-scaled
+  **A / ACCEPT** on the left home-row index key and **R / REJECT** on the right, both at
+  local matrix `(FW_CONFIRM_ROW, FW_CONFIRM_COL)` — the *same* local position on both
+  halves, and a matrix position, so the non-rectangular display grid and the right
+  half's `c--` display fold don't apply. `process_record_user` swallows every other key
+  while it is up. Side is decided by `is_left_side()`, not by which half is master, so
+  the prompt never moves between flashes.
+- **⚠️ COMMIT must NOT block waiting for the answer.** It runs inside
+  `raw_hid_receive()` on the main loop, which is also what scans the matrix — a
+  busy-wait would guarantee the keypress is never seen. So it is a state machine:
+  the first COMMIT raises the prompt and answers **`?`**; the host re-polls COMMIT
+  (~1 Hz) until a keypress or `FW_CONFIRM_WINDOW_MS` (60 s) resolves it to `.` or `S`.
+  Re-running finalize is free — `s_buf_fill` is 0 and the CRCs are untouched — but
+  COMMIT skips **re-bridging to the slave** while `fw_staging_confirm_in_progress()`,
+  or every poll would re-erase and re-stamp the slave's 4 KB staging header sector.
+- **Only the master runs `process_record`** (the slave's matrix is pulled over the
+  split link), so a press on *either* half arrives there; the matrix row says which.
+- **Accept is physical, cancel may be remote.** The threat model is any process that
+  can talk the HID flash protocol, so an acceptance sent over HID would be forgeable by
+  exactly the attacker signing defends against. A **cancel** (COMMIT with `'x'` in
+  `data[2]`) can only ever deny, so it *is* exposed — the host's abort path and the HIL
+  rig (no fingers) use it instead of leaving the board modal for the full window.
+- Housekeeping calls `fw_staging_confirm_tick()` **outside** the `!fw_up_active` gate
+  and holds `update_performed()` while pending, so the idle fade can't dim the prompt
+  out from under the user (`update_displays` early-returns once `DISP_IDLE` is set, so
+  it would never be redrawn either).
+- `kdisp_draw_glyph_double_at()` (`base/disp_array.c`) is the 2× mirror of
+  `kdisp_draw_glyph_half_at()` — the keycap fonts top out at the 27 px `_Base_` face,
+  so it is the only way to fill a 72×40 panel with one character. Both take the literal
+  top-left of the **ink** (no baseline align, no `xOffset`).
+- Layout is measured from the font metrics at runtime, not hardcoded: "REJECT" descends
+  2 px below the baseline (the J) and "ACCEPT" does not, so a fixed bottom baseline
+  clips one of them. Preview the cells with `PolyKybdHost/tools/gfx_font.py`.
+- Full user-facing story: `keyboards/polykybd/tools/SIGNING.md`. BOOTSEL/UF2 bypasses
+  `fw_staging` entirely, so enforcement can never brick a board.
+
 ### Idle anti-burn-in styles (`poly_keymap.c`)
 When the keyboard idles, the keycap legends would otherwise burn the **same**
 pixels in. **Four** styles (EEPROM `poly_eeconf_t.idle_style`, HID cmd 28, enum

--- a/keyboards/polykybd/base/disp_array.c
+++ b/keyboards/polykybd/base/disp_array.c
@@ -231,6 +231,27 @@ void kdisp_draw_glyph_half_at(const GFXfont *const *fonts, uint8_t num_fonts, in
     }
 }
 
+void kdisp_draw_glyph_double_at(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, uint32_t ch) {
+    const GFXfont *font = NULL;
+    const GFXglyph *glyph = kdisp_gfx_glyph_font(fonts, num_fonts, ch, &font);
+    if (glyph == NULL || font == NULL) return;
+    const uint8_t *bitmap = pgm_read_bitmap_ptr(font);
+    uint16_t bo = pgm_read_word(&glyph->bitmapOffset);
+    int16_t  w  = pgm_read_byte(&glyph->width);
+    int16_t  h  = pgm_read_byte(&glyph->height);
+    const uint8_t cb = (uint8_t)((h + 7) >> 3);   // column-major page-bytes per column
+    for (int16_t sx = 0; sx < w; ++sx) {
+        for (int16_t sy = 0; sy < h; ++sy) {
+            uint8_t byte = pgm_read_byte(&bitmap[bo + (uint16_t)sx * cb + (sy >> 3)]);
+            if (!(byte & (1u << (sy & 7)))) continue;
+            SET_PIXEL_CLIPPED(x + sx * 2,     y + sy * 2);
+            SET_PIXEL_CLIPPED(x + sx * 2 + 1, y + sy * 2);
+            SET_PIXEL_CLIPPED(x + sx * 2,     y + sy * 2 + 1);
+            SET_PIXEL_CLIPPED(x + sx * 2 + 1, y + sy * 2 + 1);
+        }
+    }
+}
+
 
 void kdisp_fill_rect(int8_t x_start, int8_t y_start, int8_t width, int8_t height) {
     for (int x = x_start; x < (x_start + width); ++x) {

--- a/keyboards/polykybd/base/disp_array.h
+++ b/keyboards/polykybd/base/disp_array.h
@@ -55,6 +55,13 @@ const GFXglyph *kdisp_gfx_glyph_font(const GFXfont *const *fonts, uint8_t num_fo
 // Win+Ctrl+Shift+B reload 🗘 drawn into the monitor's screen cavity).
 void kdisp_draw_glyph_half_at(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, uint32_t c);
 
+// The mirror of the above: composite a glyph scaled 2x (nearest, each source
+// pixel becomes a 2x2 block) with its top-left at buffer coords (x,y) — again no
+// baseline align, (x,y) is the literal top-left. The keycap fonts top out at the
+// 27px _Base_ face, so this is the only way to fill a 72x40 panel with a single
+// character; used for the unsigned-firmware A/R confirmation prompt.
+void kdisp_draw_glyph_double_at(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, uint32_t c);
+
 void kdisp_write_gfx_text(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, const uint32_t *text);
 
 void kdisp_write_gfx_text_cy(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, const uint32_t *text, int8_t cy_radius);

--- a/keyboards/polykybd/base/fw_staging.c
+++ b/keyboards/polykybd/base/fw_staging.c
@@ -133,6 +133,13 @@ static uint32_t s_staged_crc;    // running CRC32 of received image bytes (for O
 static uint8_t  s_signature[FW_SIG_LEN];
 static bool     s_signature_present;
 
+// FW-2 physical-presence confirmation state (see the block above
+// fw_staging_awaiting_confirm for the rationale). Declared here because
+// fw_staging_begin, further up, resets it per flash.
+static enum { CONFIRM_IDLE = 0, CONFIRM_PENDING, CONFIRM_ACCEPTED, CONFIRM_REJECTED }
+                s_confirm    = CONFIRM_IDLE;
+static uint32_t s_confirm_at = 0;
+
 static bool     s_commit_pending;
 static bool     s_reboot_pending;   // deferred plain reboot (QK_REBOOT slave path)
 static bool     s_fontpack_reload_pending;  // slave: defer the heavy FONTPACK reload to housekeeping
@@ -250,6 +257,7 @@ void fw_staging_begin_target(uint32_t image_size, uint32_t image_crc, uint8_t ta
     s_buf_fill       = 0;
     s_staged_crc     = 0;
     s_signature_present = false;  // FW-2: each new image must re-supply its signature
+    s_confirm           = CONFIRM_IDLE;   // ...and re-confirm, if it turns out unsigned
     s_commit_pending = false;
     s_erase_pending  = false;
     memset(s_page_buf, 0xFF, FLASH_PAGE_SIZE);
@@ -303,6 +311,7 @@ void fw_staging_begin_deferred_target(uint32_t image_size, uint32_t image_crc, u
     s_buf_fill       = 0;
     s_staged_crc     = 0;
     s_signature_present = false;  // FW-2: each new image must re-supply its signature
+    s_confirm           = CONFIRM_IDLE;   // ...and re-confirm, if it turns out unsigned
     s_commit_pending = false;
     memset(s_page_buf, 0xFF, FLASH_PAGE_SIZE);
 
@@ -467,17 +476,17 @@ void fw_staging_set_signature(const uint8_t sig[FW_SIG_LEN]) {
     s_signature_present = true;
 }
 
-// FW-2 physical-presence override. Under FW_REQUIRE_SIGNATURE an unsigned or badly
-// signed image is refused — but a developer flashing their own build needs a way
-// through that malware cannot take. An acknowledgement carried over HID would be
-// worthless: the HID flash surface is exactly what signing defends, so anything a
-// host can send, an attacker can send too. A KEYPRESS cannot be forged remotely,
-// so arming is a physical act on the keyboard and nothing else can do it.
+// FW-2 physical-presence confirmation. Under FW_REQUIRE_SIGNATURE an unsigned or
+// badly signed image is not simply refused — a developer flashing their own build
+// needs a way through that malware cannot take. An acknowledgement carried over
+// HID would be worthless: the HID flash surface is exactly what signing defends,
+// so anything a host can send, an attacker can send too. A KEYPRESS cannot be
+// forged remotely, so the answer is a physical act on the keyboard.
 //
-// RAM-only and time-limited on purpose: it must not survive a reboot or sit armed
-// indefinitely, or it degrades into a permanently disabled check.
-static bool     s_unsigned_armed    = false;
-static uint32_t s_unsigned_armed_at = 0;
+// The state is RAM-only and re-armed per flash (fw_staging_begin clears it), so it
+// cannot survive a reboot or linger as a permanently disabled check.
+// (s_confirm / s_confirm_at are declared up with s_signature — fw_staging_begin
+// needs to reset them and sits above this block.)
 
 // Why the last COMMIT was refused. Without this the caller cannot tell a
 // signature refusal from a CRC mismatch — fw_staging_finalize() returns a bare
@@ -486,22 +495,28 @@ static uint32_t s_unsigned_armed_at = 0;
 // CRC was perfect, and sent a diagnosis the wrong way (2026-08-05).
 static bool s_refused_unsigned = false;
 
-void fw_staging_arm_unsigned(void) {
-    s_unsigned_armed    = true;
-    s_unsigned_armed_at = timer_read32();
-    uprintf("FW_UP: unsigned-image override ARMED for %lus\n",
-            (unsigned long)(FW_UNSIGNED_ARM_WINDOW_MS / 1000));
+bool fw_staging_awaiting_confirm(void) {
+    return s_confirm == CONFIRM_PENDING;
 }
 
-bool fw_staging_unsigned_armed(void) {
+bool fw_staging_confirm_in_progress(void) {
+    return s_confirm != CONFIRM_IDLE;
+}
+
+void fw_staging_confirm_answer(bool accept) {
+    if (s_confirm != CONFIRM_PENDING) return;   // first answer wins; ignore stray keys
+    s_confirm = accept ? CONFIRM_ACCEPTED : CONFIRM_REJECTED;
+    uprintf("FW_UP: unsigned image %s on the keyboard\n", accept ? "ACCEPTED" : "REJECTED");
+}
+
+void fw_staging_confirm_tick(void) {
     // timer_elapsed32() is modular, so this stays correct across the 49.7-day
     // timer wrap — the same trap that once disabled idle for a 25-day window
     // (see the update.c signed-timestamp bug).
-    return s_unsigned_armed && timer_elapsed32(s_unsigned_armed_at) < FW_UNSIGNED_ARM_WINDOW_MS;
-}
-
-void fw_staging_disarm_unsigned(void) {
-    s_unsigned_armed = false;
+    if (s_confirm == CONFIRM_PENDING && timer_elapsed32(s_confirm_at) >= FW_CONFIRM_WINDOW_MS) {
+        s_confirm = CONFIRM_REJECTED;
+        uprint("FW_UP: unsigned-image confirmation timed out — refusing\n");
+    }
 }
 
 bool fw_staging_refused_unsigned(void) {
@@ -614,24 +629,43 @@ static bool fw_staging_finalize_impl(bool defer_fontpack_reload) {
                 uprintf("FW_UP: image UNSIGNED (no signature supplied)\n");
             }
 #ifdef FW_REQUIRE_SIGNATURE
-            // Enforcement: reject anything but a valid signature, UNLESS the user
-            // physically armed the override on the keyboard (KC_ALLOW_UNSIGNED)
-            // within the last FW_UNSIGNED_ARM_WINDOW_MS. See fw_staging_arm_unsigned.
+            // Enforcement: anything but a valid signature needs the user to confirm
+            // ON THE KEYBOARD. The first COMMIT raises the prompt and answers '?';
+            // the host re-polls COMMIT (staging state is untouched, so re-running
+            // finalize is free) until a keypress or the timeout resolves it.
+            //
+            // We must NOT block here waiting for the answer: COMMIT runs inside
+            // raw_hid_receive() on the main loop, and the matrix is scanned by that
+            // same loop — a busy-wait would guarantee the keypress is never seen.
             if (sig != 1) {
-                if (fw_staging_unsigned_armed()) {
-                    uprintf("FW_UP: unsigned/invalid image ALLOWED — physical override armed\n");
-                } else {
-                    s_refused_unsigned = true;
-                    uprintf("FW_UP: REJECTED — image not validly signed. Press the "
-                            "'allow unsigned firmware' key on the keyboard, then flash "
-                            "again within %lus.\n",
-                            (unsigned long)(FW_UNSIGNED_ARM_WINDOW_MS / 1000));
-                    ok = false;
+                switch (s_confirm) {
+                    case CONFIRM_IDLE:
+                        s_confirm    = CONFIRM_PENDING;
+                        s_confirm_at = timer_read32();
+                        uprintf("FW_UP: image not validly signed — confirm on the keyboard "
+                                "(A = accept, R = reject) within %lus\n",
+                                (unsigned long)(FW_CONFIRM_WINDOW_MS / 1000));
+                        ok = false;
+                        break;
+                    case CONFIRM_PENDING:
+                        ok = false;                 // still waiting; COMMIT answers '?'
+                        break;
+                    case CONFIRM_ACCEPTED:
+                        // Consumed here, so one confirmation authorises exactly this
+                        // image — a second unsigned flash prompts again.
+                        s_confirm = CONFIRM_IDLE;
+                        uprint("FW_UP: unsigned/invalid image ALLOWED by physical confirmation\n");
+                        break;
+                    case CONFIRM_REJECTED:
+                        s_confirm          = CONFIRM_IDLE;
+                        s_refused_unsigned = true;
+                        uprint("FW_UP: REJECTED — image not validly signed\n");
+                        ok = false;
+                        break;
                 }
+            } else if (s_confirm != CONFIRM_IDLE) {
+                s_confirm = CONFIRM_IDLE;           // signed image: nothing left to ask
             }
-            // One flash per arming: consume it either way, so a single keypress can
-            // never authorise a second image the user did not intend.
-            fw_staging_disarm_unsigned();
 #endif
         }
         // FIRMWARE: stamp the staging header {magic,size,crc} so the staged image

--- a/keyboards/polykybd/base/fw_staging.c
+++ b/keyboards/polykybd/base/fw_staging.c
@@ -637,12 +637,27 @@ static bool fw_staging_finalize_impl(bool defer_fontpack_reload) {
             // We must NOT block here waiting for the answer: COMMIT runs inside
             // raw_hid_receive() on the main loop, and the matrix is scanned by that
             // same loop — a busy-wait would guarantee the keypress is never seen.
-            if (sig != 1) {
+            //
+            // ⚠️ The prompt is offered for an image with NO signature (sig == 0) —
+            // a developer build — and NOT for one whose signature is present and
+            // fails to verify (sig == -1). Those are different events: the first is
+            // "you compiled this yourself", the second is "this file is not what it
+            // claims to be", i.e. corruption or tampering. Inviting a keypress to
+            // accept the second would hand the attacker the one thing the physical
+            // gate exists to withhold — a user who has been told to press A. So an
+            // invalid signature is refused outright, with no way through.
+            if (sig == -1) {
+                s_refused_unsigned = true;
+                uprint("FW_UP: REJECTED — signature does not verify (corrupt or tampered image). "
+                       "No confirmation is offered for this case.\n");
+                ok = false;
+                s_confirm = CONFIRM_IDLE;
+            } else if (sig == 0) {
                 switch (s_confirm) {
                     case CONFIRM_IDLE:
                         s_confirm    = CONFIRM_PENDING;
                         s_confirm_at = timer_read32();
-                        uprintf("FW_UP: image not validly signed — confirm on the keyboard "
+                        uprintf("FW_UP: image UNSIGNED — confirm on the keyboard "
                                 "(A = accept, R = reject) within %lus\n",
                                 (unsigned long)(FW_CONFIRM_WINDOW_MS / 1000));
                         ok = false;
@@ -654,12 +669,12 @@ static bool fw_staging_finalize_impl(bool defer_fontpack_reload) {
                         // Consumed here, so one confirmation authorises exactly this
                         // image — a second unsigned flash prompts again.
                         s_confirm = CONFIRM_IDLE;
-                        uprint("FW_UP: unsigned/invalid image ALLOWED by physical confirmation\n");
+                        uprint("FW_UP: unsigned image ALLOWED by physical confirmation\n");
                         break;
                     case CONFIRM_REJECTED:
                         s_confirm          = CONFIRM_IDLE;
                         s_refused_unsigned = true;
-                        uprint("FW_UP: REJECTED — image not validly signed\n");
+                        uprint("FW_UP: REJECTED — unsigned image, not confirmed\n");
                         ok = false;
                         break;
                 }

--- a/keyboards/polykybd/base/fw_staging.h
+++ b/keyboards/polykybd/base/fw_staging.h
@@ -34,24 +34,40 @@
 // The split RPC struct is 4 CRC + 4 offset + 56 data = 64 bytes < RPC_M2S_BUFFER_SIZE 72 bytes.
 #define FW_UP_CHUNK_SIZE 56
 
-// Must be called once before any other fw_staging_* function.
-// FW-2 physical-presence override: how long an arming keypress stays valid.
-// Long enough to arm, alt-tab and start a flash; short enough that it cannot be
-// left armed by accident. RAM-only — a reboot always disarms.
-#define FW_UNSIGNED_ARM_WINDOW_MS 120000u
+// FW-2 physical-presence confirmation. Under FW_REQUIRE_SIGNATURE an image that
+// is not validly signed is not refused outright: COMMIT raises a prompt ON THE
+// KEYCAPS (a big A/ACCEPT on the left half, R/REJECT on the right) and waits for
+// a keypress. The acknowledgement is deliberately NOT carried over HID — signing
+// defends against any process that can talk the flash protocol, and such a
+// process could forge a reply on that same channel. A keypress cannot be produced
+// remotely, so the answer has to come off the matrix.
+//
+// How long the prompt stays up. Long enough to read it, walk to the keyboard and
+// decide; short enough that an unattended board falls back to refusing. RAM-only,
+// and re-armed per flash — a reboot or a new BEGIN always clears it.
+#define FW_CONFIRM_WINDOW_MS 60000u
 
-// Arm/query/consume the override. Arming is deliberately reachable ONLY from a
-// keycode (KC_ALLOW_UNSIGNED): an acknowledgement sent over HID would be
-// forgeable by the very surface signing defends, so it must be a physical act.
-void fw_staging_arm_unsigned(void);
-bool fw_staging_unsigned_armed(void);
-void fw_staging_disarm_unsigned(void);
+// True while the prompt is up: COMMIT answers '?' and the keycaps show A/R.
+bool fw_staging_awaiting_confirm(void);
+// True from the moment the prompt goes up until the answer is consumed by the
+// COMMIT that acts on it. COMMIT uses this to skip re-bridging to the slave while
+// the host re-polls: the slave committed on the first COMMIT and re-running its
+// finalize would re-erase the staging header sector once per poll.
+bool fw_staging_confirm_in_progress(void);
+// The physical answer, from process_record_user on the master. Idempotent — only
+// the first call while pending decides.
+void fw_staging_confirm_answer(bool accept);
+// Times the prompt out (-> reject). Call once per housekeeping pass.
+void fw_staging_confirm_tick(void);
 
 // True when the last fw_staging_finalize() refused the image because it was not
-// validly signed (as opposed to a CRC mismatch). Lets COMMIT answer with a
-// distinct status so the host and the HIL rig can report the real reason instead
-// of guessing — they are indistinguishable from the bool alone.
+// validly signed (rejected or timed out at the prompt), as opposed to a CRC
+// mismatch. Lets COMMIT answer with a distinct status so the host and the HIL rig
+// can report the real reason instead of guessing — they are indistinguishable
+// from the bool alone.
 bool fw_staging_refused_unsigned(void);
+
+// Must be called once before any other fw_staging_* function.
 
 void fw_staging_init(void);
 

--- a/keyboards/polykybd/hid_fw_up.c
+++ b/keyboards/polykybd/hid_fw_up.c
@@ -263,22 +263,46 @@ bool hid_fw_up_receive(uint8_t *data, uint8_t length) {
             // milestone: fw_staging_finalize() verifies the O(1) running CRC, clears
             // fw_up_active and restarts core1 — it does NOT apply or reboot.  Actually
             // installing the staged image is the explicit FW_UP_APPLY step (phase 2).
+            // FW-2: an explicit cancel of a pending confirmation. Safe to expose
+            // over HID precisely because it can only ever DENY — it withdraws the
+            // prompt and refuses the image. (Accepting over HID would be worthless:
+            // the flash channel is what signing defends, so anything a host can
+            // send an attacker can send too.) Used by the HIL rig, which cannot
+            // press a key and would otherwise leave the board modal for the whole
+            // FW_CONFIRM_WINDOW_MS, and by the host's Cancel button.
+            if (data[2] == 'x' && fw_staging_awaiting_confirm()) {
+                fw_staging_confirm_answer(false);
+            }
             fw_up_commit_sync_t commit_msg = { .crc32 = 0, .op = FLASH_STAGE_COMMIT };
-            uint8_t slave_ack  = send_to_bridge(USER_SYNC_FLASH_STAGE, &commit_msg, sizeof(commit_msg), 10);
+            // FW-2: while the unsigned-image prompt is up the host re-polls COMMIT,
+            // and each poll would otherwise re-run the SLAVE's finalize — which
+            // re-erases and re-stamps its 4 KB staging header sector every time.
+            // The slave committed on the first COMMIT and skips the signature check
+            // anyway (that is the master's job), so it has nothing left to do.
+            uint8_t slave_ack = fw_staging_confirm_in_progress()
+                                    ? SYNC_ACK
+                                    : send_to_bridge(USER_SYNC_FLASH_STAGE, &commit_msg,
+                                                     sizeof(commit_msg), 10);
             bool master_ok = fw_staging_finalize();   // also clears fw_up_active + restarts master core1
             bool ok = (slave_ack == SYNC_ACK) && master_ok;
             memset(data, 0, length);
-            // Three outcomes, not two. 'S' distinguishes "refused: not validly
-            // signed" from '!' "staged CRC mismatch". They were the same byte
-            // until 2026-08-05, so the host and the HIL rig both reported a
-            // signature refusal as a CRC failure — a wrong answer at exactly the
-            // moment someone is trying to work out why a flash was rejected.
-            const char *status = ok ? "P\x42."
-                                    : (fw_staging_refused_unsigned() ? "P\x42S" : "P\x42!");
+            // Four outcomes, not two. '?' means "waiting for the user to confirm an
+            // unsigned image on the keyboard" (re-poll me); 'S' distinguishes
+            // "refused: not validly signed" from '!' "staged CRC mismatch". The
+            // last two were the same byte until 2026-08-05, so the host and the HIL
+            // rig both reported a signature refusal as a CRC failure — a wrong
+            // answer at exactly the moment someone is working out why a flash was
+            // rejected.
+            const bool awaiting = fw_staging_awaiting_confirm();
+            const char *status = ok       ? "P\x42."
+                               : awaiting ? "P\x42?"
+                               : fw_staging_refused_unsigned() ? "P\x42S"
+                                                               : "P\x42!";
             memcpy(data, status, 3);
             uprintf("FW_UP_COMMIT: slave_ack=0x%02x master_finalize=%d%s\n",
                     slave_ack, master_ok,
-                    fw_staging_refused_unsigned() ? " (refused: unsigned)" : "");
+                    awaiting ? " (awaiting keyboard confirmation)"
+                             : fw_staging_refused_unsigned() ? " (refused: unsigned)" : "");
             raw_hid_send(data, length);
             return true;
         }

--- a/keyboards/polykybd/keycode_helper.h
+++ b/keyboards/polykybd/keycode_helper.h
@@ -169,13 +169,6 @@ enum my_keycodes {
     // Settings-layer key: replay the one-time startup ("Eden") animation on demand.
     // Appended at the very end (QK_USER range) so no existing keycode is renumbered.
     KC_EDEN,
-
-    // FW-2: arm the physical-presence override that lets ONE unsigned/invalid
-    // firmware image through under FW_REQUIRE_SIGNATURE. Must be a keycode rather
-    // than a HID command — the HID flash path is precisely what signing defends,
-    // so an acknowledgement sent over it would be forgeable. Appended at the end,
-    // same reason as KC_EDEN.
-    KC_ALLOW_UNSIGNED,
 };
 static_assert((int)KC_DAUTO <= (int)QK_KB_31, "Too many custom QK key codes");
 static_assert((int)KC_DAUTO < (int)KCL_ENUS, "Overlap detected");

--- a/keyboards/polykybd/oled_helper.c
+++ b/keyboards/polykybd/oled_helper.c
@@ -25,6 +25,9 @@
 // firmware-apply screen, so no pack and no custom bitmap are needed.
 extern const GFXfont NotoSans_Regular_Mid_19px7b;
 extern const GFXfont NotoSansSymbols2_Regular_Arrows_20pt16b;
+// Defined in <variant>/status_oled.c's translation unit — extern here for the
+// same reason (its PROGMEM tables must not be duplicated at link time).
+extern const GFXfont NotoSans_Regular_Small_15px7b;
 
 // Render `value` as a char32 (U"...") display string into `buffer`. The display
 // pipeline is 32-bit (kdisp_write_gfx_text takes const uint32_t*), so each digit
@@ -194,6 +197,52 @@ void oled_fw_update_screen(void) {
     oled_render_dirty(true);
 }
 
+// FW-2: the question behind the A/R keycaps. The keycaps alone say WHICH key does
+// what but not WHY the board went modal, and a user who has never seen this before
+// has no way to find out — the host is stuck at "verifying" and the console is not
+// something anyone has open. So the status OLED states it in words, on both halves
+// (poly_sync_t.fw_confirm is synced), each naming its OWN half's key.
+//
+// Deliberately landscape on split42 too, matching the flash/apply screens there —
+// the portrait rework of those is still deferred.
+void oled_fw_confirm_screen(void) {
+    const GFXfont*  small = &NotoSans_Regular_Small_15px7b;
+    const GFXfont*  fonts[] = { small };
+    // Three lines on the 64px panel; the 32px one only has room for the verdict
+    // and the key, so it drops the "firmware!" continuation.
+    const bool      tall  = OLED_DISPLAY_HEIGHT >= 64;
+    const uint32_t* l0    = tall ? U"Unsigned" : U"Unsigned!";
+    const uint32_t* l1    = tall ? U"firmware!" : NULL;
+    const uint32_t* l2    = is_left_side() ? U"A = ACCEPT" : U"R = REJECT";
+
+    oled_on();
+    kdisp_set_buffer(0);   // clear the scratch to black
+
+    const uint32_t* lines[3] = { l0, l1, l2 };
+    const uint8_t   count    = l1 ? 3 : 2;
+    // Even vertical distribution: line i owns the band [i*H/count, (i+1)*H/count),
+    // and each line is centred in its own band from its own bbox — so a line with a
+    // descender ("firmware!" has none, but the key lines end in caps) sits level
+    // rather than being pushed by the tallest line in the set.
+    const int8_t band = (int8_t)(OLED_DISPLAY_HEIGHT / count);
+    for (uint8_t i = 0; i < count; ++i) {
+        const uint32_t* txt = lines[i];
+        int8_t x0 = 0, x1 = 0, y0 = 0, y1 = 0;
+        kdisp_gfx_text_bbox(fonts, 1, txt, &x0, &x1, &y0, &y1);
+        const int8_t w    = (int8_t)(x1 - x0 + 1);
+        int16_t      x    = (int16_t)((OLED_DISPLAY_WIDTH - w) / 2 - x0);
+        if (x < 0) x = 0;
+        const int8_t base = (int8_t)(band * i + band / 2 - (y0 + y1) / 2);
+        kdisp_write_gfx_text(fonts, 1, (int8_t)x, base, txt);
+    }
+
+    oled_write_raw((char*)get_scratch_buffer(), get_scratch_buffer_size());
+    // One synchronous pass, same reason as the flash screen: this is a full-screen
+    // transition and the user must be able to read it immediately, not watch it
+    // dribble in a block at a time.
+    oled_render_dirty(true);
+}
+
 // Shown on BOTH halves the instant a staged firmware image is applied (reboot
 // imminent). Reads across the two status OLEDs as "⟳Applying  Firmware⟳": the
 // LEFT half shows the resident circular refresh arrow U+2B6F + "Applying", the
@@ -257,7 +306,15 @@ const uint8_t wpm_gauge_bitmap[] PROGMEM = {
 };
 
 bool oled_task_user(void) {
-    if (fw_staging_fw_up_active()) {
+    // FW-2: the unsigned-image question outranks everything else — the board is a
+    // modal dialog and nothing else it could show is actionable. Checked before the
+    // flash screen because by the time the prompt goes up finalize has already
+    // cleared fw_up_active, so this would otherwise fall through to the idle/status
+    // screen and leave the keycaps asking a question the panel never states.
+    if (get_local_state()->fw_confirm) {
+        oled_scroll_off();
+        oled_fw_confirm_screen();
+    } else if (fw_staging_fw_up_active()) {
         oled_scroll_off();
         oled_fw_update_screen();
 #ifdef POLYKYBD_DOOM

--- a/keyboards/polykybd/oled_helper.h
+++ b/keyboards/polykybd/oled_helper.h
@@ -29,6 +29,10 @@ void oled_draw_poly(void);
 /* Shared OLED task functions — implemented in oled_helper.c */
 void oled_status_screen(void);
 void oled_fw_update_screen(void);
+/* FW-2: "Unsigned firmware! / A = ACCEPT" (left) resp. "R = REJECT" (right) — the
+   words behind the big A/R keycaps, so the board says WHY it went modal and not
+   just which key does what. Driven by the synced poly_sync_t.fw_confirm. */
+void oled_fw_confirm_screen(void);
 /* "⭯Applying / Firmware⭯" notice (resident circular refresh arrow U+2B6F) drawn +
    fully flushed on both halves the moment a staged firmware image is applied, right
    before the blocking self-flash + reboot. */

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -214,8 +214,10 @@ bool rgb_matrix_indicators_kb(void) {
         uint8_t phase = (uint8_t)(timer_read32() >> 3);         // ~2 s cycle
         uint8_t tri   = phase < 128 ? phase : (uint8_t)(255 - phase);  // triangle breath 0..127..0
         uint8_t v     = 5 + (tri >> 2);                         // ~5..36 (half brightness — bright enough)
-        if (fw_staging_commit_pending()) {
+        if (fw_staging_commit_pending() || get_local_state()->fw_confirm) {
             // Applying the staged firmware → reboot imminent, you can't type → orange.
+            // The FW-2 confirmation prompt joins it: while it is up every key except
+            // A/R is swallowed, which is exactly the "can't type" state orange means.
             rgb_matrix_set_color_all(v, v >> 2, 0);            // breathing orange
         } else {
             // Staging a font pack OR firmware: the board still runs and you can keep
@@ -251,7 +253,10 @@ static void flash_rgb_tick(void) {
     // Light the matrix while a flash is staging, and also while an apply is pending
     // (commit_pending) so a standalone "apply staged firmware" still shows the orange
     // reboot cue even though no chunks are streaming.
-    if (fw_staging_fw_up_active() || fw_staging_commit_pending()) {
+    // ...and while the FW-2 confirmation prompt is up (synced, so both halves glow):
+    // the board is modal there, so it belongs to the same "can't type" cue.
+    if (fw_staging_fw_up_active() || fw_staging_commit_pending() ||
+        get_local_state()->fw_confirm) {
         s_flash_rgb_seen   = timer_read();
     }
     bool want = (s_flash_rgb_seen != 0) && (timer_elapsed(s_flash_rgb_seen) < FLASH_RGB_HOLD_MS);
@@ -266,6 +271,26 @@ static void flash_rgb_tick(void) {
     }
 }
 
+#endif
+
+// Force the orange "applying — you cannot type" cue onto the LEDs synchronously.
+//
+// rgb_matrix_indicators_kb() already picks orange while commit_pending, but that
+// only runs from the next rgb_matrix_task() — and on the apply path there is no
+// next task: the blocking self-flash / mcu_reset never returns. So the cue the
+// code appears to implement was in practice never seen. Push it out here, the
+// same way oled_fw_apply_screen() flushes the status OLED in one pass.
+//
+// No-op on a variant without an RGB matrix (split42), so callers stay unguarded.
+static void poly_flash_rgb_now(void) {
+#ifdef RGB_MATRIX_ENABLE
+    if (!rgb_matrix_is_enabled()) rgb_matrix_enable_noeeprom();
+    rgb_matrix_set_color_all(24, 6, 0);      // same orange as the bootloader cue
+    rgb_matrix_update_pwm_buffers();
+#endif
+}
+
+#ifdef RGB_MATRIX_ENABLE
 #define RGB_REPEAT_INITIAL_DELAY_MS 400
 #define RGB_REPEAT_RATE_MS          40
 
@@ -887,15 +912,25 @@ void housekeeping_task_user(void) {
     // progresses and the master's apply-and-reboot fires after a successful
     // commit.
     if (fw_staging_commit_pending()) {
+        // Release anything still held. From here the main loop never scans the
+        // matrix again (the self-flash below does not return), so a key that is
+        // physically down when the apply is armed would never have its release
+        // reported — the host keeps it registered and auto-repeats until USB
+        // drops at the reboot (field: hundreds of repetitions).
+        clear_keyboard();
+        poly_flash_rgb_now();
         // Paint the "⟳Applying / Firmware⟳" notice and flush it fully BEFORE the
         // blocking self-flash + reset below (which never returns), so the status
         // OLED is completely refreshed — not torn mid-transition — as the apply
-        // begins. Runs on both halves; each draws its own side's word.
+        // begins. Runs on both halves; each draws its own side's word. Its ~26 ms
+        // of I2C also gives the clear_keyboard() report time to leave over USB.
         oled_fw_apply_screen();
         save_all_dirty();   // persist MRU/settings before the firmware swap — this path resets via watchdog (never returns) and skips shutdown_quantum. Transfer is done by commit, so the blocking flash write is safe here.
         fw_staging_apply_and_reboot();
     }
     if (fw_staging_reboot_pending()) {
+        clear_keyboard();   // same as above: no further matrix scan before the reset
+        poly_flash_rgb_now();
         save_all_dirty();   // persist before the full-chip reset — this path skips shutdown_quantum too
         mcu_reset();   // QK_REBOOT slave path — clean full-chip reset; never returns
     }
@@ -923,6 +958,15 @@ void housekeeping_task_user(void) {
         poly_sync_t *cfm_state = access_local_state();
         if (cfm_state->fw_confirm != want) {
             cfm_state->fw_confirm = want;
+            if (want) {
+                // Release anything still registered host-side BEFORE we start
+                // swallowing events. A key held when the prompt goes up would
+                // otherwise never have its release forwarded — the host keeps the
+                // keycode down and auto-repeats it for the whole window (field:
+                // "a few hundred repetitions until the keyboard rebooted"). Same
+                // reasoning, same fix as doom_begin().
+                clear_keyboard();
+            }
             request_disp_refresh();
         }
         // Hold the idle timer off while we are asking: the fade/pulse would dim
@@ -2871,7 +2915,12 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
     // process_record — the slave's matrix is pulled over the split link — so a
     // press on EITHER half arrives here, and the matrix row is what says which.
     if (fw_staging_awaiting_confirm()) {
-        if (record->event.pressed && record->event.key.col == FW_CONFIRM_COL) {
+        // Answer on the RELEASE, not the press. split72.c's matrix_scan_kb inverts a
+        // keycap on press and un-inverts it on release, entirely independently of
+        // process_record — so acting on the press tears the prompt down and redraws
+        // the normal legend while that keycap is still inverted, and it stays
+        // inverted until the finger lifts.
+        if (!record->event.pressed && record->event.key.col == FW_CONFIRM_COL) {
             if (record->event.key.row == FW_CONFIRM_ROW) {
                 fw_staging_confirm_answer(true);    // left half  -> A / ACCEPT
             } else if (record->event.key.row == FW_CONFIRM_ROW + MATRIX_ROWS_PER_SIDE) {

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -908,6 +908,31 @@ void housekeeping_task_user(void) {
         request_disp_refresh();
     }
 
+    // FW-2: drive the unsigned-image confirmation prompt. The master owns the
+    // decision, but poly_sync_t.fw_confirm is synced so BOTH halves turn their
+    // keycaps into the dialog (the slave's own render is driven by the sync
+    // handler's refresh). Deliberately outside the !fw_up_active gate below: the
+    // prompt only goes up at COMMIT, i.e. after finalize has already cleared
+    // fw_up_active, and a prompt that could not be drawn would be unanswerable.
+    // is_keyboard_master(), not is_usb_host_side(): the confirmation state only
+    // ever exists on the half that verified the signature, and fw_staging gates
+    // that on is_keyboard_master() (which the HIL images override per side).
+    if (is_keyboard_master()) {
+        fw_staging_confirm_tick();
+        const uint8_t want = fw_staging_awaiting_confirm() ? 1 : 0;
+        poly_sync_t *cfm_state = access_local_state();
+        if (cfm_state->fw_confirm != want) {
+            cfm_state->fw_confirm = want;
+            request_disp_refresh();
+        }
+        // Hold the idle timer off while we are asking: the fade/pulse would dim
+        // the prompt out from under the user (update_displays early-returns once
+        // DISP_IDLE is set, so it would never be redrawn either).
+        if (want) {
+            update_performed();
+        }
+    }
+
     // While a fw_up is in progress, skip EEPROM saves (wear-leveling consolidate
     // is ~100 ms IRQ-off) and the display refresh path (slave update_displays
     // can be ~50-100 ms over SPI, master state-push uses 10 retries × 80 ms).
@@ -2072,6 +2097,55 @@ static const GFXfont* const lang_label_fonts[] = { &NotoSans_Regular_Nano_10px7b
 // `mid_fonts` array for any misc utility-key text that wants a middle size.
 static const GFXfont* const mid_fonts[]        = { &NotoSans_Regular_Mid_19px7b };
 
+// --- FW-2 unsigned-image confirmation prompt -------------------------------
+//
+// Which key on EACH half carries the prompt. The same LOCAL matrix position on
+// both halves, so the two keycaps sit symmetrically: the home-row index finger,
+// which is findable by touch without hunting across 36 keycaps. The keycap grid
+// is not rectangular and the right half folds its display column, but this is a
+// matrix position — update_displays' loop indexes the matrix directly, so no
+// fold applies. Left half = ACCEPT, right half = REJECT (fixed by side, not by
+// which half happens to be master, so the prompt never moves between flashes).
+#if defined(KEYBOARD_polykybd_split42)
+#  define FW_CONFIRM_ROW 1      // middle letter row (a s d f g)
+#else
+#  define FW_CONFIRM_ROW 2      // split72 home row (Fn a s d f g ')
+#endif
+#define FW_CONFIRM_COL 3
+
+// Compose the prompt keycap into the scratch buffer: a big 2x letter above a tiny
+// caption. Everything is measured from the font metrics rather than hardcoded —
+// "REJECT" descends 2px below the baseline (the J) where "ACCEPT" does not, so a
+// fixed bottom baseline would clip one of them.
+static void render_fw_confirm_key(bool accept) {
+    const uint32_t  letter    = accept ? (uint32_t)'A' : (uint32_t)'R';
+    const uint32_t *caption   = accept ? U"ACCEPT" : U"REJECT";
+
+    kdisp_set_buffer(0x00);
+
+    int8_t cxmin, cxmax, cymin, cymax;
+    kdisp_gfx_text_bbox(lang_label_fonts, 1, caption, &cxmin, &cxmax, &cymin, &cymax);
+    // Pin the caption's lowest lit pixel to the last screen row.
+    const int8_t cap_base = (int8_t)(SCREEN_HEIGHT - 1 - cymax);
+    kdisp_write_gfx_text(lang_label_fonts, 1,
+                         (int8_t)(BUFFER_X + (SCREEN_WIDTH - (cxmax - cxmin + 1)) / 2 - cxmin),
+                         cap_base, caption);
+
+    // The big letter, centred in what is left above the caption.
+    const GFXfont  *lf = NULL;
+    const GFXglyph *lg = kdisp_gfx_glyph_font(mid_fonts, 1, letter, &lf);
+    if (lg == NULL) return;
+    // _double_at takes the literal top-left of the INK (no baseline align, no
+    // xOffset), so the glyph box is centred directly — nothing to compensate for.
+    const int16_t lw = (int16_t)pgm_read_byte(&lg->width)  * 2;
+    const int16_t lh = (int16_t)pgm_read_byte(&lg->height) * 2;
+    const int8_t  free_rows = (int8_t)(cap_base + cymin);   // rows 0 .. caption top - 1
+    kdisp_draw_glyph_double_at(mid_fonts, 1,
+                               (int8_t)(BUFFER_X + (SCREEN_WIDTH - lw) / 2),
+                               (int8_t)((free_rows - lh) / 2),
+                               letter);
+}
+
 static void render_lang_flag_key(uint8_t idx, const uint32_t* label, uint8_t current_lang) {
     const GFXfont* flag_font = NULL;
     const GFXglyph* g = kdisp_gfx_glyph_font(g_all_fonts, g_all_font_count,
@@ -2477,7 +2551,21 @@ void update_displays(enum refresh_mode mode) {
                     // the game-control keys keep their legends, everything
                     // else goes dark.
                     bool doom_handled = false;
-                    if (local_state->doom_ctl == 2) {
+                    // FW-2: an unsigned firmware image is waiting for a physical
+                    // yes/no. The whole board becomes the dialog — every keycap
+                    // goes dark except this half's prompt key — so it cannot be
+                    // mistaken for normal typing, and it does not depend on which
+                    // layer happens to be active. Checked first: this outranks
+                    // every other per-key mode below.
+                    if (local_state->fw_confirm) {
+                        if (r == FW_CONFIRM_ROW && c == FW_CONFIRM_COL) {
+                            render_fw_confirm_key(is_left_side());
+                        } else {
+                            kdisp_set_buffer(0x00);
+                        }
+                        kdisp_send_window();
+                        doom_handled = true;
+                    } else if (local_state->doom_ctl == 2) {
                         // Attract screensaver: chrome-free — no pad, no ESC face,
                         // no control legends. Every key belongs to the mirror
                         // blitter while its view is live (the full-viewport
@@ -2774,6 +2862,22 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
     // pulse, the first key press should dismiss it and pass through to the wake
     // (display_wakeup clears DISP_IDLE → eden_idle_tick stops the loop next pass).
     if (startup_anim_active() && !startup_anim_is_loop()) {
+        return false;
+    }
+
+    // FW-2: while the unsigned-image prompt is up the whole board IS the dialog —
+    // every key event is swallowed (nothing should reach the host mid-decision)
+    // and only the two prompt keys mean anything. Only the master runs
+    // process_record — the slave's matrix is pulled over the split link — so a
+    // press on EITHER half arrives here, and the matrix row is what says which.
+    if (fw_staging_awaiting_confirm()) {
+        if (record->event.pressed && record->event.key.col == FW_CONFIRM_COL) {
+            if (record->event.key.row == FW_CONFIRM_ROW) {
+                fw_staging_confirm_answer(true);    // left half  -> A / ACCEPT
+            } else if (record->event.key.row == FW_CONFIRM_ROW + MATRIX_ROWS_PER_SIDE) {
+                fw_staging_confirm_answer(false);   // right half -> R / REJECT
+            }
+        }
         return false;
     }
 
@@ -3122,16 +3226,6 @@ void post_process_record_user(uint16_t keycode, keyrecord_t* record) {
             request_disp_refresh();
             break;
         }
-        case KC_ALLOW_UNSIGNED:
-            // FW-2: arm the physical-presence override for one unsigned/invalid
-            // firmware image (see fw_staging_arm_unsigned). Master-only — the
-            // master is what verifies the signature and gates the apply, so
-            // arming on the slave would have nothing to authorise.
-            if (is_keyboard_master()) {
-                fw_staging_arm_unsigned();
-            }
-            break;
-
         case KC_STORE_EE:
             // Manual "commit everything to EEPROM" — for users who want to be
             // sure their changes survive a hard power-cut without suspending.

--- a/keyboards/polykybd/rules.mk
+++ b/keyboards/polykybd/rules.mk
@@ -285,10 +285,11 @@ endif
 # release produced "image signature OK" and a byte-flipped signature produced
 # "INVALID", so the check is known to discriminate rather than rubber-stamp.
 #
-# There is a deliberate escape hatch for unsigned developer builds:
-# KC_ALLOW_UNSIGNED arms a 2-minute, single-use, RAM-only override ON THE
-# KEYBOARD. It is a keycode and not a HID command because the HID flash surface
-# is exactly what this defends — an acknowledgement sent over HID would be
-# forgeable by an attacker. BOOTSEL/UF2 also remains unaffected (it bypasses
-# fw_staging entirely), so this can never brick a board.
+# There is a deliberate escape hatch for unsigned developer builds: at COMMIT the
+# keyboard turns its keycaps into an ACCEPT/REJECT dialog (big A on the left half's
+# home-row index key, big R on the right's) and waits up to FW_CONFIRM_WINDOW_MS
+# for a press. The answer comes off the MATRIX and not over HID because the HID
+# flash surface is exactly what this defends — an acknowledgement sent over it
+# would be forgeable by the attacker it is meant to stop. BOOTSEL/UF2 also remains
+# unaffected (it bypasses fw_staging entirely), so this can never brick a board.
 OPT_DEFS += -DFW_REQUIRE_SIGNATURE

--- a/keyboards/polykybd/split42/keymaps/default/keymap.c
+++ b/keyboards/polykybd/split42/keymaps/default/keymap.c
@@ -167,7 +167,7 @@ const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         KC_BASE, LBL_TEXT,KC_TOGMODS,
         KC_NO,   KC_NO,   KC_NO,   KC_NO,   QK_MAKE, QK_BOOT,
         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   QK_RBT,
-        EE_CLR,  KC_STORE_EE, KC_ALLOW_UNSIGNED, KC_NO, KC_NO,   KC_NO,
+        EE_CLR,  KC_STORE_EE, KC_NO,   KC_NO,   KC_NO,   KC_NO,
         DB_TOGG, KC_DEADKEY, KC_BASE
     ),
     // Language selection layer — mirrors the emoji picker. LEFT half: row 0 = the

--- a/keyboards/polykybd/split72/keymaps/default/keymap.c
+++ b/keyboards/polykybd/split72/keymaps/default/keymap.c
@@ -236,7 +236,7 @@ const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                     RM_PREV,   RGB_M_SW,   RGB_M_R,    KC_RGB_TOG, RGB_M_P,    RGB_M_B,    RM_NEXT,
                     KC_NO,      RM_SPDD,    RM_SPDU,    KC_NO,      RM_HUED,    RM_HUEU,    KC_NO,
         _______,    KC_NO,      RM_VALD,    RM_VALU,    KC_NO,      RM_SATD,    RM_SATU,    KC_NO,
-        EE_CLR,     KC_STORE_EE, KC_EDEN,   KC_ALLOW_UNSIGNED, KC_NO, KC_NO,   KC_NO,      KC_NO,
+        EE_CLR,     KC_STORE_EE, KC_EDEN,    KC_NO,      KC_NO,      KC_NO,      KC_NO,      KC_NO,
         DB_TOGG,    KC_DEADKEY, KC_NO,                  KC_NO,      KC_NO,      KC_NO,      KC_BASE
         ),
     // Language Selection Layer — mirrors the emoji picker. TOP row of the LEFT

--- a/keyboards/polykybd/split_sync.c
+++ b/keyboards/polykybd/split_sync.c
@@ -96,8 +96,11 @@ void user_sync_poly_data_handler(uint8_t in_len, const void* in_data, uint8_t ou
     // animation when the slave is idle — a genuine HID replay (cmd 31) or a
     // KC_EDEN-rearmed boot where the slave's own marker was already consumed.
     bool anim_replay = (incoming->anim_nonce != current->anim_nonce) && !startup_anim_active();
+    // FW-2: the master raised or cleared the unsigned-image confirmation prompt ->
+    // re-render this half's keycaps (into the prompt, or back to the legends).
+    bool fw_confirm_changed = incoming->fw_confirm != current->fw_confirm;
     copy_local_state(incoming);
-    if (doom_ctl_changed) {
+    if (doom_ctl_changed || fw_confirm_changed) {
         request_disp_refresh();
     }
     if (anim_replay) {

--- a/keyboards/polykybd/state.h
+++ b/keyboards/polykybd/state.h
@@ -146,6 +146,12 @@ typedef struct _poly_sync_t {
     // when it sees the value change (see user_sync_poly_data_handler). It is a
     // nonce, not a state — any change triggers exactly one replay.
     uint8_t  anim_nonce;
+    // FW-2 unsigned-image confirmation prompt active on the master (0/1). Synced so
+    // BOTH halves turn their keycaps into the prompt: update_displays blanks every
+    // key and draws A/ACCEPT (left half) or R/REJECT (right half) on the home-row
+    // middle key. The answer comes back over the normal matrix pull — only the
+    // master runs process_record, so it sees either half's press.
+    uint8_t  fw_confirm;
 } poly_sync_t;
 
 typedef struct _poly_last_t {

--- a/keyboards/polykybd/tools/SIGNING.md
+++ b/keyboards/polykybd/tools/SIGNING.md
@@ -61,18 +61,32 @@ over HID. Two ways through:
    python3 keyboards/polykybd/tools/sign_firmware.py --privkey fw_signing_key.bin out.bin
    ```
 
-2. **Arm the physical override**: press **`KC_ALLOW_UNSIGNED`** on the keyboard
-   (settings layer, next to the Eden key), then start the flash within
-   **`FW_UNSIGNED_ARM_WINDOW_MS`** (2 minutes). It is **single-use** — consumed by
-   the next COMMIT whether or not that image was signed — and **RAM-only**, so a
-   reboot disarms it.
+2. **Confirm it on the keyboard**: just flash. At COMMIT the keyboard notices the
+   image is not validly signed and **turns its keycaps into a dialog** — every key
+   goes dark except one on each half: a big **A / ACCEPT** on the left home-row
+   index key (`D`) and a big **R / REJECT** on the right one (`J`). Press A to let
+   this image through, R to refuse. The host shows "Confirm on the KEYBOARD…" and
+   re-polls until you answer.
 
-⚠️ **Why a keycode and not a host dialog / HID command.** The threat FW-2 addresses
-is *any process that can talk the HID flash protocol*. An acknowledgement carried
-over that same channel is forgeable by exactly the attacker it is meant to stop:
-malware would set the flag and flash whatever it liked. A keypress cannot be
-produced remotely, so the override is worth something. Do not "improve" this into a
-host-side confirmation.
+   * The prompt lasts **`FW_CONFIRM_WINDOW_MS`** (60 s); a timeout means *reject*.
+   * It authorises **exactly the image being committed** — the state is consumed
+     by the COMMIT that acts on it, so the next unsigned flash asks again.
+   * It is **RAM-only** and reset by every `BEGIN`, so nothing survives a reboot or
+     leaks between flashes.
+   * All other keys are swallowed while the prompt is up — the board *is* the
+     dialog, so it cannot be mistaken for normal typing.
+
+⚠️ **Why the answer comes off the matrix and not from a host dialog / HID command.**
+The threat FW-2 addresses is *any process that can talk the HID flash protocol*. An
+acknowledgement carried over that same channel is forgeable by exactly the attacker
+it is meant to stop: malware would set the flag and flash whatever it liked. A
+keypress cannot be produced remotely, so the confirmation is worth something. Do
+not "improve" this into a host-side confirmation.
+
+The one thing HID *may* do is **cancel** the prompt (a COMMIT carrying `'x'` in
+`data[2]`), because cancelling can only ever DENY. The host's abort path uses it so
+a cancelled flash takes the dialog off the keycaps, and the HIL rig uses it because
+it has no fingers and would otherwise leave the board modal for the full window.
 
 **BOOTSEL/UF2 is unaffected** — it bypasses `fw_staging` entirely, so it remains an
 unconditional recovery path and enforcement cannot brick a board. That also means


### PR DESCRIPTION
## Summary

Replaces the pre-armed `KC_ALLOW_UNSIGNED` escape hatch with a prompt the keyboard raises when it actually matters. At COMMIT, an image that is not validly signed turns the whole board into a dialog: every keycap goes dark except a 2×-scaled **A / ACCEPT** on the left half's home-row index key and **R / REJECT** on the right half's, the status OLED states the question in words, and every other key event is swallowed.

The old hatch asked the user to remember a key, find it on a settings layer, and start a flash inside a two-minute window — before anything had told them a signature was missing. It also silently consumed the arming on any COMMIT, signed or not.

**COMMIT must not block waiting for the answer.** It runs inside `raw_hid_receive()` on the main loop, which is also what scans the matrix, so a busy-wait would guarantee the keypress is never seen. It is a state machine instead: the first COMMIT raises the prompt and answers a new `?` status; the host re-polls until a press or `FW_CONFIRM_WINDOW_MS` (60 s, timeout = reject) resolves it to `.` or `S`. Re-running finalize is free, but COMMIT skips re-bridging to the slave while a prompt is up — every poll would otherwise re-erase and re-stamp the slave's 4 KB staging header sector.

**Accepting stays physical**; cancelling (COMMIT carrying `'x'`) is exposed over HID because it can only ever deny — the host's abort path and the HIL rig use it.

Later commits fix what the first hardware round turned up:

- **Held keys were stranded.** A key down when the prompt went up had its release swallowed, so the host kept the keycode registered and auto-repeated it. The same happened on a plain *signed* apply for a different reason: the main loop never scans the matrix again once `fw_staging_apply_and_reboot()` is entered. Both fixed with `clear_keyboard()` before the point of no return — the same call, for the same reason, `doom_begin()` already makes.
- **The prompt answered on the press**, so the restored legend was drawn under a still-inverted keycap (`matrix_scan_kb` inverts on press, un-inverts on release, independently of `process_record`). Now answered on the release.
- **The orange "can't type" cue had never been visible.** `rgb_matrix_indicators_kb` has picked orange while `commit_pending` for a long time, but it only paints from the next `rgb_matrix_task()` — and on the apply path there is no next task. Now pushed synchronously.
- **An invalid signature no longer offers the prompt at all.** No signature (`sig == 0`) is a developer build; a signature that is present and fails to verify (`sig == -1`) is an image that is not what it claims to be. Offering a keypress for the second would hand an attacker the one thing the physical gate exists to withhold — a user who has been told to press A.

Needs the matching host PR to be usable for unsigned images: a host without the `?` handling falls into its generic failure branch and the progress dialog stalls.

## Version bump label

No label — patch bump. `PROTOCOL_VERSION` is unchanged: `?` is a new *status byte* on an existing command, not a wire-format change, and `hid_fw_up` is dispatched independently of the protocol version by design.

## Testing
- [x] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`), plus split42 and the `POLYKYBD_DOOM` monolith (the RAM-tightest flavour, since this adds statics) — 13,668 B `.heap` free on the pack flavour
- [x] `qmk lint --strict` passes on both keyboards
- [x] Flashed and tested on hardware — prompt raised, A accepted, R rejected, keycap/OLED/RGB behaviour confirmed by the maintainer
- [x] If protocol changed: n/a (no protocol change); host updated and tested together

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qc8ktXFoysiKAfTSSjpkB

---
_Generated by [Claude Code](https://claude.ai/code/session_014qc8ktXFoysiKAfTSSjpkB)_

## Summary by Sourcery

Introduce a physical on-keyboard confirmation dialog for applying unsigned firmware images, replacing the previous pre-armed override, and integrate it into the firmware staging, display, RGB, and HID flows.

New Features:
- Add an on-keycap A/ACCEPT and R/REJECT confirmation dialog for unsigned firmware images, driven by firmware staging state and shown symmetrically on both halves.
- Display a textual unsigned-firmware confirmation screen on the status OLED explaining the modal state and the A/R choices.
- Provide a new 2x glyph rendering helper to draw oversized characters on keycap displays for the confirmation prompt.

Bug Fixes:
- Ensure held keys are released via clear_keyboard() before firmware apply or reboot paths to prevent stuck or autorepeating keys during updates.
- Make the orange "cannot type" RGB cue appear synchronously during firmware apply and reboot, and while the confirmation prompt is active, so users reliably see the state. 
- Avoid mismatched keycap inversion by resolving the confirmation answer on key release rather than key press.
- Prevent idle dimming from obscuring the confirmation prompt by suppressing idle while a decision is pending.

Enhancements:
- Refine firmware signing enforcement so unsigned images can be explicitly confirmed on-device, while images with invalid signatures are rejected outright without a prompt.
- Extend split sync state to propagate confirmation-prompt status so both halves render and clear the dialog consistently.
- Improve COMMIT status reporting over HID to distinguish CRC errors, signature refusals, and pending on-keyboard confirmation.
- Simplify firmware staging confirmation logic into an explicit state machine with timeout and expose helpers for other modules to query and drive it.
- Update documentation to describe the new confirmation flow, rationale, and signing behavior, and adjust rules.mk comments to match.

Documentation:
- Document the firmware signing enforcement model and the new on-keycap confirmation flow in CLAUDE.md and SIGNING.md, including threat-model rationale and host behavior.