### PR TITLE
CLAUDE.md: record what the FW-2 hardware round taught

### DIFF
--- a/.claude/skills/measure-firmware-perf/SKILL.md
+++ b/.claude/skills/measure-firmware-perf/SKILL.md
@@ -77,6 +77,14 @@ print('console_tail:', d['console_tail'][:3])
 Reject the run if any of these fail:
 - **`ready_gate_ok` or `settled` is false** → it measured the master's boot-time
   busy window, not the workload. Re-run; never baseline it.
+- ⚠️ **`hid_latency.misses > 0`** → the gates can BOTH pass and the run still be
+  unbankable. One unanswered GET_ID out of 100 is the rig's known transient
+  deafness, not a latency regression — but the retry lands in the sample set as a
+  ~1000 ms `max`. Seen 2026-08-05: `p50 3.0 / p95 4.01 / max 1006.12 ms, 1 miss(es)`,
+  reported as **+20062 %**. Reading `p50` and `p95` (both unmoved) is what identifies
+  it as an outlier. **Never baseline a run with misses**: storing that `max` bakes
+  200× phantom headroom into the one metric meant to catch a latency regression, and
+  the guard never fires again. Re-run until `0 miss(es)`.
 - **`ovl_iters != reports`** → the instrumentation is broken (one bulk overlay
   report must produce exactly one tagged iteration). No timing from that window is
   trustworthy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,13 @@ inherited-upstream noise:
   (`!keyboards/polykybd/**/*.png`) — all three verified to make `qmk lint --strict`
   pass. **This contradicts the "lint passes green on every normal commit" line
   above** — that holds only while no such file exists.
+- ⚠️ **Applying N labels in ONE API call fires N `labeled` events, i.e. N workflow
+  runs.** `qmk-test.yml` listens for `labeled` (it must, or the `perf` label would
+  trigger nothing), so adding `perf` + `bump:minor` together started **two identical
+  perf runs** — a wasted rig build + flash each (2026-08-05). The rig executes one job
+  at a time so they queue rather than collide, but cancel the duplicate. Apply labels
+  one call at a time when one of them is a trigger, or expect to clean up. This is a
+  *different* mechanism from the push/pull_request duplication below.
 - ⚠️ **A workflow yields TWO check runs — `push` and `pull_request` — whenever the
   branch matches BOTH triggers, and re-running one does NOT touch the other.**
   Here that mostly doesn't happen: `qmk-test.yml` pushes only on `PolyKybd`/
@@ -635,6 +642,34 @@ An image that fails that check is **not refused outright** — the keyboard asks
   exactly the attacker signing defends against. A **cancel** (COMMIT with `'x'` in
   `data[2]`) can only ever deny, so it *is* exposed — the host's abort path and the HIL
   rig (no fingers) use it instead of leaving the board modal for the full window.
