### PR TITLE
Intl letter remap: a key can host another letter's variation row

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,17 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
     an empty directory`, and carries on to a doomed build (2026-08-12).
 - **Build**: `qmk compile -kb polykybd/split72 -km default` (or `make polykybd/split72:default`). Output `.uf2` lands in the repo root and `.build/`.
 - **Deliverable for testing is the `.bin`, NOT the `.uf2`** — the user flashes over HID via PolyKybdHost's firmware updater (`polyhost/device/hid_fw_up.py`), which takes the raw RP2040 image: `arm-none-eabi-objcopy -O binary .build/<target>.elf .build/<target>.bin`. The `.uf2` is only for manual bootloader-drive recovery.
+  - ⚠️ **Put the commit sha in the FILENAME — every test build reports the same
+    `FW_VERSION`, so they are otherwise indistinguishable once flashed.** `FW_VERSION`
+    only moves on the post-merge auto-bump, so a session with several hardware rounds
+    hands over N files that all answer `0.13.1` to `polyctl fw version` and carry
+    near-identical names (`…_fix` / `…_legend` / `…_invert`). That cost a full round
+    (2026-08-13): a correct build was reported as "I did not see the new behavior",
+    and the only way to settle it was to md5 the delivered file against a fresh
+    rebuild and grep the image for a changed string literal. `split72_<sha>_<slug>.bin`
+    takes the ambiguity away. Better still, when a change alters something **visible
+    on a keycap**, say which pixel tells the builds apart — that is a check the user
+    can run without any tooling.
 - **Docker is NOT usable** in the remote container (no daemon) — use the native toolchain above, not the qmk docker image.
 - The `firmware-size-diff` skill builds HEAD vs working tree and diffs sizes / `.text`.
 - ⚠️ **In the session container `qmk` is at `/root/.qmk_venv/bin/qmk` and is NOT on
@@ -1049,6 +1060,84 @@ The mechanism is worth knowing because it is not the obvious implementation:
   hardcoded hint straight back over the variation.
 - The armed indicator is the inverted Ctrl keycap — see the two rendering bullets
   above (render it, don't `kdisp_invert()`; and pass `cy_radius` 0).
+
+### Intl letter remap — a key can host ANOTHER letter's row (`KC_LAT_REMAP`)
+
+French needs `è é ê` at once, which one letter's picker cannot give: the picker
+chooses another *form* of the letter a key already hosts. So a key can now be
+**reassigned to a different base letter**. Hold Intl, tap the remap key (split72
+`[4,1]`, beside the Ctrl at `[4,0]`; split42 `[3,4]`), press the key to change (it
+inverts), then the letter it should host. `e`, `q` and `j` can then carry `é`, `è`
+and `ê` — and the sparse letters (`q` has one variation, `j` two) stop being dead
+keys on this layer.
+
+- **The storage splits two things the code had conflated.** The ROW comes from the
+  letter a key HOSTS (`latin_ex_map`); the PICK comes from the KEY's own slot
+  (`latin_sync_t.ex`). They are the same number only while nothing is remapped,
+  which is why one index sufficed for years. Two keys on the same letter share a
+  row but need independent picks — storing the pick at the row index has one key
+  silently overwrite the other's choice. `latin_sync_t.assign[20]` holds one 6-bit
+  base letter per target key, **shared across case** so Shift follows the remap
+  (`r → e` gives E's upper-case form, not `<`); the pick stays per case because the
+  two rows are not parallel (lower `n` has 12 variations, upper `N` 11).
+- Pick fields are **case-INTERLEAVED** (`slot*2 + case`), not case-blocked, so
+  growing `LATIN_TARGETS` appends fields instead of inserting a block mid-array.
+  Extending the targets to the punctuation keys is the obvious next step —
+  `KC_MINUS 0x2D … KC_SLASH 0x38` is a contiguous run of 12 printable punctuation
+  keycodes, so `kc - KC_MINUS + 26` needs no table. It costs ~43 bytes (the pick
+  array grows too), which is why `POLY_EECONFIG_USER_RESERVED` was taken 128 → 256
+  in the letters-only change: that relocation resets the dynamic keymap once, and
+  paying it early means punctuation later costs no second reset.
+- **Re-assigning a key to its OWN letter is the per-key reset** (stored as
+  `LATIN_ASSIGN_NONE`), so it needs no gesture of its own. **Shift+remap clears
+  everything** — once the board is remapped the Intl legends no longer match the
+  printed letters, so there has to be one way back that does not depend on
+  remembering what was changed.
+
+⚠️ **Four traps this feature hit, all of which generalise beyond it:**
+
+- **An unwritten EEPROM byte reads `0x00` here, NOT `0xFF` — never infer "never
+  written" from the bytes.** The assignment map was designed to need no migration
+  sentinel because `LATIN_ASSIGN_NONE` is all-bits-set and "erased flash reads
+  0xFF". QMK's **wear-levelling normalises its backing store so cleared bytes
+  arrive as ZERO** (`quantum/wear_leveling/wear_leveling.c` clears its cache with
+  `memset(...,0)` and its header requires a 0xFF-based store to return the
+  *complement* "such that this wear-leveling algorithm receives zeros"). The map
+  therefore read back all-zero = "every key hosts letter 0", and **every Intl
+  keycap rendered a variation of `a`** (field, first flash). Gate such a field on
+  the `latin_pick_migrated` **format version**, which is what that byte is for.
+  - ⚠️ **A version gate alone does not HEAL an already-flashed board** — the broken
+    build persisted the zeros at the next suspend *and stamped them valid*. The
+    recovery is to **retire the version value**: `0xC3` now means "picks are fine,
+    discard the map" and `0xD7` is current. Walk every version a field EEPROM can
+    present before shipping such a fix.
+  - ⚠️ The reservation bump relocates the **dynamic keymap** only. `poly_eeconf_t`
+    sits *before* it at a fixed address and is **not** reset — which is exactly why
+    the stale zeros survived the flash that was supposed to clear everything.
+- **`render_key()` is only consulted when `to_static_text()` returns NULL.** A key
+  that HAS a legend bypasses it completely. The remap prompt blanks the board from
+  inside `render_key()`, so every non-letter *with a legend* — including the remap
+  key itself — sailed past and kept drawing normally: never blanked, never
+  inverted, so nothing on the board said the latched mode was open. Any future
+  "the board becomes a dialog" mode must **also suppress `text`** in
+  `update_displays()`, not just return false from `render_key()`.
+- **Keep every glyph of a multi-glyph legend in ONE font.**
+  `kdisp_write_gfx_char` baseline-aligns by `font->yAdvance - fonts[0]->yAdvance`,
+  so glyphs from different fonts land on different baselines. `a` is in `_Base_`
+  (yAdvance 37 → −3 px) while `»`/`ñ` are in `_SupAndExtA_` (44 → +4 px): the
+  legend `a»ñ` sat its `a` **7 px** high. `Á»Æ` is even only because all three of
+  its glyphs are Latin-1, i.e. one font — hence `INTL_REMAP_LEGEND` is **`à»ñ`**.
+  ⚠️ `oled_preview.py` **cannot** show this (it models `xOffset`/`yOffset` but not
+  the baseline-align shift), so both legends render identically there — the check
+  is the font metrics, not the preview.
+- **The "gate the release swallow on OWNERSHIP" rule applies to LAYER keys too.**
+  The remap block returned `false` for every release, which swallowed the release
+  of **`MO(_ADDLANG1)` itself** — QMK never unregistered the layer, so Intl went
+  down and never came back up and the mode could not be escaped at all; a held
+  Shift was stuck the same way. Modifiers and layer keys
+  (`IS_MODIFIER_KEYCODE` / `IS_QK_MOMENTARY` / `IS_QK_TO`) must fall through. This
+  is the same rule already written up for the picker's Ctrl latch, one function
+  away, and it was still missed.
 
 ### Glyph-script override (`poly_keymap.c`, HID cmd 30, protocol v9+; expanded v10)
 An OS-independent **override** of the language-layer legends with an alternative

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -786,6 +786,38 @@ touching at a **0px** gap, while 4 rows sat unused under the bottom row.
 ### Split synchronisation
 Seven custom QMK transaction IDs (`USER_SYNC_POLY_DATA`, `USER_SYNC_OVERLAY_DATA`, `USER_SYNC_COMPRESSED_DATA`, `USER_SYNC_ROI_DATA`, etc.) carry state and overlay data to the slave half over UART with CRC32 validation and up to 10 retries.
 
+⚠️ **`RPC_M2S_BUFFER_SIZE` is a SILENT CEILING on every one of them, and it is a
+CAPACITY, not a transfer size.** Two independent facts, both easy to get backwards:
+
+- **Outgrowing it does not fail loudly.** `transaction_rpc_exec()`
+  (`quantum/split_common/transactions.c`) checks `initiator2target_buffer_size >
+  RPC_M2S_BUFFER_SIZE` and **returns false before sending anything** — while the bulk
+  `send_to_bridge()` call sites discard the ack (the *discarding* sibling of the
+  "never bool-test `send_to_bridge()`" rule). So a struct that grows past the cap
+  produces a master that applies the change and a slave that never hears it, with
+  **nothing in the log**. Caught in review, 2026-08-13: `latin_sync_t` went 63 → 90 B
+  when the Intl remap gained the punctuation targets. `state.h` now carries a
+  `static_assert(sizeof(latin_sync_t) <= RPC_M2S_BUFFER_SIZE)`; add one for any
+  struct that can grow.
+- **Raising it costs RAM and nothing else — measured, not reasoned.** The constant
+  appears in exactly three places in QMK: the array declaration and the two rejection
+  checks. Both ends size the real transfer from `rpc_info.payload.m2s_length`, i.e.
+  the caller's own byte count. Verified by building the same tree at 96 and 128 and
+  diffing the disassembly: `.text` identical in size, `.bss` +32 (exactly the delta),
+  and of 954 differing lines **922 are `.word` RAM address literals**; the only real
+  instruction changes are the `cmp` bounds check and two `adds` offsets into shmem.
+  **No length, loop-count or transfer-size instruction changes anywhere in the
+  image** — so unrelated traffic (matrix scan, pointing pull, overlay bursts) is
+  byte-for-byte unaffected. Raised 72 → 96 in the same change; the monolith's `.heap`
+  went 3852 → 3828.
+
+⚠️ **The overlay path sits 3 bytes under the old cap — check it before adding a
+field.** The 72 was sized for exactly these, all derived from `HID_REPORT_SIZE` 64:
+`overlay_sync_t` 67 B, `overlay_map_sync_t` / `dynamic_keymap_sync_t` 68 B, and
+**`compressed_overlay_sync_t` / `roi_overlay_sync_t` 69 B**. One more field, or an
+`HID_REPORT_SIZE` bump, and an app switch would hit the silent rejection above and
+present as missing keycap images. At 96 that path has 27 B of headroom.
+
 ### Firmware signing enforcement & the on-keycap confirmation (FW-2)
 
 `rules.mk` sets `-DFW_REQUIRE_SIGNATURE`, so `fw_staging_finalize()` only stamps the

--- a/keyboards/polykybd/config.h
+++ b/keyboards/polykybd/config.h
@@ -105,8 +105,15 @@
 #define RP2040_BOOTLOADER_DOUBLE_TAP_RESET_TIMEOUT 1000U
 
 // Master to slave:
-#define RPC_M2S_BUFFER_SIZE 72
-// Slave to master:
+// ⚠️ This is a CAPACITY CAP, not a transfer size — transaction_rpc_exec() puts only
+// the caller's `initiator2target_buffer_size` bytes on the wire, so raising it costs
+// RAM in split_shared_memory_t and nothing per transaction.  It is also a SILENT
+// ceiling: an oversized payload makes transaction_rpc_exec() `return false` before
+// sending anything, and the bulk send_to_bridge() call sites discard the ack — so the
+// halves just diverge with no log line.  96 fits the largest payload, latin_sync_t
+// (90 B, asserted in state.h); the next largest is the 72 B doom mirror.
+#define RPC_M2S_BUFFER_SIZE 96
+// Slave to master: replies are a single ack byte, so this needs no headroom.
 #define RPC_S2M_BUFFER_SIZE 72
 
 // During fw_up the slave runs a deferred sector-by-sector erase (~50 ms per

--- a/keyboards/polykybd/keycode_helper.c
+++ b/keyboards/polykybd/keycode_helper.c
@@ -118,6 +118,7 @@ const uint32_t* keycode_to_static_text(uint16_t keycode, led_t state, uint8_t st
         case OSL(_UL):                      return U"Util*\r\v\t" ICON_LAYER;
         case TO(_UL):                       return U"Util\r\v\t" ICON_LAYER;
         case MO(_ADDLANG1):                 return (state_flags & MORE_TEXT) != 0 ? U"Intl" : INTL_LAYER_LEGEND;
+        case KC_LAT_REMAP:                  return (state_flags & MORE_TEXT) != 0 ? U"Map" : INTL_REMAP_LEGEND;
         case KC_F1:                         return U" F1";
         case KC_F2:                         return U" F2";
         case KC_F3:                         return U" F3";

--- a/keyboards/polykybd/keycode_helper.h
+++ b/keyboards/polykybd/keycode_helper.h
@@ -21,10 +21,16 @@
 // frame turned out to add nothing the letters were not already saying.
 #define INTL_LAYER_LEGEND   U"\x130\xF1\x21B\x142"   // Intl, spelled in accented latin
 #define INTL_PICKER_LEGEND  U"\xC1\xBB\xC6"           // Á»Æ — Ctrl: pick another variation
-// a»ñ — reassign which LETTER this key hosts (vs Á»Æ, which picks another form of
+// à»ñ — reassign which LETTER this key hosts (vs Á»Æ, which picks another form of
 // the SAME letter). Same "»" = "becomes" idiom, lower case and a different letter
 // on the right, so the pair reads as one family without looking identical.
-#define INTL_REMAP_LEGEND   U"a\xBB\xF1"
+// ⚠️ à, NOT a: kdisp_write_gfx_char baseline-aligns every glyph by
+// `font->yAdvance - fonts[0]->yAdvance`, so glyphs from DIFFERENT fonts land on
+// different baselines. Plain 'a' is in _Base_ (yAdvance 37 => -3px) while » and ñ
+// are in _SupAndExtA_ (44 => +4px), which sat the 'a' SEVEN pixels high. Á»Æ above
+// is even only because all three of its glyphs are Latin-1, i.e. one font. Keep
+// every glyph in a multi-glyph legend inside one font, or position it explicitly.
+#define INTL_REMAP_LEGEND   U"\xE0\xBB\xF1"
 
 /*[[[cog
 import cog

--- a/keyboards/polykybd/keycode_helper.h
+++ b/keyboards/polykybd/keycode_helper.h
@@ -21,6 +21,10 @@
 // frame turned out to add nothing the letters were not already saying.
 #define INTL_LAYER_LEGEND   U"\x130\xF1\x21B\x142"   // Intl, spelled in accented latin
 #define INTL_PICKER_LEGEND  U"\xC1\xBB\xC6"           // Á»Æ — Ctrl: pick another variation
+// a»ñ — reassign which LETTER this key hosts (vs Á»Æ, which picks another form of
+// the SAME letter). Same "»" = "becomes" idiom, lower case and a different letter
+// on the right, so the pair reads as one family without looking identical.
+#define INTL_REMAP_LEGEND   U"a\xBB\xF1"
 
 /*[[[cog
 import cog
@@ -100,6 +104,11 @@ enum my_keycodes {
     // the position is the same muscle memory on split72 (12 slots) and split42 (10).
     KC_LAT_PAGE_PREV,
     KC_LAT_PAGE_NEXT,
+    // Reassign which LETTER a key hosts on the Intl layer, so several keys can carry
+    // variations of the same letter (French wants e, è, é and ê at once). Held with
+    // Intl it opens remap mode: pick the key, then pick the letter; Shift+it clears
+    // every assignment. See latin_remap_* in poly_keymap.c.
+    KC_LAT_REMAP,
     /*[[[cog
         # Joined for the same reason as the KC_LAT block above — no trailing space.
         cog.out(", ".join("KCL_ENUS = QK_USER_0" if lang == "ENUS" else f"KCL_{lang}"
@@ -203,8 +212,8 @@ static_assert((int)KC_DAUTO <= (int)QK_KB_31, "Too many custom QK key codes");
 // appended after it, so the two asserts above silently stopped covering the tail
 // they exist to bound.  Re-anchor these whenever something is appended to the
 // QK_KB_0 block.
-static_assert((int)KC_LAT_PAGE_NEXT <= (int)QK_KB_MAX, "Too many custom QK key codes");
-static_assert((int)KC_LAT_PAGE_NEXT < (int)KCL_ENUS, "Overlap detected");
+static_assert((int)KC_LAT_REMAP <= (int)QK_KB_MAX, "Too many custom QK key codes");
+static_assert((int)KC_LAT_REMAP < (int)KCL_ENUS, "Overlap detected");
 static_assert((int)KC_LANG_END <= 0x7FFF, "Emoji/Lang keycodes exceed QK_USER_MAX");
 static_assert((int)KC_OS_SET_END <= 0x7FFF, "OS action keycodes exceed QK_USER_MAX");
 

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -615,6 +615,7 @@ static bool s_picker_latched = false;
 
 // Sets layer state variable tracking the active keyboard layer.
 static void latin_picker_reset_page(void);   // defined with the picker helpers below
+static void latin_remap_cancel(void);        // ditto
 
 layer_state_t layer_state_set_user(layer_state_t state) {
     access_local_layer()->layer = state;
@@ -630,6 +631,9 @@ layer_state_t layer_state_set_user(layer_state_t state) {
         // user can hold Ctrl themselves and page, in which case s_picker_latched is
         // false and the page would survive to the next visit to the layer.
         latin_picker_reset_page();
+        // Same reason: an abandoned remap would otherwise still be showing its
+        // "pick a key" prompt on the next visit to the layer.
+        latin_remap_cancel();
     }
     return state;
 }
@@ -1732,6 +1736,43 @@ static int8_t latin_picker_index(uint8_t row, uint8_t page, int8_t slot) {
     return (idx < latin_variation_count(row)) ? (int8_t)idx : -1;
 }
 
+// Leave remap mode without changing anything.
+static void latin_remap_cancel(void) {
+    poly_layer_t* ll = access_local_layer();
+    ll->remap_mode   = LATIN_REMAP_OFF;
+    ll->remap_target = 0;
+    request_disp_refresh();
+}
+
+// Point `slot` at `letter`'s variation row, or back at its own letter when the two
+// are the same — so re-picking a key's own letter is the per-key reset, with no
+// separate gesture to learn.
+static void latin_remap_apply(uint8_t slot, uint8_t letter) {
+    if(slot >= LATIN_TARGETS || letter >= LATIN_TARGETS) {
+        return;
+    }
+    latin_sync_t* table = access_global_latin_table();
+    latin_assign_set(table->assign, slot, (slot == letter) ? LATIN_ASSIGN_NONE : letter);
+    // The key now indexes a different row, so its stored pick is meaningless there
+    // (and may be past the end of a shorter row). Start it at the first variation
+    // rather than leaving a stale index for latin_variation() to fall back from.
+    latin_pick_set(table->ex, latin_pick_field((int8_t)slot, true),  0);
+    latin_pick_set(table->ex, latin_pick_field((int8_t)slot, false), 0);
+    send_to_bridge(USER_SYNC_LATIN_EX_DATA, (void*)table, sizeof(*table), 10);
+    mark_latin_dirty();
+}
+
+// Clear every assignment. Reached by tapping the remap key on the Intl layer
+// WITHOUT opening the mode — see process_record_user.
+static void latin_remap_reset_all(void) {
+    latin_sync_t* table = access_global_latin_table();
+    memset(table->assign, 0xFF, sizeof(table->assign));   // 0xFF == all LATIN_ASSIGN_NONE
+    memset(table->ex, 0, sizeof(table->ex));
+    send_to_bridge(USER_SYNC_LATIN_EX_DATA, (void*)table, sizeof(*table), 10);
+    mark_latin_dirty();
+    request_disp_refresh();
+}
+
 // Back to page 0.  Anything that makes the current page meaningless calls this:
 // picking a variation, changing the letter (a one-page letter would otherwise show
 // a whole row of blanks while page 1 was still selected), and leaving the layer.
@@ -1784,6 +1825,48 @@ bool render_key(uint16_t keycode, led_t state, uint8_t mods) {
     const bool add_lang = get_highest_layer(local_layer->layer)==_ADDLANG1;
     const bool picker_mod = ((local_layer->mods & LATIN_PICKER_MOD) != 0);
     const bool is_letter = keycode>=KC_A && keycode<=KC_Z;
+
+    // --- letter-remap mode: the board becomes a "which key?" / "which letter?"
+    // prompt.  Everything that is not a letter blanks out, so the only thing to
+    // look at is the set you are choosing from.
+    if(add_lang && local_layer->remap_mode != LATIN_REMAP_OFF) {
+        if(!is_letter) {
+            return false;                   // blank — nothing else is pressable now
+        }
+        const int8_t  slot   = latin_target_slot(keycode);
+        const bool    picked = (local_layer->remap_mode == LATIN_REMAP_PICKLTR) &&
+                               (slot >= 0) && ((uint8_t)slot == local_layer->remap_target);
+        // ⚠️ Render the inversion, do NOT call kdisp_invert(): matrix_scan_kb toggles
+        // that on every press/release independently of process_record, so a latched
+        // indicator driven through it is undone by the next keypress.  Fill the
+        // ground and erase the glyph out of it instead — and with cy_radius 0, or
+        // the courtyard clear eats a dark halo and the key reads as outlined.
+        if(picked) {
+            kdisp_set_buffer(0xFF);
+            kdisp_set_gfx_erase(true);
+        }
+        // In PICKKEY every letter still shows what it currently hosts (so you can
+        // see what you are about to change); in PICKLTR the letters are the SOURCE
+        // menu, so each shows its own plain letter.
+        bool drawn;
+        if(local_layer->remap_mode == LATIN_REMAP_PICKKEY) {
+            const uint32_t* variation = latin_variation(keycode, shift || state.caps_lock);
+            drawn = (variation != NULL);
+            if(drawn) {
+                kdisp_write_gfx_text_cy(g_all_fonts, g_all_font_count, BUFFER_X, 23, variation, 0);
+            }
+        } else {
+            const uint32_t letter[2] = { (uint32_t)('a' + (keycode - KC_A)), 0 };
+            kdisp_write_gfx_text_cy(g_all_fonts, g_all_font_count, BUFFER_X, 23, letter, 0);
+            drawn = true;
+        }
+        if(picked) {
+            kdisp_set_gfx_erase(false);     // static flag — leaving it on blanks every later key
+            drawn = true;                   // the filled ground IS the render
+        }
+        return drawn;
+    }
+
     if(is_letter && add_lang) {
         //display the previously selected latin variation of the letter
         const uint32_t* variation = latin_variation(keycode, shift || state.caps_lock);
@@ -3323,6 +3406,59 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
 
     const bool addlang = get_highest_layer(get_local_layer()->layer)==_ADDLANG1;
     const poly_layer_t* global_layer = get_global_layer();
+
+    // --- Intl letter remap ----------------------------------------------------
+    // Runs BEFORE the letter / picker handling below, because in remap mode a
+    // letter press means "this one", not "emit your variation".
+    if(addlang && access_local_layer()->remap_mode != LATIN_REMAP_OFF) {
+        if(!record->event.pressed) {
+            return false;                   // swallow the release of whatever we consumed
+        }
+        const int8_t slot = latin_target_slot(keycode);
+        if(keycode == KC_LAT_REMAP) {
+            latin_remap_cancel();           // tap the remap key again to back out
+        } else if(slot >= 0) {
+            poly_layer_t* ll = access_local_layer();
+            if(ll->remap_mode == LATIN_REMAP_PICKKEY) {
+                ll->remap_target = (uint8_t)slot;
+                ll->remap_mode   = LATIN_REMAP_PICKLTR;
+            } else {
+                latin_remap_apply(ll->remap_target, (uint8_t)slot);
+                latin_remap_cancel();
+            }
+            request_disp_refresh();
+        }
+        // Everything else is inert while the prompt is up — the board is a dialog.
+        return false;
+    }
+    if(keycode == KC_LAT_REMAP) {
+        if(record->event.pressed && addlang) {
+            // Shift+remap clears EVERY assignment. Once the board is remapped the
+            // Intl legends no longer match the printed letters, so there has to be
+            // one way back that does not depend on remembering what was changed.
+            // (The per-key reset needs no gesture of its own: re-assigning a key to
+            // its own letter is the same thing, and latin_remap_apply stores
+            // LATIN_ASSIGN_NONE for it.)
+            if((get_mods() & MOD_MASK_SHIFT) != 0) {
+                latin_remap_reset_all();
+                return false;
+            }
+            // Held with Intl: open remap mode. The Intl layer is the only place the
+            // key exists, so there is no "outside the layer" case to guard.
+            poly_layer_t* ll = access_local_layer();
+            ll->remap_mode   = LATIN_REMAP_PICKKEY;
+            ll->remap_target = 0;
+            // Drop the variation picker if it was open: the two prompts would
+            // otherwise both claim the keycaps.
+            if(s_picker_latched) {
+                unregister_mods(MOD_MASK_CTRL);
+                s_picker_latched = false;
+            }
+            latin_picker_reset_page();
+            request_disp_refresh();
+        }
+        return false;
+    }
     // The latch toggles on the PRESS, so the release of the tap that ARMED it must
     // be swallowed too — otherwise QMK unregisters the modifier we just registered
     // and the latch is over before the finger lifts.

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -1766,7 +1766,7 @@ static void latin_remap_apply(uint8_t slot, uint8_t letter) {
 // WITHOUT opening the mode — see process_record_user.
 static void latin_remap_reset_all(void) {
     latin_sync_t* table = access_global_latin_table();
-    memset(table->assign, 0xFF, sizeof(table->assign));   // 0xFF == all LATIN_ASSIGN_NONE
+    memset(table->assign, LATIN_ASSIGN_FILL, sizeof(table->assign));
     memset(table->ex, 0, sizeof(table->ex));
     send_to_bridge(USER_SYNC_LATIN_EX_DATA, (void*)table, sizeof(*table), 10);
     mark_latin_dirty();
@@ -4125,11 +4125,27 @@ void keyboard_post_init_user(void) {
     // carried forward every time the other case is re-picked.
     latin_sync_t* latin_table = access_global_latin_table();
     bool latin_normalised = false;
-    // The assignment map needs no conversion at any version: LATIN_ASSIGN_NONE is
-    // all-bits-set, so the 0xFF an EEPROM written before this field existed reads
-    // back here is already "every key unassigned".
-    memcpy(latin_table->assign, ee.latin_assign, sizeof(latin_table->assign));
-    if(ee.latin_pick_migrated == LATIN_PICK_INTERLEAVED) {
+    // ⚠️ The assignment map MUST be gated on the version byte — do NOT infer "never
+    // written" from the bytes themselves. An earlier version of this relied on
+    // LATIN_ASSIGN_NONE being all-bits-set and an unwritten EEPROM reading 0xFF;
+    // that is wrong for this backend. QMK's wear-levelling normalises its backing
+    // store so cleared bytes arrive as ZERO (quantum/wear_leveling/wear_leveling.c
+    // clears the cache with memset(...,0) and requires a 0xFF store to return the
+    // complement), so the map read back as all 0x00 = "every key hosts letter 0",
+    // and every keycap on the Intl layer showed a variation of 'a' (field, first
+    // flash). LATIN_PICK_INTERLEAVED is only ever stamped by firmware that writes
+    // this field in the same breath, so it is the one trustworthy witness that the
+    // bytes mean anything.
+    if(ee.latin_pick_migrated == LATIN_PICK_ASSIGN_OK) {
+        memcpy(latin_table->assign, ee.latin_assign, sizeof(latin_table->assign));
+    } else {
+        // Includes LATIN_PICK_INTERLEAVED, whose stored map is the persisted
+        // all-zero garbage described in state.h — discarding it is the recovery.
+        memset(latin_table->assign, LATIN_ASSIGN_FILL, sizeof(latin_table->assign));
+        latin_normalised = true;           // re-stamp at the next flush
+    }
+    if(ee.latin_pick_migrated == LATIN_PICK_ASSIGN_OK ||
+       ee.latin_pick_migrated == LATIN_PICK_INTERLEAVED) {
         memcpy(latin_table->ex, ee.latin_ex_wide, sizeof(latin_table->ex));
     } else if(ee.latin_pick_migrated == LATIN_PICK_MIGRATED) {
         // Re-index case-BLOCKED (case*26 + letter) to case-INTERLEAVED (slot*2 +
@@ -4262,11 +4278,10 @@ void eeconfig_init_user(void) {
     // A fresh EEPROM is born already widened: zeroed picks (every letter on its
     // first variation) plus the sentinel, so it never runs the legacy conversion.
     memset(ee.latin_ex_wide, 0, sizeof(ee.latin_ex_wide));
-    ee.latin_pick_migrated = LATIN_PICK_INTERLEAVED;
-    // ⚠️ 0xFF, NOT the struct-wide {0}: LATIN_ASSIGN_NONE is all-bits-set, so a
-    // zeroed map would read as "every key assigned to A" and the whole Intl layer
-    // would show A's variations.
-    memset(ee.latin_assign, 0xFF, sizeof(ee.latin_assign));
+    ee.latin_pick_migrated = LATIN_PICK_ASSIGN_OK;
+    // ⚠️ LATIN_ASSIGN_FILL, NOT the struct-wide {0}: a zeroed map reads as "every
+    // key assigned to A" and the whole Intl layer shows A's variations.
+    memset(ee.latin_assign, LATIN_ASSIGN_FILL, sizeof(ee.latin_assign));
     // Empty MRU recents: the serialised form uses 0 == empty for both lists, so
     // a zeroed block reads back as "no recent" (no stray category-0 / lang-0).
     memset(ee.mru_emoji, 0, sizeof(ee.mru_emoji));

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -3428,6 +3428,16 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
     // Runs BEFORE the letter / picker handling below, because in remap mode a
     // letter press means "this one", not "emit your variation".
     if(addlang && access_local_layer()->remap_mode != LATIN_REMAP_OFF) {
+        // ⚠️ Modifiers and LAYER keys must fall through — this block used to
+        // `return false` for every release, which swallowed the release of
+        // MO(_ADDLANG1) ITSELF.  QMK therefore never unregistered the layer: Intl
+        // went down and never came back up, so releasing it did not leave the
+        // prompt and there was no way out of the mode (field).  A held Shift was
+        // stuck the same way.  This is the picker's documented "gate the swallow on
+        // OWNERSHIP, not on the keycode" rule, which this block ignored.
+        if(IS_MODIFIER_KEYCODE(keycode) || IS_QK_MOMENTARY(keycode) || IS_QK_TO(keycode)) {
+            return true;
+        }
         if(!record->event.pressed) {
             return false;                   // swallow the release of whatever we consumed
         }

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -1792,10 +1792,24 @@ static void latin_remap_apply(uint8_t slot, uint8_t letter) {
 
 // Clear every assignment. Reached by tapping the remap key on the Intl layer
 // WITHOUT opening the mode — see process_record_user.
+//
+// ⚠️ Clears the picks of the REMAPPED slots only, not the whole ex[] array. A key
+// that was never remapped still hosts its own letter, so its pick is still valid
+// and is the user's own choice — wiping it would make "clear the assignments" also
+// silently discard every accent anyone had ever chosen (caught in review, #206).
+// A remapped slot's pick, by contrast, indexes the row it is losing and may be past
+// the end of its own, so that one must go back to 0.
 static void latin_remap_reset_all(void) {
     latin_sync_t* table = access_global_latin_table();
+    for(uint8_t slot = 0; slot < LATIN_TARGETS; slot++) {
+        // The RAW field, not latin_assign_get(): the getter substitutes the key's
+        // own letter for an unassigned slot, which is exactly the case to skip.
+        if(latin_bits_get(table->assign, LATIN_ASSIGN_BYTES, slot) < LATIN_LETTER_TARGETS) {
+            latin_pick_set(table->ex, latin_pick_field(slot, true),  0);
+            latin_pick_set(table->ex, latin_pick_field(slot, false), 0);
+        }
+    }
     memset(table->assign, LATIN_ASSIGN_FILL, sizeof(table->assign));
-    memset(table->ex, 0, sizeof(table->ex));
     send_to_bridge(USER_SYNC_LATIN_EX_DATA, (void*)table, sizeof(*table), 10);
     mark_latin_dirty();
     request_disp_refresh();
@@ -3541,6 +3555,13 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
             poly_layer_t* ll = access_local_layer();
             ll->remap_mode   = LATIN_REMAP_PICKKEY;
             ll->remap_target = 0;
+            // ⚠️ The prompt swallows every non-modifier release from here on, so a key
+            // QMK had ALREADY registered when the mode opened would never be
+            // unregistered — the host would hold it down and auto-repeat until USB
+            // dropped. Reachable: a letter with no variation falls through to QMK on
+            // this layer, so it can genuinely be down at this moment. Same remedy the
+            // firmware-confirm prompt and doom_begin() use for the same reason.
+            clear_keyboard();
             // Drop the variation picker if it was open: the two prompts would
             // otherwise both claim the keycaps.
             if(s_picker_latched) {

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -2870,6 +2870,11 @@ void update_displays(enum refresh_mode mode) {
     // gate is the SYNCED mods bit (poly_layer_t), not the master-only latch static,
     // so the slave inverts its Ctrl too when Ctrl lives on that half.
     const bool picker_open = add_lang && ((mods & LATIN_PICKER_MOD) != 0);
+    // The letter-remap prompt needs the same treatment for the same reason, and
+    // more so: the remap key LATCHES on a tap, so without an inverted keycap
+    // nothing on the board says the mode is open at all (field — "it does latch,
+    // but I did not recognize it as it did not invert").
+    const bool remap_open = add_lang && (local_layer->remap_mode != LATIN_REMAP_OFF);
     //the left side has an offset of 0, the right side an offset of MATRIX_ROWS_PER_SIDE
     const uint8_t offset = is_left_side() ? 0 : MATRIX_ROWS_PER_SIDE;
     uint8_t start_row = 0;
@@ -3055,12 +3060,24 @@ void update_displays(enum refresh_mode mode) {
                             kdisp_send_window();
                         } else {
                         const uint32_t* text = to_static_text(keycode, state);
+                        // ⚠️ The remap prompt blanks the board through render_key(),
+                        // which is only consulted when there is NO static text — so a
+                        // key that HAS one (the remap key itself, and any other legend
+                        // on this layer) sailed straight past it and kept drawing.
+                        // Drop the text here and the existing render_key() blanking
+                        // takes over. The remap key is exempt: it stays visible so it
+                        // can render inverted and offer the way out.
+                        if(remap_open && keycode != KC_LAT_REMAP &&
+                           !(keycode >= KC_A && keycode <= KC_Z)) {
+                            text = NULL;
+                        }
                         // Ctrl while the picker is armed: white ground, legend
                         // erased out of it. Paired reset below — the plotter flags
                         // are static, so leaving erase on would blank every
                         // following keycap on this pass.
-                        const bool invert_key = picker_open &&
-                                                (keycode == KC_LEFT_CTRL || keycode == KC_RIGHT_CTRL);
+                        const bool invert_key = (picker_open &&
+                                                 (keycode == KC_LEFT_CTRL || keycode == KC_RIGHT_CTRL)) ||
+                                                (remap_open && keycode == KC_LAT_REMAP);
                         kdisp_set_buffer(invert_key ? 0xFF : 0x00);
                         if(invert_key) {
                             kdisp_set_gfx_erase(true);

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -1694,22 +1694,42 @@ static int8_t latin_target_slot(uint16_t keycode) {
     if(keycode >= KC_A && keycode <= KC_Z) {
         return (int8_t)(keycode - KC_A);
     }
+    // KC_MINUS .. KC_SLASH is a contiguous run of the twelve printable punctuation
+    // keycodes, so no table. Whether a given board can actually REACH one is the
+    // keymap's business: a position masked with KC_NO on _ADDLANG1 (split42's ')
+    // or absent entirely (split42 has no [ ] `) simply never produces the keycode.
+    if(keycode >= KC_MINUS && keycode <= KC_SLASH) {
+        return (int8_t)(LATIN_LETTER_TARGETS + (keycode - KC_MINUS));
+    }
     return -1;
 }
 
