### PR TITLE
Document QMK community-module mechanics + add extract-qmk-module skill

### DIFF
--- a/.claude/skills/extract-qmk-module/SKILL.md
+++ b/.claude/skills/extract-qmk-module/SKILL.md
@@ -176,7 +176,7 @@ make test:polymod_<name>
 ```
 
 Then **break the driver on purpose and confirm the right test fails** — two mutations
-is enough (e.g. swap a byte order; delete a bound). A green suite against a
+are enough (e.g. swap a byte order; delete a bound). A green suite against a
 deliberately broken driver is measuring nothing, and this is the only cheap proof it
 isn't. Restore from a copy afterwards and re-run to confirm green.
 

--- a/.claude/skills/extract-qmk-module/SKILL.md
+++ b/.claude/skills/extract-qmk-module/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: extract-qmk-module
+description: Extract a self-contained subsystem out of keyboards/polykybd/ into a reusable QMK community module under modules/polykybd/ — assess the coupling, scaffold the module, convert consumers to its auto-hooks, add a mocked unit-test suite, and verify with a both-variant build + lint. Use when asked to "make X a module", "extract the <driver/library> into a community module", "modularise <subsystem>", "can this be a qmk module", or when a piece of firmware code turns out to be generic enough to share. NOT for adding a font, language, glyph script or keycap hint (those have their own skills), and NOT for code that touches the overlay/display stack, the HID protocol or poly_keymap's layer logic — that is the product, not a library.
+---
+
+# Extract a subsystem into a QMK community module
+
+Turning `keyboards/polykybd/<thing>.c` into `modules/polykybd/polymod_<thing>/`. The
+existing modules are `polymod_crc32`, `polymod_rle` (pure-algorithm libraries) and
+`polymod_ltr559` (a driver with hooks + tests) — the last is the fullest worked
+example of this procedure.
+
+Background facts this skill relies on are in `CLAUDE.md` § "Community modules" and
+§ "Unit tests"; read them if anything below is surprising.
+
+## 0. Decide whether it should be a module at all
+
+Run the filter **before** touching anything. A candidate qualifies when:
+
+- its `.c` includes **no PolyKybd headers** — check first, it's one command:
+  ```bash
+  grep '#include' keyboards/polykybd/<path>.c
+  ```
+  QMK core headers (`i2c_master.h`, `timer.h`, `quantum.h`) are fine; `polykybd.h`,
+  `base/com.h`, `state.h`, `QMK_KEYBOARD_H` are disqualifying (or a decoupling job
+  first — say so and stop).
+- it uses **no PolyKybd types** in its public API (`poly_sync_t`, `poly_layer_t`,
+  `enum poly_os`, display/overlay structs).
+- **every consumer already lives outside it** — the seam exists:
+  ```bash
+  grep -rn "<public_symbol>" keyboards/polykybd --include=*.c --include=*.h | grep -v '^keyboards/polykybd/<path>'
+  ```
+  All hits in one or two files = clean. Hits scattered through the display/overlay
+  stack = not a module.
+- it would plausibly be **useful to another keyboard**. A module nobody else could
+  use is just a moved file; say so and let the user decide if it's still worth it.
+
+Report the verdict with the evidence before proceeding.
+
+## 1. Scaffold
+
+```bash
+mkdir -p modules/polykybd/polymod_<name>/tests
+git mv keyboards/polykybd/<path>.c modules/polykybd/polymod_<name>/polymod_<name>.c
+git mv keyboards/polykybd/<path>.h modules/polykybd/polymod_<name>/polymod_<name>.h
+```
+
+Use `git mv` so the diff reads as a **rename** — reviewers can then see the real
+changes instead of a delete+add of several hundred lines. Guard the rest of the
+procedure against destroying that: avoid gratuitous reformatting of the moved file
+(see §5).
+
+`qmk_module.json` — minimum is `module_name` + `maintainer`; add `license` and `url`:
+
+```json
+{
+    "module_name": "<Human readable name>",
+    "maintainer": "PolyKybd",
+    "license": "GPL-2.0-or-later",
+    "url": "https://github.com/thpoll83/qmk_firmware"
+}
+```
+
+Add `"keycodes": [{"key": "COMMUNITY_MODULE_<X>", "aliases": ["CM_<X>"]}]` only if the
+module genuinely owns new keycodes, and `"features": {…}` only if it needs a QMK
+feature switched on.
+
+## 2. Drop the old enable define; the build provides one
+
+In the module `.c`, **remove the `#ifdef POLYKYBD_<X>` wrapper** — a module's source
+is compiled only when the module is listed, so the guard is now redundant.
+
+Then in **`<variant>/rules.mk`**, delete both the `SRC += <path>.c` line and the
+`-DPOLYKYBD_<X>` enable define, and in **`<variant>/keyboard.json`** add the module
+(keep the array alphabetical):
+
+```json
+"modules": [
+    "polykybd/polymod_crc32",
+    "polykybd/polymod_<name>",
+    "polykybd/polymod_rle"
+],
+```
+
+Consumers now gate on the generated **`COMMUNITY_MODULE_POLYMOD_<NAME>_ENABLE`**.
+Keep any *separate* policy define (e.g. `POLYKYBD_LTR559_DRIVE`) — that is a different
+question from "is the driver present", and splitting them is part of the value.
+
+## 3. Convert consumers to the module's hooks
+
+If the subsystem has an init and/or a periodic task that `poly_keymap.c` calls
+explicitly, move them into the module:
+
+```c
+void keyboard_post_init_polymod_<name>(void) {
+    keyboard_post_init_polymod_<name>_kb();   // must call the _kb link yourself
+    <thing>_init();
+}
+
+void housekeeping_task_polymod_<name>(void) {
+    housekeeping_task_polymod_<name>_kb();
+    <thing>_task();
+}
+```
+
+…and **delete the explicit calls** from `poly_keymap.c` — keeping both double-runs
+the work. This is safe because `quantum/keyboard.c` dispatches `*_modules()` **before**
+`_kb`/`_user`; re-confirm that if the QMK version has moved:
+
+```bash
+grep -n "post_init_modules\|housekeeping_task_modules" quantum/keyboard.c
+```
+
+A consumer that used the init's **return value** (`if (x_init()) uprint(...)`) should
+switch to the availability accessor (`if (x_available())`), which the earlier module
+hook has already populated.
+
+Guard the hook block with `#ifndef <NAME>_UNIT_TEST` so the test build (§4) can link
+the driver without the generated `community_modules.h`.
+
+## 4. Add a mocked unit-test suite
+
+`quantum/wear_leveling/tests/` is the pattern. Mock the **bus/backing store**, not the
+subsystem — the tests should drive the *real* code.
+
+`tests/rules.mk`:
+```make
+POLYMOD_<NAME>_PATH := modules/polykybd/polymod_<name>
+polymod_<name>_DEFS := -D<NAME>_UNIT_TEST
+polymod_<name>_SRC := \
+	$(POLYMOD_<NAME>_PATH)/polymod_<name>.c \
+	$(POLYMOD_<NAME>_PATH)/tests/<mock>.cpp \
+	$(POLYMOD_<NAME>_PATH)/tests/<name>_tests.cpp \
+	$(PLATFORM_PATH)/timer.c \
+	$(PLATFORM_PATH)/test/timer.c
+polymod_<name>_INC := \
+	$(POLYMOD_<NAME>_PATH) \
+	$(POLYMOD_<NAME>_PATH)/tests
+```
+
+`tests/testlist.mk`: `TEST_LIST += polymod_<name>` (⚠️ no `-` in test names).
+
+Register both, next to the `quantum/*/tests/` lines:
+- `builddefs/testlist.mk` → `include modules/polykybd/polymod_<name>/tests/testlist.mk`
+- `builddefs/build_test.mk` → `include modules/polykybd/polymod_<name>/tests/rules.mk`
+
+Expose a test-only reset (the driver is a singleton over file statics):
+```c
+#ifdef <NAME>_UNIT_TEST
+void <thing>_reset_for_test(void);
+#endif
+```
+
+Run it:
+```bash
+git submodule update --init --depth 1 --no-recommend-shallow lib/googletest
+export QMK_HOME=$PWD && export PATH="/root/.qmk_venv/bin:$PATH"
+make test:polymod_<name>
+```
+
+**Test the behaviours that were learned on hardware** — the ones living in comments
+that a refactor would silently break: bounded retries, refusal paths, wire byte order,
+sample-validity rules, windowing/averaging. Those are the tests worth having.
+
+## 5. Verify — and mutation-test the tests
+
+```bash
+export QMK_HOME=$PWD && export PATH="/root/.qmk_venv/bin:$PATH"
+qmk compile -kb polykybd/split72 -km default
+qmk compile -kb polykybd/split42 -km default
+qmk lint --strict --keyboard polykybd/split72
+qmk lint --strict --keyboard polykybd/split42
+clang-format --dry-run -Werror modules/polykybd/polymod_<name>/*.[ch] \
+                               modules/polykybd/polymod_<name>/tests/*.[ch]pp
+make test:polymod_<name>
+```
+
+Then **break the driver on purpose and confirm the right test fails** — two mutations
+is enough (e.g. swap a byte order; delete a bound). A green suite against a
+deliberately broken driver is measuring nothing, and this is the only cheap proof it
+isn't. Restore from a copy afterwards and re-run to confirm green.
+
+## Output
+
+Report: the coupling verdict + evidence; what moved; which defines changed; whether
+explicit calls became hooks; the test count and what they pin; the mutation-test
+result; and build/lint status for **both** variants. State plainly that hardware
+behaviour is unverified unless someone flashed it.
+
+## Pitfalls
+
+- ⚠️ **Don't keep the explicit init/task calls "just in case"** once the hooks exist —
+  that double-probes and double-polls.
+- ⚠️ **Don't invent a new `-DPOLYKYBD_<X>` enable.** The build already emits
+  `COMMUNITY_MODULE_POLYMOD_<NAME>_ENABLE`; a second define drifts out of sync.
+- ⚠️ **Don't run the local formatter over the moved `.c`.** The container's
+  clang-format is a different version from CI's and will rewrite files CI accepts —
+  which both adds churn and breaks the rename. Format only what the lint job named,
+  and confirm skew by testing the base-branch copy (CLAUDE.md § CI).
+- ⚠️ **A `.c` that keeps `#include QMK_KEYBOARD_H` is not extractable** — that pulls
+  the whole keyboard in. If §0 finds one, the decoupling is the task, not the move.
+- ⚠️ **`git mv` before editing**, not after, or the rename detection is lost and the
+  reviewer sees a wall of green.
+- Keep the module **single-purpose**. Two subsystems that merely ship together are two
+  modules.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,18 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
     as reviewed. There is no way to get it reviewed short of splitting the PR — so
     for a merge PR, treat the **build + HIL checks and hardware testing as the only
     real verification**, and don't count the green board as review cover.
