### PR TITLE
fw signing: fail the release build instead of shipping unsigned

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,19 +85,42 @@ jobs:
           fi
 
       # FW-2: sign the .bin with the project's Ed25519 key so the firmware can
-      # verify image authenticity at flash time. No-op (unsigned release) when the
-      # FW_SIGNING_KEY secret is not set, so releases work before a key exists.
+      # verify image authenticity at flash time.
+      #
+      # This step USED to no-op when FW_SIGNING_KEY was unset, which was correct while
+      # verification was warn-only. Enforcement is now ON (rules.mk:
+      # -DFW_REQUIRE_SIGNATURE), so an unsigned release is no longer a soft downgrade:
+      # every keyboard flashing it is refused at COMMIT and falls through to the
+      # on-keycap ACCEPT/REJECT prompt. Users who meet that prompt on every official
+      # release learn to press ACCEPT reflexively — which is precisely the habit FW-2
+      # exists to prevent. So a real release with no key now FAILS here instead of
+      # quietly shipping unsigned. Non-release builds (a workflow_dispatch smoke test
+      # off a branch) still skip signing.
       - name: Sign .bin (FW-2)
         env:
           FW_SIGNING_KEY: ${{ secrets.FW_SIGNING_KEY }}
+          IS_RELEASE: ${{ github.event_name == 'release' || github.ref_type == 'tag' }}
         run: |
+          TARGET=$(echo "${{ env.KB }}" | tr '/' '_')_${{ env.KM }}
           if [ -z "${FW_SIGNING_KEY:-}" ]; then
-            echo "::notice::FW_SIGNING_KEY not set — releasing UNSIGNED firmware (verify is warn-only)."
+            if [ "${IS_RELEASE}" = "true" ]; then
+              echo "::error::FW_SIGNING_KEY is not set, but the firmware enforces signatures"
+              echo "::error::(-DFW_REQUIRE_SIGNATURE). Releasing unsigned would make every keyboard"
+              echo "::error::prompt for a manual ACCEPT. Set the FW_SIGNING_KEY secret and re-run."
+              echo "::error::See keyboards/polykybd/tools/SIGNING.md."
+              exit 1
+            fi
+            echo "::notice::FW_SIGNING_KEY not set - skipping signing on this non-release build."
             exit 0
           fi
           python3 -m pip install --quiet cryptography
-          TARGET=$(echo "${{ env.KB }}" | tr '/' '_')_${{ env.KM }}
           python3 keyboards/polykybd/tools/sign_firmware.py "${TARGET}.bin"
+          # Fail loudly rather than let the release step's `[ -f ... ]` silently drop
+          # the asset: a release that is meant to be signed must not ship without .sig.
+          if [ ! -s "${TARGET}.bin.sig" ]; then
+            echo "::error::signing reported success but produced no ${TARGET}.bin.sig"
+            exit 1
+          fi
 
       # Runs on a tag push, on publishing a release, or on a manual dispatch.
       # Idempotent: creates the release if missing, otherwise (re-)uploads the

--- a/keyboards/polykybd/base/fw_staging.c
+++ b/keyboards/polykybd/base/fw_staging.c
@@ -523,6 +523,26 @@ bool fw_staging_refused_unsigned(void) {
     return s_refused_unsigned;
 }
 
+// Is a real signing key compiled in, or is this still the all-zero placeholder that
+// fw_pubkey.h ships before `gen_signing_key.py` has been run?
+//
+// ⚠️ The all-zero key is NOT an inert value that simply fails every check. Its
+// encoding is y=0, which decodes to a point that is genuinely ON the curve with
+// ORDER 4 — and crypto_eddsa_check_equation() only verifies that A and R are on the
+// curve and that 0 <= S < L. It has no low-order-key rejection. With an order-4 A,
+// [h]A depends only on h mod 4, so an attacker can guess that value and land a
+// forgery in a handful of attempts. A placeholder key therefore makes enforcement
+// FORGEABLE rather than fail-closed — the opposite of the intuition that a dummy key
+// "rejects everything". Guard it explicitly so a botched key regeneration or a bad
+// merge can never silently downgrade FW_REQUIRE_SIGNATURE into theatre.
+static bool fw_pubkey_provisioned(void) {
+    uint8_t acc = 0;
+    for (size_t i = 0; i < sizeof(FW_SIGNING_PUBKEY); i++) {
+        acc |= FW_SIGNING_PUBKEY[i];
+    }
+    return acc != 0;
+}
+
 // FW-2: verify the staged FIRMWARE image's Ed25519 signature against the embedded
 // public key. The image is read straight from XIP flash (memory-mapped), so no RAM
 // copy of the (up to ~2 MB) image is needed. Returns:
