### PR TITLE
fontpack: split FONTPACK_COMMIT's failure byte into rejected vs slave-unconfirmed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1738,6 +1738,38 @@ flashes all stale bundles, `flash <id>` force-flashes one).
   byte-identity with the master's verified pack) and defers the heavy reload to
   `fw_staging_process_fontpack_reload()` in housekeeping. **Never do heavy work in a
   split-transaction handler.**
+  - **FONTPACK_COMMIT has THREE status bytes** (`hid_fontpack.h` `FONTPACK_COMMIT_*`):
+    `.` both halves finalized, **`R`** the master's finalize *rejected* the image (staged
+    CRC / not a valid PlyF), **`L`** the master committed but the slave did not ACK within
+    the bridge's 10 retries — a *link* failure, where the master's copy is live and
+    `reply[3..4]` carries its `content_version`. Before the split (2026-08-17) `ok =
+    slave_ok && master_ok` collapsed both into `!`, so the host reported *"CRC mismatch or
+    the font pack was rejected"* for a pack whose CRC was perfect and whose data was
+    already live — sending the field diagnosis after the data for two rounds while the real
+    culprit was the split link (`giveup=44` in that window). **This is the same mistake
+    `FW_UP_COMMIT` was split into four statuses to fix**, one command over; don't collapse
+    them back. Bumps **no** `PROTOCOL_VERSION`: the font-pack commands are dispatched
+    independently of it, an old host reads any non-`.` as failure, and a new host maps the
+    old `!` to "unspecified" — so it degrades in both directions.
+    - ⚠️ **A status letter that is a HEX DIGIT breaks the literal**: `"P\x52C"` is a single
+      `\x52C` escape, not three bytes. `R`/`L` are safe; anything in `[0-9a-fA-F]` needs a
+      split literal (`"P\x52" "C"`). Verify by grepping the built ELF — `strings` shows
+      `PRR`/`PRL` (P, 0x52, letter) exactly once each.
+    - **Re-running COMMIT is free, which is what makes `L` actionable.**
+      `fw_staging_finalize_impl` leaves `s_staged_crc`/`s_image_crc`/`s_next_offset`
+      untouched and only clears `s_commit_pending`/`s_fw_up_active`, and the slave's
+      `flash_stage_commit` is likewise idempotent — so a second COMMIT re-runs the bridge
+      with fresh retries and re-reloads, and the host retries instead of re-streaming the
+      pack. Unlike the FIRMWARE target there is no header sector to re-erase (FONTPACK
+      writes in place), so re-bridging is safe.
+  - ⚠️ **Because FONTPACK writes IN PLACE, a slot is a valid, current bundle as soon as the
+    last chunk lands — COMMIT is not what makes it so.** `fontpack_load()` validates each
+    slot with the pack's own CRC32 over everything after the 32-byte header, so a *complete*
+    stream reads back as present at the shipped `content_version` even if COMMIT never
+    succeeded (a truncated one fails that CRC and reads as absent, which is why a partial
+    write cannot fake a version). The host consequences — never trusting the version
+    comparison alone to decide a re-flash — are written up in `PolyKybdHost/CLAUDE.md`
+    under the font-pack bundles note.
 - **Wipe** = flash a 32-byte **empty pack** (`font_count == 0`), a valid empty PlyF
   sentinel → that slot contributes no fonts. `polyctl fontpack wipe [id]` wipes one
   slot, or **all** slots when `id` is omitted. ⚠️ **The FONTPACK COMMIT gates success