+- ⚠️ **An UNSIGNED image (`sig == 0`) gets the prompt; an INVALID one (`sig == -1`) is
+  refused outright.** They are opposite events: the first is "you compiled this
+  yourself", the second is a file that is not what it claims to be. Offering a keypress
+  for the second would hand an attacker the one thing the physical gate exists to
+  withhold — a user who has been told to press A. The host tells the two apart from a
+  single `S` status because it knows whether it sent a signature.
+- ⚠️ **`clear_keyboard()` before ANY path that swallows keys or does not return.** Two
+  different mechanisms stranded a held key on the host, both fixed the same way (the
+  call `doom_begin()` already made, for the same reason): the prompt swallows the
+  *release* of a key that was already down, and the apply path never scans the matrix
+  again once `fw_staging_apply_and_reboot()`/`mcu_reset()` is entered, so the release is
+  never even produced. Either way the host keeps the keycode registered and auto-repeats
+  it until USB drops — field-reported as "a few hundred repetitions until the keyboard
+  rebooted". On the apply path the following `oled_fw_apply_screen()` conveniently gives
+  the cleared report ~26 ms to leave over USB.
+- **Answer the prompt on the RELEASE, not the press.** `split72.c`'s `matrix_scan_kb`
+  inverts a keycap on press and un-inverts on release *independently of
+  `process_record`*, so acting on the press tears the prompt down and redraws the normal
+  legend while that keycap is still inverted — and it stays inverted until the finger
+  lifts.
+- ⚠️ **A visual cue set on a path that never returns is never painted.**
+  `rgb_matrix_indicators_kb` had picked orange while `commit_pending` for a long time,
+  but it only runs from the next `rgb_matrix_task()` — and on the apply path there is no
+  next task. The cue the code appeared to implement had, in practice, **never been
+  seen**. `poly_flash_rgb_now()` pushes it synchronously (`rgb_matrix_update_pwm_buffers`),
+  the same way `oled_fw_apply_screen()` flushes the status OLED in one pass. Generalise:
+  anything that must be *visible* before a blocking self-flash / reset has to be flushed
+  by the code that draws it, not left to a periodic task.
 - Housekeeping calls `fw_staging_confirm_tick()` **outside** the `!fw_up_active` gate
   and holds `update_performed()` while pending, so the idle fade can't dim the prompt
   out from under the user (`update_displays` early-returns once `DISP_IDLE` is set, so


### PR DESCRIPTION
## Summary

Documentation and skill updates only — no code. The FW-2 section was written before the confirmation prompt met real hardware, so it captured the design and none of the four things that only appeared once a person pressed the key.

**Added to `CLAUDE.md` §FW-2:**

- `clear_keyboard()` before **any** path that swallows keys or does not return. Two different mechanisms stranded a held key on the host — the prompt swallows the *release* of a key already down, and the apply path never scans the matrix again — producing the same symptom either way: the host auto-repeating until USB drops.
- Answer on the **release**, not the press. `matrix_scan_kb` inverts a keycap independently of `process_record`, so acting on the press redraws the legend under a still-inverted panel.
- **A cue set on a path that never returns is never painted.** The orange "can't type" backlight had been in the code a long time and had, in practice, never been seen — `rgb_matrix_indicators_kb` only runs from the next `rgb_matrix_task()`, and the apply path has no next task. Generalised, since the status OLED had already solved the same problem the same way.
- An unsigned image and an invalid signature are opposite events and must not share a path.

**Added to `CLAUDE.md` §CI:** applying N labels in one API call fires N `labeled` events. Adding `perf` + `bump:minor` together started two identical perf runs and cost a rig build + flash. Distinct from the push/pull_request duplication documented below it.

**`measure-firmware-perf` skill:** reject a run with `hid_latency.misses > 0`. It already rejected a failed readiness gate; this is the subtler case where **both** gates pass and the run still cannot be banked — one unanswered GET_ID in 100 landed as a 1006 ms `max` (+20062 %), and storing it would have baked 200× phantom headroom into the one metric meant to catch a latency regression.

## Version bump label

None — patch. Docs/skills only.

## Testing
- [x] Compiled successfully — n/a, no code changed
- [x] Flashed and tested on hardware — n/a; the content *records* this session's hardware round
- [x] If protocol changed: n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qc8ktXFoysiKAfTSSjpkB

---
_Generated by [Claude Code](https://claude.ai/code/session_014qc8ktXFoysiKAfTSSjpkB)_

## Summary by Sourcery

Document firmware confirmation-prompt hardware findings and CI label-trigger behavior, and tighten performance run acceptance criteria in the firmware perf measurement skill.

Enhancements:
- Clarify the semantics of unsigned versus invalid firmware images in the confirmation workflow to align documentation with current security behavior.

Documentation:
- Expand CLAUDE.md with FW-2 hardware-round lessons around key handling, visual cues, and signature validation in the firmware confirmation flow.
- Document GitHub labeling behavior where applying multiple labels in one API call triggers multiple perf workflows and how to avoid duplicate runs.

Tests:
- Update the measure-firmware-perf skill to reject runs with nonzero hid_latency.misses to prevent baselining outlier latency samples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance to reject performance runs with HID latency misses and rerun until results are reliable.
  * Documented CI label-handling considerations to help avoid duplicate performance jobs.
  * Added firmware-update safety guidance for signature validation, keyboard state clearing, confirmation handling, and RGB feedback during resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->