### PR TITLE
Correct the docs-build guidance in update-polykybd-docs: npm ci works

### DIFF
--- a/.claude/skills/update-polykybd-docs/SKILL.md
+++ b/.claude/skills/update-polykybd-docs/SKILL.md
@@ -86,9 +86,25 @@ grep -rhoE '\]\(/[a-z0-9-]+/[a-z0-9-]+' src/content/docs --include='*.md' --incl
   | while read -r l; do [ -f "src/content/docs$l.mdx" ] || [ -f "src/content/docs$l.md" ] || echo "BROKEN: $l"; done
 ```
 
-Then a full build. ⚠️ **`npm ci` fails in the sandbox because `sharp` can't fetch
-its prebuilt binary through the proxy (HTTP 403)** — this is an environment limit,
-not your change. Work around it:
+Then a full build. **Try plain `npm ci` first — it works, and `sharp` installs:**
+
+```bash
+npm ci --no-audit --no-fund
+npx astro build                    # expect "N page(s) built", no errors
+```
+
+⚠️ **The `--ignore-scripts` + `passthroughImageService` workaround below is a
+FALLBACK, not the default** — an earlier version of this skill presented it as
+mandatory ("`npm ci` fails because sharp can't fetch its prebuilt binary, HTTP
+403"). That was environment-specific and no longer holds (verified 2026-08:
+plain `npm ci` installed sharp and the build emitted real WebP).
+
+**Never use the fallback when the change involves images.** Passthrough disables
+resizing and WebP conversion entirely, so the build no longer reflects what the
+site serves — any check of an image's dimensions or weight silently measures the
+*source* file instead of the emitted asset, and reads as a pass.
+
+Only if `npm ci` genuinely fails on sharp's postinstall:
 
 ```bash
 npm ci --ignore-scripts            # installs deps, skips sharp's postinstall
@@ -115,8 +131,10 @@ between words yields a double hyphen).
   auto-add it, and an orphan page is invisible.
 - **Docs are a separate PR** in `polykybd-docs` (base `main`) — do not bury a docs
   edit inside a firmware/host PR; they merge on different branches.
-- **Never commit the passthrough image-service tweak** — it's only to let the build
-  run in the sandbox; restore `astro.config.mjs` before committing.
+- **Never commit the passthrough image-service tweak** — it's only a fallback for
+  a broken sharp install; restore `astro.config.mjs` before committing. And never
+  reach for it at all on an image change: it turns off resize + WebP, so the build
+  stops reflecting what the site serves.
 - **User voice, not dev notes.** These pages are for keyboard owners; put deep
   mechanism in the firmware/host `CLAUDE.md` or the `development/` section, not the
   user pages.


### PR DESCRIPTION
One file: `.claude/skills/update-polykybd-docs/SKILL.md`. Mirror of thpoll83/PolyKybdHost#146 — the two copies of this skill are kept byte-identical, and I diffed them before and after the edit.

The skill stated as fact that `npm ci` fails in the sandbox because `sharp` can't fetch its prebuilt binary (HTTP 403), and prescribed `--ignore-scripts` plus a `passthroughImageService` patch as **the** way to build the docs site.

Verified 2026-08 while doing image work in `polykybd-docs`: plain `npm ci` installs sharp and the build emits real WebP. The workaround is now demoted to a fallback for a genuinely broken sharp install.

**Why this is worth a PR rather than a note.** Passthrough turns *off* resize and WebP conversion. Following the old instruction while working on images means the build stops reflecting what the site serves — so checking an image's dimensions or weight silently measures the **source** file and reads as a pass. That's a verification step that cannot fail, which is worse than not checking at all. Called out both at the point of use and in Pitfalls.

No firmware code is touched, so the build and HIL checks are unaffected by the content of this change.

Found by the `session-retro` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkWN6TkmAAbdF6WGEU3sV8

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkWN6TkmAAbdF6WGEU3sV8)_

## Summary by Sourcery

Update the PolyKybd docs update skill to prefer a standard npm ci build and treat the passthrough image-service workaround as a last-resort fallback, especially for image-related changes.

Documentation:
- Revise docs-build guidance to state that plain npm ci is now the default and generally succeeds for installing sharp.
- Clarify that the --ignore-scripts plus passthroughImageService workaround is only a fallback for genuinely broken sharp installs and must not be used for image changes.
- Reinforce that the passthrough image-service tweak must never be committed, as it disables resizing and WebP conversion and makes builds diverge from production behavior.