### PR TITLE
Record the 0.33.13 upstream-merge learnings; bump to 0.12.0

### DIFF
--- a/.claude/skills/merge-upstream-into-branch/SKILL.md
+++ b/.claude/skills/merge-upstream-into-branch/SKILL.md
@@ -8,7 +8,45 @@ description: Merge upstream/master into the current branch (typically PolyKybd),
 Integrates `qmk/qmk_firmware:master` into the current branch (normally `PolyKybd`).
 Conflicts are expected — the files most likely to conflict are listed in the pitfalls section below.
 
-Repo root: `/home/thpoll/Repos/qmk_firmware`
+Repo root: `/home/thpoll/Repos/qmk_firmware` on the user's machine,
+**`/home/user/qmk_firmware`** in a Claude Code web/remote container.
+
+## Step 0 — container prerequisites (skip on the user's own machine)
+
+A fresh remote-container clone is **shallow** and has no `upstream` remote, which
+makes every history answer below wrong until fixed:
+
+```bash
+git rev-parse --is-shallow-repository                    # true → fix before trusting anything
+git fetch origin --unshallow --no-recurse-submodules     # ~1-2 min on this repo
+git remote add upstream https://github.com/qmk/qmk_firmware   # if missing
+git fetch upstream --tags --no-recurse-submodules
+```
+
+⚠️ **On a shallow clone `git merge-base` returns an EMPTY STRING, not an error.**
+Anything comparing this branch to upstream then silently degrades — a script using
+`$(git merge-base …)` reports tens of thousands of "unrelated" commits for a fork
+whose merge base is one of its own branches. After unshallowing, the merge base
+should resolve to the fork's own `master`; that is the check that it worked.
+
+`--no-recurse-submodules` throughout: the `qmk/*` submodule repos are not
+proxy-authorized, so a plain fetch ends in `Could not access submodule 'lib/chibios'`
+noise that hides the real result.
+
+## Which upstream point to merge — tag vs master
+
+Merging a **stable tag** (`0.33.13`) rather than `upstream/master` gives a base
+people can look up, and is what the fork does. Two consequences:
+
+- `master` may be **ahead** of the merged tag. That is fine (it is a mirror), but it
+  makes `UPSTREAM_PATCHES.md`'s `git diff master..HEAD` check approximate by exactly
+  that gap — check `git diff --stat <tag>..master -- tmk_core quantum platforms builddefs lib`
+  is empty, or diff against the tag you actually merged.
+- A tag can carry a **new lint/CI rule whose fixes landed after it** (see step 7).
+
+```bash
+git tag --list --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -5
+```
 
 ## Procedure
 