+  - ⚠️ **Sourcery's rate-limit is QUIETER than CodeRabbit's: the `Sourcery review`
+    check run goes GREEN (`success`) while no review happened.** When its weekly
+    diff-character budget is spent it submits a `COMMENTED` review whose entire body
+    is *"you have reached your weekly rate limit of 500000 diff characters"* — and
+    that still counts as a completed check. So the PR shows a green Sourcery tick
+    with **zero findings**, which reads exactly like a clean review. CodeRabbit at
+    least renders a `> [!WARNING] Review limit reached` banner. Both were
+    simultaneously unavailable on #203 (2026-08-12), leaving a fully green board
+    that **no reviewer had read**. To tell them apart, read the review *body* via
+    `pull_request_read` `get_reviews` — do not infer from the check conclusion.
+    (The sibling rule "a bot comment is not a review" is in `PolyKybdHost/CLAUDE.md`;
+    this is the same failure with a green check instead of a long comment.)
 
 - **Verify an AI reviewer's finding against the code before acting on it — several
   arrive confidently wrong.** Of 7 CodeRabbit findings on one PR (2026-08-01), 3
@@ -82,6 +94,26 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
     ```
     ⚠️ **The old `codeload.github.com` tarball recipe is DEAD — it now returns 403**, with a JSON body telling you to use `add_repo` (2026-08-11; it was documented here as "allowed (200), verified 2026-06-25", so believe the error, not this file's history). It also fails *quietly* in a pipeline: `curl -sSL … | tar xz` prints only `gzip: stdin: not in gzip format` while the shell reports success, so a loop over five submodules can look like it worked. `curl -w "HTTP=%{http_code}"` is the check.
   - ⚠️ **An upstream merge BUMPS the submodule pins, and nothing checks them out for you.** The 0.33.13 merge moved `lib/chibios` `8bd61b80→6170ddf9` and `lib/chibios-contrib` `8d863d9e→5a9ad82b`. Re-run the init above **after** the merge (`git submodule status` shows the `-`/`+` prefixes), or you link a new QMK against an old ChibiOS — which compiles cleanly and fails at runtime.
+  - ⚠️ **A `lib/*` dir can be FULL OF FILES and still be uninitialised — leftover
+    extracted tarballs from the dead codeload recipe, pinned to the wrong revision.**
+    This is a third state beyond "empty clone" and "pin bumped", and it looks healthy:
+    `ls lib/chibios` shows a complete tree, so the natural conclusion is that
+    submodules are fine. The tells: **`git submodule status` prefixes it `-`** (not
+    initialised) and **`lib/<m>/.git` does not exist**. The build then dies on a
+    *version* mismatch rather than a missing file — the signature is
+    ```
+    ./lib/chibios/os/hal/include/hal.h:136:2: error: #error "obsolete or unknown configuration file"
+    ```
+    Fix: `rm -rf` the stale dirs and re-init properly (after `add_repo`, above):
+    ```bash
+    rm -rf lib/chibios lib/chibios-contrib lib/pico-sdk lib/printf lib/lufa
+    for m in lib/chibios lib/chibios-contrib lib/printf lib/lufa lib/pico-sdk; do
+        git submodule update --init --depth 1 --no-recommend-shallow $m
+    done
+    ```
+    ⚠️ `make`'s own auto-`git-submodule` step does **not** rescue this: it tries to
+    clone into the non-empty dir, prints `destination path … already exists and is not
+    an empty directory`, and carries on to a doomed build (2026-08-12).
 - **Build**: `qmk compile -kb polykybd/split72 -km default` (or `make polykybd/split72:default`). Output `.uf2` lands in the repo root and `.build/`.
 - **Deliverable for testing is the `.bin`, NOT the `.uf2`** — the user flashes over HID via PolyKybdHost's firmware updater (`polyhost/device/hid_fw_up.py`), which takes the raw RP2040 image: `arm-none-eabi-objcopy -O binary .build/<target>.elf .build/<target>.bin`. The `.uf2` is only for manual bootloader-drive recovery.
 - **Docker is NOT usable** in the remote container (no daemon) — use the native toolchain above, not the qmk docker image.
@@ -223,6 +255,27 @@ inherited-upstream noise:
   ```
   ⚠️ Drop `keyboards/polykybd/tools/__pycache__` first or it shows up as a false
   positive in the ignored-files list (CI checks out clean, so it never sees it).
+  - ⚠️ **The lint job runs `format-c` (clang-format) as well as `format-text`, and
+    the container can only run one of them — so "format clean" locally can be a
+    FALSE PASS.** `qmk format-text` needs **`dos2unix`, which is not installed**
+    (`FileNotFoundError: 'dos2unix'`); its job is only line endings + trailing
+    newline, which `grep -qP '\r'` and `[ -n "$(tail -c1 f)" ]` check by hand. The
+    *other* half, `qmk format-c`, is what actually fails PRs — with
+    `File '…' Requires Formatting` per file — and `clang-format` **is** installed.
+    Check the C/C++ files you touched with
+    `clang-format --dry-run -Werror <files>` before pushing (2026-08-12: verifying
+    only the line endings let a trailing-comment-spacing failure through to CI).
+  - ⚠️ **The container's clang-format is a DIFFERENT VERSION from CI's, so it flags
+    files CI accepts — do not "fix" those.** Local is clang-format 18; it wanted to
+    reformat a file the lint job had passed. **The test is whether the same file is
+    also flagged on the base branch**: if it is, it is version skew, not a finding —
+    reformatting it adds churn CI never asked for and (on a moved file) destroys
+    git's rename detection.
+    ```bash
+    git show origin/PolyKybd:<path> > /tmp/base_copy.c && cp .clang-format /tmp/
+    (cd /tmp && clang-format --dry-run -Werror base_copy.c)   # flagged too => skew
+    ```
+    Only reformat what the CI log named.
 - **`get_job_logs` works — ask for 150–350 `tail_lines`.** An earlier version of
   this file claimed it "caps its response at ~2 KB *regardless of `tail_lines`*";
   that is **wrong** (`tail_lines: 330` returned ~15 KB, 2026-08). The real problem
@@ -1114,6 +1167,87 @@ only split72 defines the macros.
   removed once it worked; the bus scan is kept as a disabled `#if 0` reference block in
   `ltr559.c`. No shared timed-log framework yet — see `readme.md` "Diagnostics" →
   "Timed console logs".
+
+### Community modules (`modules/polykybd/`)
+
+Self-contained, keyboard-independent code lives in **QMK community modules** rather
+than `keyboards/polykybd/`: currently `polymod_crc32` and `polymod_rle` (both ~55 LOC
+pure-algorithm libraries), with `polymod_ltr559` (the LTR-559 driver) extracted the
+same way. The mechanics are not obvious from the QMK docs alone:
+
+- **Declared in `keyboard.json`, not `keymap.json`.** Both variants carry a
+  `"modules": ["polykybd/polymod_crc32", …]` array. The docs describe the
+  `keymap.json` route (and External Userspace); the keyboard-level array is what this
+  fork uses, so a module lands on every keymap of that board.
+- **Listing a module IS the enable — the build defines
+  `COMMUNITY_MODULE_<NAME>_ENABLE`** (upper-cased directory name) for you, plus
+  `COMMUNITY_MODULES_ENABLE`. So a module needs **no `SRC +=` line and no bespoke
+  `-D<FEATURE>` in `rules.mk`**; gate consumer code on the generated define instead of
+  inventing a parallel one. `modules/<ns>/<name>/<name>.c` is compiled automatically
+  (matching the directory name); any *other* source file needs `SRC +=` in the module's
+  own `rules.mk`.
+- ⚠️ **Module hooks run BEFORE `_kb`/`_user`.** `quantum/keyboard.c` calls
+  `keyboard_post_init_modules()` then `keyboard_post_init_kb()`, and
+  `housekeeping_task_modules()` then `_kb` then `_user`. **This is what makes a
+  self-driving module safe**: a module that probes hardware in its post_init hook is
+  already done by the time `keyboard_post_init_user()` runs, and one that polls in its
+  housekeeping hook has produced *this* pass's sample before `housekeeping_task_user()`
+  reads it. Verify this before deleting explicit init/task calls in favour of hooks —
+  it is the whole argument.
+- ⚠️ **Overriding the non-suffixed hook means you must call the `_kb` link yourself.**
+  The build generates a weak `<api>_<module>()` → `<api>_<module>_kb()` →
+  `<api>_<module>_user()` chain. Defining `housekeeping_task_<module>()` replaces the
+  top of that chain, so it must call `housekeeping_task_<module>_kb()` or the keyboard/
+  keymap specialisations are silently dropped. `modules/qmk/hello_world` is the pattern.
+- **This fork is on module API 1.1.2.** The available hooks are the union of
+  `data/constants/module_hooks/*.hjson` (0.1.0 → 1.1.2); read those files rather than
+  the docs table, which stops at 1.1.0. 1.1.1 added LED/RGB matrix effects, **1.1.2
+  added custom split data sync** (`SPLIT_TRANSACTION_IDS_MODULE_<MODULE>`) — relevant
+  here, where several subsystems carry their own split transactions. Assert the floor
+  you rely on with `ASSERT_COMMUNITY_MODULES_MIN_API_VERSION(1, 0, 0);` (commas, not
+  periods) after `#include "community_modules.h"`.
+- **What is worth extracting**: code with no PolyKybd types and no display/protocol
+  coupling. Surveyed 2026-08: the remaining strong candidates are `base/crypto/`
+  (vendored Monocypher Ed25519), `base/multicore/` (RP2040 core1 launch + FIFO),
+  `os_actions.c` (per-OS chord table — the best *community* candidate, since
+  `qmk_module.json` `keycodes` is built for exactly that), and with a decoupling pass
+  the idle-timestamp half of `base/update.c` and `base/fw_staging.c`. **Not**
+  `poly_keymap.c` / `hid_com.c` / the overlay + display stack — that is the product.
+  The `extract-qmk-module` skill drives the whole conversion.
+
+### Unit tests (`make test:<name>`)
+
+QMK has a googletest harness; a **standalone** test (one that links a subsystem
+against mocks, rather than booting a whole fake keyboard) is the right shape for
+module code. `quantum/wear_leveling/tests/` is the model to copy — it mocks its
+backing store the way a driver test should mock its bus.
+
+```bash
+git submodule update --init --depth 1 --no-recommend-shallow lib/googletest  # needs add_repo qmk/googletest first
+export QMK_HOME=$PWD && export PATH="/root/.qmk_venv/bin:$PATH"
+make test:polymod_ltr559          # ~1 s
+```
+
+Wiring a new one needs **two** registrations plus one non-obvious source list:
+
+- `builddefs/testlist.mk` — `include <path>/tests/testlist.mk` (which does
+  `TEST_LIST += <name>`). ⚠️ Test names **cannot contain `-`**; the makefile
+  hard-errors.
+- `builddefs/build_test.mk` — `include <path>/tests/rules.mk`, alongside the
+  `quantum/*/tests/rules.mk` lines. This defines `<name>_SRC/_INC/_DEFS`.
+- ⚠️ **A standalone test must put the timer in its own `_SRC`.**
+  `platforms/common.mk` adds `platforms/timer.c` + `platforms/test/timer.c` to `SRC`,
+  which only the **full-keyboard** harness consumes — so a standalone test links with
+  `undefined reference to timer_read32 / timer_elapsed32` until you list both files
+  yourself.
+- ⚠️ **`set_time()` / `advance_time()` have no header.** They are defined only in
+  `platforms/test/timer.c`; every test that drives the clock forward-declares them
+  (see `quantum/sequencer/tests/sequencer_tests.cpp`).
+- **Mutation-test the suite before trusting it.** Break the thing on purpose (swap a
+  byte order, delete a bound) and confirm the *expected* test fails — the same
+  discipline as "verify against the rendered glyph shape, not a transform∘inverse
+  round-trip". A suite that passes against a deliberately broken driver is measuring
+  nothing.
 
 ### Notable QMK features enabled
 RGB matrix (72 LEDs, 35 effects), dynamic keymap (9 host-remappable layers), unicode input (Linux/macOS/Windows/BSD), Cirque trackpad (split72 variant), `USE_CORE1` multicore.


### PR DESCRIPTION
## Summary

Session retro from the `polymod_ltr559` extraction (#203). **Docs and one new skill — no firmware code changed.** Cut fresh from `PolyKybd`, so it's independent of #203 and can merge in either order.

Five learnings that each cost a round to find, plus the workflow codified so the next extraction doesn't re-derive them.

### `CLAUDE.md`

**New "Community modules" section** — the mechanics that aren't in the QMK docs:
- modules are declared in **`keyboard.json`** here, not `keymap.json` (the docs describe the other route)
- **listing one IS the enable** — the build defines `COMMUNITY_MODULE_<NAME>_ENABLE`, so no `SRC +=` and no bespoke `-D`
- **`quantum/keyboard.c` dispatches `*_modules()` BEFORE `_kb`/`_user`** — this is the whole argument for replacing explicit init/task calls with hooks, and worth verifying rather than assuming
- overriding a non-suffixed hook means calling the `_kb` link yourself
- this fork is on **API 1.1.2**; the real hook list is `data/constants/module_hooks/*.hjson`, not the docs table (which stops at 1.1.0 and so omits split data sync)
- records the surveyed remaining extraction candidates, and what is deliberately *not* one

**New "Unit tests" section** — wiring a standalone suite needs registrations in **both** `builddefs/testlist.mk` and `builddefs/build_test.mk`, and must list `platforms/timer.c` + `platforms/test/timer.c` in its own `_SRC` (because `platforms/common.mk` puts them in `SRC`, which only the full-keyboard harness consumes). `set_time`/`advance_time` have no header. Test names can't contain `-`. Mutation-test the suite before trusting it.

**CI section** — the lint job runs `format-c` *as well as* `format-text`, and this container can only run one of them, so a local "format clean" can be a **false pass**: `dos2unix` is absent (so `format-text` dies), while `clang-format` is present and is what actually fails PRs. And the local clang-format is a **different version from CI's**, so it flags files CI accepts — the test is whether the *base-branch copy* is flagged too; if so it's skew, and reformatting adds churn and destroys rename detection.

**Building section** — a `lib/*` dir can be **full of files and still uninitialised** (leftover extracted tarballs at the wrong revision). It looks healthy; the tells are a `-` in `git submodule status` and no `lib/<m>/.git`, and the build fails on ChibiOS `"obsolete or unknown configuration file"` rather than a missing file. `make`'s auto-submodule step doesn't rescue it.

**Code review conventions** — Sourcery's rate-limit is **quieter than CodeRabbit's**: the `Sourcery review` check run goes **green** while the review body is only *"you have reached your weekly rate limit"*. Both bots were silently unavailable on #203, leaving a fully green board that no reviewer had read. Read the review *body*, not the check conclusion.

### New skill: `.claude/skills/extract-qmk-module/`

Drives the whole conversion: the coupling filter that decides whether something is extractable at all, `git mv` to preserve the rename, the define swap, converting consumers to hooks, the mocked test suite, and the both-variant build + lint + mutation check. Written against the ltr559 extraction as the worked example, with its pitfalls as the Pitfalls section.

## Version bump label

None — docs only, no firmware change.

## Testing

- [x] `qmk lint --strict` passes for both variants (unchanged code, but confirms nothing was disturbed)
- [ ] Compiled — n/a, no code touched
- [ ] Flashed and tested on hardware — n/a
- [ ] If protocol changed: host updated and tested together — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EvnQHve4R4NLuU9NXW4pi

---
_Generated by [Claude Code](https://claude.ai/code/session_012EvnQHve4R4NLuU9NXW4pi)_

## Summary by Sourcery

Document QMK community-module and unit-test mechanics and add an AI skill for extracting PolyKybd subsystems into reusable QMK modules.

Documentation:
- Expand CLAUDE.md with guidance on CI bot review reliability, submodule initialisation pitfalls, lint/format behaviour, and detailed mechanics for QMK community modules and standalone unit tests.

Chores:
- Add the extract-qmk-module Claude skill describing the workflow for turning PolyKybd subsystems into reusable QMK community modules with hooks and tests.