### PR TITLE
Measure performance after an upstream merge

### DIFF
--- a/.claude/skills/merge-upstream-into-branch/SKILL.md
+++ b/.claude/skills/merge-upstream-into-branch/SKILL.md
@@ -173,11 +173,25 @@ git tag --list --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -5
    git push origin $(git branch --show-current)
    ```
 
+8b. **Label the PR `perf`.** A catch-up merge is the change most likely to move
+   main-loop timing with **no PolyKybd source touched** — new ChibiOS / pico-sdk pins
+   and core split/USB/scheduler changes — and it is the PR CodeRabbit skips, so
+   `Build firmware` + `HIL test` are the only other checks and neither measures
+   timing. `Performance measurement (split72)` is report-only, so it cannot redden the
+   PR. Apply it as its **own** label call: each label fires its own workflow run, so
+   batching it with `bump:*` starts two identical rig runs.
+
+   After the merge lands and the number is understood, **move the baseline** —
+   `polykybd-ctnd`'s `perf/baselines/split72.json` is compared against, never
+   auto-updated, so leaving it pre-merge makes every later PR report the merge's
+   delta as a phantom regression.
+
 9. **Report**:
    - Number of upstream commits merged.
    - Any files that had conflicts and how they were resolved.
    - New HEAD SHA.
    - Whether a build check was run and whether it passed.
+   - The perf table vs. the baseline, and whether the baseline was moved.
 
 ## Known conflict-prone files
 

--- a/.claude/skills/merge-upstream-into-branch/SKILL.md
+++ b/.claude/skills/merge-upstream-into-branch/SKILL.md
@@ -181,10 +181,23 @@ git tag --list --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -5
    PR. Apply it as its **own** label call: each label fires its own workflow run, so
    batching it with `bump:*` starts two identical rig runs.
 
-   After the merge lands and the number is understood, **move the baseline** —
+   After the merge lands, **move the baseline only if something actually moved.**
    `polykybd-ctnd`'s `perf/baselines/split72.json` is compared against, never
-   auto-updated, so leaving it pre-merge makes every later PR report the merge's
-   delta as a phantom regression.
+   auto-updated, so a real shift left unrecorded becomes a phantom regression on
+   every later PR — but a re-baseline is not free either. ⚠️ **"Idle — worst
+   iteration" is a max-of-window sample and swings ~2× run to run.** The 0.33.13
+   measurement read 1.88 ms against a 3.85 ms baseline — a headline "-51%" that the
+   histogram refutes outright: that window was 4055 iterations `<1 ms` + 110 in
+   `1-2 ms` and **nothing above 2 ms**, so the baseline's 3.85 ms was one outlier
+   iteration, and the mean-like metric over the same window (main-loop rate) moved
+   -1.3%. Re-baselining to a lucky-low sample makes the next ordinary run look like
+   a +100% regression. Judge each row against its own stability — trust the
+   rate/total rows, treat the worst-iteration rows as anecdotes — and re-baseline
+   only when a stable metric has genuinely shifted.
+
+   For reference, 0.33.13 itself was **performance-neutral**: every metric within
+   ~1% except that idle artefact and a ~1 ms wobble on the 12 ms RLE total. The
+   baseline was deliberately left where it was.
 
 9. **Report**:
    - Number of upstream commits merged.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,11 +274,18 @@ inherited-upstream noise:
   files), so `Build firmware` + `HIL test` are the only other verification and
   neither measures timing. The job is report-only, so it cannot redden an already
   unreviewable PR. Apply `perf` as its **own** label call (N labels in one call fire
-  N runs — see the labeling note above). ⚠️ **Then move the baseline.**
-  `perf/baselines/split72.json` is compared against, never auto-updated, so once the
-  post-merge number is understood commit that run's JSON to `polykybd-ctnd` —
-  otherwise every later PR's report carries the merge's delta as a phantom
-  regression against a pre-merge reference.
+  N runs — see the labeling note above). ⚠️ **Then move the baseline — but only if
+  something actually moved.** `perf/baselines/split72.json` is compared against,
+  never auto-updated, so a real shift left unrecorded becomes a phantom regression
+  on every later PR; equally, re-baselining on noise creates a phantom regression in
+  the other direction. **"Idle — worst iteration" is a max-of-window sample and
+  swings ~2× run to run** — the 0.33.13 dispatch read 1.88 ms against a 3.85 ms
+  baseline ("-51%") on a window whose histogram was 4055 iterations `<1 ms` + 110 in
+  `1-2 ms` and *nothing above 2 ms*, i.e. the old value was one outlier iteration,
+  while the main-loop rate over the same window moved -1.3%. Trust the rate/total
+  rows; treat the worst-iteration rows as anecdotes. **0.33.13 measured
+  performance-neutral** (everything within ~1%), so its baseline was deliberately
+  left in place.
 
 ## Releases
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,6 +267,18 @@ inherited-upstream noise:
   flash a build and paste the console log.** See
   `keyboards/polykybd/profiling/README.md` (§ on-demand control, HID cmd 32) and the
   `polykybd-ctnd` CLAUDE.md § Performance measurement.
+- **An upstream merge is the canonical case for the `perf` label.** A catch-up merge
+  bumps the ChibiOS / pico-sdk pins and pulls core QMK changes (split transport, USB
+  stack, scheduler) — exactly the things that can move main-loop timing with **no
+  PolyKybd source changed** — and it is also the PR CodeRabbit skips outright (>100
+  files), so `Build firmware` + `HIL test` are the only other verification and
+  neither measures timing. The job is report-only, so it cannot redden an already
+  unreviewable PR. Apply `perf` as its **own** label call (N labels in one call fire
+  N runs — see the labeling note above). ⚠️ **Then move the baseline.**
+  `perf/baselines/split72.json` is compared against, never auto-updated, so once the
+  post-merge number is understood commit that run's JSON to `polykybd-ctnd` —
+  otherwise every later PR's report carries the merge's delta as a phantom
+  regression against a pre-merge reference.
 
 ## Releases
 


### PR DESCRIPTION
Carries over the one commit that missed #199 — it was pushed while that PR was being merged, so the merge took the previous head and this note never landed.

## What it adds

A catch-up merge bumps the ChibiOS / pico-sdk pins and pulls core QMK changes (split transport, USB stack, scheduler) — the changes most able to move main-loop timing with **no PolyKybd source touched**. It is also the one PR CodeRabbit skips outright (>100 files), so `Build firmware` + `HIL test` are the only other verification and neither measures timing.

`Performance measurement (split72)` already exists and is report-only, so this is a process gap rather than a missing capability: label the merge PR `perf`. Recorded as step 8b in the `merge-upstream-into-branch` skill (so the next merge picks it up automatically) and as a bullet in the CI section of `CLAUDE.md` (for a merge driven without the skill).

Both note the two traps:

- Apply `perf` as its **own** label call — each label fires its own workflow run, so batching it with `bump:*` starts two identical rig runs.
- **Move the baseline afterwards.** `polykybd-ctnd`'s `perf/baselines/split72.json` is compared against, never auto-updated, so leaving it pre-merge makes every later PR report the merge's delta as a phantom regression.

That second point is currently live: the baseline was last moved at the 200 MHz re-baseline, i.e. before 0.33.13, and no post-merge measurement was taken.

Docs only — no source, no build impact.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PM5DsXYGeDCg7WVuoqszkD)_

## Summary by Sourcery

Document performance measurement requirements and baseline updates for upstream merge PRs.

Documentation:
- Update the upstream-merge skill to require labeling catch-up PRs with `perf` and to record perf results and baseline movement in the merge report.
- Clarify in CLAUDE.md that upstream merges should use the `perf` label and that baselines must be updated after measuring post-merge performance to avoid phantom regressions.