@@ -531,6 +551,12 @@ bool fw_staging_refused_unsigned(void) {
 // transaction window.
 static int fw_staging_check_signature(void) {
     if (!s_signature_present) return 0;
+    if (!fw_pubkey_provisioned()) {
+        // Report INVALID, not UNSIGNED: a signature WAS supplied, we just have no
+        // trustworthy key to judge it with. Under enforcement both are refused.
+        uprintf("FW_UP: no signing key provisioned (placeholder pubkey) — cannot verify\n");
+        return -1;
+    }
     const uint8_t *img = (const uint8_t *)(XIP_BASE + FW_STAGING_DATA_OFFSET);
     // monocypher crypto_ed25519_check() returns 0 on success, -1 on any failure.
     return (crypto_ed25519_check(s_signature, FW_SIGNING_PUBKEY, img, s_image_size) == 0) ? 1 : -1;

--- a/keyboards/polykybd/tools/SIGNING.md
+++ b/keyboards/polykybd/tools/SIGNING.md
@@ -140,21 +140,25 @@ it during the flash.
 
 ## Key rotation
 
-Re-run `gen_signing_key.py`, commit the new `fw_pubkey.h`, update the
-`FW_SIGNING_KEY` secret, ship a firmware build carrying the new public key, and
-re-sign releases.
+⚠️ **The order is not the obvious one, and getting it wrong strands the fleet on a
+manual prompt.** A keyboard can only verify against the public key baked into the
+firmware it is *currently running*, so the release that **carries** a new public key
+cannot be **signed** with the new private key — every keyboard still on the old
+firmware would refuse it and drop to the ACCEPT/REJECT prompt. The release workflow
+signs with whatever `FW_SIGNING_KEY` holds at the time, so the secret must be rotated
+*after* the transition release, never before it.
 
-⚠️ **Rotation is harder now that enforcement is on**, and the old advice here — "rotate
-the firmware first while still in warn-only mode" — no longer describes anything that
-exists. A keyboard can only verify against the key baked into the firmware it is
-*currently running*, so the release that carries a new public key cannot be signed
-with the new private key: every keyboard still on the old firmware would refuse it and
-drop to the manual ACCEPT/REJECT prompt.
+(The old advice here — "rotate the firmware first while still in warn-only mode" — no
+longer describes anything that exists; warn-only is gone.)
 
-**Sign the rotation release with the OLD private key.** Keyboards verify it against the
-old public key they already trust, install the image, and come up carrying the new
-public key. Only the release *after* that one is signed with the new key. Retire the
-old private key only once the fleet has taken the rotation build.
+1. Re-run `gen_signing_key.py` and commit the new `fw_pubkey.h`.
+2. **Leave `FW_SIGNING_KEY` set to the OLD private key.**
+3. Publish the transition release. It carries the new public key and is signed with the
+   old one, so keyboards verify it against the key they already trust, install it, and
+   come up carrying the new public key.
+4. Only once the fleet has taken that build, update `FW_SIGNING_KEY` to the new private
+   key. Every later release is signed with it.
+5. Retire the old private key.
 
 A botched regeneration is also guarded: if `fw_pubkey.h` ever reverts to the all-zero
 placeholder, `fw_staging_check_signature()` refuses outright rather than verifying

--- a/keyboards/polykybd/tools/SIGNING.md
+++ b/keyboards/polykybd/tools/SIGNING.md
@@ -15,16 +15,17 @@ proves integrity, not authenticity).
 Ed25519 here is RFC 8032 (SHA-512), so `cryptography` / `libsodium` / Monocypher
 are byte-compatible (verified with a cross-implementation test).
 
-## Rollout: Phase A (current) → enforce
+## Rollout: enforced (Phase A is history)
 
-This is shipped in **Phase A**: the firmware **verifies and logs** the signature
-but does **not reject** an unsigned or badly-signed image. Flashing keeps working
-exactly as before, so there is zero brick risk while the key + signed-release
-pipeline are put in place. The serial/HID console shows one of:
+The serial/HID console shows one of:
 
     FW_UP: image signature OK
     FW_UP: image signature INVALID
     FW_UP: image UNSIGNED (no signature supplied)
+
+Phase A — verify-and-log, reject nothing — is **over**; it existed only to carry the
+project from "no signing at all" to a provisioned key without brick risk. Do not
+describe current behaviour in Phase A terms.
 
 **ENFORCEMENT IS NOW ON** (2026-08-04, `rules.mk`: `OPT_DEFS += -DFW_REQUIRE_SIGNATURE`).
 An image without a valid signature is refused at COMMIT. Enabled only after the
@@ -124,9 +125,15 @@ Automated (releases): signing is built **into the existing release build**
 (`.github/workflows/release.yml`). On a `PolyKybd-fw-v*` tag / published release it
 builds split72, objcopies the `.bin`, then the **Sign .bin (FW-2)** step signs it
 with `FW_SIGNING_KEY` and the release step uploads `<target>.bin.sig` alongside the
-`.uf2`/`.bin`. The signing step is a **no-op when `FW_SIGNING_KEY` is unset**, so
-releases keep working (unsigned) until you add the secret — nothing to wire up
-beyond the one-time key setup above.
+`.uf2`/`.bin`.
+
+⚠️ **A release build with no `FW_SIGNING_KEY` secret now FAILS the job.** While
+verification was warn-only the step deliberately no-op'd, so releases kept working
+before a key existed. Under enforcement that default inverted: an unsigned release is
+refused by every keyboard at COMMIT and falls through to the on-keycap ACCEPT/REJECT
+prompt, teaching users to accept unsigned images on sight — the exact habit FW-2 is
+meant to prevent. Failing the release is the cheaper outcome. Non-release builds (a
+`workflow_dispatch` smoke test off a branch) still skip signing.
 
 PolyKybdHost picks up `<image>.bin.sig` next to the `.bin` automatically and sends
 it during the flash.
@@ -134,10 +141,25 @@ it during the flash.
 ## Key rotation
 
 Re-run `gen_signing_key.py`, commit the new `fw_pubkey.h`, update the
-`FW_SIGNING_KEY` secret, ship a firmware build with the new public key, and
-re-sign releases. (Until a keyboard runs firmware carrying the new public key, it
-can't verify signatures made with the new private key — rotate the firmware first
-while still in warn-only mode.)
+`FW_SIGNING_KEY` secret, ship a firmware build carrying the new public key, and
+re-sign releases.
+
+⚠️ **Rotation is harder now that enforcement is on**, and the old advice here — "rotate
+the firmware first while still in warn-only mode" — no longer describes anything that
+exists. A keyboard can only verify against the key baked into the firmware it is
+*currently running*, so the release that carries a new public key cannot be signed
+with the new private key: every keyboard still on the old firmware would refuse it and
+drop to the manual ACCEPT/REJECT prompt.
+
+**Sign the rotation release with the OLD private key.** Keyboards verify it against the
+old public key they already trust, install the image, and come up carrying the new
+public key. Only the release *after* that one is signed with the new key. Retire the
+old private key only once the fleet has taken the rotation build.
+
+A botched regeneration is also guarded: if `fw_pubkey.h` ever reverts to the all-zero
+placeholder, `fw_staging_check_signature()` refuses outright rather than verifying
+against it (that key is an order-4 curve point, so it would otherwise be *forgeable* —
+see the comment on `fw_pubkey_provisioned()` in `base/fw_staging.c`).
 
 ## Scope: master-only verification (deliberate)
 


### PR DESCRIPTION
## Summary

Enforcement went on in `0bbeb72a` (`rules.mk`: `-DFW_REQUIRE_SIGNATURE`), but the release workflow kept its pre-enforcement behaviour — sign only if `FW_SIGNING_KEY` happens to be set, otherwise print a notice and ship unsigned. **That default inverted when enforcement landed**, and nothing caught it because the notice still says "verify is warn-only".

Three changes, one theme: make the signing chain fail closed and stop describing itself in Phase A terms.

### 1. `release.yml` — a real release with no key now fails the job

An unsigned official release is no longer a soft downgrade. Every keyboard refuses it at COMMIT and drops to the on-keycap ACCEPT/REJECT prompt, so users would meet that prompt on **every** official update and learn to press ACCEPT on sight — the exact habit FW-2 exists to prevent. Failing the build is the cheaper outcome.

- Release events (`release` / tag push) with no secret → **error + exit 1**
- Non-release builds (`workflow_dispatch` smoke test off a branch) → still skip, unchanged
- Post-check that `.bin.sig` was actually produced, so the release step's `[ -f ... ]` can't silently drop the asset

### 2. `fw_staging.c` — guard against an unprovisioned public key

The all-zero placeholder in `fw_pubkey.h` is **not inert**. Its encoding is `y=0`, which decodes to a genuine curve point of **order 4**, and `crypto_eddsa_check_equation()` only checks that A and R are on the curve and `0 <= S < L` — it has no low-order-key rejection. With an order-4 A, `[h]A` depends only on `h mod 4`, so a forgery is findable in a handful of tries.

So a placeholder key makes enforcement **forgeable rather than fail-closed** — the opposite of the intuition that a dummy key rejects everything. `fw_staging_check_signature()` now refuses outright when the key is all-zero, so a botched keygen or a bad merge can't silently downgrade `FW_REQUIRE_SIGNATURE` into theatre.

Verified the curve claim rather than assuming it:

```
all-zero pubkey decodes to a point ON the curve: True
order of that point: 4
```

### 3. `SIGNING.md` — three stale passages

- The `## Rollout: Phase A (current)` heading and its "does **not reject**" body contradicted the **ENFORCEMENT IS NOW ON** note two paragraphs below
- "no-op when `FW_SIGNING_KEY` is unset, so releases keep working (unsigned)" — now describes the bug this PR fixes
- Key rotation said "rotate the firmware first while still in warn-only mode", which no longer exists. Replaced with what actually works: **sign the rotation release with the OLD key**, since a keyboard can only verify against the key baked into the firmware it is currently running

## Version bump label

Patch (no label) — hardening + CI + docs, no protocol or feature change.

## Testing

- `release.yml` parses as YAML; the `run:` block extracted and `bash -n` clean
- Both gate branches exercised directly: release-event-without-secret → `exit 1`; non-release-without-secret → `exit 0`
- Curve order of the all-zero key computed independently (above)
- ⚠️ **Not compiled locally** — no ARM toolchain on this machine. The `Build firmware` check is the real verification for the `fw_staging.c` change; it is small and isolated, but please let CI go green before merging.

## Note for the maintainer

If the `FW_SIGNING_KEY` secret is **not yet configured**, this PR makes the next release fail loudly instead of shipping unsigned. That is the intent, but set the secret before cutting a release — see `keyboards/polykybd/tools/SIGNING.md` § One-time setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce firmware signing end-to-end by failing unsigned release builds and hardening key handling and documentation.

Bug Fixes:
- Prevent official release builds from silently shipping unsigned firmware when the signing key secret is missing.
- Reject signatures when the compiled-in public key is the all-zero placeholder instead of a real provisioning key.

Enhancements:
- Add a runtime guard in firmware to detect an unprovisioned signing public key and treat it as a verification failure.
- Verify that the release signing step actually produces a .bin.sig artifact and fail the job otherwise.

Build:
- Update the release CI workflow to fail release jobs without FW_SIGNING_KEY while still allowing unsigned non-release smoke builds.

Documentation:
- Revise firmware signing documentation to reflect that enforcement is active, clarify release signing behaviour, and document the correct key rotation and placeholder-key handling procedure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Release firmware builds now require signing and fail if signing is unavailable or produces an invalid signature.
  * Firmware with an unprovisioned signing key rejects supplied signatures safely.
* **Documentation**
  * Updated signing guidance to reflect enforced release signing and revised key-rotation procedures.
  * Clarified that manual non-release builds may continue without signing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->