### PR TITLE
CLAUDE.md: warn that signing does not cover the resource region (FW-9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -683,6 +683,22 @@ An image that fails that check is **not refused outright** — the keyboard asks
   clips one of them. Preview the cells with `PolyKybdHost/tools/gfx_font.py`.
 - Full user-facing story: `keyboards/polykybd/tools/SIGNING.md`. BOOTSEL/UF2 bypasses
   `fw_staging` entirely, so enforcement can never brick a board.
+- ⚠️ **Signing gates the FIRMWARE image only — it does NOT close the code-execution
+  surface, and this section reads as though it does.** `fw_staging_check_signature()`
+  is called exclusively in the `FW_TARGET_FIRMWARE` branch of `fw_staging_finalize()`;
+  the **resource region** (4–8 MB) has no signature check at any target. That matters
+  because one of the things flashed there is **executable code**: `doom_pack_load.c`
+  validates the `.plyx` engine pack with magic / ABI / size / RAM-pairing / **CRC32
+  only**, then calls `init(&s_fw_api)` — branching to an offset the pack itself names,
+  on an M0+ with no MPU, so the loaded code is unconfined. The whole chain is remote
+  over HID with no keypress: flash a crafted `.plyx` (cmds `0x50`–`0x52`) → set
+  `IDLE_STYLE_IDDQD` (cmd 28) → the next idle runs it. So the A/ACCEPT prompt guards
+  the firmware image while an unguarded path loads code beside it. Tracked as **FW-9**
+  (open, high) in `polykybd-ctnd/docs/SECURITY_AUDIT.md`, with the fix sketch — verify
+  the pack with the Ed25519 machinery already compiled in, **at load time, not at
+  COMMIT** (flash can be rewritten after a COMMIT succeeds). Interim mitigation:
+  build without `POLYKYBD_DOOM_PACK`. `.whx` / `.plyf` ride the same unsigned
+  transport but are data, not code.
 
 ### Idle anti-burn-in styles (`poly_keymap.c`)
 When the keyboard idles, the keycap legends would otherwise burn the **same**


### PR DESCRIPTION
Follow-up to the security evaluation (companion: [polykybd-ctnd #63](https://github.com/thpoll83/polykybd-ctnd/pull/63)). Documentation only.

The "Firmware signing enforcement & the on-keycap confirmation (FW-2)" section currently reads as though `FW_REQUIRE_SIGNATURE` closes the code-execution surface. It doesn't, and that gap is easy to miss because the section is otherwise thorough:

- `fw_staging_check_signature()` is called **only** in the `FW_TARGET_FIRMWARE` branch of `fw_staging_finalize()` — the resource region (4–8 MB) has no signature check at any target.
- One of the things flashed there is executable code. `doom_pack_load.c` validates the `.plyx` engine pack with magic / ABI / size / RAM-pairing / **CRC32 only**, then calls `init(&s_fw_api)`, branching to an offset the pack itself names — on an M0+ with no MPU, so it's unconfined.
- The chain is remote over HID with no keypress: flash a crafted `.plyx` (cmds `0x50`–`0x52`) → set `IDLE_STYLE_IDDQD` (cmd 28) → next idle runs it.

So the A/ACCEPT prompt guards the firmware image while an unguarded path loads code beside it. The bullet records that, points at **FW-9** in `polykybd-ctnd/docs/SECURITY_AUDIT.md`, and carries the two things worth knowing up front: the fix belongs at **load time, not COMMIT** (flash can be rewritten after a COMMIT succeeds), and the interim mitigation is building without `POLYKYBD_DOOM_PACK`.

No code change, so nothing to build or flash.

---
_Generated by [Claude Code](https://claude.ai/code/session_014qc8ktXFoysiKAfTSSjpkB)_

## Summary by Sourcery

Documentation:
- Add a security warning that firmware signing does not cover the resource region and references the tracked FW-9 issue and mitigation options.