--- a/keyboards/polykybd/hid_fontpack.c
+++ b/keyboards/polykybd/hid_fontpack.c
@@ -159,19 +159,49 @@ bool hid_fontpack_receive(uint8_t *data, uint8_t length) {
             bool is_doom = s_fontpack_bundle == FONTPACK_BUNDLE_DOOMWAD ||
                            s_fontpack_bundle == FONTPACK_BUNDLE_DOOMPACK;
             bool ok = (slave_ack == SYNC_ACK) && master_ok;
+
+            // THREE distinct statuses, not one '!'. A dropped split-link ACK and a
+            // staged-CRC mismatch are opposite events with opposite remedies, and
+            // collapsing them made the host report "CRC mismatch or the font pack was
+            // rejected" for a pack whose CRC was perfect and whose data was already
+            // live on the master (field 2026-08-17) — which sent the diagnosis the
+            // wrong way for two rounds. Exactly the confusion FW_UP_COMMIT was split
+            // into four statuses to end; this is the same mistake one command over.
+            //   '.' both halves finalized + reloaded
+            //   'R' the MASTER's finalize REJECTED the image (staged CRC mismatch, or
+            //       the flashed slot did not load as a valid PlyF) — a real data
+            //       problem; the host must re-flash.
+            //   'L' the master committed but the slave did not ACK within the bridge's
+            //       retries (a LINK failure). The master's copy is live and correct;
+            //       re-sending COMMIT is free (finalize leaves s_staged_crc/s_image_crc
+            //       and the write cursor untouched, and the slave's flash_stage_commit
+            //       is likewise idempotent), so the host retries rather than re-streams.
+            // ⚠️ Letters that are hex digits must not follow a `\xHH` escape — the
+            // compiler would merge them into one oversized character constant ("P\x52C"
+            // is a single 0x52C escape, not three bytes). 'R'/'L' are safe; if you ever
+            // pick a hex-digit letter here, split the literal ("P\x52" "C").
+            const char *status = ok         ? "P\x52."
+                               : !master_ok ? "P\x52R"
+                                            : "P\x52L";
             memset(data, 0, length);
-            memcpy(data, ok ? "P\x52." : "P\x52!", 3);
-            if (ok && !is_doom) {
+            memcpy(data, status, 3);
+            // Report the slot's content_version whenever the MASTER's copy is live —
+            // including 'L', where it is precisely what tells the host the data landed
+            // and only the acknowledgement was lost.
+            if (master_ok && !is_doom) {
                 uint16_t cver = fontpack_bundle_version(s_fontpack_bundle);
                 memcpy(&data[3], &cver, 2);
             }
+            const char *outcome = ok ? (is_doom ? "installed" : "live")
+                                     : (!master_ok ? "REJECTED (master finalize)"
+                                                   : "UNCONFIRMED (slave ACK lost)");
             if (is_doom) {
                 uprintf("FONTPACK_COMMIT: %s slave=0x%02x master=%d -> %s\n",
                         s_fontpack_bundle == FONTPACK_BUNDLE_DOOMWAD ? "DOOMWAD" : "DOOMPACK",
-                        slave_ack, master_ok, ok ? "installed" : "INVALID");
+                        slave_ack, master_ok, outcome);
             } else {
                 uprintf("FONTPACK_COMMIT: bundle=%u slave=0x%02x master=%d -> %s (present=%d fonts=%u cver=%u)\n",
-                        s_fontpack_bundle, slave_ack, master_ok, ok ? "live" : "INVALID",
+                        s_fontpack_bundle, slave_ack, master_ok, outcome,
                         fontpack_bundle_present(s_fontpack_bundle), fontpack_font_count(),
                         fontpack_bundle_version(s_fontpack_bundle));
             }

--- a/keyboards/polykybd/hid_fontpack.c
+++ b/keyboards/polykybd/hid_fontpack.c
@@ -31,6 +31,22 @@
 // so COMMIT can report the just-flashed bundle's content_version.
 static uint8_t s_fontpack_bundle = 0;
 
+// Writes the 3-byte reply header for a command whose status is one of several
+// values: 'P', the command id, then the status byte. The sibling of hid_com.c's
+// boolean `hid_reply()`, which cannot express COMMIT's three outcomes.
+//
+// Building the bytes instead of writing a `"P\x52R"` literal is deliberate twice
+// over: the status comes from the FONTPACK_COMMIT_* constants (so the header owns
+// the wire values and cannot drift from what is emitted), and there is no `\xHH`
+// escape for a following letter to be swallowed into — `"P\x52C"` would be a
+// single 0x52C character constant, not three bytes, and 'C' being a hex digit is
+// the only thing that decides it. Nothing here can hit that trap.
+static inline void fontpack_reply_status(uint8_t *data, uint8_t cmd, uint8_t status) {
+    data[0] = 'P';
+    data[1] = cmd;
+    data[2] = status;
+}
+
 bool hid_fontpack_receive(uint8_t *data, uint8_t length) {
     switch (data[1]) {
 
@@ -167,7 +183,8 @@ bool hid_fontpack_receive(uint8_t *data, uint8_t length) {
             // live on the master (field 2026-08-17) — which sent the diagnosis the
             // wrong way for two rounds. Exactly the confusion FW_UP_COMMIT was split
             // into four statuses to end; this is the same mistake one command over.
-            //   '.' both halves finalized + reloaded
+            //   '.' both halves finalized (the slave's font-table reload is deferred to
+            //       its housekeeping by design, and cannot fail — see hid_fontpack.h)
             //   'R' the MASTER's finalize REJECTED the image (staged CRC mismatch, or
             //       the flashed slot did not load as a valid PlyF) — a real data
             //       problem; the host must re-flash.
@@ -176,15 +193,11 @@ bool hid_fontpack_receive(uint8_t *data, uint8_t length) {
             //       re-sending COMMIT is free (finalize leaves s_staged_crc/s_image_crc
             //       and the write cursor untouched, and the slave's flash_stage_commit
             //       is likewise idempotent), so the host retries rather than re-streams.
-            // ⚠️ Letters that are hex digits must not follow a `\xHH` escape — the
-            // compiler would merge them into one oversized character constant ("P\x52C"
-            // is a single 0x52C escape, not three bytes). 'R'/'L' are safe; if you ever
-            // pick a hex-digit letter here, split the literal ("P\x52" "C").
-            const char *status = ok         ? "P\x52."
-                               : !master_ok ? "P\x52R"
-                                            : "P\x52L";
+            uint8_t status = ok         ? FONTPACK_COMMIT_OK
+                           : !master_ok ? FONTPACK_COMMIT_REJECTED
+                                        : FONTPACK_COMMIT_NO_SLAVE;
             memset(data, 0, length);
-            memcpy(data, status, 3);
+            fontpack_reply_status(data, CMD_FONTPACK_COMMIT, status);
             // Report the slot's content_version whenever the MASTER's copy is live —
             // including 'L', where it is precisely what tells the host the data landed
             // and only the acknowledgement was lost.

--- a/keyboards/polykybd/hid_fontpack.h
+++ b/keyboards/polykybd/hid_fontpack.h
@@ -14,9 +14,26 @@
 // a link failure and a data failure need opposite responses from the host, and a
 // single '!' for both made a perfectly-flashed bundle read as corrupt (see the long
 // comment at CMD_FONTPACK_COMMIT in hid_fontpack.c).
-#define FONTPACK_COMMIT_OK        '.'  // both halves finalized; reply[3..4] = content_version
+#define FONTPACK_COMMIT_OK        '.'  // both halves FINALIZED (see the reload note below)
 #define FONTPACK_COMMIT_REJECTED  'R'  // master finalize refused the image (staged CRC / invalid PlyF)
 #define FONTPACK_COMMIT_NO_SLAVE  'L'  // master committed (reply[3..4] valid), slave did not ACK — retry COMMIT
+// reply[3..4] = the slot's content_version, written whenever the MASTER's copy is
+// live ('.' and 'L'). ⚠️ FONT bundles only: the DOOMWAD/DOOMPACK pseudo-bundles have
+// no font-pack version, so those bytes stay 0 and the host does not read them (its
+// flash_doomwad/flash_doompack discard the reply).
+// ⚠️ '.' means both halves FINALIZED, not "the slave has rebuilt its font table".
+// The slave defers the ~50 ms reload to housekeeping deliberately —
+// fw_staging_finalize_defer_reload() must not do heavy work inside the split
+// transaction (that overran the window and mis-reported COMMIT as a CRC failure
+// once already). It ACKs on the O(1) transport CRC, which proves byte-identity
+// with the master's already-verified pack, so the deferred reload cannot fail;
+// it lands within a housekeeping tick.
+// ⚠️ 'L' cannot tell a LOST ack from an explicit slave REFUSAL: both
+// bridge_helper's retry give-up and the slave's own finalize failure surface as
+// SYNC_CRC32_ERR. Distinguishing them needs a new slave→master ack value in
+// poly_sync_reply_t, which every bridge consumer shares — not done here. The host
+// therefore treats 'L' as "the other half is unverified" and re-flashes the bundle
+// on the next pass rather than trusting it.
 // A host that predates these reads any non-'.' as a failure, and firmware that
 // predates them answers '!', which a new host treats as "unspecified" — so the pair
 // degrades gracefully in both directions and needs no PROTOCOL_VERSION bump (the

--- a/keyboards/polykybd/hid_fontpack.h
+++ b/keyboards/polykybd/hid_fontpack.h
@@ -9,6 +9,18 @@
 #define CMD_FONTPACK_BEGIN   0x50  // data[2..5]=pack_size, data[6..9]=pack_crc32 (whole pack)
 #define CMD_FONTPACK_CHUNK   0x51  // data[2..5]=offset, data[6..61]=FW_UP_CHUNK_SIZE bytes
 #define CMD_FONTPACK_COMMIT  0x52  // verify CRC from flash + reload (no reboot); reply[3..4]=content_version
+
+// COMMIT reply status byte (reply[2]). Three outcomes, deliberately distinguishable:
+// a link failure and a data failure need opposite responses from the host, and a
+// single '!' for both made a perfectly-flashed bundle read as corrupt (see the long
+// comment at CMD_FONTPACK_COMMIT in hid_fontpack.c).
+#define FONTPACK_COMMIT_OK        '.'  // both halves finalized; reply[3..4] = content_version
+#define FONTPACK_COMMIT_REJECTED  'R'  // master finalize refused the image (staged CRC / invalid PlyF)
+#define FONTPACK_COMMIT_NO_SLAVE  'L'  // master committed (reply[3..4] valid), slave did not ACK — retry COMMIT
+// A host that predates these reads any non-'.' as a failure, and firmware that
+// predates them answers '!', which a new host treats as "unspecified" — so the pair
+// degrades gracefully in both directions and needs no PROTOCOL_VERSION bump (the
+// font-pack commands are dispatched independently of it).
 #define CMD_FONTPACK_STATUS  0x53  // reply: [3]=present [4]=abi [5..6]=content_version [7]=font_count
 
 // Handle HID font-pack commands (0x50–0x53). Called from raw_hid_receive() when


### PR DESCRIPTION
## Summary

`FONTPACK_COMMIT` answered `.` or `!`, with `ok = slave_ok && master_ok`. The master's finalize runs regardless of the slave's ACK, so the common failure — master committed, slave's bridge gave up — was indistinguishable on the wire from a staged-CRC mismatch. The host printed *"CRC mismatch or the font pack was rejected"* for a pack whose CRC was perfect and whose data was already live on the keyboard.

That happened in the field on 2026-08-17. The `symbol` bundle reported a failed flash; the keyboard afterwards advertised the new `content_version` (FONTPACK writes **in place**, so the slot was complete and CRC-valid as soon as the last chunk landed), and the split link logged `giveup=44` across the flash window. Two rounds went into the CRC before the link was suspected.

COMMIT now answers three statuses:

| byte | meaning | remedy |
|---|---|---|
| `.` | both halves finalized and reloaded | — |
| `R` | the **master's** finalize rejected the image (staged CRC / not a valid PlyF) | re-flash |
| `L` | the master committed but the slave did not ACK within the bridge's 10 retries | re-send COMMIT (free) |

`L` also carries the slot's `content_version` in `reply[3..4]` — that value is precisely what tells a host the data landed and only the acknowledgement was lost. The console line names the outcome instead of printing `INVALID` for both.

This is the same mistake `FW_UP_COMMIT` was split into four statuses to fix, one command over.

**No `PROTOCOL_VERSION` bump.** The font-pack commands are dispatched independently of it; an old host reads any non-`.` as a failure, and a new host maps the legacy `!` to "unspecified" — so the pair degrades in both directions.

The paired host change is thpoll83/PolyKybdHost#166, which consumes these statuses (retries `L`, verifies a failed COMMIT against `GET_ID`, and stops treating a lost ACK as a permanent failure).

### Note for reviewers

⚠️ A status letter that is a **hex digit** silently breaks the literal: `"P\x52C"` is a single `\x52C` escape, not three bytes. `R`/`L` are safe; anything in `[0-9a-fA-F]` would need a split literal. There's a comment at the call site, and the ELF grep below is the check.

## Version bump label

Patch (no label) — a wire/semantic refinement of an existing command, no new feature and no protocol change.

## Testing

- [x] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`)
- [ ] Flashed and tested on hardware — **not done**, needs a hardware round
- [x] If protocol changed: n/a — deliberately no `PROTOCOL_VERSION` bump (rationale above)

Also verified:

- `qmk lint --strict` passes on `polykybd/split72` and `polykybd/split42`; no tracked-but-gitignored files under `keyboards/polykybd/`.
- The built ELF carries `PRR` and `PRL` (P, 0x52, letter) **exactly once each** — i.e. neither status letter merged into the `\x52` escape.
- Re-running COMMIT is safe to rely on: `fw_staging_finalize_impl` leaves `s_staged_crc`/`s_image_crc`/`s_next_offset` untouched and only clears `s_commit_pending`/`s_fw_up_active`, and the slave's `flash_stage_commit` is likewise idempotent. Unlike the FIRMWARE target there is no header sector to re-erase, so re-bridging is free.

What a hardware round should confirm: a font-pack flash on a healthy link still reports `.` and the console prints `-> live`; and, if a bundle ever fails, that the console names `REJECTED (master finalize)` or `UNCONFIRMED (slave ACK lost)` rather than the old `INVALID`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Font-pack commit operations now report distinct outcomes for success, master-side rejection, and missing slave acknowledgements.
  - Successful or partially confirmed responses include the current content version when available.
  - Existing clients remain compatible without requiring a protocol version change.

- **Bug Fixes**
  - Improved handling of incomplete writes through validation before finalization.
  - Safe retries no longer require re-streaming the font-pack data.

- **Documentation**
  - Documented commit statuses, retry behavior, compatibility, and validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->