### PR TITLE
fix(flash): fully leave idle before a flash, and hold it off during it

### DIFF
--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -619,20 +619,38 @@ static int8_t jitter_axis(uint32_t epoch, uint32_t salt, int8_t lo, int8_t hi) {
 // legends during the (mostly-blocking) transfer. Called from the HID BEGIN
 // handlers BEFORE fw_up activates (which freezes display updates).
 void poly_prepare_for_flash(void) {
-    // Exit idle FIRST. If the keyboard had dimmed/idled (DISP_IDLE, or contrast
-    // pulsed down to DISP_OFF) when the flash begins, the keycaps were dark and
-    // update_displays() early-returns while DISP_IDLE is set — so the legible
-    // base legends never get drawn and "some keys are not lit" during the flash.
-    // Force a full wake (mirrors suspend_wakeup_init_kb / the cmd-15 stop-idle
-    // path) so contrast is restored and the refresh below actually renders.
+    // Exit idle FIRST, in EVERY flavour it comes in. If the keyboard had
+    // dimmed/idled when the flash begins, the keycaps were dark and
+    // update_displays() early-returns — so the legible base legends never get
+    // drawn and "some keys are not lit" during the flash. The two animated idle
+    // styles do NOT show up as "DISP_IDLE, or contrast pulsed to DISP_OFF", and
+    // both own the keycaps through a tick that housekeeping FREEZES for the whole
+    // flash (doom_tick / eden_idle_tick sit behind the !fw_up_active gate), so
+    // neither can tear itself down once staging starts:
+    //   * DOOM attract (IDLE_STYLE_IDDQD) runs with STATUS_DISP_ON SET and
+    //     DISP_IDLE CLEARED at the user brightness — it matches no idle test at
+    //     all, and left up it holds a half-drawn demo frame and swallows keys for
+    //     the whole transfer. Screensaver only, never an active game — the same
+    //     rule poly_force_wake()/poly_suspend() follow.
+    //   * Eden (IDLE_STYLE_EDEN) does set DISP_IDLE, but clearing the flag is not
+    //     enough: update_displays() also early-returns while startup_anim_active(),
+    //     so the render below would draw nothing.
+    // Mirrors display_wakeup() / poly_force_wake(); deliberately UNCONDITIONAL —
+    // a partial fade (IDLE_TRANSITION, contrast somewhere in between) matches
+    // neither of the old tests, and on an awake keyboard the assignments are a
+    // no-op while the timestamp below must be stamped either way.
+    doom_screensaver_stop();   // self-guards: only an active attract demo
+    startup_anim_stop();       // looping Eden (and a one-shot mid-flight)
     poly_sync_t* local_state = access_local_state();
-    if ((local_state->flags & DISP_IDLE) != 0 || local_state->contrast == DISP_OFF) {
-        local_state->flags &= ~((uint8_t)DISP_IDLE) & ~((uint8_t)IDLE_TRANSITION);
-        local_state->flags |= STATUS_DISP_ON;
-        local_state->contrast = get_active_brightness();
-        reset_idle_jitter();       // fresh centred legends, not jittered offsets
-        update_performed();
-    }
+    local_state->flags &= ~((uint8_t)DISP_IDLE) & ~((uint8_t)IDLE_TRANSITION);
+    local_state->flags |= STATUS_DISP_ON;
+    local_state->contrast = get_active_brightness();
+    reset_idle_jitter();       // fresh centred legends, not jittered offsets
+    // Restart the idle countdown from the start of the flash — a deliberate host
+    // command, so this is real activity by update.h's rule. Unconditional matters:
+    // a keyboard 100 s into its 120 s FADE_OUT_TIME was awake (so the old gated
+    // stamp never ran) and would fade out 20 s into the transfer.
+    update_performed();
     // Momentary/toggle layers off, then back onto the PolyKybd default layout.
     // A bare layer_clear() falls through to QMK's *saved* default layer
     // (default_layer_state), NOT the Poly def_layer — which is a layer INDEX
@@ -975,6 +993,18 @@ void housekeeping_task_user(void) {
         if (want) {
             update_performed();
         }
+    }
+
+    // Hold the idle countdown off for the whole transfer, the same way the
+    // confirmation prompt above does. The idle state machine below is NOT behind
+    // the !fw_up_active gate (only the refresh that would act on it is), so a
+    // flash long enough to cross FADE_OUT_TIME with nobody typing flips the state
+    // to idle mid-transfer — the keycaps poly_prepare_for_flash() just made
+    // legible then go dark the moment the flash releases the display path (a
+    // font-pack flash, which does not reboot, shows this plainly). A flash is a
+    // deliberate host command, so this is legitimate activity by update.h's rule.
+    if (fw_staging_fw_up_active()) {
+        update_performed();
     }
 
     // While a fw_up is in progress, skip EEPROM saves (wear-leveling consolidate


### PR DESCRIPTION
## Summary

When a firmware or font-pack flash starts while the keyboard is idling, it has to stop idling first. `poly_prepare_for_flash()` already tried to, but its gate was `DISP_IDLE set || contrast == DISP_OFF`, which misses most of the shapes idle comes in — and the countdown kept running for the whole transfer. Two holes:

**1. Idle wasn't fully left at the start of the flash** (`poly_prepare_for_flash`)

The two animated screensavers both own the keycaps through a tick that housekeeping **freezes** while `fw_up_active` (`doom_tick` / `eden_idle_tick` sit behind that gate), so once staging starts neither can tear itself down:

- **DOOM attract** (`IDLE_STYLE_IDDQD`) runs with `STATUS_DISP_ON` **set** and `DISP_IDLE` **cleared** at the user brightness — it matched neither test, so nothing happened at all. The panels held a half-drawn demo frame and kept swallowing keys for the whole transfer.
- **Eden** (`IDLE_STYLE_EDEN`) does set `DISP_IDLE`, so the flags were cleared — but `update_displays()` *also* early-returns while `startup_anim_active()`, so the render drew nothing and the legends never appeared.
- A **partial fade** (`IDLE_TRANSITION`, contrast somewhere in between) matched neither test either and stayed dim.

Fix: `doom_screensaver_stop()` + `startup_anim_stop()` first (both self-guard, so they are no-ops when nothing is running), then do the wake **unconditionally** — mirroring `display_wakeup()` / `poly_force_wake()`. On an awake keyboard the assignments are a no-op. Screensaver only, never an active game, same rule `poly_force_wake()`/`poly_suspend()` follow.

**2. Idle could re-enter *during* the flash** (`housekeeping_task_user`)

The idle state machine is **not** behind the `!fw_staging_fw_up_active()` gate — only the refresh that would act on it is. So a transfer crossing `FADE_OUT_TIME` (120 s) with nobody typing flipped the state to idle mid-flash, and the freshly-drawn legends went dark the moment the display path came back. A **font-pack** flash shows this plainly since it does not reboot afterwards.

The old `update_performed()` also sat *inside* the gated branch, so a keyboard that was awake but already 100 s into its 120 s countdown got no stamp at all and faded ~20 s into the transfer. The stamp is now unconditional in prepare, and repeated from housekeeping while `fw_up_active` — exactly the way the signature-confirm prompt already holds the fade off a few lines above.

No wire-protocol change, no new statics, no host-side change.

## Version bump label

*(none)* — bug fix, patch bump.

## Testing
- [x] Compiled successfully — split72 `default`, `-e POLYKYBD_DOOM_PACK=yes`, and the `-e POLYKYBD_DOOM=yes` **monolith** (the tightest-RAM flavour PR CI does not build), plus split42 `default`
- [ ] Flashed and tested on hardware — needs a real flash started while a screensaver is up (IDDQD / Eden) and a long font-pack flash to confirm the keycaps stay legible throughout
- [x] Protocol unchanged, so no host update needed

### Known caveat (pre-existing, unchanged)
The slave tears its own Eden loop down from `eden_idle_tick()` once the master's cleared `DISP_IDLE` arrives, which needs a housekeeping pass to land between the poly-state bridge and the `FLASH_STAGE` bridge that sets the slave's `fw_up_active`. That is the same window the existing base-layer render already relies on, so it was left alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xx2fgnTcyP55ATN22fsp6U)_

## Summary by Sourcery

Ensure keyboard display fully exits idle before firmware/font-pack flashes and stays awake for the duration of the transfer so legends remain visible and key input is not swallowed.

Bug Fixes:
- Always wake the display from all idle states, including animated screensavers and partial fades, before starting a flash so keycaps render correctly and do not capture input.
- Prevent the idle state machine from dimming or blanking the display during long firmware or font-pack flashes by continually marking activity while flashing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Firmware flashing now reliably exits screensaver and startup animations.
  * Display state and brightness are restored before flashing begins.
  * Prevented the keyboard from entering idle mode during firmware transfers.
  * Reset idle display movement and timers for a more consistent flashing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->