@@ -62,6 +100,34 @@ Repo root: `/home/thpoll/Repos/qmk_firmware`
    ```
    Confirm all `+` prefixes are gone after the update. If a submodule commit is not present locally, `git submodule update` will fetch it from the remote.
 
+   ⚠️ **In a container that fetch 403s** — the `qmk/*` submodule repos are not in the
+   session's authorized set. Call **`add_repo`** once per submodule repo
+   (`qmk/ChibiOS`, `qmk/ChibiOS-Contrib`, `qmk/lufa`, `qmk/printf`, `qmk/pico-sdk`);
+   each answers `read_available` **without attaching anything**, after which the
+   ordinary command works:
+   ```bash
+   git submodule update --init --depth 1 --no-recommend-shallow lib/chibios   # …and the rest
+   ```
+   The old `codeload.github.com` tarball workaround is **dead** (403 as of 2026-08-11)
+   and fails *quietly* inside a pipeline — `curl … | tar xz` prints only
+   `gzip: stdin: not in gzip format` while the shell reports success.
+
+6b. **Prove the UPSTREAM_PATCHES survived — diff the diffs, don't read them.** A
+   clean merge is not evidence: git resolves those files silently whenever upstream
+   didn't touch the same hunks, so "no conflicts" and "patch silently dropped" look
+   identical from the merge output.
+   ```bash
+   # BEFORE the merge
+   git diff <old-merge-base>..HEAD -- tmk_core quantum platforms builddefs drivers > /tmp/before.diff
+   # AFTER
+   git diff <tag>..HEAD           -- tmk_core quantum platforms builddefs drivers > /tmp/after.diff
+   diff /tmp/before.diff /tmp/after.diff && echo "all patches intact, context unchanged"
+   ```
+   Identical output means every patch survived *and* upstream didn't restructure
+   around it. Finish with a `grep` for one marker per patch (`raw_hid_pre_receive_kb`,
+   `ifndef RAW_EPSIZE`, `POLY_SPLIT_SHMEM_RPC_GUARD`, `POLYKYBD_VREG_VSEL`,
+   `oled_render_dirty(true)`). Full procedure in `keyboards/polykybd/UPSTREAM_PATCHES.md`.
+
 7. **Verify the build is not broken** (optional but recommended for large upstream pulls):
    Activate the QMK virtualenv and do a quick compile check:
    ```bash
@@ -69,6 +135,38 @@ Repo root: `/home/thpoll/Repos/qmk_firmware`
    qmk compile -kb polykybd/split72 -km default 2>&1 | tail -20
    ```
    If it fails, diagnose before pushing. **Do not push a firmware that was built before step 6 — the old submodule checkouts (especially pico-sdk) can cause subtle runtime bugs like broken HID communication even when the build succeeds.**
+
+   In the container: `export QMK_HOME=$PWD && export PATH="/root/.qmk_venv/bin:$PATH"`
+   (there is no `~/qmk_env`). Build **both** variants, and prefer
+   `keyboards/polykybd/doom/pack/build_pack.sh` on a DOOM-capable tree — it also
+   builds the **monolith**, the RAM-tightest flavour, which PR CI never covers.
+
+   ⚠️ **When an upstream merge breaks the build, suspect the vendored DOOM engine
+   first.** QMK builds `-Werror`, so any warning upstream adds to
+   `builddefs/common_rules.mk` becomes a hard failure in `doom/engine/`
+   (third-party rp2040-doom). 0.33.13 added `-Wunused-but-set-variable`/`-parameter`
+   — as collateral of *"GCC 16.1 compatibility fix" (#26216)*, so the commit subject
+   gave no warning — and six `m_menu.c` callbacks failed. Fix in the **doom-scoped
+   `-Wno-` demotion block in `keyboards/polykybd/rules.mk`**, never in vendored code.
+
+7b. **Sweep for new lint/CI rules the tag brought.** A stable tag can add a rule whose
+   fixes for upstream's *own* keyboards landed after it, so `lint` goes red on files
+   this fork does not maintain. Reproduce the job locally (~1 min) rather than reading
+   the CI log — `qmk info -l` fills the log tail with keyboard ASCII art, so any
+   excerpt is a partial list:
+   ```bash
+   export QMK_HOME=$PWD
+   git diff --name-only origin/PolyKybd...HEAD > /tmp/changed.txt
+   for KB in $(qmk list-keyboards); do
+     CH=$(grep -E "^keyboards/${KB}/" /tmp/changed.txt); [ -z "$CH" ] && continue
+     [ "$(echo "$CH" | grep -cv /keymaps/)" -gt 0 ] || continue
+     qmk lint --strict --keyboard "$KB" >/dev/null 2>&1 || echo "FAIL: $KB"
+   done
+   ```
+   Collect **every** failure before fixing any. Where upstream has already fixed it
+   past the tag, cherry-pick their commit (byte-identical ⇒ no future conflict);
+   otherwise write the fix taking real facts from `git log --diff-filter=A` rather
+   than inventing them. See the CI section of `CLAUDE.md` for the 0.33.13 worked case.
 
 8. **Push**:
    ```bash
@@ -97,6 +195,15 @@ These files are modified by PolyKybd and are also touched periodically by upstre
 ## Notes / pitfalls
 
 - **Merge, don't rebase `PolyKybd`**. Rebasing 196+ custom commits onto a 1034-commit upstream delta would rewrite all SHA history, requiring a force-push and invalidating any open PRs. Merge commits are the right call for a long-lived integration branch.
+- ⚠️ **CodeRabbit will SKIP the PR entirely — a merge PR gets no bot review.** Its
+  limit is 100 changed files (*"Review skipped — Too many files"*), and a catch-up
+  merge is several hundred. The skip renders as an ordinary status comment, so the
+  PR reads as reviewed. Treat **`Build firmware` + `HIL test` + a hardware flash** as
+  the only real verification, and say so when reporting the PR as ready.
+- **Check upstream's breaking-changes doc for removals that touch us**, and grep
+  before assuming: 0.33.13 removed `isLeftHand` and `FORCE_NKRO`, both of which
+  PolyKybd happened not to use — but that was worth *verifying*, not hoping, since a
+  removed `FORCE_NKRO` silently changes behaviour rather than failing to build.
 - **Run `mirror-master-with-upstream` first** so `origin/master` is current — it's a good checkpoint even if this skill doesn't depend on it.
 - **Do not merge upstream directly into a short-lived feature branch** — merge into `PolyKybd` first, then rebase the feature branch onto the updated `PolyKybd`.
 - If upstream has **removed a file** that PolyKybd still uses (shows as a `CONFLICT (modify/delete)`), keep the file and add a comment explaining it was removed upstream but retained for PolyKybd compatibility.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,16 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
     full review`**, which re-reviews the whole diff regardless of state — that is
     also the command to reach for after an aborted run, since the failed run
     recorded nothing but the head has already moved.
+  - ⚠️ **CodeRabbit SKIPS any PR over 100 changed files, so an upstream-merge PR
+    gets NO review at all** — *"Review skipped — Too many files! This PR contains
+    N files, which is M over the limit of 100."* This is a second, different tell
+    from the rate-limit one above, with the same consequence and the difference
+    that it is **guaranteed** on a catch-up merge rather than occasional. The
+    0.33.13 merge (#197) was skipped on all four pushes (401 → 425 files), each
+    time rendering as an ordinary status comment with a file table, so the PR read
+    as reviewed. There is no way to get it reviewed short of splitting the PR — so
+    for a merge PR, treat the **build + HIL checks and hardware testing as the only
+    real verification**, and don't count the green board as review cover.
 
 - **Verify an AI reviewer's finding against the code before acting on it — several
   arrive confidently wrong.** Of 7 CodeRabbit findings on one PR (2026-08-01), 3
@@ -156,6 +166,29 @@ inherited-upstream noise:
   (`!keyboards/polykybd/**/*.png`) — all three verified to make `qmk lint --strict`
   pass. **This contradicts the "lint passes green on every normal commit" line
   above** — that holds only while no such file exists.
+- ⚠️ **An upstream-merge PR lints UPSTREAM's keyboards too, so it can go red on
+  files this fork does not maintain — and a stable tag inherits a new lint rule
+  WITHOUT its post-tag fixes.** `lint.yml` lints every keyboard with a changed file
+  outside `keymaps/`, and a catch-up merge puts most of upstream's tree in that set
+  (~60 keyboards for the 161-commit 0.33.13 merge). 0.33.13 added a **license-header
+  check** to `qmk lint --strict` (`_has_license()` — crudely, the first line must
+  start with `/*` or `//`; there is no ignore mechanism), which failed **6**
+  keyboards: 1 ours (`split72/keymaps/revision2`, genuinely missing) and 5
+  upstream's. Three of those five were fixed upstream in `14774c8482` (#26382) —
+  **7 commits AFTER tag `0.33.13`** — so merging the tag brought the rule but not
+  the fix; the other two are still unfixed on upstream master today, and are green
+  upstream only because upstream lints just the keyboards *its* PR touches.
+  - The condition is **self-clearing**: once the merge lands, those keyboards are
+    in the base branch, so later PRs no longer see them as changed.
+  - Resolution used for 0.33.13 (2026-08-11): cherry-pick upstream's own fix where
+    one exists (byte-identical afterwards ⇒ no conflict at the next merge), and for
+    the rest add `// Copyright <year> <author>` + SPDX taking the **real** author and
+    year from `git log --diff-filter=A` on each file. Don't invent attribution.
+  - ⚠️ **Enumerate ALL the failures before fixing any** — `qmk info -l` prints a
+    keyboard-layout ASCII diagram per keyboard, so the CI log tail is mostly art and
+    any excerpt of it is a partial list. Fixing the 5 files a truncated view showed
+    left **13** more in `handwired/onekey` and cost an extra CI round. Run the job's
+    loop locally and collect every `☒` line first.
 - ⚠️ **Applying N labels in ONE API call fires N `labeled` events, i.e. N workflow
   runs.** `qmk-test.yml` listens for `labeled` (it must, or the `perf` label would
   trigger nothing), so adding `perf` + `bump:minor` together started **two identical


### PR DESCRIPTION
## Summary

Two things: the retro learnings from the QMK 0.33.13 merge, and the **`bump:minor` label** that takes the firmware to **0.12.0**.

### Version bump to 0.12.0

The 0.33.13 merge (#197) landed without a bump label, so `bump-version.yml` applied the default **patch** bump → `0.11.7`. For a 161-commit upstream jump across a QMK minor boundary (0.32 → 0.33), including a ChibiOS/RP2040 HAL update, that reads as understated.

This PR carries **`bump:minor`**, which the workflow turns into `0.11.7 → 0.12.0` on merge.

⚠️ **It deliberately does not edit `FW_VERSION` itself.** `bump-version.yml` bumps *after* merge by reading the current value out of `config.h`, so an edited version file would be bumped on top of — the documented way to move the version is a labelled PR that leaves the file alone.

### Learnings recorded

**`CLAUDE.md` — CI section**

- An upstream-merge PR lints **upstream's** keyboards, not just ours: `lint.yml` lints every keyboard with a changed file outside `keymaps/`, and a catch-up merge puts most of upstream's tree in that set. So it can go red on files this fork doesn't maintain — and the condition **self-clears** once the merge lands.
- A stable tag inherits a new rule **without its post-tag fixes**. 0.33.13 added the license-header check to `qmk lint --strict`; upstream's fix for three of its own keyboards (`14774c8482`, #26382) landed **7 commits after the tag**. Records the resolution: cherry-pick upstream's fix where one exists (byte-identical ⇒ no future conflict), otherwise take the real author and year from `git log --diff-filter=A` rather than inventing attribution.
- **Enumerate every failure before fixing any** — `qmk info -l` fills the CI log tail with keyboard ASCII art, so any excerpt is a partial list. Acting on the 5 files a truncated view showed left **13** more in `handwired/onekey` and cost an extra CI round.

**`CLAUDE.md` — code-review conventions**

- CodeRabbit **skips any PR over 100 changed files**, so a merge PR gets no bot review at all. Same consequence as the documented rate-limit tell, but *guaranteed* on a catch-up merge rather than occasional, and it renders as an ordinary status comment with a file table — #197 was skipped on all four pushes (401 → 425 files). Conclusion recorded: treat build + HIL + a hardware flash as the only real verification there.

**`merge-upstream-into-branch` skill** — updated where it was wrong or silent for this environment:

- Container Step 0: unshallow + upstream remote, and the trap that `git merge-base` returns an **empty string** rather than an error on a shallow clone.
- Tag-vs-master guidance, including what it does to `UPSTREAM_PATCHES.md`'s check when `master` is ahead.
- The **`add_repo`** submodule path — the `codeload.github.com` workaround the skill implied is dead (403) and fails *quietly* in a pipeline.
- The **diff-the-diffs** proof that the patches survived, since a clean merge is not evidence.
- The vendored-DOOM `-Werror` rule (fix in the doom-scoped demotion block, never in vendored code).
- A post-merge **sweep for new lint rules**, with a runnable loop.
- Build **both** variants plus the monolith; expect the CodeRabbit skip.

## Testing

Documentation and skill text only — no code, no build inputs touched. The learnings are drawn from #197, whose `Build firmware` and `HIL test (split72)` both passed and which was flashed to hardware three times (plus DOOM) by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PM5DsXYGeDCg7WVuoqszkD

---
_Generated by [Claude Code](https://claude.ai/code/session_01PM5DsXYGeDCg7WVuoqszkD)_

## Summary by Sourcery

Document upstream-merge learnings and update internal guidance for integrating QMK upstream into the PolyKybd fork.

Documentation:
- Expand CLAUDE.md with learnings from the QMK 0.33.13 upstream merge, covering CI/lint behavior on upstream keyboards and CodeRabbit review limits for large PRs.

Chores:
- Enhance the merge-upstream-into-branch skill with container-specific prerequisites, tag-vs-master guidance, submodule access handling, patch-preservation checks, build and lint workflows, and additional pitfalls for future upstream merges.