-// The base letter a target key hosts -- its own unless it has been reassigned.
-static uint8_t latin_slot_letter(int8_t slot) {
+// The base letter a target key hosts, or -1 for none. A letter defaults to itself;
+// a punctuation key defaults to nothing, so it keeps typing its own symbol until
+// it is deliberately mapped.
+static int8_t latin_slot_letter(int8_t slot) {
     if(slot < 0) {
-        return 0;
+        return -1;
     }
     return latin_assign_get(get_global_latin_table()->assign, (uint8_t)slot);
 }
 
+// True when this key currently HOSTS a variation row.  Every letter does by
+// default; a punctuation key only once it has deliberately been mapped, so an
+// unmapped one keeps typing and drawing its own symbol on the Intl layer.  This
+// is the gate the picker and the emit path use -- NOT `keycode >= KC_A`, which
+// was the same test only while the letters were the only targets.
+static bool latin_has_row(uint16_t keycode) {
+    return latin_slot_letter(latin_target_slot(keycode)) >= 0;
+}
+
 // The row the picker is currently showing, for the key last touched.  Both the
 // render and the press path must agree on this, so it lives in one place.
+// ⚠️ Precondition: latin_has_row(last_latin_keycode).  The clamp is only so a
+// stray call can never index latin_ex_map out of bounds.
 static uint8_t latin_picker_row(uint16_t last_latin_keycode, bool upper_case) {
-    const int8_t slot = latin_target_slot(last_latin_keycode);
-    return (uint8_t)((upper_case ? 0 : 26) + latin_slot_letter(slot));
+    const int8_t letter = latin_slot_letter(latin_target_slot(last_latin_keycode));
+    return (uint8_t)((upper_case ? 0 : 26) + (letter < 0 ? 0 : letter));
 }
 
 // Absolute variation index for a picker slot on the currently-shown page, or -1
@@ -1748,7 +1768,15 @@ static void latin_remap_cancel(void) {
 // are the same — so re-picking a key's own letter is the per-key reset, with no
 // separate gesture to learn.
 static void latin_remap_apply(uint8_t slot, uint8_t letter) {
-    if(slot >= LATIN_TARGETS || letter >= LATIN_TARGETS) {
+    // ⚠️ The two bounds are deliberately DIFFERENT. Any target can be remapped, but
+    // only a LETTER can be the source — a punctuation key hosts a letter's row,
+    // never the reverse. The one exception is slot == letter, the "point this key
+    // back at itself" clear, which is the only per-key way to unmap a punctuation
+    // key (it has no own letter to re-pick).
+    if(slot >= LATIN_TARGETS) {
+        return;
+    }
+    if(letter >= LATIN_LETTER_TARGETS && letter != slot) {
         return;
     }
     latin_sync_t* table = access_global_latin_table();
@@ -1801,7 +1829,11 @@ static const uint32_t* latin_variation(uint16_t keycode, bool upper_case) {
     // own, unless reassigned); the pick comes from the KEY's own storage slot. They
     // must not be collapsed back into one: two keys assigned to the same letter
     // share a row but need independent picks -- that is the entire feature.
-    const uint8_t row = (uint8_t)((upper_case ? 0 : 26) + latin_slot_letter(slot));
+    const int8_t letter = latin_slot_letter(slot);
+    if (letter < 0) {
+        return NULL;                        // punctuation key, not mapped to anything
+    }
+    const uint8_t row = (uint8_t)((upper_case ? 0 : 26) + letter);
     if (latin_ex_map[row][0] == NULL) {
         return NULL;                        // this letter has no variations
     }
@@ -1827,15 +1859,23 @@ bool render_key(uint16_t keycode, led_t state, uint8_t mods) {
     const bool is_letter = keycode>=KC_A && keycode<=KC_Z;
 
     // --- letter-remap mode: the board becomes a "which key?" / "which letter?"
-    // prompt.  Everything that is not a letter blanks out, so the only thing to
-    // look at is the set you are choosing from.
+    // prompt.  Everything outside the set being chosen from blanks out, so the only
+    // thing to look at is that set.
     if(add_lang && local_layer->remap_mode != LATIN_REMAP_OFF) {
-        if(!is_letter) {
-            return false;                   // blank — nothing else is pressable now
-        }
         const int8_t  slot   = latin_target_slot(keycode);
         const bool    picked = (local_layer->remap_mode == LATIN_REMAP_PICKLTR) &&
                                (slot >= 0) && ((uint8_t)slot == local_layer->remap_target);
+        // The two steps offer DIFFERENT sets. PICKKEY picks the key to change, so
+        // every TARGET is live — the letters and the twelve punctuation keys alike.
+        // PICKLTR picks the letter that key should host, and only a letter can be a
+        // source, so the punctuation keys go dark again — EXCEPT the one that was
+        // just picked, which has to stay visible (inverted) or the board stops
+        // showing what is being changed.
+        const bool selectable = (local_layer->remap_mode == LATIN_REMAP_PICKKEY) ? (slot >= 0)
+                                                                                 : (is_letter || picked);
+        if(!selectable) {
+            return false;                   // blank — nothing else is pressable now
+        }
         // ⚠️ Render the inversion, do NOT call kdisp_invert(): matrix_scan_kb toggles
         // that on every press/release independently of process_record, so a latched
         // indicator driven through it is undone by the next keypress.  Fill the
@@ -1845,20 +1885,37 @@ bool render_key(uint16_t keycode, led_t state, uint8_t mods) {
             kdisp_set_buffer(0xFF);
             kdisp_set_gfx_erase(true);
         }
-        // In PICKKEY every letter still shows what it currently hosts (so you can
+        // In PICKKEY every target still shows what it currently hosts (so you can
         // see what you are about to change); in PICKLTR the letters are the SOURCE
         // menu, so each shows its own plain letter.
         bool drawn;
         if(local_layer->remap_mode == LATIN_REMAP_PICKKEY) {
             const uint32_t* variation = latin_variation(keycode, shift || state.caps_lock);
+            if(variation == NULL) {
+                // A punctuation key that has not been mapped yet hosts nothing —
+                // draw its own symbol, so the set you are choosing from reads as the
+                // actual keyboard rather than a row of holes.
+                variation = translate_keycode(get_local_state()->lang, keycode,
+                                              shift, state.caps_lock);
+            }
             drawn = (variation != NULL);
             if(drawn) {
                 kdisp_write_gfx_text_cy(g_all_fonts, g_all_font_count, BUFFER_X, 23, variation, 0);
             }
-        } else {
+        } else if(is_letter) {
             const uint32_t letter[2] = { (uint32_t)('a' + (keycode - KC_A)), 0 };
             kdisp_write_gfx_text_cy(g_all_fonts, g_all_font_count, BUFFER_X, 23, letter, 0);
             drawn = true;
+        } else {
+            // Only reachable for a PICKED punctuation target (see `selectable`), so
+            // it must draw its own symbol -- 'a' + (keycode - KC_A) would be a
+            // nonsense codepoint here.
+            const uint32_t* sym = translate_keycode(get_local_state()->lang, keycode,
+                                                    shift, state.caps_lock);
+            drawn = (sym != NULL);
+            if(drawn) {
+                kdisp_write_gfx_text_cy(g_all_fonts, g_all_font_count, BUFFER_X, 23, sym, 0);
+            }
         }
         if(picked) {
             kdisp_set_gfx_erase(false);     // static flag — leaving it on blanks every later key
@@ -1867,7 +1924,11 @@ bool render_key(uint16_t keycode, led_t state, uint8_t mods) {
         return drawn;
     }
 
-    if(is_letter && add_lang) {
+    // ⚠️ Gated on "hosts a row", not on is_letter: a punctuation key that has been
+    // remapped shows its host letter's variation here, and an unmapped one must
+    // fall THROUGH to the normal translate_keycode path below so it keeps drawing
+    // (and typing) its own symbol.
+    if(add_lang && latin_has_row(keycode)) {
         //display the previously selected latin variation of the letter
         const uint32_t* variation = latin_variation(keycode, shift || state.caps_lock);
         if(variation!=NULL) {
@@ -1879,8 +1940,7 @@ bool render_key(uint16_t keycode, led_t state, uint8_t mods) {
 
     //variation selection on the picker row
     uint16_t local_last_latin_keycode = get_local_last_latin_keycode();
-    const bool picker_open = add_lang && picker_mod &&
-                             local_last_latin_keycode>=KC_A && local_last_latin_keycode<=KC_Z;
+    const bool picker_open = add_lang && picker_mod && latin_has_row(local_last_latin_keycode);
     const int8_t picker_slot = latin_picker_slot(keycode);
     if(picker_slot >= 0) {
         if(picker_open) {
@@ -3449,7 +3509,13 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
             if(ll->remap_mode == LATIN_REMAP_PICKKEY) {
                 ll->remap_target = (uint8_t)slot;
                 ll->remap_mode   = LATIN_REMAP_PICKLTR;
-            } else {
+            } else if((uint8_t)slot == ll->remap_target || slot < LATIN_LETTER_TARGETS) {
+                // Only a LETTER can be a source, so a punctuation key is inert as a
+                // choice here (and renders blank) — with one exception: the TARGET
+                // itself, which is how a key is cleared. For a letter that is
+                // "re-pick your own letter"; for a punctuation key, which has no own
+                // letter, it is the only per-key way back to plain typing. Both land
+                // on LATIN_ASSIGN_NONE inside latin_remap_apply().
                 latin_remap_apply(ll->remap_target, (uint8_t)slot);
                 latin_remap_cancel();
             }
@@ -3536,6 +3602,15 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
                 return true;   // let QMK's QK_REBOOT handler reset the master
             }
             case KC_A ... KC_Z:
+            case KC_MINUS ... KC_SLASH:
+                // A punctuation key is a target too, but ONLY once it has been
+                // mapped. Until then it must behave exactly as it does everywhere
+                // else — never become the picker's subject, never swallow its own
+                // keystroke — so it leaves here before touching any of that. The
+                // guard is a no-op for letters, which always host themselves.
+                if(!latin_has_row(keycode)) {
+                    break;
+                }
                 // A different letter has a different variation count, so the page
                 // that was showing may not exist on it.  Reset here rather than in
                 // the picker-open branch below: this case runs on EVERY letter press,
@@ -3603,7 +3678,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
             // elsewhere in the enum, so the picker slots are resolved by helper.
             const int8_t pick_slot = latin_picker_slot(keycode);
             if(pick_slot >= 0) {
-                if( last_latin_keycode>=KC_A && last_latin_keycode<=KC_Z) {
+                if( latin_has_row(last_latin_keycode)) {
                     const bool pick_upper = ((get_mods() & MOD_MASK_SHIFT) != 0) || global_layer->led_state.caps_lock;
                     const uint8_t pick_row = latin_picker_row(last_latin_keycode, pick_upper);
                     // Only the slots that exist are drawn on the picker keycaps
@@ -3642,7 +3717,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
             switch(keycode) {
                 case KC_LAT_PAGE_PREV:
                 case KC_LAT_PAGE_NEXT:
-                    if( last_latin_keycode>=KC_A && last_latin_keycode<=KC_Z) {
+                    if( latin_has_row(last_latin_keycode)) {
                         const bool pg_upper = ((get_mods() & MOD_MASK_SHIFT) != 0) || global_layer->led_state.caps_lock;
                         const uint8_t pages = latin_page_count(latin_picker_row(last_latin_keycode, pg_upper));
                         if(pages > 1) {
@@ -3666,6 +3741,11 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
                     }
                     break;
                 case KC_A ... KC_Z:
+                case KC_MINUS ... KC_SLASH:
+                    // Switching the picker's subject: redraw so the slots show the
+                    // new row. Punctuation is included because a mapped one is a
+                    // subject like any letter; an unmapped one already left the
+                    // outer switch without becoming one, so this is just a repaint.
                     request_disp_refresh();
                     break;
                 default:
@@ -4163,8 +4243,14 @@ void keyboard_post_init_user(void) {
     // flash). LATIN_PICK_INTERLEAVED is only ever stamped by firmware that writes
     // this field in the same breath, so it is the one trustworthy witness that the
     // bytes mean anything.
+    // ⚠️ The letter block is copied at LATIN_*_BASE_BYTES, not sizeof(): EEPROM
+    // keeps the letters and the punctuation apart so the letter block can keep the
+    // size and offset it shipped with (see state.h). The punctuation half of both
+    // arrays is filled from the ext block further down — unconditionally, because
+    // the ASSIGN split is not byte-aligned (26 x 6 = 156 bits), so the 20th base
+    // byte carries four bits of the first punctuation field with it.
     if(ee.latin_pick_migrated == LATIN_PICK_ASSIGN_OK) {
-        memcpy(latin_table->assign, ee.latin_assign, sizeof(latin_table->assign));
+        memcpy(latin_table->assign, ee.latin_assign, LATIN_ASSIGN_BASE_BYTES);
     } else {
         // Includes LATIN_PICK_INTERLEAVED, whose stored map is the persisted
         // all-zero garbage described in state.h — discarding it is the recovery.
@@ -4173,15 +4259,15 @@ void keyboard_post_init_user(void) {
     }
     if(ee.latin_pick_migrated == LATIN_PICK_ASSIGN_OK ||
        ee.latin_pick_migrated == LATIN_PICK_INTERLEAVED) {
-        memcpy(latin_table->ex, ee.latin_ex_wide, sizeof(latin_table->ex));
+        memcpy(latin_table->ex, ee.latin_ex_wide, LATIN_PICK_BASE_BYTES);
     } else if(ee.latin_pick_migrated == LATIN_PICK_MIGRATED) {
         // Re-index case-BLOCKED (case*26 + letter) to case-INTERLEAVED (slot*2 +
         // case). Same 52 values, same width -- only the field numbering moves, so
         // every pick is preserved.
         memset(latin_table->ex, 0, sizeof(latin_table->ex));
         for(uint8_t i = 0; i < 26; i++) {
-            latin_pick_set(latin_table->ex, latin_pick_field(i, true),  latin_bits_get(ee.latin_ex_wide, LATIN_PICK_BYTES, i));
-            latin_pick_set(latin_table->ex, latin_pick_field(i, false), latin_bits_get(ee.latin_ex_wide, LATIN_PICK_BYTES, (uint8_t)(26 + i)));
+            latin_pick_set(latin_table->ex, latin_pick_field(i, true),  latin_bits_get(ee.latin_ex_wide, LATIN_PICK_BASE_BYTES, i));
+            latin_pick_set(latin_table->ex, latin_pick_field(i, false), latin_bits_get(ee.latin_ex_wide, LATIN_PICK_BASE_BYTES, (uint8_t)(26 + i)));
         }
         latin_normalised = true;           // force the flush that stamps the new version
     } else {
@@ -4195,18 +4281,42 @@ void keyboard_post_init_user(void) {
         }
         latin_normalised = true;
     }
+    // The punctuation targets, from their own appended block. An EEPROM written
+    // before they existed reads this as zeros (wear-levelling clears to 0, NOT to
+    // 0xFF — see state.h), which is why "never written" is decided by the format
+    // byte and not by the bytes: zeroed assignments would mean "every punctuation
+    // key hosts A", the exact failure the letter map already shipped once.
+    if(ee.latin_ext_fmt == LATIN_EXT_OK) {
+        memcpy(latin_table->ex + LATIN_PICK_BASE_BYTES, ee.latin_ex_ext, LATIN_PICK_EXT_BYTES);
+        for(uint8_t i = 0; i < LATIN_PUNCT_TARGETS; i++) {
+            latin_assign_set(latin_table->assign, (uint8_t)(LATIN_LETTER_TARGETS + i),
+                             latin_bits_get(ee.latin_assign_ext, LATIN_ASSIGN_EXT_BYTES, i));
+        }
+    } else {
+        memset(latin_table->ex + LATIN_PICK_BASE_BYTES, 0, LATIN_PICK_EXT_BYTES);
+        for(uint8_t i = 0; i < LATIN_PUNCT_TARGETS; i++) {
+            latin_assign_set(latin_table->assign, (uint8_t)(LATIN_LETTER_TARGETS + i), LATIN_ASSIGN_NONE);
+        }
+        latin_normalised = true;           // stamp the ext block at the next flush
+    }
     // ⚠️ Validate each pick against the row its key actually HOSTS, not against the
     // field index. Those are the same number only while every key is unassigned;
     // once a key is remapped, checking latin_ex_map[field] would validate the pick
     // against the wrong letter and zero perfectly good choices.
     for(uint8_t slot = 0; slot < LATIN_TARGETS; slot++) {
-        const uint8_t letter = latin_assign_get(latin_table->assign, slot);
+        const int8_t letter = latin_assign_get(latin_table->assign, slot);
         for(uint8_t c = 0; c < 2; c++) {
             const bool    upper = (c == 0);
             const uint8_t field = latin_pick_field(slot, upper);
-            const uint8_t row   = (uint8_t)((upper ? 0 : 26) + letter);
             const uint8_t idx   = latin_pick_get(latin_table->ex, field);
-            if(idx >= LATIN_EX_VARIATIONS || latin_ex_map[row][idx] == NULL) {
+            // An unassigned punctuation key hosts no row at all, so there is nothing
+            // to validate against — its pick must simply be 0, ready for whatever it
+            // is later mapped to.
+            const bool bad = (letter < 0)
+                                 ? (idx != 0)
+                                 : (idx >= LATIN_EX_VARIATIONS ||
+                                    latin_ex_map[(uint8_t)((upper ? 0 : 26) + letter)][idx] == NULL);
+            if(bad) {
                 latin_pick_set(latin_table->ex, field, 0);
                 latin_normalised = true;
             }
@@ -4309,6 +4419,11 @@ void eeconfig_init_user(void) {
     // ⚠️ LATIN_ASSIGN_FILL, NOT the struct-wide {0}: a zeroed map reads as "every
     // key assigned to A" and the whole Intl layer shows A's variations.
     memset(ee.latin_assign, LATIN_ASSIGN_FILL, sizeof(ee.latin_assign));
+    // Same for the punctuation block, and for the same reason — plus its own format
+    // byte, so a fresh EEPROM is born with the extension already valid.
+    memset(ee.latin_ex_ext, 0, sizeof(ee.latin_ex_ext));
+    memset(ee.latin_assign_ext, LATIN_ASSIGN_FILL, sizeof(ee.latin_assign_ext));
+    ee.latin_ext_fmt = LATIN_EXT_OK;
     // Empty MRU recents: the serialised form uses 0 == empty for both lists, so
     // a zeroed block reads back as "no recent" (no stray category-0 / lang-0).
     memset(ee.mru_emoji, 0, sizeof(ee.mru_emoji));

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -1679,10 +1679,33 @@ static uint8_t latin_page_count(uint8_t row) {
                : (uint8_t)((n + LATIN_PICKER_SLOTS - 1) / LATIN_PICKER_SLOTS);
 }
 
-// The row the picker is currently showing, for the letter last touched.  Both the
+// --- target slots and the assignment indirection ------------------------------
+//
+// A "target" is a key that can carry an Intl variation.  Today that is A..Z and
+// slot == letter index, but the two are deliberately separate concepts: the slot
+// addresses the STORAGE (which key), the letter addresses the TABLE (whose
+// variations).  They diverge the moment a key is remapped -- which is the whole
+// point, since French wants e, and two other keys, all showing forms of e.
+static int8_t latin_target_slot(uint16_t keycode) {
+    if(keycode >= KC_A && keycode <= KC_Z) {
+        return (int8_t)(keycode - KC_A);
+    }
+    return -1;
+}
+
+// The base letter a target key hosts -- its own unless it has been reassigned.
+static uint8_t latin_slot_letter(int8_t slot) {
+    if(slot < 0) {
+        return 0;
+    }
+    return latin_assign_get(get_global_latin_table()->assign, (uint8_t)slot);
+}
+
+// The row the picker is currently showing, for the key last touched.  Both the
 // render and the press path must agree on this, so it lives in one place.
 static uint8_t latin_picker_row(uint16_t last_latin_keycode, bool upper_case) {
-    return (uint8_t)((upper_case ? 0 : 26) + (last_latin_keycode - KC_A));
+    const int8_t slot = latin_target_slot(last_latin_keycode);
+    return (uint8_t)((upper_case ? 0 : 26) + latin_slot_letter(slot));
 }
 
 // Absolute variation index for a picker slot on the currently-shown page, or -1
@@ -1729,14 +1752,19 @@ static void latin_picker_reset_page(void) {
 // picker now refuses to store an empty slot (see process_record_user), but a byte
 // written before that guard — or a stale/garbage EEPROM — still arrives here.
 static const uint32_t* latin_variation(uint16_t keycode, bool upper_case) {
-    if (keycode < KC_A || keycode > KC_Z) {
+    const int8_t slot = latin_target_slot(keycode);
+    if (slot < 0) {
         return NULL;
     }
-    const uint8_t row = (upper_case ? 0 : 26) + (uint8_t)(keycode - KC_A);
+    // ⚠️ Two DIFFERENT indices. The row comes from the letter this key HOSTS (its
+    // own, unless reassigned); the pick comes from the KEY's own storage slot. They
+    // must not be collapsed back into one: two keys assigned to the same letter
+    // share a row but need independent picks -- that is the entire feature.
+    const uint8_t row = (uint8_t)((upper_case ? 0 : 26) + latin_slot_letter(slot));
     if (latin_ex_map[row][0] == NULL) {
         return NULL;                        // this letter has no variations
     }
-    const uint8_t   idx    = latin_pick_get(get_global_latin_table()->ex, row);
+    const uint8_t   idx    = latin_pick_get(get_global_latin_table()->ex, latin_pick_field(slot, upper_case));
     const uint32_t* chosen = (idx < LATIN_EX_VARIATIONS) ? latin_ex_map[row][idx] : NULL;
     // Fall back when the pick names a slot this build does not have (a stale
     // EEPROM), and ALSO when it names a real variation whose GLYPH is missing --
@@ -3428,9 +3456,12 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
                         // The ABSOLUTE variation index is what gets stored, not the
                         // slot — so a pick made on page 1 still reads back correctly,
                         // and on a variant with a different LATIN_PICKER_SLOTS.
-                        // The field index IS the latin_ex_map row, so the two can
-                        // never disagree about which case is being written.
-                        latin_pick_set(global_latin_table->ex, pick_row, (uint8_t)pick_idx);
+                        // ⚠️ Stored against the KEY's field, read from the HOSTED
+                        // row (pick_row above). Writing it at pick_row would work
+                        // only while nothing is remapped, then silently overwrite
+                        // the pick of whichever key owns that letter.
+                        const int8_t pick_target = latin_target_slot(last_latin_keycode);
+                        latin_pick_set(global_latin_table->ex, latin_pick_field(pick_target, pick_upper), (uint8_t)pick_idx);
                         send_to_bridge(USER_SYNC_LATIN_EX_DATA, (void*)global_latin_table, sizeof(*global_latin_table), 10);
 
                         // "or an alternative character has been selected"
@@ -3958,24 +3989,48 @@ void keyboard_post_init_user(void) {
     // carried forward every time the other case is re-picked.
     latin_sync_t* latin_table = access_global_latin_table();
     bool latin_normalised = false;
-    if(ee.latin_pick_migrated == LATIN_PICK_MIGRATED) {
+    // The assignment map needs no conversion at any version: LATIN_ASSIGN_NONE is
+    // all-bits-set, so the 0xFF an EEPROM written before this field existed reads
+    // back here is already "every key unassigned".
+    memcpy(latin_table->assign, ee.latin_assign, sizeof(latin_table->assign));
+    if(ee.latin_pick_migrated == LATIN_PICK_INTERLEAVED) {
         memcpy(latin_table->ex, ee.latin_ex_wide, sizeof(latin_table->ex));
+    } else if(ee.latin_pick_migrated == LATIN_PICK_MIGRATED) {
+        // Re-index case-BLOCKED (case*26 + letter) to case-INTERLEAVED (slot*2 +
+        // case). Same 52 values, same width -- only the field numbering moves, so
+        // every pick is preserved.
+        memset(latin_table->ex, 0, sizeof(latin_table->ex));
+        for(uint8_t i = 0; i < 26; i++) {
+            latin_pick_set(latin_table->ex, latin_pick_field(i, true),  latin_bits_get(ee.latin_ex_wide, LATIN_PICK_BYTES, i));
+            latin_pick_set(latin_table->ex, latin_pick_field(i, false), latin_bits_get(ee.latin_ex_wide, LATIN_PICK_BYTES, (uint8_t)(26 + i)));
+        }
+        latin_normalised = true;           // force the flush that stamps the new version
     } else {
         // One-time widening of the legacy nibble pairs (one byte per letter, high
         // nibble = uppercase) into the 6-bit fields. Every legacy value is < 16 so
         // it lands in the wider field unchanged and the user keeps their picks.
         memset(latin_table->ex, 0, sizeof(latin_table->ex));
         for(uint8_t i = 0; i < 26; i++) {
-            latin_pick_set(latin_table->ex, i,      (uint8_t)(ee.latin_ex[i] >> 4));
-            latin_pick_set(latin_table->ex, 26 + i, (uint8_t)(ee.latin_ex[i] & 0x0F));
+            latin_pick_set(latin_table->ex, latin_pick_field(i, true),  (uint8_t)(ee.latin_ex[i] >> 4));
+            latin_pick_set(latin_table->ex, latin_pick_field(i, false), (uint8_t)(ee.latin_ex[i] & 0x0F));
         }
-        latin_normalised = true;           // force the flush that stamps the sentinel
+        latin_normalised = true;
     }
-    for(uint8_t row = 0; row < LATIN_PICK_FIELDS; row++) {
-        const uint8_t idx = latin_pick_get(latin_table->ex, row);
-        if(idx >= LATIN_EX_VARIATIONS || latin_ex_map[row][idx] == NULL) {
-            latin_pick_set(latin_table->ex, row, 0);
-            latin_normalised = true;
+    // ⚠️ Validate each pick against the row its key actually HOSTS, not against the
+    // field index. Those are the same number only while every key is unassigned;
+    // once a key is remapped, checking latin_ex_map[field] would validate the pick
+    // against the wrong letter and zero perfectly good choices.
+    for(uint8_t slot = 0; slot < LATIN_TARGETS; slot++) {
+        const uint8_t letter = latin_assign_get(latin_table->assign, slot);
+        for(uint8_t c = 0; c < 2; c++) {
+            const bool    upper = (c == 0);
+            const uint8_t field = latin_pick_field(slot, upper);
+            const uint8_t row   = (uint8_t)((upper ? 0 : 26) + letter);
+            const uint8_t idx   = latin_pick_get(latin_table->ex, field);
+            if(idx >= LATIN_EX_VARIATIONS || latin_ex_map[row][idx] == NULL) {
+                latin_pick_set(latin_table->ex, field, 0);
+                latin_normalised = true;
+            }
         }
     }
     if(latin_normalised) {
@@ -4071,7 +4126,11 @@ void eeconfig_init_user(void) {
     // A fresh EEPROM is born already widened: zeroed picks (every letter on its
     // first variation) plus the sentinel, so it never runs the legacy conversion.
     memset(ee.latin_ex_wide, 0, sizeof(ee.latin_ex_wide));
-    ee.latin_pick_migrated = LATIN_PICK_MIGRATED;
+    ee.latin_pick_migrated = LATIN_PICK_INTERLEAVED;
+    // ⚠️ 0xFF, NOT the struct-wide {0}: LATIN_ASSIGN_NONE is all-bits-set, so a
+    // zeroed map would read as "every key assigned to A" and the whole Intl layer
+    // would show A's variations.
+    memset(ee.latin_assign, 0xFF, sizeof(ee.latin_assign));
     // Empty MRU recents: the serialised form uses 0 == empty for both lists, so
     // a zeroed block reads back as "no recent" (no stray category-0 / lang-0).
     memset(ee.mru_emoji, 0, sizeof(ee.mru_emoji));

--- a/keyboards/polykybd/split42/config.h
+++ b/keyboards/polykybd/split42/config.h
@@ -115,7 +115,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // budget rather than tracking the live EECONFIG_USER_DATA_SIZE; the actual size must stay
 // <= the reservation (static_assert in state.h). Bumping the reservation relocates the
 // keymap once (one final reset), then it stays put across firmware updates.
-#define POLY_EECONFIG_USER_RESERVED 128
+// Raised 128->256 (2026-08-13) for the Intl key->letter assignment map. This
+// RELOCATES the dynamic keymap once, so it resets any host-customised layout --
+// paid deliberately while there are only testers, and generously, so that
+// extending the remappable target set to the punctuation keys later (which needs
+// ~43 more bytes) costs no second reset.
+#define POLY_EECONFIG_USER_RESERVED 256
 #define DYNAMIC_KEYMAP_EEPROM_ADDR  (EECONFIG_BASE_SIZE + EECONFIG_KB_DATA_SIZE + POLY_EECONFIG_USER_RESERVED)
 #define POLY_EEPROM_MAGIC_ADDR      DYNAMIC_KEYMAP_EEPROM_ADDR
 

--- a/keyboards/polykybd/split42/keymaps/default/config.h
+++ b/keyboards/polykybd/split42/keymaps/default/config.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 #define ENABLE_COMPILE_KEYCODE
 
-#define EECONFIG_USER_DATA_SIZE 126  // +39 latin_ex_wide (6-bit picks) +1 format version
+#define EECONFIG_USER_DATA_SIZE 154  // +39 latin_ex_wide +1 fmt +20 latin_assign, then +18/+9/+1 for the punctuation targets
                                      // +20 latin_assign (6-bit base-letter per key).
                                      // POLY_EECONFIG_USER_RESERVED was raised 128->256 for
                                      // this: 126 still fits 128, but with 2 bytes left the

--- a/keyboards/polykybd/split42/keymaps/default/config.h
+++ b/keyboards/polykybd/split42/keymaps/default/config.h
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 #define ENABLE_COMPILE_KEYCODE
 
-#define EECONFIG_USER_DATA_SIZE 106  // +39 latin_ex_wide (6-bit picks) +1 latin_pick_migrated (within POLY_EECONFIG_USER_RESERVED=128, no keymap relocation)
+#define EECONFIG_USER_DATA_SIZE 126  // +39 latin_ex_wide (6-bit picks) +1 format version
+                                     // +20 latin_assign (6-bit base-letter per key).
+                                     // POLY_EECONFIG_USER_RESERVED was raised 128->256 for
+                                     // this: 126 still fits 128, but with 2 bytes left the
+                                     // next field of any kind would relocate the keymap, so
+                                     // the one-time reset is paid here rather than twice.
 
 #define USB_VBUS_PIN GP24
 

--- a/keyboards/polykybd/split42/keymaps/default/keymap.c
+++ b/keyboards/polykybd/split42/keymaps/default/keymap.c
@@ -205,7 +205,11 @@ const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         _______, _______, _______, _______, _______, _______,
         _______, _______, _______, _______, _______, _______,
         // Ctrl (LATIN_PICKER_MOD) must reach the base layer -- see the split72 note.
-        _______, KC_NO,   _______,
+        // [3,4] is dead on this layer and is the thumb next to [3,3], which holds
+        // Ctrl on _L1.._L4, so KC_LAT_REMAP lands beside the picker modifier here
+        // too. (split72 pairs them at [4,0]/[4,1]; split42 cannot match that exactly
+        // because its Ctrl moves between bases -- [1,0] on _L0, [3,3] elsewhere.)
+        _______, KC_LAT_REMAP, _______,
         KC_LAT5, KC_LAT6, KC_LAT7, KC_LAT8, KC_LAT9, KC_LAT_PAGE_NEXT,
         _______, _______, _______, _______, _______, KC_NO,
         _______, _______, _______, _______, _______, _______,

--- a/keyboards/polykybd/split72/config.h
+++ b/keyboards/polykybd/split72/config.h
@@ -121,7 +121,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // budget rather than tracking the live EECONFIG_USER_DATA_SIZE; the actual size must stay
 // <= the reservation (static_assert in state.h). Bumping the reservation relocates the
 // keymap once (one final reset), then it stays put across firmware updates.
-#define POLY_EECONFIG_USER_RESERVED 128
+// Raised 128->256 (2026-08-13) for the Intl key->letter assignment map. This
+// RELOCATES the dynamic keymap once, so it resets any host-customised layout --
+// paid deliberately while there are only testers, and generously, so that
+// extending the remappable target set to the punctuation keys later (which needs
+// ~43 more bytes) costs no second reset.
+#define POLY_EECONFIG_USER_RESERVED 256
 #define DYNAMIC_KEYMAP_EEPROM_ADDR  (EECONFIG_BASE_SIZE + EECONFIG_KB_DATA_SIZE + POLY_EECONFIG_USER_RESERVED)
 #define POLY_EEPROM_MAGIC_ADDR      DYNAMIC_KEYMAP_EEPROM_ADDR
 

--- a/keyboards/polykybd/split72/keymaps/default/config.h
+++ b/keyboards/polykybd/split72/keymaps/default/config.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 #define ENABLE_COMPILE_KEYCODE
 
-#define EECONFIG_USER_DATA_SIZE 126  // +39 latin_ex_wide (6-bit picks) +1 format version
+#define EECONFIG_USER_DATA_SIZE 154  // +39 latin_ex_wide +1 fmt +20 latin_assign, then +18/+9/+1 for the punctuation targets
                                      // +20 latin_assign (6-bit base-letter per key).
                                      // POLY_EECONFIG_USER_RESERVED was raised 128->256 for
                                      // this: 126 still fits 128, but with 2 bytes left the

--- a/keyboards/polykybd/split72/keymaps/default/config.h
+++ b/keyboards/polykybd/split72/keymaps/default/config.h
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 #define ENABLE_COMPILE_KEYCODE
 
-#define EECONFIG_USER_DATA_SIZE 106  // +39 latin_ex_wide (6-bit picks) +1 latin_pick_migrated (within POLY_EECONFIG_USER_RESERVED=128, no keymap relocation)
+#define EECONFIG_USER_DATA_SIZE 126  // +39 latin_ex_wide (6-bit picks) +1 format version
+                                     // +20 latin_assign (6-bit base-letter per key).
+                                     // POLY_EECONFIG_USER_RESERVED was raised 128->256 for
+                                     // this: 126 still fits 128, but with 2 bytes left the
+                                     // next field of any kind would relocate the keymap, so
+                                     // the one-time reset is paid here rather than twice.
 
 // Emoji picker: 38 slots/page (rows 2-4; the top row is the MRU, row 1 the tabs).
 #define EMJ_SLOTS_PER_PAGE 38

--- a/keyboards/polykybd/split72/keymaps/default/keymap.c
+++ b/keyboards/polykybd/split72/keymaps/default/keymap.c
@@ -282,7 +282,11 @@ const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         // picker was on Alt.  Alt is now KC_NO instead: the picker swallows the keys
         // it handles, so the host saw a bare Alt tap and Windows moved focus to the
         // menu bar, right in the middle of typing an accented letter.
-        _______,    KC_NO,      KC_NO,      _______,                _______,    _______,    _______,
+        // [4,1] (GUI on the base layers) carries KC_LAT_REMAP: it is dead on this
+        // layer and sits directly beside the Ctrl at [4,0], so the two picker
+        // gestures -- Ctrl picks another FORM, this picks another LETTER -- are
+        // adjacent on the same hand.
+        _______,    KC_LAT_REMAP, KC_NO,    _______,                _______,    _______,    _______,
 
                     KC_LAT6,    KC_LAT7,    KC_LAT8,    KC_LAT9,    KC_LAT10,   KC_LAT11,   KC_LAT_PAGE_NEXT,
                     _______,    _______,    _______,    _______,    _______,    _______,    KC_NO,

--- a/keyboards/polykybd/split72/keymaps/revision2/config.h
+++ b/keyboards/polykybd/split72/keymaps/revision2/config.h
@@ -3,5 +3,10 @@
 
 #define ENABLE_COMPILE_KEYCODE
 
-#define EECONFIG_USER_DATA_SIZE 106  // +39 latin_ex_wide (6-bit picks) +1 latin_pick_migrated (within POLY_EECONFIG_USER_RESERVED=128, no keymap relocation)
+#define EECONFIG_USER_DATA_SIZE 126  // +39 latin_ex_wide (6-bit picks) +1 format version
+                                     // +20 latin_assign (6-bit base-letter per key).
+                                     // POLY_EECONFIG_USER_RESERVED was raised 128->256 for
+                                     // this: 126 still fits 128, but with 2 bytes left the
+                                     // next field of any kind would relocate the keymap, so
+                                     // the one-time reset is paid here rather than twice.
 

--- a/keyboards/polykybd/split72/keymaps/revision2/config.h
+++ b/keyboards/polykybd/split72/keymaps/revision2/config.h
@@ -3,7 +3,7 @@
 
 #define ENABLE_COMPILE_KEYCODE
 
-#define EECONFIG_USER_DATA_SIZE 126  // +39 latin_ex_wide (6-bit picks) +1 format version
+#define EECONFIG_USER_DATA_SIZE 154  // +39 latin_ex_wide +1 fmt +20 latin_assign, then +18/+9/+1 for the punctuation targets
                                      // +20 latin_assign (6-bit base-letter per key).
                                      // POLY_EECONFIG_USER_RESERVED was raised 128->256 for
                                      // this: 126 still fits 128, but with 2 bytes left the

--- a/keyboards/polykybd/state.c
+++ b/keyboards/polykybd/state.c
@@ -199,7 +199,11 @@ void save_user_settings(void) {
 void save_user_latin(void) {
     eeconfig_update_user_datablock(g_latin.ex, offsetof(poly_eeconf_t, latin_ex_wide),
                                    sizeof(g_latin.ex));
-    const uint8_t marker = LATIN_PICK_MIGRATED;
+    eeconfig_update_user_datablock(g_latin.assign, offsetof(poly_eeconf_t, latin_assign),
+                                   sizeof(g_latin.assign));
+    // Stamp the format version LAST, so an interrupted write can never leave the
+    // block claiming a layout it does not have.
+    const uint8_t marker = LATIN_PICK_INTERLEAVED;
     eeconfig_update_user_datablock(&marker, offsetof(poly_eeconf_t, latin_pick_migrated),
                                    sizeof(marker));
 }

--- a/keyboards/polykybd/state.c
+++ b/keyboards/polykybd/state.c
@@ -192,20 +192,43 @@ void save_user_settings(void) {
 }
 
 // Writes only the packed latin variation picks to EEPROM.
-// ⚠️ These go to latin_ex_wide, NOT the legacy latin_ex: g_latin.ex is now
-// LATIN_PICK_BYTES (39) wide, so writing it at the old 26-byte offset would run
-// straight into mru_emoji. The sentinel is stamped in the same breath, so a
-// half-written migration cannot leave the wide block claiming to be converted.
+// ⚠️ These go to latin_ex_wide, NOT the legacy latin_ex: g_latin.ex is 6-bit
+// fields, so writing it at the old 26-byte offset would run straight into
+// mru_emoji. The sentinel is stamped in the same breath, so a half-written
+// migration cannot leave the wide block claiming to be converted.
+//
+// ⚠️ The RAM table is one flat array over all LATIN_TARGETS, but EEPROM keeps the
+// letters and the punctuation in SEPARATE blocks — the letter block must keep the
+// size and offset it shipped with, or the format byte behind it moves and can no
+// longer be found (see state.h). So each write is explicitly bounded rather than
+// sizeof(g_latin.ex): the letters go to the original block, the rest to the tail.
 void save_user_latin(void) {
     eeconfig_update_user_datablock(g_latin.ex, offsetof(poly_eeconf_t, latin_ex_wide),
-                                   sizeof(g_latin.ex));
+                                   LATIN_PICK_BASE_BYTES);
     eeconfig_update_user_datablock(g_latin.assign, offsetof(poly_eeconf_t, latin_assign),
-                                   sizeof(g_latin.assign));
-    // Stamp the format version LAST, so an interrupted write can never leave the
+                                   LATIN_ASSIGN_BASE_BYTES);
+    // Picks split on a byte boundary (39 = 52 fields x 6 bits), so the tail is a
+    // plain slice of the same array. Assignments do NOT (26 x 6 = 156 bits), so the
+    // punctuation ones are re-packed into their own array indexed from zero.
+    eeconfig_update_user_datablock(g_latin.ex + LATIN_PICK_BASE_BYTES,
+                                   offsetof(poly_eeconf_t, latin_ex_ext),
+                                   LATIN_PICK_EXT_BYTES);
+    uint8_t assign_ext[LATIN_ASSIGN_EXT_BYTES] = {0};
+    for(uint8_t i = 0; i < LATIN_PUNCT_TARGETS; i++) {
+        latin_bits_set(assign_ext, LATIN_ASSIGN_EXT_BYTES, i,
+                       latin_bits_get(g_latin.assign, LATIN_ASSIGN_BYTES,
+                                      (uint8_t)(LATIN_LETTER_TARGETS + i)));
+    }
+    eeconfig_update_user_datablock(assign_ext, offsetof(poly_eeconf_t, latin_assign_ext),
+                                   sizeof(assign_ext));
+    // Stamp the format versions LAST, so an interrupted write can never leave a
     // block claiming a layout it does not have.
     const uint8_t marker = LATIN_PICK_ASSIGN_OK;
     eeconfig_update_user_datablock(&marker, offsetof(poly_eeconf_t, latin_pick_migrated),
                                    sizeof(marker));
+    const uint8_t ext_marker = LATIN_EXT_OK;
+    eeconfig_update_user_datablock(&ext_marker, offsetof(poly_eeconf_t, latin_ext_fmt),
+                                   sizeof(ext_marker));
 }
 
 // Saves both settings and latin table. Use save_user_settings() or save_user_latin() when only one part changed.

--- a/keyboards/polykybd/state.c
+++ b/keyboards/polykybd/state.c
@@ -203,7 +203,7 @@ void save_user_latin(void) {
                                    sizeof(g_latin.assign));
     // Stamp the format version LAST, so an interrupted write can never leave the
     // block claiming a layout it does not have.
-    const uint8_t marker = LATIN_PICK_INTERLEAVED;
+    const uint8_t marker = LATIN_PICK_ASSIGN_OK;
     eeconfig_update_user_datablock(&marker, offsetof(poly_eeconf_t, latin_pick_migrated),
                                    sizeof(marker));
 }

--- a/keyboards/polykybd/state.h
+++ b/keyboards/polykybd/state.h
@@ -219,10 +219,38 @@ typedef struct _poly_last_t {
 // change into a silent corruption of the other case's pick.
 #define LATIN_PICK_BITS    6
 #define LATIN_PICK_MAX     (1u << LATIN_PICK_BITS)             /* 64 */
-#define LATIN_TARGETS      26                                  /* A..Z; punctuation may follow */
+// Slots 0..25 are the LETTERS A..Z; 26..37 are the printable punctuation keys,
+// KC_MINUS 0x2D .. KC_SLASH 0x38 — a CONTIGUOUS run of twelve, so the mapping is
+// `kc - KC_MINUS + 26` with no table (see latin_target_slot()).  The run is taken
+// whole rather than hand-filtered: a key that is masked or absent on a given board
+// is simply unreachable there, which excludes `\` / non-US-hash by itself on the
+// layouts that do not want them, and costs nothing on the ones that do.
+// Only a letter can be a SOURCE — a punctuation key hosts a letter's row, never
+// the other way round — so the two bounds are deliberately separate constants.
+#define LATIN_LETTER_TARGETS 26
+#define LATIN_PUNCT_TARGETS  12
+#define LATIN_TARGETS      (LATIN_LETTER_TARGETS + LATIN_PUNCT_TARGETS)   /* 38 */
 #define LATIN_PICK_FIELDS  (LATIN_TARGETS * 2)                 /* upper + lower  */
-#define LATIN_PICK_BYTES   ((LATIN_PICK_FIELDS * LATIN_PICK_BITS + 7) / 8)  /* 39 */
-#define LATIN_ASSIGN_BYTES ((LATIN_TARGETS * LATIN_PICK_BITS + 7) / 8)      /* 20 */
+#define LATIN_PICK_BYTES   ((LATIN_PICK_FIELDS * LATIN_PICK_BITS + 7) / 8)  /* 57 */
+#define LATIN_ASSIGN_BYTES ((LATIN_TARGETS * LATIN_PICK_BITS + 7) / 8)      /* 29 */
+
+// ⚠️ EEPROM keeps the letters and the punctuation in SEPARATE blocks, and the
+// letter block keeps its original offsets and size.  Growing the stored arrays in
+// place would shift latin_pick_migrated, and a version byte that MOVES cannot be
+// found — the load would read a pick byte as the version and could not tell a real
+// format from a coincidence.  Appending instead means an old EEPROM reads the new
+// block as zeros (wear-levelling, above), which is unambiguously "not written",
+// and every existing pick and assignment survives untouched.
+//
+// The PICK split lands on a byte boundary, which is what makes it a plain memcpy:
+// 52 letter fields x 6 bits = 312 = 39 bytes exactly, and the 24 punctuation
+// fields x 6 = 144 = 18 bytes exactly, starting at byte 39.  The ASSIGN split does
+// NOT (26 x 6 = 156 bits = 19.5 bytes), so the punctuation assignments live in
+// their own array indexed FROM ZERO and are copied field-by-field, not blitted.
+#define LATIN_PICK_BASE_BYTES   ((LATIN_LETTER_TARGETS * 2 * LATIN_PICK_BITS + 7) / 8) /* 39 */
+#define LATIN_PICK_EXT_BYTES    (LATIN_PICK_BYTES - LATIN_PICK_BASE_BYTES)             /* 18 */
+#define LATIN_ASSIGN_BASE_BYTES ((LATIN_LETTER_TARGETS * LATIN_PICK_BITS + 7) / 8)     /* 20 */
+#define LATIN_ASSIGN_EXT_BYTES  ((LATIN_PUNCT_TARGETS * LATIN_PICK_BITS + 7) / 8)      /* 9  */
 #define LATIN_ASSIGN_NONE  (uint8_t)(LATIN_PICK_MAX - 1u)      /* 0x3F -- see above */
 // Byte fill that makes EVERY 6-bit field read LATIN_ASSIGN_NONE. 0x3F does not tile
 // a byte (6 does not divide 8), so memset(map, LATIN_ASSIGN_NONE, n) would leave a
@@ -242,6 +270,15 @@ typedef struct _latin_sync_t {
     uint8_t  ex[LATIN_PICK_BYTES];
     uint8_t  assign[LATIN_ASSIGN_BYTES];
 } latin_sync_t;
+
+// ⚠️ The whole table crosses the split link in ONE RPC (USER_SYNC_LATIN_EX_DATA), and
+// transaction_rpc_exec() refuses a payload larger than the buffer by returning false
+// BEFORE sending anything -- while the bulk send_to_bridge() call sites discard the
+// ack.  So outgrowing this cap does not fail loudly: the master applies the change,
+// the slave never hears it, and half the board keeps the old legends with nothing in
+// the log.  Adding targets grows this struct, so assert it rather than remember it.
+static_assert(sizeof(latin_sync_t) <= RPC_M2S_BUFFER_SIZE,
+              "latin_sync_t no longer fits one split RPC -- raise RPC_M2S_BUFFER_SIZE");
 
 // A field can straddle a byte boundary (6 does not divide 8), so both helpers
 // read/write a 16-bit window -- guarded by the array's own length, because the
@@ -278,12 +315,15 @@ static inline void latin_pick_set(uint8_t* ex, uint8_t field, uint8_t value) {
     latin_bits_set(ex, LATIN_PICK_BYTES, field, value);
 }
 
-// The letter whose variation row this key hosts.  Unassigned (or a stale value
-// past the alphabet) falls back to the key's own letter, so a fresh EEPROM and a
-// corrupt one both behave like the un-remapped keyboard.
-static inline uint8_t latin_assign_get(const uint8_t* assign, uint8_t slot) {
+// The letter whose variation row this key hosts, or -1 for "none".  Unassigned
+// (or a stale value past the alphabet) falls back to the key's OWN letter, so a
+// fresh EEPROM and a corrupt one both behave like the un-remapped keyboard — but
+// only slots 0..25 have an own letter to fall back to.  An unassigned punctuation
+// key has no row at all, which is what keeps `,` a comma until someone maps it.
+static inline int8_t latin_assign_get(const uint8_t* assign, uint8_t slot) {
     const uint8_t v = latin_bits_get(assign, LATIN_ASSIGN_BYTES, slot);
-    return (v < LATIN_TARGETS) ? v : slot;
+    if (v < LATIN_LETTER_TARGETS) return (int8_t)v;
+    return (slot < LATIN_LETTER_TARGETS) ? (int8_t)slot : -1;
 }
 
 static inline void latin_assign_set(uint8_t* assign, uint8_t slot, uint8_t letter) {
@@ -326,7 +366,12 @@ typedef struct _poly_eeconf_t {
     // APPENDED rather than widening latin_ex[] in place: that array sits ahead of
     // mru_emoji/mru_lang, so resizing it would shift every later field and an
     // existing EEPROM would read its MRU lists out of the shifted bytes.
-    uint8_t  latin_ex_wide[LATIN_PICK_BYTES];
+    // ⚠️ Sized LATIN_PICK_BASE_BYTES, NOT LATIN_PICK_BYTES: this array must keep the
+    // size it shipped with.  Growing it in place is what would shift the version
+    // byte below, and a version byte that MOVES cannot be found -- the load would
+    // read a pick byte where it expects the sentinel.  The extra targets go in
+    // latin_ex_ext at the tail instead.
+    uint8_t  latin_ex_wide[LATIN_PICK_BASE_BYTES];
     // FORMAT VERSION for latin_ex_wide, not a boolean. "Looks empty" is NOT
     // decidable here -- all-zero is a legitimate every-letter-on-its-first-variation
     // state and erased flash reads 0xFF -- so each conversion is gated on an
@@ -341,7 +386,14 @@ typedef struct _poly_eeconf_t {
     // already "every key unassigned". ⚠️ That is also why eeconfig_init_user() has
     // to memset this to 0xFF rather than let the struct-wide {0} stand -- zeroed,
     // it would read as "every key assigned to A".
-    uint8_t  latin_assign[LATIN_ASSIGN_BYTES];
+    uint8_t  latin_assign[LATIN_ASSIGN_BASE_BYTES];
+    // Punctuation targets (slots 26..37), APPENDED rather than grown into the two
+    // arrays above — see the byte-boundary note by LATIN_PICK_BASE_BYTES. An old
+    // EEPROM reads this whole block as zeros, so latin_ext_fmt != LATIN_EXT_OK is
+    // an unambiguous "never written" and the letters keep their offsets and data.
+    uint8_t  latin_ex_ext[LATIN_PICK_EXT_BYTES];
+    uint8_t  latin_assign_ext[LATIN_ASSIGN_EXT_BYTES];
+    uint8_t  latin_ext_fmt;
 } poly_eeconf_t;
 
 #define BOOT_INTRO_DONE     0x5A   // sentinel written after the startup animation has played
@@ -349,7 +401,8 @@ typedef struct _poly_eeconf_t {
 // unrecognised means the legacy one-byte-per-letter nibble pairs in latin_ex[].
 #define LATIN_PICK_MIGRATED    0xA5 // 6-bit fields, case-BLOCKED; no assignment map
 #define LATIN_PICK_INTERLEAVED 0xC3 // ...case-INTERLEAVED; assignment map UNTRUSTWORTHY
-#define LATIN_PICK_ASSIGN_OK   0xD7 // ...and the assignment map is real (current)
+#define LATIN_PICK_ASSIGN_OK   0xD7 // ...and the assignment map is real (letters only)
+#define LATIN_EXT_OK           0x6B // latin_*_ext hold the punctuation targets
 // ⚠️ 0xC3 is deliberately NOT the current version. The build that introduced it
 // assumed an unwritten EEPROM reads 0xFF, so it copied the assignment map straight
 // out of a block that had never held one — read back as all-zero, i.e. "every key

--- a/keyboards/polykybd/state.h
+++ b/keyboards/polykybd/state.h
@@ -166,51 +166,102 @@ typedef struct _poly_last_t {
     uint16_t latin_kc;
 } poly_last_t;
 
-// --- Intl latin-variation picks: one 6-bit field per letter PER CASE ----------
+// --- Intl latin variations: which letter a key hosts, and which form it picks --
 //
-// Field index is the `latin_ex_map` ROW index -- 0..25 uppercase, 26..51 lowercase
-// -- so the storage and the table are addressed identically and cannot drift.
+// Two 6-bit arrays, both indexed by TARGET SLOT (the remappable key), not by
+// letter.  Today the targets are A..Z, so slot == letter index by default and the
+// two readings coincide -- which is exactly why an existing EEPROM keeps working.
 //
-// This was a nibble per case packed into one byte per letter (26 bytes, 16
-// variations).  Six bits covers every letter+combining-mark form that exists in
-// Unicode: the widest is O at 34 (16 single-mark plus 18 Vietnamese double-mark),
-// so 64 leaves room that will not be exhausted by anything Latin.
+//   assign[slot]        the base LETTER whose variation row this key hosts.
+//                       LATIN_ASSIGN_NONE = "this key's own natural behaviour",
+//                       i.e. its own letter.  Shared across case: remapping is a
+//                       property of the KEY, so Shift follows it (r -> e means
+//                       Shift+r gives E's upper-case form, not <).
+//   ex[slot][case]      the chosen variation WITHIN that row.  Per case, because
+//                       the two rows are not parallel -- lower n has 12 variations
+//                       and upper N has 11, so one shared index would be out of
+//                       range for one of them.
+//
+// Six bits covers every letter+combining-mark form that exists in Unicode (the
+// widest is O at 34 -- 16 single-mark plus 18 Vietnamese double-mark) and, for
+// assign, the 26 letters plus the sentinel.  It also means BOTH arrays use the
+// same accessor.
+//
+// ⚠️ LATIN_ASSIGN_NONE is all-bits-set ON PURPOSE: erased flash reads 0xFF, so a
+// region that has never been written decodes to "every key unassigned" -- the
+// correct default -- with no migration and no sentinel.  eeconfig_init_user()
+// must therefore memset the map to 0xFF, NOT zero it with the rest of the struct.
 //
 // ⚠️ Go through latin_pick_get/set.  The old width was open-coded at the call site
 // as `(pick << 4) | (cur & 0xf)`, which is precisely the shape that turns a width
 // change into a silent corruption of the other case's pick.
-#define LATIN_PICK_BITS   6
-#define LATIN_PICK_MAX    (1u << LATIN_PICK_BITS)              /* 64 */
-#define LATIN_PICK_FIELDS (26 * 2)                             /* upper + lower  */
-#define LATIN_PICK_BYTES  ((LATIN_PICK_FIELDS * LATIN_PICK_BITS + 7) / 8)  /* 39 */
+#define LATIN_PICK_BITS    6
+#define LATIN_PICK_MAX     (1u << LATIN_PICK_BITS)             /* 64 */
+#define LATIN_TARGETS      26                                  /* A..Z; punctuation may follow */
+#define LATIN_PICK_FIELDS  (LATIN_TARGETS * 2)                 /* upper + lower  */
+#define LATIN_PICK_BYTES   ((LATIN_PICK_FIELDS * LATIN_PICK_BITS + 7) / 8)  /* 39 */
+#define LATIN_ASSIGN_BYTES ((LATIN_TARGETS * LATIN_PICK_BITS + 7) / 8)      /* 20 */
+#define LATIN_ASSIGN_NONE  (uint8_t)(LATIN_PICK_MAX - 1u)      /* 0x3F -- see above */
+
+// Pick fields are CASE-INTERLEAVED (slot*2 + case), not case-blocked.  Growing
+// LATIN_TARGETS then APPENDS fields instead of inserting a second block in the
+// middle, so the existing letters keep their field indices.  Blocked layout was
+// the original and is converted once at load (LATIN_PICK_INTERLEAVED).
+#define LATIN_PICK_UPPER   0
+#define LATIN_PICK_LOWER   1
+#define latin_pick_field(slot, upper) (uint8_t)((slot) * 2u + ((upper) ? LATIN_PICK_UPPER : LATIN_PICK_LOWER))
 
 typedef struct _latin_sync_t {
     uint32_t crc32;
     uint8_t  ex[LATIN_PICK_BYTES];
+    uint8_t  assign[LATIN_ASSIGN_BYTES];
 } latin_sync_t;
 
 // A field can straddle a byte boundary (6 does not divide 8), so both helpers
-// read/write a 16-bit window -- guarded, because the last field ends exactly on
-// the final byte and ex[LATIN_PICK_BYTES] would be one past the array.
-static inline uint8_t latin_pick_get(const uint8_t* ex, uint8_t field) {
+// read/write a 16-bit window -- guarded by the array's own length, because the
+// last field ends exactly on the final byte and buf[len] would be one past it.
+// ⚠️ `len` is why these take the size rather than assuming LATIN_PICK_BYTES: the
+// same accessor serves the 39-byte pick array and the 20-byte assignment map, and
+// a hardcoded bound would read past the end of the shorter one.
+static inline uint8_t latin_bits_get(const uint8_t* buf, uint8_t len, uint8_t field) {
     const uint16_t bit = (uint16_t)field * LATIN_PICK_BITS;
     const uint16_t by  = bit >> 3;
     const uint8_t  sh  = (uint8_t)(bit & 7u);
-    uint16_t w = (uint16_t)ex[by];
-    if (by + 1u < LATIN_PICK_BYTES) w |= (uint16_t)ex[by + 1u] << 8;
+    uint16_t       w   = (uint16_t)buf[by];
+    if (by + 1u < len) w |= (uint16_t)buf[by + 1u] << 8;
     return (uint8_t)((w >> sh) & (LATIN_PICK_MAX - 1u));
 }
 
-static inline void latin_pick_set(uint8_t* ex, uint8_t field, uint8_t value) {
+static inline void latin_bits_set(uint8_t* buf, uint8_t len, uint8_t field, uint8_t value) {
     const uint16_t bit  = (uint16_t)field * LATIN_PICK_BITS;
     const uint16_t by   = bit >> 3;
     const uint8_t  sh   = (uint8_t)(bit & 7u);
     const uint16_t mask = (uint16_t)(LATIN_PICK_MAX - 1u) << sh;
     const uint16_t val  = (uint16_t)(value & (LATIN_PICK_MAX - 1u)) << sh;
-    ex[by] = (uint8_t)((ex[by] & ~(uint8_t)mask) | (uint8_t)val);
-    if (by + 1u < LATIN_PICK_BYTES) {
-        ex[by + 1u] = (uint8_t)((ex[by + 1u] & ~(uint8_t)(mask >> 8)) | (uint8_t)(val >> 8));
+    buf[by]             = (uint8_t)((buf[by] & ~(uint8_t)mask) | (uint8_t)val);
+    if (by + 1u < len) {
+        buf[by + 1u] = (uint8_t)((buf[by + 1u] & ~(uint8_t)(mask >> 8)) | (uint8_t)(val >> 8));
     }
+}
+
+static inline uint8_t latin_pick_get(const uint8_t* ex, uint8_t field) {
+    return latin_bits_get(ex, LATIN_PICK_BYTES, field);
+}
+
+static inline void latin_pick_set(uint8_t* ex, uint8_t field, uint8_t value) {
+    latin_bits_set(ex, LATIN_PICK_BYTES, field, value);
+}
+
+// The letter whose variation row this key hosts.  Unassigned (or a stale value
+// past the alphabet) falls back to the key's own letter, so a fresh EEPROM and a
+// corrupt one both behave like the un-remapped keyboard.
+static inline uint8_t latin_assign_get(const uint8_t* assign, uint8_t slot) {
+    const uint8_t v = latin_bits_get(assign, LATIN_ASSIGN_BYTES, slot);
+    return (v < LATIN_TARGETS) ? v : slot;
+}
+
+static inline void latin_assign_set(uint8_t* assign, uint8_t slot, uint8_t letter) {
+    latin_bits_set(assign, LATIN_ASSIGN_BYTES, slot, letter);
 }
 
 typedef struct _poly_eeconf_t {
@@ -250,15 +301,26 @@ typedef struct _poly_eeconf_t {
     // mru_emoji/mru_lang, so resizing it would shift every later field and an
     // existing EEPROM would read its MRU lists out of the shifted bytes.
     uint8_t  latin_ex_wide[LATIN_PICK_BYTES];
-    // Migration marker for latin_ex_wide. "Looks empty" is NOT decidable here --
-    // all-zero is a legitimate every-letter-on-its-first-variation state and erased
-    // flash reads 0xFF -- so the one-time conversion from the legacy nibbles is
-    // gated on an explicit sentinel instead of a guess.
+    // FORMAT VERSION for latin_ex_wide, not a boolean. "Looks empty" is NOT
+    // decidable here -- all-zero is a legitimate every-letter-on-its-first-variation
+    // state and erased flash reads 0xFF -- so each conversion is gated on an
+    // explicit sentinel instead of a guess. Anything unrecognised means the legacy
+    // one-byte-per-letter nibble pairs in latin_ex[].
+    //   LATIN_PICK_MIGRATED    6-bit fields, CASE-BLOCKED  (case*26 + letter)
+    //   LATIN_PICK_INTERLEAVED 6-bit fields, CASE-INTERLEAVED (slot*2 + case)
     uint8_t  latin_pick_migrated;
+    // Which base letter each target key hosts. Appended at the tail (like os_state
+    // / glyph_script) so every earlier offset is untouched. It needs NO sentinel:
+    // LATIN_ASSIGN_NONE is all-bits-set, so the 0xFF an old EEPROM reads here is
+    // already "every key unassigned". ⚠️ That is also why eeconfig_init_user() has
+    // to memset this to 0xFF rather than let the struct-wide {0} stand -- zeroed,
+    // it would read as "every key assigned to A".
+    uint8_t  latin_assign[LATIN_ASSIGN_BYTES];
 } poly_eeconf_t;
 
 #define BOOT_INTRO_DONE     0x5A   // sentinel written after the startup animation has played
-#define LATIN_PICK_MIGRATED 0xA5   // sentinel written once latin_ex[] has been widened
+#define LATIN_PICK_MIGRATED 0xA5   // latin_ex[] widened to 6-bit fields, case-BLOCKED
+#define LATIN_PICK_INTERLEAVED 0xC3 // ...and re-indexed case-INTERLEAVED (current)
 
 
 static_assert(sizeof(poly_eeconf_t) == EECONFIG_USER_DATA_SIZE, "Mismatch in keyboard EECONFIG stored data");

--- a/keyboards/polykybd/state.h
+++ b/keyboards/polykybd/state.h
@@ -103,7 +103,25 @@ typedef struct _poly_layer_t {
     // bytes in base/com.h are full).  sync_and_refresh_displays() diffs this struct
     // with memcmp over sizeof(), so the field joins the existing sync for free.
     uint8_t       picker_page;
+    // Intl letter-remap mode, synced for exactly the same reason as picker_page:
+    // the slave draws the keys that land on its own half and only ever sees
+    // poly_layer_t, and both flag bytes in base/com.h are full so there is no bit
+    // to ride on.  See enum poly_latin_remap.
+    uint8_t       remap_mode;
+    // The target slot chosen in PICKKEY, so BOTH halves can invert the right keycap
+    // — the target is often on the other side from the key that was pressed.
+    uint8_t       remap_target;
 } poly_layer_t;
+
+// Intl letter-remap: a two-step gesture that reassigns which LETTER a key hosts,
+// so several keys can carry variations of the same letter (French wants e, è, é
+// and ê at once).  Distinct from the variation picker, which chooses another form
+// of the letter a key ALREADY hosts.
+enum poly_latin_remap {
+    LATIN_REMAP_OFF     = 0,   // not remapping
+    LATIN_REMAP_PICKKEY = 1,   // non-letters blanked; waiting for the target key
+    LATIN_REMAP_PICKLTR = 2,   // target chosen (drawn inverted); waiting for the letter
+};
 
 typedef struct _poly_sync_t {
     uint32_t crc32;

--- a/keyboards/polykybd/state.h
+++ b/keyboards/polykybd/state.h
@@ -352,15 +352,17 @@ typedef struct _poly_eeconf_t {
     // Persisted glyph-script override (enum poly_glyph_script). Appended at the end
     // (like os_state) so latin_ex/mru offsets are unchanged; an old EEPROM reads an
     // uninitialised byte here, so load_user_eeconf() bounds-guards it to GLYPH_STD.
-    // Growing EECONFIG_USER_DATA_SIZE 64->65 stays within POLY_EECONFIG_USER_RESERVED
-    // (128), so the dynamic keymap does NOT relocate — no user EEPROM reset needed.
+    // Growing EECONFIG_USER_DATA_SIZE 64->65 stayed within the reservation as it then
+    // was (128), so the dynamic keymap did NOT relocate — no user EEPROM reset needed.
+    // (The reservation is 256 now; the live bound is the static_assert at the end of
+    // this header, not this note.)
     uint8_t  glyph_script;
     // First-boot marker for the one-time startup animation. Appended tail byte
     // (same pattern as os_state/glyph_script) so earlier offsets are unchanged.
     // A fresh/erased EEPROM reads 0xFF (or 0 after eeconfig_init) — anything other
     // than BOOT_INTRO_DONE means "not yet played", so the intro runs once and then
-    // writes BOOT_INTRO_DONE. Growing EECONFIG_USER_DATA_SIZE 65->66 stays within
-    // POLY_EECONFIG_USER_RESERVED (128): no keymap relocation / user reset.
+    // writes BOOT_INTRO_DONE. Growing EECONFIG_USER_DATA_SIZE 65->66 likewise stayed
+    // within the then-128-byte reservation: no keymap relocation / user reset.
     uint8_t  boot_flags;
     // Widened Intl variation picks (6 bits per case -- see LATIN_PICK_* above).
     // APPENDED rather than widening latin_ex[] in place: that array sits ahead of

--- a/keyboards/polykybd/state.h
+++ b/keyboards/polykybd/state.h
@@ -205,10 +205,14 @@ typedef struct _poly_last_t {
 // assign, the 26 letters plus the sentinel.  It also means BOTH arrays use the
 // same accessor.
 //
-// ⚠️ LATIN_ASSIGN_NONE is all-bits-set ON PURPOSE: erased flash reads 0xFF, so a
-// region that has never been written decodes to "every key unassigned" -- the
-// correct default -- with no migration and no sentinel.  eeconfig_init_user()
-// must therefore memset the map to 0xFF, NOT zero it with the rest of the struct.
+// ⚠️ NEVER infer "this map was never written" from its bytes -- gate it on the
+// latin_pick_migrated format version instead.  An earlier version of this relied
+// on LATIN_ASSIGN_NONE being all-bits-set and an unwritten EEPROM reading 0xFF.
+// That is wrong here: QMK's wear-levelling normalises its backing store so cleared
+// bytes arrive as ZERO (it memsets its cache to 0 and requires a 0xFF-based store
+// to return the complement), so the map read back all-0x00 = "every key hosts
+// letter 0" and the whole Intl layer showed variations of 'a' (field, first flash).
+// LATIN_ASSIGN_NONE stays all-bits-set only because it must be a non-letter value.
 //
 // ⚠️ Go through latin_pick_get/set.  The old width was open-coded at the call site
 // as `(pick << 4) | (cur & 0xf)`, which is precisely the shape that turns a width
@@ -220,6 +224,10 @@ typedef struct _poly_last_t {
 #define LATIN_PICK_BYTES   ((LATIN_PICK_FIELDS * LATIN_PICK_BITS + 7) / 8)  /* 39 */
 #define LATIN_ASSIGN_BYTES ((LATIN_TARGETS * LATIN_PICK_BITS + 7) / 8)      /* 20 */
 #define LATIN_ASSIGN_NONE  (uint8_t)(LATIN_PICK_MAX - 1u)      /* 0x3F -- see above */
+// Byte fill that makes EVERY 6-bit field read LATIN_ASSIGN_NONE. 0x3F does not tile
+// a byte (6 does not divide 8), so memset(map, LATIN_ASSIGN_NONE, n) would leave a
+// mix of values -- it is 0xFF that fills every field with all-ones.
+#define LATIN_ASSIGN_FILL  0xFFu
 
 // Pick fields are CASE-INTERLEAVED (slot*2 + case), not case-blocked.  Growing
 // LATIN_TARGETS then APPENDS fields instead of inserting a second block in the
@@ -337,8 +345,18 @@ typedef struct _poly_eeconf_t {
 } poly_eeconf_t;
 
 #define BOOT_INTRO_DONE     0x5A   // sentinel written after the startup animation has played
-#define LATIN_PICK_MIGRATED 0xA5   // latin_ex[] widened to 6-bit fields, case-BLOCKED
-#define LATIN_PICK_INTERLEAVED 0xC3 // ...and re-indexed case-INTERLEAVED (current)
+// Format versions for latin_ex_wide + latin_assign, oldest first. Anything
+// unrecognised means the legacy one-byte-per-letter nibble pairs in latin_ex[].
+#define LATIN_PICK_MIGRATED    0xA5 // 6-bit fields, case-BLOCKED; no assignment map
+#define LATIN_PICK_INTERLEAVED 0xC3 // ...case-INTERLEAVED; assignment map UNTRUSTWORTHY
+#define LATIN_PICK_ASSIGN_OK   0xD7 // ...and the assignment map is real (current)
+// ⚠️ 0xC3 is deliberately NOT the current version. The build that introduced it
+// assumed an unwritten EEPROM reads 0xFF, so it copied the assignment map straight
+// out of a block that had never held one — read back as all-zero, i.e. "every key
+// hosts letter 0", and every Intl keycap rendered a variation of 'a' (field, first
+// flash). Worse, the next suspend PERSISTED those zeros under 0xC3, so a version
+// gate alone cannot tell them from a real map. Retiring the value is what heals an
+// already-flashed board: 0xC3 now means "picks are fine, discard the map".
 
 
 static_assert(sizeof(poly_eeconf_t) == EECONFIG_USER_DATA_SIZE, "Mismatch in keyboard EECONFIG stored data");


### PR DESCRIPTION
## Summary

The Intl variation picker chooses another *form* of the letter a key already hosts, which cannot give French `è é ê` at once. A key can now be **reassigned to a different base letter**, so several keys can carry forms of the same one — and the sparse letters (`q` has one variation, `j` two) stop being dead keys on this layer.

Hold Intl, tap the new remap key (`à»ñ`, split72 `[4,1]`; split42 `[3,4]`), press the key to change (it inverts), then press the letter it should host.

**Targets are the 26 letters plus the twelve printable punctuation keycodes**, `KC_MINUS 0x2D … KC_SLASH 0x38` — a contiguous run, so the mapping needs no table. The run is taken whole rather than hand-filtered: a position masked with `KC_NO` on `_ADDLANG1`, or absent from the board, simply never produces the keycode. Read out of the compiled `keymaps[]`, that means split72 reaches 9 of the 12 (`= [ ] ; ' ` , . /`) and split42 reaches 4 (`; , . /`) — and `\` / non-US-hash exclude themselves on both.

Only a **letter** can be a source; a punctuation key hosts a letter's row, never the reverse. Re-picking a key's own letter is the per-key reset, and pressing the picked target again is how a punctuation key (which has no own letter) is unmapped. Shift+remap clears everything.

### Storage

The change splits two things the code had conflated: the **row** comes from the letter a key hosts, the **pick** from the key's own slot. They are the same number only while nothing is remapped — two keys on the same letter share a row but need independent picks.

EEPROM **appends** rather than grows. Widening `latin_ex_wide[]` in place would shift `latin_pick_migrated` behind it, and a version byte that moves cannot be found. So the letter block keeps the size and offset it shipped with and the punctuation targets ride in their own tail block behind their own format byte.

⚠️ `EECONFIG_USER_DATA_SIZE` 126 → 154 relocates the dynamic keymap once (a one-time keymap reset on first boot). Picks and assignments sit before the relocation and survive.

### `RPC_M2S_BUFFER_SIZE` 72 → 96

`latin_sync_t` grew 63 → 90 B and crosses the split link in one RPC. `transaction_rpc_exec()` rejects an oversized payload by returning false **before sending anything**, while the bulk `send_to_bridge()` call sites discard the ack — so this would not have failed loudly: the master applies the remap, the slave never hears it, nothing in the log. Now asserted in `state.h`.

The cap is a capacity, not a transfer size — only the caller's byte count goes on the wire. Verified by building the same tree at 96 and 128 and diffing the disassembly: `.text` identical in size, `.bss` +32, and of 954 differing lines **922 are `.word` RAM address literals**; the only real instruction changes are the `cmp` bounds check and two `adds` offsets into shmem. No length or loop-count instruction changes anywhere, so overlay bursts and the matrix/pointing pulls are byte-for-byte unaffected. Cost is 24 B of `.bss` (monolith `.heap` 3852 → 3828).

Worth noting for the future: `compressed_overlay_sync_t` and `roi_overlay_sync_t` were sitting at **69 B under the old 72 B cap**. One more field there would have hit the same silent rejection and presented as missing keycap images.

## Version bump label

`bump:minor` — new feature, no protocol change (`PROTOCOL_VERSION` untouched; this is all firmware-side state plus one keycode).

## Testing
- [x] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`), split42 too, and the RAM-tight monolith (`POLYKYBD_DOOM=yes`) which PR CI does not build
- [x] Flashed and tested on hardware — remap flow confirmed, and confirmed with the DOOM pack flavour, which exercises the same split RPC path
- [x] If protocol changed: n/a — no protocol change

Also verified off-hardware: the split-block EEPROM packing round-trips over 20 000 random tables including the byte shared between fields 25/26; an old EEPROM migrates with letters intact and punctuation unassigned; target reachability read from the compiled `keymaps[]` rather than counting columns in the `LAYOUT` macro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wq3vgv2x4YnHt74nv8NZ2H

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wq3vgv2x4YnHt74nv8NZ2H)_

## Summary by Sourcery

Add an Intl letter-remap feature that lets keys host another letter’s variation row, extend storage and sync structures to track per-key assignments safely across EEPROM and split RPC, and adjust keymaps and display handling to support the new remap workflow.

New Features:
- Introduce KC_LAT_REMAP and a two-step Intl remap mode so any target key (letters plus selected punctuation) can be reassigned to host another letter’s variation row with per-key reset and global clear gestures.

Enhancements:
- Refactor latin variation handling so row selection (hosted letter) and stored picks (per target key, per case) are separate, enabling multiple keys to share a letter while keeping independent variation choices.
- Extend the latin_sync_t and EEPROM layout with assignment and extended pick blocks for punctuation targets, using explicit format/version markers to keep legacy data compatible and recover from past miswrites.
- Improve display rendering logic so remap mode properly blanks non-participating keys, inverts the remap key, and treats remapped punctuation keys as first-class picker subjects.
- Document the Intl remap behavior, storage layout, and RPC buffer ceiling considerations in CLAUDE.md for future development and debugging.

Build:
- Increase RPC_M2S_BUFFER_SIZE from 72 to 96 bytes to accommodate the larger latin_sync_t payload while preserving existing split transaction semantics.
- Increase POLY_EECONFIG_USER_RESERVED to 256 and bump EECONFIG_USER_DATA_SIZE to account for the new latin assignment and extended pick data, triggering a one-time dynamic keymap relocation on first boot.

Documentation:
- Expand CLAUDE.md with guidance on the Intl letter-remap feature, EEPROM versioning pitfalls, and RPC buffer sizing and behavior for split sync traffic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Intl Latin remapping for letters and printable punctuation keys.
  * Added on-device prompts, variation selection, paging, reset/cancel controls, and updated legends.
  * Added remapping controls to the default keyboard layouts.
  * Increased split communication capacity for larger synchronization payloads.

* **Documentation**
  * Documented remapping behavior, storage migration, buffer limits, and build artifact naming guidance.

* **Maintenance**
  * Increased saved-settings capacity for remapping data; existing layouts may reset once during migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->