### PR TITLE
split: give a slave REFUSAL its own ack, and probe the slave when the answer is lost

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1428,6 +1428,24 @@ Wiring a new one needs **two** registrations plus one non-obvious source list:
   hard-errors.
 - `builddefs/build_test.mk` — `include <path>/tests/rules.mk`, alongside the
   `quantum/*/tests/rules.mk` lines. This defines `<name>_SRC/_INC/_DEFS`.
+  - ⚠️ **A test under `keyboards/` must NOT name that file `rules.mk` — CI reads it as
+    a KEYBOARD.** `qmk ci-validate-keyboard-targets` globs `keyboards/**/rules.mk` and
+    flags every hit whose path lacks a directory named `keymaps`, `common` or `lib` and
+    which has no `keyboard.json` beneath it (`lib/python/qmk/cli/ci/
+    validate_keyboard_targets.py`, 17 lines — read it, it is the whole rule). There is
+    no exemption for tests, because upstream keeps none under `keyboards/`. The failure
+    is `keyboards/polykybd/base/tests::Legacy target detected` and it is a **separate
+    lint-job step from `qmk lint`**, so `qmk lint --strict` passing tells you nothing
+    about it. `keyboards/polykybd/base/tests/` therefore uses **`test_rules.mk`**; the
+    `build_test.mk` include names the file explicitly, so the name is free.
+    (`testlist.mk` is unaffected — only `rules.mk` is globbed.) Cost a CI round
+    2026-08-17.
+  - ⚠️ **So run the WHOLE lint job locally, not just `qmk lint`.** The recipe in the CI
+    section above already lists all of it; the two `ci-validate-*` commands are the
+    ones easy to skip, and they are ~1 s each:
+    ```bash
+    qmk ci-validate-keyboard-targets && qmk ci-validate-aliases   # both must exit 0
+    ```
 - ⚠️ **A standalone test must put the timer in its own `_SRC`.**
   `platforms/common.mk` adds `platforms/timer.c` + `platforms/test/timer.c` to `SRC`,
   which only the **full-keyboard** harness consumes — so a standalone test links with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,16 +266,38 @@ inherited-upstream noise:
   ```
   ⚠️ Drop `keyboards/polykybd/tools/__pycache__` first or it shows up as a false
   positive in the ignored-files list (CI checks out clean, so it never sees it).
-  - ⚠️ **The lint job runs `format-c` (clang-format) as well as `format-text`, and
-    the container can only run one of them — so "format clean" locally can be a
-    FALSE PASS.** `qmk format-text` needs **`dos2unix`, which is not installed**
-    (`FileNotFoundError: 'dos2unix'`); its job is only line endings + trailing
-    newline, which `grep -qP '\r'` and `[ -n "$(tail -c1 f)" ]` check by hand. The
-    *other* half, `qmk format-c`, is what actually fails PRs — with
-    `File '…' Requires Formatting` per file — and `clang-format` **is** installed.
-    Check the C/C++ files you touched with
-    `clang-format --dry-run -Werror <files>` before pushing (2026-08-12: verifying
-    only the line endings let a trailing-comment-spacing failure through to CI).
+  - ⚠️ **WHICH formatter runs is decided by the changed PATHS, and clang-format does
+    NOT cover `keyboards/**`.** An earlier version of this file said "the lint job runs
+    `format-c` as well as `format-text`" and told you to clang-format every C file you
+    touched. That is wrong for keyboard work, and following it means reformatting files
+    CI never looks at. The actual wiring (read the three workflows, verified
+    2026-08-17):
+    - **`lint.yml`** ("PR Lint keyboards") triggers on `keyboards/**` and runs
+      **`qmk format-text` only**, then fails any changed file that `git diff` shows as
+      modified — that is where `File '…' Requires Formatting` comes from.
+    - **`format.yml`** ("PR Lint Format") is the one that runs clang-format, and its
+      `paths:` are `drivers/ lib/arm_atsam/ lib/lib8tion/ lib/python/ modules/
+      platforms/ quantum/ tests/ tmk_core/` — **no `keyboards/`**.
+    - **`format_push.yml`** only fires on pushes to `master`/`develop`, i.e. the
+      upstream-mirror branches, never on `PolyKybd` or a `claude/**` PR.
+    - So the 2026-08-12 clang-format failure was real but path-specific: that change
+      extracted the LTR-559 driver into **`modules/`**, which `format.yml` does cover.
+      **Rule: clang-format only what you put under those paths.**
+  - ⚠️ **Corollary — do NOT clang-format a new file under `keyboards/`.** The
+    container's clang-format 18 disagrees with the prevailing style there on ~every
+    file (`.clang-format` sets `ColumnLimit: 1000` and `AlignConsecutive*: true`, so it
+    unwraps hand-wrapped signatures and collapses aligned `#define` columns). The
+    version-skew test in the next bullet needs a base version to compare against, which
+    a new file does not have — the check that replaces it is **whether the same
+    objection reproduces on a neighbouring committed file**. It does: the aligned
+    `#define SYNC_ACK_SIG    0b…` block is flagged identically in
+    `origin/PolyKybd:keyboards/polykybd/split_sync.h`, which CI has been passing for
+    months.
+  - `qmk format-text` itself cannot be run in the container — it needs **`dos2unix`,
+    which is not installed** (`FileNotFoundError: 'dos2unix'`). Its whole job is line
+    endings + a trailing newline, so check those by hand:
+    `grep -qP '\r' <file>` (must not match) and `[ -n "$(tail -c1 <file>)" ]` (must be
+    false, i.e. the file ends in a newline).
   - ⚠️ **The container's clang-format is a DIFFERENT VERSION from CI's, so it flags
     files CI accepts — do not "fix" those.** Local is clang-format 18; it wanted to
     reformat a file the lint job had passed. **The test is whether the same file is
@@ -1364,8 +1386,40 @@ backing store the way a driver test should mock its bus.
 ```bash
 git submodule update --init --depth 1 --no-recommend-shallow lib/googletest  # needs add_repo qmk/googletest first
 export QMK_HOME=$PWD && export PATH="/root/.qmk_venv/bin:$PATH"
-make test:polymod_ltr559          # ~1 s
+make test:polymod_ltr559          # ~1 s, 19 tests — the LTR-559 driver vs a mock I2C bus
+make test:fw_up_verdict           # ~1 s, 21 tests — the flash-staging COMMIT decision layer
 ```
+
+- **`fw_up_verdict` is the pattern for testing DECISION logic** (as opposed to
+  `polymod_ltr559`, which is the pattern for a driver vs a mock bus). It covers the
+  COMMIT-failure classification, the ack vocabulary, the STATUS-snapshot CRC guard and
+  the font-pack status byte. **Getting it testable required decoupling first, and that
+  decoupling was worth doing on its own terms** — the two smells it exposed:
+  - `split_sync.h` conflated a **protocol contract** (4 ack bytes + `sync_succeeded`)
+    with the sync **payload structs**, which need `config.h`/`state.h`/`mru.h`. So
+    asking "is this ack a success?" pulled in the whole keyboard config, and
+    `sync_succeeded()` — the helper guarding every `send_to_bridge` call site, and
+    itself the subject of a field bug — had no test for years. The vocabulary now
+    lives in dependency-free **`base/sync_ack.h`**, re-exported by `split_sync.h` so
+    all consumers are unchanged.
+  - `fw_up_slave_refused_commit()` mixed RPC transport, CRC validation, the decision
+    and `uprintf` in one function; the decision was the only part with a bug history
+    and the only part unreachable. It is now pure in **`base/fw_up_verdict.c`**, with
+    the I/O and the four diagnostic lines left in `split_fw_up.c`. This mirrors what
+    the host repo does deliberately (`polyhost/core/decisions.py`,
+    `decide_stale_bundles`, `classify_commit_reply`) — the firmware just never had
+    the seams.
+  - ⚠️ `base/fw_up_verdict.c` is listed in the **shared** `POLY_SRC` in
+    `keyboards/polykybd/rules.mk`, NOT with the other `base/*.c` in the per-variant
+    `rules.mk` — its consumer `split_fw_up.c` is in that shared list, so a variant
+    that forgot the line would just fail to link.
+- **A host fixture can never catch THIS end emitting the wrong byte.** PolyKybdHost has
+  had `classify_commit_reply` under test for a while, but those tests encode the
+  firmware's reply bytes as fixtures — so they only catch the *host* misreading a
+  status, which is the opposite direction from the bug that actually shipped. Both ends
+  of the font-pack COMMIT contract are now pinned: `fontpack_commit_status()` is a pure
+  `static inline` in `hid_fontpack.h` (which is why that header now includes
+  stdint/stdbool instead of `quantum.h` — nothing in it needed quantum.h).
 
 Wiring a new one needs **two** registrations plus one non-obvious source list:
 
@@ -1386,7 +1440,19 @@ Wiring a new one needs **two** registrations plus one non-obvious source list:
   byte order, delete a bound) and confirm the *expected* test fails — the same
   discipline as "verify against the rendered glyph shape, not a transform∘inverse
   round-trip". A suite that passes against a deliberately broken driver is measuring
-  nothing.
+  nothing. `fw_up_verdict` was validated this way against 7 mutations (dropped
+  `!status_ok` guard, `recorded != SYNC_ACK` as the refusal test, probe outranking an
+  explicit refusal, `sync_succeeded` as a blacklist, a 1-bit-spaced ack value, a slave
+  refusal reported as retryable, and a CRC check that always passes) — each caught by
+  the intended test.
+  - ⚠️ **Strip ANSI escapes before grepping gtest output, or the mutation harness
+    FAILS OPEN.** gtest prints `\e[0;32m[  FAILED  ]`, so a regex anchored on a leading
+    `[` matches nothing and **every** mutation reads as "still green" — i.e. the
+    harness reports the exact result that means "your tests are worthless", for all of
+    them, which is itself the tell that the detector and not the suite is broken. Pipe
+    through `sed 's/\x1b\[[0-9;]*m//g'` first. Cost a full round (2026-08-17); a
+    single manual mutation is the 30 s way to confirm the harness works before
+    trusting a sweep.
 
 ### Notable QMK features enabled
 RGB matrix (72 LEDs, 35 effects), dynamic keymap (9 host-remappable layers), unicode input (Linux/macOS/Windows/BSD), Cirque trackpad (split72 variant), `USE_CORE1` multicore.
@@ -1751,6 +1817,14 @@ flashes all stale bundles, `flash <id>` force-flashes one).
     them back. Bumps **no** `PROTOCOL_VERSION`: the font-pack commands are dispatched
     independently of it, an old host reads any non-`.` as failure, and a new host maps the
     old `!` to "unspecified" — so it degrades in both directions.
+    - **The status selection is a pure `static inline fontpack_commit_status()` in
+      `hid_fontpack.h`, unit-tested** (`make test:fw_up_verdict`,
+      `FontpackCommitStatusTest`): master rejection outranks a healthy slave, a slave
+      *refusal* is `'R'` and not `'L'`, a lost ack is `'L'`, the three bytes are
+      distinct, none reuses the legacy `'!'`, and none is a hex digit (the
+      string-literal trap below). This is the firmware half of a contract the host
+      tests from its side — and the half that matters, since a host fixture can only
+      catch the host *misreading* a status, never this end emitting the wrong one.
     - ⚠️ **A status letter that is a HEX DIGIT breaks the literal**: `"P\x52C"` is a single
       `\x52C` escape, not three bytes. `R`/`L` are safe; anything in `[0-9a-fA-F]` needs a
       split literal (`"P\x52" "C"`). Verify by grepping the built ELF — `strings` shows
@@ -2515,6 +2589,25 @@ that ring/reflect on a longer split cable.
   corrupted reply can turn a real `SYNC_ACK` into a non-ACK → master retries (safe,
   idempotent) or, ~1/256, into a false ACK. Low impact, but it's why a tiny
   fraction of `crc_err` counts can be reply corruption rather than payload.
+  - **That missing CRC is why the ack BYTE VALUES are Hamming-spaced**, and the
+    vocabulary now lives in dependency-free **`base/sync_ack.h`** (re-exported by
+    `split_sync.h`, so consumers are unchanged) with a test enforcing it:
+    `SyncAckTest.AckValuesStayHammingSpaced` requires min pairwise distance **4**
+    across `SYNC_ACK` / `SYNC_ACK_SIG` / `SYNC_CRC32_ERR` / `SYNC_NACK_REFUSED`.
+    ⚠️ **Adding a fifth value must keep that distance** or the single-bit tolerance
+    degrades for the *whole* set; an exhaustive search says **12 spare codewords**
+    preserve it, so there is plenty of room — but avoid `0x00`/`0xFF`, which are what
+    a stuck or floating line reads as (also asserted). `sync_succeeded()` is a
+    deliberate **whitelist** so a new failure value is a failure at all 14 existing
+    call sites with no edits; `SyncSucceededIsFailClosedAcrossEveryByte` sweeps all
+    256 bytes to pin that, because a blacklist implementation passes every other test.
+  - ⚠️ **`SYNC_CRC32_ERR` is still TRIPLE-overloaded** — "still erasing" (a normal
+    `flash_stage_begin` re-poll state), "your frame arrived garbled", and
+    "send_to_bridge gave up". Only the *refusal* case was peeled off (into
+    `SYNC_NACK_REFUSED`); the remaining three are separated by nothing but a comment.
+    The clean follow-up is a distinct `SYNC_BUSY` and a distinct give-up value, which
+    the 12 spare codewords comfortably allow — then callers could back off vs retry vs
+    escalate instead of inferring from context.
 
 **How CRC32 + retries + noise interact** (the model that drives the retry-count
 choice). With `p` = probability a single frame is corrupted (and caught by CRC32),

--- a/builddefs/build_test.mk
+++ b/builddefs/build_test.mk
@@ -69,6 +69,7 @@ include $(QUANTUM_PATH)/os_detection/tests/rules.mk
 include $(QUANTUM_PATH)/sequencer/tests/rules.mk
 include $(QUANTUM_PATH)/wear_leveling/tests/rules.mk
 include modules/polykybd/polymod_ltr559/tests/rules.mk
+include keyboards/polykybd/base/tests/rules.mk
 include $(QUANTUM_PATH)/logging/print.mk
 include $(PLATFORM_PATH)/test/rules.mk
 ifneq ($(filter $(FULL_TESTS),$(TEST)),)

--- a/builddefs/build_test.mk
+++ b/builddefs/build_test.mk
@@ -69,7 +69,7 @@ include $(QUANTUM_PATH)/os_detection/tests/rules.mk
 include $(QUANTUM_PATH)/sequencer/tests/rules.mk
 include $(QUANTUM_PATH)/wear_leveling/tests/rules.mk
 include modules/polykybd/polymod_ltr559/tests/rules.mk
-include keyboards/polykybd/base/tests/rules.mk
+include keyboards/polykybd/base/tests/test_rules.mk
 include $(QUANTUM_PATH)/logging/print.mk
 include $(PLATFORM_PATH)/test/rules.mk
 ifneq ($(filter $(FULL_TESTS),$(TEST)),)

--- a/builddefs/testlist.mk
+++ b/builddefs/testlist.mk
@@ -9,6 +9,7 @@ include $(QUANTUM_PATH)/sequencer/tests/testlist.mk
 include $(QUANTUM_PATH)/wear_leveling/tests/testlist.mk
 include $(PLATFORM_PATH)/test/testlist.mk
 include modules/polykybd/polymod_ltr559/tests/testlist.mk
+include keyboards/polykybd/base/tests/testlist.mk
 
 define VALIDATE_TEST_LIST
     ifneq ($1,)

--- a/keyboards/polykybd/base/fw_staging.c
+++ b/keyboards/polykybd/base/fw_staging.c
@@ -163,6 +163,7 @@ static uint16_t s_process_deferred_calls;     // every entry into process_deferr
 static uint16_t s_process_deferred_advances;  // every actual sector erase
 static uint32_t s_last_chunk_offset;
 static uint8_t  s_last_chunk_ack;
+static uint8_t  s_last_commit_ack;   // ack the slave's COMMIT handler last returned
 
 // ---------------------------------------------------------------------------
 // Helper: chain CRC32 over a large buffer in 60 000-byte chunks
@@ -236,6 +237,7 @@ void fw_staging_init(void) {
     // last-chunk fields so they only ever describe the most recent attempt.
     s_last_chunk_offset    = 0;
     s_last_chunk_ack       = 0;
+    s_last_commit_ack      = 0;
 #ifdef USE_CORE1
     s_core1_halted   = false;
 #endif
@@ -795,6 +797,7 @@ void fw_staging_get_status(fw_staging_status_t *out) {
     out->fw_up_active         = s_fw_up_active ? 1 : 0;
     out->erase_pending        = s_erase_pending ? 1 : 0;
     out->last_chunk_ack       = s_last_chunk_ack;
+    out->last_commit_ack      = s_last_commit_ack;
     out->erase_sector_next    = (uint16_t)s_erase_sector_next;
     out->erase_sector_count   = (uint16_t)s_erase_sector_count;
     out->next_offset          = s_next_offset;
@@ -820,6 +823,10 @@ void fw_staging_note_chunk_call(uint32_t offset, uint8_t ack) {
     if (ack != 0xCA /* SYNC_ACK */) {
         if (s_chunk_handler_errors != UINT16_MAX) s_chunk_handler_errors++;
     }
+}
+
+void fw_staging_note_commit_ack(uint8_t ack) {
+    s_last_commit_ack = ack;
 }
 
 void fw_staging_set_fw_up_active(bool active) {

--- a/keyboards/polykybd/base/fw_staging.c
+++ b/keyboards/polykybd/base/fw_staging.c
@@ -272,6 +272,13 @@ void fw_staging_begin_target(uint32_t image_size, uint32_t image_crc, uint8_t ta
     s_image_size = image_size;
     s_image_crc  = image_crc;
     s_fw_up_active = true;
+    // Per ATTEMPT, not per boot: fw_staging_init() runs once at keyboard_post_init,
+    // so clearing the verdict only there let a second flash in the same power cycle
+    // inherit the first one's. That matters because the master now READS this to
+    // classify a lost COMMIT ack — a stale refusal would turn a genuine link failure
+    // into a reported data rejection and cost a full re-stream instead of a free
+    // COMMIT retry, which is the exact case the probe exists to get right.
+    s_last_commit_ack = 0;
 
     // Erase the header sector (FIRMWARE only) then each data sector individually.
     // Re-enabling interrupts between sectors keeps USB/watchdog responsive
@@ -326,6 +333,13 @@ void fw_staging_begin_deferred_target(uint32_t image_size, uint32_t image_crc, u
     s_image_size = image_size;
     s_image_crc  = image_crc;
     s_fw_up_active = true;
+    // Per ATTEMPT, not per boot: fw_staging_init() runs once at keyboard_post_init,
+    // so clearing the verdict only there let a second flash in the same power cycle
+    // inherit the first one's. That matters because the master now READS this to
+    // classify a lost COMMIT ack — a stale refusal would turn a genuine link failure
+    // into a reported data rejection and cost a full re-stream instead of a free
+    // COMMIT retry, which is the exact case the probe exists to get right.
+    s_last_commit_ack = 0;
 
     uint32_t data_sectors   = (image_size + FLASH_SECTOR_SIZE - 1) / FLASH_SECTOR_SIZE;
     // FIRMWARE: index 0 = header sector, 1..N = data. FONTPACK: 0..N-1 = data (no header).

--- a/keyboards/polykybd/base/fw_staging.h
+++ b/keyboards/polykybd/base/fw_staging.h
@@ -245,7 +245,14 @@ typedef struct _fw_staging_status_t {
     uint16_t chunk_handler_errors;   // chunks that hit CRC mismatch / write fail
     uint16_t process_deferred_calls; // times fw_staging_process_deferred() entered
     uint16_t process_deferred_advances; // times a sector was actually erased
-    uint16_t pad;
+    // Last ack the slave's COMMIT handler returned (0 = it has never run one).
+    // This is what lets the master tell a REFUSAL from a lost acknowledgement when
+    // the COMMIT reply itself goes missing: fw_up_active is cleared by finalize
+    // either way, so it cannot distinguish them, but this records the verdict.
+    // Consumes half the old pad, so the struct size — and therefore the RPC reply
+    // size — is unchanged.
+    uint8_t  last_commit_ack;
+    uint8_t  pad;
 } fw_staging_status_t;
 
 // Fill `out` with the current internal state.  Safe to call from anywhere.
@@ -254,6 +261,9 @@ void fw_staging_get_status(fw_staging_status_t *out);
 // Counter / state mutators used by the split handlers in split_fw_up.c.
 void fw_staging_note_begin_call(void);
 void fw_staging_note_chunk_call(uint32_t offset, uint8_t ack);
+// Record the ack the slave's COMMIT handler is about to return, so a later STATUS
+// probe can report the verdict even if that reply never reached the master.
+void fw_staging_note_commit_ack(uint8_t ack);
 
 // Diagnostic helper used while bisecting the fw_up slave-hang bug
 // (see FW_UP_DEBUG_NOTES.md): set the s_fw_up_active flag without

--- a/keyboards/polykybd/base/fw_up_verdict.c
+++ b/keyboards/polykybd/base/fw_up_verdict.c
@@ -1,0 +1,40 @@
+// Copyright 2026 thpoll83
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "fw_up_verdict.h"
+
+#include "polymod_crc32.h"
+
+bool fw_up_commit_ack_is_self_describing(uint8_t slave_ack) {
+    return slave_ack == SYNC_NACK_REFUSED;
+}
+
+enum fw_up_commit_verdict fw_up_classify_commit_failure(uint8_t slave_ack, bool status_ok,
+                                                       uint8_t recorded_ack) {
+    // An explicit refusal is final. It must NOT be overridden by the probe: a
+    // snapshot can be stale, corrupt or unobtainable, and none of that makes the
+    // refusal we already received less true.
+    if (fw_up_commit_ack_is_self_describing(slave_ack)) {
+        return FW_UP_COMMIT_REFUSED;
+    }
+    // No trustworthy snapshot — fall back to the conservative reading. This is also
+    // the path for a slave too old to record a verdict, and it is never worse than
+    // the pre-probe behaviour: a retry of a genuinely bad image just fails again,
+    // whereas a wrong "refused" costs a full re-stream.
+    if (!status_ok) {
+        return FW_UP_COMMIT_LINK_FAILURE;
+    }
+    // The refusal ack itself was lost, but the slave wrote down what it answered.
+    if (recorded_ack == SYNC_NACK_REFUSED) {
+        return FW_UP_COMMIT_REFUSED;
+    }
+    // Anything else — an unset verdict (0, cleared at the start of this attempt) or
+    // a recorded SYNC_ACK (the slave committed and the ACK was lost) — is a link
+    // failure, and a link failure is free to retry.
+    return FW_UP_COMMIT_LINK_FAILURE;
+}
+
+bool fw_up_status_crc_ok(const fw_staging_status_t *status, uint32_t claimed_crc) {
+    if (!status) return false;
+    return crc32_1byte((const uint8_t *)status, sizeof(*status), 0) == claimed_crc;
+}

--- a/keyboards/polykybd/base/fw_up_verdict.h
+++ b/keyboards/polykybd/base/fw_up_verdict.h
@@ -1,0 +1,59 @@
+// Copyright 2026 thpoll83
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+// Pure DECISION layer for the flash-staging COMMIT outcome.
+//
+// The classification lived inline in split_fw_up.c's fw_up_slave_refused_commit(),
+// mixed in with the RPC call and its uprintf() lines. That made the one part with a
+// bug history — deciding whether a failed COMMIT means "the data is bad" or "the
+// answer got lost" — the one part no test could reach, because reaching it needed
+// the split transport, the keyboard config and a slave.
+//
+// So the decision moved here: no RPC, no logging, no globals. split_fw_up.c keeps
+// the I/O and the diagnostics and calls in for the verdict. This mirrors what the
+// host repo already does deliberately (polyhost/core/decisions.py,
+// decide_stale_bundles, classify_commit_reply) — pure seams so the decisions can be
+// tested; the firmware simply never had them.
+//
+// Depends on sync_ack.h + fw_staging.h (both dependency-free) and crc32_1byte.
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "sync_ack.h"
+#include "fw_staging.h"
+
+// Why a COMMIT that did not come back SYNC_ACK failed. The two need OPPOSITE
+// responses, which is the whole reason this distinction exists: re-flashing a
+// dropped ack wastes tens of KB over a busy link, and retrying genuinely bad data
+// just fails again.
+enum fw_up_commit_verdict {
+    FW_UP_COMMIT_REFUSED,       // the slave processed it and said no  -> re-flash
+    FW_UP_COMMIT_LINK_FAILURE,  // the answer never arrived            -> retry COMMIT (free)
+};
+
+// True when the ack byte alone settles it, so the caller must NOT spend a STATUS
+// RPC. A refusal is self-describing; SYNC_CRC32_ERR is the ambiguous one (it means
+// three different things — see sync_ack.h). Keeping this separate from the
+// classification below is what lets the caller short-circuit before doing I/O
+// inside raw_hid_receive(), which runs on the main loop.
+bool fw_up_commit_ack_is_self_describing(uint8_t slave_ack);
+
+// Classify a non-ACK COMMIT.
+//   slave_ack    — what came back (or SYNC_CRC32_ERR when send_to_bridge gave up)
+//   status_ok    — a CRC-VALID status snapshot was obtained from the slave
+//   recorded_ack — that snapshot's last_commit_ack (ignored when !status_ok)
+//
+// ⚠️ fw_up_active is deliberately NOT an input. finalize clears it whether it
+// succeeded or refused, so "cleared" is equally consistent with a refusal and with
+// a SUCCESS whose ack was lost in transit — treating that as a refusal turns the
+// common lost-ack case into a full re-stream. Only the recorded verdict can tell
+// them apart.
+enum fw_up_commit_verdict fw_up_classify_commit_failure(uint8_t slave_ack, bool status_ok,
+                                                        uint8_t recorded_ack);
+
+// The STATUS snapshot's own integrity check. A snapshot decides whether a flash
+// landed, so a corrupt one must be refused rather than believed — the reply rides
+// the same un-CRC'd link as everything else.
+bool fw_up_status_crc_ok(const fw_staging_status_t *status, uint32_t claimed_crc);

--- a/keyboards/polykybd/base/sync_ack.h
+++ b/keyboards/polykybd/base/sync_ack.h
@@ -1,0 +1,70 @@
+// Copyright 2026 thpoll83
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+// The split-link ACK VOCABULARY, on purpose in a header of its own.
+//
+// These four byte values plus sync_succeeded() are a protocol CONTRACT, not part
+// of the sync payload structs. They used to live in split_sync.h, which needs
+// config.h (BYTES_PER_SEGMENT), state.h (poly_sync_t) and mru.h (MRU_CAP) for its
+// struct definitions — so a caller that only wanted to ask "is this ack a
+// success?" had to drag in the entire keyboard configuration. That is why
+// sync_succeeded(), which guards every send_to_bridge() call site and is itself
+// the subject of a field bug (see the "never bool-test send_to_bridge()" note in
+// CLAUDE.md), had no unit test for years.
+//
+// This header depends on stdint/stdbool and nothing else, so the contract can be
+// tested standalone. split_sync.h includes it, so every existing consumer is
+// unchanged.
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#define SYNC_ACK_SIG    0b01001101
+#define SYNC_ACK        0b11001010
+#define SYNC_CRC32_ERR  0b00110101
+// The slave ANSWERED and refused the request (its own validation failed), as
+// opposed to SYNC_CRC32_ERR, which cannot say which of three things happened:
+//   * "still erasing"        — flash_stage_begin's re-poll state, a NORMAL state
+//                              hid_fw_up actually counts to log erase progress
+//   * "your frame arrived garbled" — a request-CRC mismatch, which SHOULD be retried
+//   * "no answer at all"     — send_to_bridge exhausting its retries
+// A refusal needs the opposite response from all three: re-flash, don't retry.
+// Collapsing it into SYNC_CRC32_ERR is why a font-pack COMMIT could tell the host
+// "retry me" for a half whose flash was genuinely bad. Do NOT repurpose
+// SYNC_CRC32_ERR for this — the begin re-poll depends on its existing meaning.
+//
+// The value is not arbitrary: the reply carries NO CRC (see the split-link notes in
+// CLAUDE.md), so these bytes are spaced by Hamming distance to survive a flipped
+// bit. 0xB2 is the complement of SYNC_ACK_SIG, making the set two complement pairs;
+// it ties for the best achievable min-distance (4) from all three existing values
+// and is balanced (popcount 4), unlike the equally-spaced 0x00/0xFF, which are
+// exactly what a stuck or floating line reads as.
+//
+// ⚠️ Adding a fifth value: keep the min pairwise Hamming distance at 4 or the
+// single-bit-error tolerance above degrades for the WHOLE set, silently. There are
+// 12 spare codewords that preserve it (0x00 and 0x1B among them, though avoid the
+// all-zero/all-one ones for the stuck-line reason above). SyncAckTest.
+// AckValuesStayHammingSpaced in base/tests/ enforces this — it is not advice.
+#define SYNC_NACK_REFUSED 0b10110010
+
+typedef struct _poly_sync_reply_t {
+    uint8_t ack;
+} poly_sync_reply_t;
+
+// send_to_bridge() returns the slave's reply ack byte, or SYNC_CRC32_ERR after
+// exhausting its retries. SYNC_NACK_REFUSED needs no case here — it is not an ACK,
+// so every existing "not ACK == failure" caller already treats it correctly; only a
+// caller that wants to tell a refusal from a link drop looks at it specifically.
+// ALL of SYNC_ACK / SYNC_ACK_SIG / SYNC_CRC32_ERR are
+// non-zero, so a bare truthiness test — `if(!send_to_bridge(...))` — is NOT a
+// failure check: it is false for the failure value too, so the caller would
+// treat a give-up as success and advance its global snapshot, never re-firing
+// the lost sync. Always classify the return through this helper.
+//
+// It is deliberately a WHITELIST (fail-closed): a new failure value is a failure
+// at all 14 existing call sites the moment it exists, with no edits. Never invert
+// it into a blacklist of known failures.
+static inline bool sync_succeeded(uint8_t ack) {
+    return ack == SYNC_ACK || ack == SYNC_ACK_SIG;
+}

--- a/keyboards/polykybd/base/tests/fw_up_verdict_tests.cpp
+++ b/keyboards/polykybd/base/tests/fw_up_verdict_tests.cpp
@@ -1,0 +1,244 @@
+// Copyright 2026 thpoll83
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// Unit tests for the flash-staging COMMIT decision layer.
+//
+// Why these exist: the host side has had this contract under test for a while
+// (PolyKybdHost tests/device/hid_fontpack_test.py — classify_commit_reply, the
+// retry/no-retry behaviour per status). But those tests encode the firmware's reply
+// bytes as FIXTURES, so they can only catch the HOST misreading a status. They can
+// never catch this end EMITTING the wrong one — and "emitting the wrong one" is
+// exactly the bug that shipped: a dropped split-link ACK reported as a CRC mismatch,
+// which sent a field diagnosis the wrong way for two rounds (2026-08-17).
+//
+// So the same contract is now pinned from both ends.
+
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "sync_ack.h"
+#include "fw_staging.h"
+#include "fw_up_verdict.h"
+#include "hid_fontpack.h"
+#include "polymod_crc32.h"
+}
+
+namespace {
+
+// Every ack value the split link can put in poly_sync_reply_t.
+const uint8_t kAllAcks[] = {SYNC_ACK, SYNC_ACK_SIG, SYNC_CRC32_ERR, SYNC_NACK_REFUSED};
+
+int popcount8(uint8_t v) {
+    int n = 0;
+    for (int i = 0; i < 8; i++) n += (v >> i) & 1;
+    return n;
+}
+
+int hamming(uint8_t a, uint8_t b) { return popcount8((uint8_t)(a ^ b)); }
+
+fw_staging_status_t crc_stamped(fw_staging_status_t s, uint32_t *out_crc) {
+    *out_crc = crc32_1byte((const uint8_t *)&s, sizeof(s), 0);
+    return s;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// The ack vocabulary itself (base/sync_ack.h)
+// ---------------------------------------------------------------------------
+
+TEST(SyncAckTest, SyncSucceededAcceptsExactlyTheTwoAcks) {
+    EXPECT_TRUE(sync_succeeded(SYNC_ACK));
+    EXPECT_TRUE(sync_succeeded(SYNC_ACK_SIG));
+    EXPECT_FALSE(sync_succeeded(SYNC_CRC32_ERR));
+    EXPECT_FALSE(sync_succeeded(SYNC_NACK_REFUSED));
+}
+
+// The helper must be a WHITELIST, not a blacklist of known failures. That property
+// is what let SYNC_NACK_REFUSED be introduced without touching any of the 14
+// existing "not ACK == failure" call sites: a new value is a failure the moment it
+// exists. Sweeping all 256 bytes is what distinguishes the two implementations.
+TEST(SyncAckTest, SyncSucceededIsFailClosedAcrossEveryByte) {
+    for (int v = 0; v <= 0xFF; v++) {
+        uint8_t ack      = (uint8_t)v;
+        bool    expected = (ack == SYNC_ACK || ack == SYNC_ACK_SIG);
+        EXPECT_EQ(sync_succeeded(ack), expected) << "ack=0x" << std::hex << v;
+    }
+}
+
+// The reply carries NO CRC, so the ack values are deliberately spaced to survive a
+// flipped bit. This is documented in sync_ack.h; the test makes it enforceable, so a
+// fifth value cannot silently degrade the tolerance for the whole set.
+TEST(SyncAckTest, AckValuesStayHammingSpaced) {
+    const size_t n = sizeof(kAllAcks) / sizeof(kAllAcks[0]);
+    for (size_t i = 0; i < n; i++) {
+        for (size_t j = i + 1; j < n; j++) {
+            EXPECT_GE(hamming(kAllAcks[i], kAllAcks[j]), 4)
+                << "0x" << std::hex << (int)kAllAcks[i] << " vs 0x" << (int)kAllAcks[j]
+                << " — a new ack value must keep the min pairwise distance at 4";
+        }
+    }
+}
+
+// 0x00 and 0xFF are what a stuck-low or floating line reads as, so they must never
+// be a meaningful ack however well-spaced they are.
+TEST(SyncAckTest, NoAckValueIsAStuckLineReading) {
+    for (uint8_t ack : kAllAcks) {
+        EXPECT_NE(ack, 0x00);
+        EXPECT_NE(ack, 0xFF);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The COMMIT-failure classification (base/fw_up_verdict.c)
+// ---------------------------------------------------------------------------
+
+TEST(FwUpVerdictTest, OnlyARefusalAckIsSelfDescribing) {
+    EXPECT_TRUE(fw_up_commit_ack_is_self_describing(SYNC_NACK_REFUSED));
+    // SYNC_CRC32_ERR means three different things, so it settles nothing — this is
+    // what makes the caller spend a STATUS probe.
+    EXPECT_FALSE(fw_up_commit_ack_is_self_describing(SYNC_CRC32_ERR));
+    EXPECT_FALSE(fw_up_commit_ack_is_self_describing(SYNC_ACK));
+}
+
+// An explicit refusal must not be second-guessed by the probe: a snapshot can be
+// stale, corrupt or unobtainable, and none of that makes the refusal we already
+// received less true.
+TEST(FwUpVerdictTest, ExplicitRefusalWinsOverEveryProbeResult) {
+    EXPECT_EQ(fw_up_classify_commit_failure(SYNC_NACK_REFUSED, true, SYNC_NACK_REFUSED),
+              FW_UP_COMMIT_REFUSED);
+    EXPECT_EQ(fw_up_classify_commit_failure(SYNC_NACK_REFUSED, true, SYNC_ACK),
+              FW_UP_COMMIT_REFUSED);
+    EXPECT_EQ(fw_up_classify_commit_failure(SYNC_NACK_REFUSED, true, 0), FW_UP_COMMIT_REFUSED);
+    EXPECT_EQ(fw_up_classify_commit_failure(SYNC_NACK_REFUSED, false, 0), FW_UP_COMMIT_REFUSED);
+}
+
+// The case the whole last_commit_ack field exists for: the slave answered "no", that
+// answer was lost on the wire, and only its recorded verdict can still say so.
+TEST(FwUpVerdictTest, LostRefusalAckIsRecoveredFromTheRecordedVerdict) {
+    EXPECT_EQ(fw_up_classify_commit_failure(SYNC_CRC32_ERR, true, SYNC_NACK_REFUSED),
+              FW_UP_COMMIT_REFUSED);
+}
+
+// The expensive mistake to avoid. The verdict is cleared at the start of every
+// staging attempt, so 0 means "the slave's COMMIT handler never ran this attempt" —
+// a link failure, and retrying COMMIT is free. Calling this a refusal costs a full
+// re-stream of the pack over the very link that just dropped a frame.
+TEST(FwUpVerdictTest, ClearedVerdictIsARetryableLinkFailure) {
+    EXPECT_EQ(fw_up_classify_commit_failure(SYNC_CRC32_ERR, true, 0), FW_UP_COMMIT_LINK_FAILURE);
+}
+
+// A SUCCESS whose ack was lost in transit. fw_up_active is cleared by finalize on
+// both success and refusal, which is precisely why it is not an input here.
+TEST(FwUpVerdictTest, LostSuccessAckIsARetryableLinkFailure) {
+    EXPECT_EQ(fw_up_classify_commit_failure(SYNC_CRC32_ERR, true, SYNC_ACK),
+              FW_UP_COMMIT_LINK_FAILURE);
+}
+
+// !status_ok must make the recorded value unreadable, not merely unlikely — the
+// snapshot is zeroed/garbage when the RPC or its CRC failed, so trusting a byte out
+// of it would invent a verdict.
+TEST(FwUpVerdictTest, AFailedProbeIgnoresTheRecordedVerdictEntirely) {
+    EXPECT_EQ(fw_up_classify_commit_failure(SYNC_CRC32_ERR, false, SYNC_NACK_REFUSED),
+              FW_UP_COMMIT_LINK_FAILURE);
+    EXPECT_EQ(fw_up_classify_commit_failure(SYNC_CRC32_ERR, false, 0), FW_UP_COMMIT_LINK_FAILURE);
+}
+
+// Backward compatibility: a slave too old to record a verdict answers with the field
+// as 0, which must degrade to the conservative reading rather than to a refusal.
+TEST(FwUpVerdictTest, ASlaveThatRecordsNoVerdictDegradesToLinkFailure) {
+    fw_staging_status_t old_slave = {};   // every field zero, as an older reply reads
+    EXPECT_EQ(fw_up_classify_commit_failure(SYNC_CRC32_ERR, true, old_slave.last_commit_ack),
+              FW_UP_COMMIT_LINK_FAILURE);
+}
+
+// ---------------------------------------------------------------------------
+// The STATUS snapshot integrity check
+// ---------------------------------------------------------------------------
+
+TEST(FwUpStatusCrcTest, AValidSnapshotPasses) {
+    fw_staging_status_t s = {};
+    s.fw_up_active        = true;
+    s.next_offset         = 38632;
+    s.last_commit_ack     = SYNC_NACK_REFUSED;
+    uint32_t crc          = 0;
+    s                     = crc_stamped(s, &crc);
+    EXPECT_TRUE(fw_up_status_crc_ok(&s, crc));
+}
+
+// A snapshot decides whether a flash landed, so a corrupt one must be refused rather
+// than believed — it rides the same un-CRC'd link as everything else.
+TEST(FwUpStatusCrcTest, AFlippedBitInTheSnapshotFails) {
+    fw_staging_status_t s = {};
+    s.next_offset         = 38632;
+    s.last_commit_ack     = SYNC_ACK;
+    uint32_t crc          = 0;
+    s                     = crc_stamped(s, &crc);
+
+    s.last_commit_ack = SYNC_NACK_REFUSED;   // the one field the decision reads
+    EXPECT_FALSE(fw_up_status_crc_ok(&s, crc));
+}
+
+TEST(FwUpStatusCrcTest, AWrongClaimedCrcFails) {
+    fw_staging_status_t s   = {};
+    uint32_t            crc = 0;
+    s                       = crc_stamped(s, &crc);
+    EXPECT_FALSE(fw_up_status_crc_ok(&s, crc ^ 1u));
+}
+
+TEST(FwUpStatusCrcTest, ANullSnapshotFails) {
+    EXPECT_FALSE(fw_up_status_crc_ok(nullptr, 0));
+}
+
+// ---------------------------------------------------------------------------
+// The font-pack COMMIT status byte (the host-visible half of the contract)
+// ---------------------------------------------------------------------------
+
+TEST(FontpackCommitStatusTest, BothHalvesOkIsDot) {
+    EXPECT_EQ(fontpack_commit_status(true, true, false), FONTPACK_COMMIT_OK);
+}
+
+// A master rejection outranks everything, including a perfectly healthy slave: there
+// is no point telling the host to retry a half whose own copy is bad.
+TEST(FontpackCommitStatusTest, MasterRejectionIsRejectedRegardlessOfTheSlave) {
+    EXPECT_EQ(fontpack_commit_status(false, true, false), FONTPACK_COMMIT_REJECTED);
+    EXPECT_EQ(fontpack_commit_status(false, false, false), FONTPACK_COMMIT_REJECTED);
+    EXPECT_EQ(fontpack_commit_status(false, false, true), FONTPACK_COMMIT_REJECTED);
+}
+
+TEST(FontpackCommitStatusTest, SlaveRefusalIsRejectedNotUnconfirmed) {
+    EXPECT_EQ(fontpack_commit_status(true, false, true), FONTPACK_COMMIT_REJECTED);
+}
+
+// The status that started all of this: the master's copy is live and only the
+// acknowledgement was lost, so the host must retry COMMIT rather than re-stream.
+TEST(FontpackCommitStatusTest, LostSlaveAckIsNoSlave) {
+    EXPECT_EQ(fontpack_commit_status(true, false, false), FONTPACK_COMMIT_NO_SLAVE);
+}
+
+// Collapsing these back into one failure byte is the regression this guards: it is
+// what made a perfect pack read as corrupt.
+TEST(FontpackCommitStatusTest, TheThreeStatusesAreDistinct) {
+    EXPECT_NE(FONTPACK_COMMIT_OK, FONTPACK_COMMIT_REJECTED);
+    EXPECT_NE(FONTPACK_COMMIT_OK, FONTPACK_COMMIT_NO_SLAVE);
+    EXPECT_NE(FONTPACK_COMMIT_REJECTED, FONTPACK_COMMIT_NO_SLAVE);
+    // '!' is the legacy collapsed value; a new status must not reuse it, since a new
+    // host maps it to "unspecified".
+    EXPECT_NE(FONTPACK_COMMIT_REJECTED, '!');
+    EXPECT_NE(FONTPACK_COMMIT_NO_SLAVE, '!');
+}
+
+// A status letter that is a hex digit cannot be written next to a \xNN escape:
+// "P\x52C" is the single escape \x52C, not three bytes. The reply is built from
+// constants now, so this is a guard against anyone going back to a literal.
+TEST(FontpackCommitStatusTest, StatusBytesAreSafeInAStringLiteral) {
+    for (uint8_t st : {(uint8_t)FONTPACK_COMMIT_OK, (uint8_t)FONTPACK_COMMIT_REJECTED,
+                       (uint8_t)FONTPACK_COMMIT_NO_SLAVE}) {
+        EXPECT_GE(st, 0x21) << "must be printable in a log";
+        EXPECT_LE(st, 0x7E);
+        bool hex_digit = (st >= '0' && st <= '9') || (st >= 'a' && st <= 'f') ||
+                         (st >= 'A' && st <= 'F');
+        EXPECT_FALSE(hex_digit) << "0x" << std::hex << (int)st
+                                << " would merge into a preceding \\xNN escape";
+    }
+}

--- a/keyboards/polykybd/base/tests/rules.mk
+++ b/keyboards/polykybd/base/tests/rules.mk
@@ -1,0 +1,17 @@
+POLY_BASE_PATH   := keyboards/polykybd/base
+POLY_CRC32_PATH  := modules/polykybd/polymod_crc32
+
+# The decision layer is deliberately dependency-free apart from crc32, so this links
+# without the keyboard config, the split transport or a display — that decoupling IS
+# the reason the tests can exist (see the header comments in fw_up_verdict.h).
+# No timer needed: nothing here reads the clock, so platforms/timer.c is not listed.
+fw_up_verdict_SRC := \
+	$(POLY_BASE_PATH)/fw_up_verdict.c \
+	$(POLY_CRC32_PATH)/polymod_crc32.c \
+	$(POLY_BASE_PATH)/tests/fw_up_verdict_tests.cpp
+
+fw_up_verdict_INC := \
+	$(POLY_BASE_PATH) \
+	$(POLY_BASE_PATH)/tests \
+	$(POLY_CRC32_PATH) \
+	keyboards/polykybd

--- a/keyboards/polykybd/base/tests/test_rules.mk
+++ b/keyboards/polykybd/base/tests/test_rules.mk
@@ -1,3 +1,10 @@
+# ⚠️ This file is deliberately NOT called rules.mk, and renaming it back breaks CI.
+# qmk ci-validate-keyboard-targets globs `keyboards/**/rules.mk` and treats every hit
+# as a keyboard unless the path contains a directory named keymaps, common or lib —
+# there is no exemption for tests, because upstream keeps none under keyboards/. So a
+# rules.mk here fails the lint job with "keyboards/polykybd/base/tests::Legacy target
+# detected". The include in builddefs/build_test.mk names this file explicitly, so the
+# name is free.
 POLY_BASE_PATH   := keyboards/polykybd/base
 POLY_CRC32_PATH  := modules/polykybd/polymod_crc32
 

--- a/keyboards/polykybd/base/tests/testlist.mk
+++ b/keyboards/polykybd/base/tests/testlist.mk
@@ -1,0 +1,1 @@
+TEST_LIST += fw_up_verdict

--- a/keyboards/polykybd/hid_fontpack.c
+++ b/keyboards/polykybd/hid_fontpack.c
@@ -203,9 +203,7 @@ bool hid_fontpack_receive(uint8_t *data, uint8_t length) {
             // inside raw_hid_receive(), which runs on the main loop.
             bool slave_refused = !slave_ok && master_ok &&
                                  fw_up_slave_refused_commit(slave_ack, "FONTPACK_COMMIT");
-            uint8_t status = ok                            ? FONTPACK_COMMIT_OK
-                           : (!master_ok || slave_refused) ? FONTPACK_COMMIT_REJECTED
-                                                           : FONTPACK_COMMIT_NO_SLAVE;
+            uint8_t status = fontpack_commit_status(master_ok, slave_ok, slave_refused);
             memset(data, 0, length);
             fontpack_reply_status(data, CMD_FONTPACK_COMMIT, status);
             // Report the slot's content_version whenever the MASTER's copy is live —

--- a/keyboards/polykybd/hid_fontpack.c
+++ b/keyboards/polykybd/hid_fontpack.c
@@ -174,7 +174,8 @@ bool hid_fontpack_receive(uint8_t *data, uint8_t length) {
             bool master_ok = fw_staging_finalize();   // FONTPACK target: verifies CRC + fontpack_reload()
             bool is_doom = s_fontpack_bundle == FONTPACK_BUNDLE_DOOMWAD ||
                            s_fontpack_bundle == FONTPACK_BUNDLE_DOOMPACK;
-            bool ok = (slave_ack == SYNC_ACK) && master_ok;
+            bool slave_ok = (slave_ack == SYNC_ACK);
+            bool ok = slave_ok && master_ok;
 
             // THREE distinct statuses, not one '!'. A dropped split-link ACK and a
             // staged-CRC mismatch are opposite events with opposite remedies, and
@@ -188,14 +189,23 @@ bool hid_fontpack_receive(uint8_t *data, uint8_t length) {
             //   'R' the MASTER's finalize REJECTED the image (staged CRC mismatch, or
             //       the flashed slot did not load as a valid PlyF) — a real data
             //       problem; the host must re-flash.
-            //   'L' the master committed but the slave did not ACK within the bridge's
-            //       retries (a LINK failure). The master's copy is live and correct;
-            //       re-sending COMMIT is free (finalize leaves s_staged_crc/s_image_crc
-            //       and the write cursor untouched, and the slave's flash_stage_commit
-            //       is likewise idempotent), so the host retries rather than re-streams.
-            uint8_t status = ok         ? FONTPACK_COMMIT_OK
-                           : !master_ok ? FONTPACK_COMMIT_REJECTED
-                                        : FONTPACK_COMMIT_NO_SLAVE;
+            //   'L' the master committed but the slave did not ANSWER within the
+            //       bridge's retries (a LINK failure). The master's copy is live and
+            //       correct; re-sending COMMIT is free (finalize leaves
+            //       s_staged_crc/s_image_crc and the write cursor untouched, and the
+            //       slave's flash_stage_commit is likewise idempotent), so the host
+            //       retries rather than re-streams. A slave that ANSWERED and refused
+            //       is NOT this case — it is 'R', because retrying cannot change what
+            //       is in that half's flash.
+            // Only ask the slave when its answer is genuinely ambiguous: a refusal ack
+            // is self-describing, and if the MASTER already rejected the image the
+            // status is 'R' regardless — so short-circuit rather than spend an RPC
+            // inside raw_hid_receive(), which runs on the main loop.
+            bool slave_refused = !slave_ok && master_ok &&
+                                 fw_up_slave_refused_commit(slave_ack, "FONTPACK_COMMIT");
+            uint8_t status = ok                            ? FONTPACK_COMMIT_OK
+                           : (!master_ok || slave_refused) ? FONTPACK_COMMIT_REJECTED
+                                                           : FONTPACK_COMMIT_NO_SLAVE;
             memset(data, 0, length);
             fontpack_reply_status(data, CMD_FONTPACK_COMMIT, status);
             // Report the slot's content_version whenever the MASTER's copy is live —
@@ -206,8 +216,9 @@ bool hid_fontpack_receive(uint8_t *data, uint8_t length) {
                 memcpy(&data[3], &cver, 2);
             }
             const char *outcome = ok ? (is_doom ? "installed" : "live")
-                                     : (!master_ok ? "REJECTED (master finalize)"
-                                                   : "UNCONFIRMED (slave ACK lost)");
+                                     : !master_ok    ? "REJECTED (master finalize)"
+                                     : slave_refused ? "REJECTED (slave refused)"
+                                                     : "UNCONFIRMED (slave ACK lost)";
             if (is_doom) {
                 uprintf("FONTPACK_COMMIT: %s slave=0x%02x master=%d -> %s\n",
                         s_fontpack_bundle == FONTPACK_BUNDLE_DOOMWAD ? "DOOMWAD" : "DOOMPACK",

--- a/keyboards/polykybd/hid_fontpack.h
+++ b/keyboards/polykybd/hid_fontpack.h
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 #pragma once
 
-#include "quantum.h"
+// stdint/stdbool only — deliberately NOT quantum.h. Nothing here needs it (the one
+// declaration below uses uint8_t and bool), and keeping the header standalone is what
+// lets the COMMIT status contract be unit-tested without the keyboard config. The
+// host's classify_commit_reply() tests the same contract from its side; a firmware
+// test is what catches this end EMITTING the wrong byte, which a host fixture cannot.
+#include <stdint.h>
+#include <stdbool.h>
 
 // HID font-pack command IDs (command byte in the HID report). Parallel to the
 // firmware-update commands (0x40–0x44) but target the external-flash font pack.
@@ -38,6 +44,23 @@
 // predates them answers '!', which a new host treats as "unspecified" — so the pair
 // degrades gracefully in both directions and needs no PROTOCOL_VERSION bump (the
 // font-pack commands are dispatched independently of it).
+// Pick the COMMIT status byte. Pure, so the host↔firmware contract is testable from
+// this end too (base/tests/fw_up_verdict_tests.cpp).
+//   master_ok     — the master's own finalize accepted the image
+//   slave_ok      — the slave answered SYNC_ACK
+//   slave_refused — the slave answered/recorded a REFUSAL. Only meaningful when
+//                   !slave_ok && master_ok; the caller passes false otherwise,
+//                   because it deliberately does NOT spend a STATUS RPC when the
+//                   master already rejected the image (the answer is 'R' either way)
+//                   or when the ack is self-describing.
+// ⚠️ A master rejection outranks everything: there is no point telling the host to
+// retry a half whose own copy is bad.
+static inline uint8_t fontpack_commit_status(bool master_ok, bool slave_ok, bool slave_refused) {
+    if (master_ok && slave_ok)      return FONTPACK_COMMIT_OK;
+    if (!master_ok || slave_refused) return FONTPACK_COMMIT_REJECTED;
+    return FONTPACK_COMMIT_NO_SLAVE;
+}
+
 #define CMD_FONTPACK_STATUS  0x53  // reply: [3]=present [4]=abi [5..6]=content_version [7]=font_count
 
 // Handle HID font-pack commands (0x50–0x53). Called from raw_hid_receive() when

--- a/keyboards/polykybd/hid_fw_up.c
+++ b/keyboards/polykybd/hid_fw_up.c
@@ -24,33 +24,9 @@
 // first reports ready) so we can tell from the master serial log whether
 // the slave is alive at all, whether the chunk handler ran, and what its
 // next_offset / counters look like.  See FW_UP_DEBUG_NOTES.md.
-static void fw_up_log_slave_status(const char *tag) {
-    fw_up_status_request_t req = { .crc32 = 0, .op = FLASH_STAGE_STATUS, .dummy = 0 };
-    fw_up_status_reply_t   reply;
-    memset(&reply, 0, sizeof(reply));
-    // Use transaction_rpc_exec directly — send_to_bridge hardcodes the
-    // 1-byte poly_sync_reply_t and can't carry our bigger status struct.
-    bool ok = transaction_rpc_exec(USER_SYNC_FLASH_STAGE,
-                                   sizeof(req), &req,
-                                   sizeof(reply), &reply);
-    if (!ok) {
-        uprintf("slave status (%s): RPC FAILED — slave unresponsive\n", tag);
-        return;
-    }
-    const fw_staging_status_t *s = &reply.status;
-    uprintf("slave status (%s): init=%u active=%u erase_pending=%u erase=%u/%u "
-            "next_off=%lu begin_calls=%u chunk_calls=%u chunk_errs=%u "
-            "last_chunk_off=%lu last_ack=0x%02x pd_calls=%u pd_advances=%u\n",
-            tag,
-            (unsigned)s->initialized, (unsigned)s->fw_up_active, (unsigned)s->erase_pending,
-            (unsigned)s->erase_sector_next, (unsigned)s->erase_sector_count,
-            (unsigned long)s->next_offset,
-            (unsigned)s->begin_handler_calls, (unsigned)s->chunk_handler_calls,
-            (unsigned)s->chunk_handler_errors,
-            (unsigned long)s->last_chunk_offset, (unsigned)s->last_chunk_ack,
-            (unsigned)s->process_deferred_calls,
-            (unsigned)s->process_deferred_advances);
-}
+// fw_up_log_slave_status() and the STATUS probe behind it now live in
+// split_fw_up.c, shared with the font-pack COMMIT path (which needs the same
+// probe to tell a slave refusal from a dropped acknowledgement).
 
 bool hid_fw_up_receive(uint8_t *data, uint8_t length) {
     switch (data[1]) {
@@ -285,6 +261,13 @@ bool hid_fw_up_receive(uint8_t *data, uint8_t length) {
                                                      sizeof(commit_msg), 10);
             bool master_ok = fw_staging_finalize();   // also clears fw_up_active + restarts master core1
             bool ok = (slave_ack == SYNC_ACK) && master_ok;
+            // The firmware-update COMMIT keeps its four statuses (a fifth for "the
+            // slave refused" would need a matching host change), but the distinction
+            // is now at least DIAGNOSABLE: this logs whether a non-ACK slave really
+            // refused or just lost its answer, which the single '!' cannot say.
+            if (!ok && slave_ack != SYNC_ACK && !fw_staging_awaiting_confirm()) {
+                (void)fw_up_slave_refused_commit(slave_ack, "FW_UP_COMMIT");
+            }
             memset(data, 0, length);
             // Four outcomes, not two. '?' means "waiting for the user to confirm an
             // unsigned image on the keyboard" (re-poll me); 'S' distinguishes

--- a/keyboards/polykybd/rules.mk
+++ b/keyboards/polykybd/rules.mk
@@ -69,7 +69,12 @@ OS_DETECTION_ENABLE = yes
 # poly_keymap.c holds the shared keymap logic compiled for every variant
 # (split72, split42). Each variant's keymaps/default/keymap.c carries only its
 # data (keymaps[] / encoder_map[] / g_led_config).
-POLY_SRC := poly_keymap.c boot_diag.c side.c state.c split_sync.c split_fw_up.c multicore_exec.c hid_com.c hid_fw_up.c hid_fontpack.c fill_overlay.c poly_util.c matrix_helper.c bridge_helper.c oled_helper.c keycode_helper.c mru.c lang_layer.c os_actions.c anim/startup_anim.c
+# base/fw_up_verdict.c is listed HERE, not in the per-variant rules.mk where the other
+# base/*.c sources live: its consumer (split_fw_up.c) is in this shared list, so a
+# variant that forgot the line would simply fail to link — exactly the split72/split42
+# drift the shared keymap exists to prevent. It also gets the strict PolyKybd warning
+# flags applied below, which the per-variant base sources do not.
+POLY_SRC := poly_keymap.c boot_diag.c side.c state.c split_sync.c split_fw_up.c multicore_exec.c hid_com.c hid_fw_up.c hid_fontpack.c fill_overlay.c poly_util.c matrix_helper.c bridge_helper.c oled_helper.c keycode_helper.c mru.c lang_layer.c os_actions.c anim/startup_anim.c base/fw_up_verdict.c
 SRC += $(POLY_SRC)
 
 # Extra compiler warnings for the PolyKybd (non-QMK-core) sources ONLY. QMK already

--- a/keyboards/polykybd/split_fw_up.c
+++ b/keyboards/polykybd/split_fw_up.c
@@ -221,7 +221,99 @@ static void flash_stage_commit(uint8_t in_len, const void* in_data, uint8_t out_
     // window, so the master timed out and mis-reported COMMIT as a CRC failure
     // even though the pack loaded. Firmware-target finalize is O(1) (unaffected).
     bool ok = fw_staging_finalize_defer_reload();
-    ((poly_sync_reply_t *)out_data)->ack = ok ? SYNC_ACK : SYNC_CRC32_ERR;
+    // A refusal gets SYNC_NACK_REFUSED, NOT SYNC_CRC32_ERR. We answered and the
+    // answer is "no": the master must re-flash, whereas SYNC_CRC32_ERR asks it to
+    // retry — which for a genuinely bad staged image just fails again. The garbled
+    // request above keeps SYNC_CRC32_ERR, because there a retry is exactly right.
+    uint8_t ack = ok ? SYNC_ACK : SYNC_NACK_REFUSED;
+    // Recorded so a STATUS probe can still report this verdict if the reply below
+    // never reaches the master (the case that made the two indistinguishable).
+    fw_staging_note_commit_ack(ack);
+    ((poly_sync_reply_t *)out_data)->ack = ack;
+}
+
+// Read-only STATUS probe of the other half (master side). Returns false when the
+// RPC fails or the reply's own CRC does not check out — a corrupted snapshot must
+// not be believed, since the caller uses it to decide whether a flash landed.
+//
+// Uses transaction_rpc_exec directly: send_to_bridge hardcodes the 1-byte
+// poly_sync_reply_t and cannot carry this bigger struct.
+// The bare RPC. Split out so the logger can still PRINT a snapshot whose CRC does
+// not check out (labelled as suspect) while the decision path below refuses it — a
+// corrupt snapshot is worth seeing but must never be acted on.
+static bool fetch_slave_status(fw_up_status_reply_t *reply) {
+    fw_up_status_request_t req = { .crc32 = 0, .op = FLASH_STAGE_STATUS, .dummy = 0 };
+    memset(reply, 0, sizeof(*reply));
+    return transaction_rpc_exec(USER_SYNC_FLASH_STAGE, sizeof(req), &req, sizeof(*reply), reply);
+}
+
+static bool slave_status_crc_ok(const fw_up_status_reply_t *reply) {
+    return crc32_1byte((const uint8_t *)&reply->status, sizeof(reply->status), 0) == reply->crc32;
+}
+
+bool fw_up_query_slave_status(fw_staging_status_t *out) {
+    if (!out) return false;
+    fw_up_status_reply_t reply;
+    if (!fetch_slave_status(&reply) || !slave_status_crc_ok(&reply)) return false;
+    *out = reply.status;
+    return true;
+}
+
+void fw_up_log_slave_status(const char *tag) {
+    fw_up_status_reply_t reply;
+    if (!fetch_slave_status(&reply)) {
+        uprintf("slave status (%s): RPC FAILED — slave unresponsive\n", tag);
+        return;
+    }
+    // Printed either way; the tag says whether to trust the numbers.
+    const char *suspect = slave_status_crc_ok(&reply) ? "" : " [CRC BAD — values suspect]";
+    const fw_staging_status_t s = reply.status;
+    uprintf("slave status (%s): init=%u active=%u erase_pending=%u erase=%u/%u "
+            "next_off=%lu begin_calls=%u chunk_calls=%u chunk_errs=%u "
+            "last_chunk_off=%lu last_ack=0x%02x last_commit_ack=0x%02x "
+            "pd_calls=%u pd_advances=%u%s\n",
+            tag,
+            (unsigned)s.initialized, (unsigned)s.fw_up_active, (unsigned)s.erase_pending,
+            (unsigned)s.erase_sector_next, (unsigned)s.erase_sector_count,
+            (unsigned long)s.next_offset,
+            (unsigned)s.begin_handler_calls, (unsigned)s.chunk_handler_calls,
+            (unsigned)s.chunk_handler_errors,
+            (unsigned long)s.last_chunk_offset, (unsigned)s.last_chunk_ack,
+            (unsigned)s.last_commit_ack,
+            (unsigned)s.process_deferred_calls, (unsigned)s.process_deferred_advances, suspect);
+}
+
+// Classify a non-ACK COMMIT ack, asking the slave directly when the ack itself is
+// ambiguous. Returns true when the slave REFUSED (a data failure: re-flash), false
+// when this looks like a link failure (retrying the COMMIT is free and usually works).
+//
+// ⚠️ fw_up_active is NOT a usable discriminator on its own: finalize clears it
+// whether it succeeded or refused, so "cleared" is equally consistent with a
+// refusal and with a SUCCESS whose ack was lost in transit. Treating that as a
+// refusal would turn the common lost-ack case — which a single free COMMIT retry
+// fixes — into a full re-stream of the pack. So we read the recorded verdict.
+bool fw_up_slave_refused_commit(uint8_t slave_ack, const char *tag) {
+    if (slave_ack == SYNC_NACK_REFUSED) {
+        uprintf("%s: slave REFUSED (ack=0x%02x) -> data failure\n", tag, slave_ack);
+        return true;
+    }
+    fw_staging_status_t s;
+    if (!fw_up_query_slave_status(&s)) {
+        uprintf("%s: slave ack=0x%02x and the status probe failed too "
+                "-> assuming link failure\n", tag, slave_ack);
+        return false;
+    }
+    if (s.last_commit_ack == SYNC_NACK_REFUSED) {
+        uprintf("%s: slave ack=0x%02x lost, but its recorded verdict is REFUSED "
+                "(last_commit_ack=0x%02x) -> data failure\n",
+                tag, slave_ack, (unsigned)s.last_commit_ack);
+        return true;
+    }
+    uprintf("%s: slave ack=0x%02x, recorded verdict 0x%02x (active=%u next_off=%lu) "
+            "-> link failure, COMMIT is safe to retry\n",
+            tag, slave_ack, (unsigned)s.last_commit_ack,
+            (unsigned)s.fw_up_active, (unsigned long)s.next_offset);
+    return false;
 }
 
 // Single slave-side dispatcher for the flash-staging stream.  Reads the `op`

--- a/keyboards/polykybd/split_fw_up.c
+++ b/keyboards/polykybd/split_fw_up.c
@@ -6,6 +6,7 @@
 #include "polymod_crc32.h"
 #include "base/fw_staging.h"   // fw_staging_set_fontpack_slot
 #include "base/fontpack.h"     // fontpack_slot, FW_TARGET_FONTPACK via fw_staging.h
+#include "base/fw_up_verdict.h"  // pure COMMIT-failure classification (unit-tested)
 
 #include <transactions.h>
 #include <print.h>
@@ -248,7 +249,7 @@ static bool fetch_slave_status(fw_up_status_reply_t *reply) {
 }
 
 static bool slave_status_crc_ok(const fw_up_status_reply_t *reply) {
-    return crc32_1byte((const uint8_t *)&reply->status, sizeof(reply->status), 0) == reply->crc32;
+    return fw_up_status_crc_ok(&reply->status, reply->crc32);
 }
 
 bool fw_up_query_slave_status(fw_staging_status_t *out) {
@@ -292,28 +293,35 @@ void fw_up_log_slave_status(const char *tag) {
 // refusal and with a SUCCESS whose ack was lost in transit. Treating that as a
 // refusal would turn the common lost-ack case — which a single free COMMIT retry
 // fixes — into a full re-stream of the pack. So we read the recorded verdict.
+// The DECISION itself is fw_up_classify_commit_failure() in base/fw_up_verdict.c —
+// pure and unit-tested (base/tests/fw_up_verdict_tests.cpp). What stays here is the
+// I/O the decision needs and the diagnostics a field log is read from.
 bool fw_up_slave_refused_commit(uint8_t slave_ack, const char *tag) {
-    if (slave_ack == SYNC_NACK_REFUSED) {
+    // Short-circuit before any RPC: a refusal is self-describing, and this runs
+    // inside raw_hid_receive() on the main loop.
+    if (fw_up_commit_ack_is_self_describing(slave_ack)) {
         uprintf("%s: slave REFUSED (ack=0x%02x) -> data failure\n", tag, slave_ack);
         return true;
     }
-    fw_staging_status_t s;
-    if (!fw_up_query_slave_status(&s)) {
+    fw_staging_status_t s        = {0};
+    bool                status_ok = fw_up_query_slave_status(&s);
+    enum fw_up_commit_verdict verdict =
+        fw_up_classify_commit_failure(slave_ack, status_ok, s.last_commit_ack);
+
+    if (!status_ok) {
         uprintf("%s: slave ack=0x%02x and the status probe failed too "
                 "-> assuming link failure\n", tag, slave_ack);
-        return false;
-    }
-    if (s.last_commit_ack == SYNC_NACK_REFUSED) {
+    } else if (verdict == FW_UP_COMMIT_REFUSED) {
         uprintf("%s: slave ack=0x%02x lost, but its recorded verdict is REFUSED "
                 "(last_commit_ack=0x%02x) -> data failure\n",
                 tag, slave_ack, (unsigned)s.last_commit_ack);
-        return true;
+    } else {
+        uprintf("%s: slave ack=0x%02x, recorded verdict 0x%02x (active=%u next_off=%lu) "
+                "-> link failure, COMMIT is safe to retry\n",
+                tag, slave_ack, (unsigned)s.last_commit_ack,
+                (unsigned)s.fw_up_active, (unsigned long)s.next_offset);
     }
-    uprintf("%s: slave ack=0x%02x, recorded verdict 0x%02x (active=%u next_off=%lu) "
-            "-> link failure, COMMIT is safe to retry\n",
-            tag, slave_ack, (unsigned)s.last_commit_ack,
-            (unsigned)s.fw_up_active, (unsigned long)s.next_offset);
-    return false;
+    return verdict == FW_UP_COMMIT_REFUSED;
 }
 
 // Single slave-side dispatcher for the flash-staging stream.  Reads the `op`

--- a/keyboards/polykybd/split_fw_up.h
+++ b/keyboards/polykybd/split_fw_up.h
@@ -91,6 +91,14 @@ typedef struct _fw_up_status_reply_t {
     fw_staging_status_t status;
 } fw_up_status_reply_t;
 
+// The slave→master RPC buffer is a SILENT ceiling: transaction_rpc_exec refuses a
+// transfer bigger than it and returns false BEFORE sending anything, so outgrowing
+// it would make the status probe simply stop answering with nothing in the log.
+// (last_commit_ack was added inside the existing pad, so this is unchanged — the
+// assert is here to keep it that way.)
+static_assert(sizeof(fw_up_status_reply_t) <= RPC_S2M_BUFFER_SIZE,
+              "fw_up_status_reply_t exceeds RPC_S2M_BUFFER_SIZE — the STATUS probe would silently stop answering");
+
 // Reset/apply coordination (master → slave).  ONE transaction (USER_SYNC_RESET)
 // carries every "make the other half restart" action; the `action` byte selects
 // which.  A magic guard — on top of the CRC32 and QMK's own transport checksum —
@@ -129,6 +137,13 @@ bool fw_up_relay_chunk_to_slave(uint32_t offset, const uint8_t *chunk_data, cons
 // One slave-side dispatcher for the whole flash-staging stream (BEGIN / CHUNK /
 // COMMIT / STATUS); it reads the `op` word and routes to the per-op logic.
 void user_sync_flash_stage_handler  (uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data);
+
+// Master-side helpers over the read-only FLASH_STAGE_STATUS op.
+bool fw_up_query_slave_status(fw_staging_status_t *out);
+void fw_up_log_slave_status(const char *tag);
+// True when a non-ACK COMMIT means the slave REFUSED (re-flash) rather than the
+// link dropping the answer (retry). `tag` prefixes the diagnostic line.
+bool fw_up_slave_refused_commit(uint8_t slave_ack, const char *tag);
 // One transaction (USER_SYNC_RESET) for apply-and-reboot, plain reboot, and the
 // handedness-change reboot; the poly_reset_sync_t `action` byte selects which.
 void user_sync_reset_handler        (uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data);

--- a/keyboards/polykybd/split_sync.h
+++ b/keyboards/polykybd/split_sync.h
@@ -13,13 +13,34 @@
 #define SYNC_ACK_SIG    0b01001101
 #define SYNC_ACK        0b11001010
 #define SYNC_CRC32_ERR  0b00110101
+// The slave ANSWERED and refused the request (its own validation failed), as
+// opposed to SYNC_CRC32_ERR, which cannot say which of three things happened:
+//   * "still erasing"        — flash_stage_begin's re-poll state, a NORMAL state
+//                              hid_fw_up actually counts to log erase progress
+//   * "your frame arrived garbled" — a request-CRC mismatch, which SHOULD be retried
+//   * "no answer at all"     — send_to_bridge exhausting its retries
+// A refusal needs the opposite response from all three: re-flash, don't retry.
+// Collapsing it into SYNC_CRC32_ERR is why a font-pack COMMIT could tell the host
+// "retry me" for a half whose flash was genuinely bad. Do NOT repurpose
+// SYNC_CRC32_ERR for this — the begin re-poll depends on its existing meaning.
+//
+// The value is not arbitrary: the reply carries NO CRC (see the split-link notes in
+// CLAUDE.md), so these bytes are spaced by Hamming distance to survive a flipped
+// bit. 0xB2 is the complement of SYNC_ACK_SIG, making the set two complement pairs;
+// it ties for the best achievable min-distance (4) from all three existing values
+// and is balanced (popcount 4), unlike the equally-spaced 0x00/0xFF, which are
+// exactly what a stuck or floating line reads as.
+#define SYNC_NACK_REFUSED 0b10110010
 
 typedef struct _poly_sync_reply_t {
     uint8_t ack;
 } poly_sync_reply_t;
 
 // send_to_bridge() returns the slave's reply ack byte, or SYNC_CRC32_ERR after
-// exhausting its retries. ALL of SYNC_ACK / SYNC_ACK_SIG / SYNC_CRC32_ERR are
+// exhausting its retries. SYNC_NACK_REFUSED needs no case here — it is not an ACK,
+// so every existing "not ACK == failure" caller already treats it correctly; only a
+// caller that wants to tell a refusal from a link drop looks at it specifically.
+// ALL of SYNC_ACK / SYNC_ACK_SIG / SYNC_CRC32_ERR are
 // non-zero, so a bare truthiness test — `if(!send_to_bridge(...))` — is NOT a
 // failure check: it is false for the failure value too, so the caller would
 // treat a give-up as success and advance its global snapshot, never re-firing

--- a/keyboards/polykybd/split_sync.h
+++ b/keyboards/polykybd/split_sync.h
@@ -6,48 +6,15 @@
 #include "config.h"
 #include "state.h"
 #include "mru.h"     // MRU_EMOJI_PACKED / MRU_CAP used by mru_sync_t below
+// The ack vocabulary (SYNC_ACK / SYNC_ACK_SIG / SYNC_CRC32_ERR /
+// SYNC_NACK_REFUSED, poly_sync_reply_t, sync_succeeded) lives in its own
+// dependency-free header so the contract can be unit-tested without the keyboard
+// config this file needs for the structs below. Re-exported here, so every
+// existing `#include "split_sync.h"` consumer is unaffected.
+#include "base/sync_ack.h"
 
 #include <stdint.h>
 #include <stdbool.h>
-
-#define SYNC_ACK_SIG    0b01001101
-#define SYNC_ACK        0b11001010
-#define SYNC_CRC32_ERR  0b00110101
-// The slave ANSWERED and refused the request (its own validation failed), as
-// opposed to SYNC_CRC32_ERR, which cannot say which of three things happened:
-//   * "still erasing"        — flash_stage_begin's re-poll state, a NORMAL state
-//                              hid_fw_up actually counts to log erase progress
-//   * "your frame arrived garbled" — a request-CRC mismatch, which SHOULD be retried
-//   * "no answer at all"     — send_to_bridge exhausting its retries
-// A refusal needs the opposite response from all three: re-flash, don't retry.
-// Collapsing it into SYNC_CRC32_ERR is why a font-pack COMMIT could tell the host
-// "retry me" for a half whose flash was genuinely bad. Do NOT repurpose
-// SYNC_CRC32_ERR for this — the begin re-poll depends on its existing meaning.
-//
-// The value is not arbitrary: the reply carries NO CRC (see the split-link notes in
-// CLAUDE.md), so these bytes are spaced by Hamming distance to survive a flipped
-// bit. 0xB2 is the complement of SYNC_ACK_SIG, making the set two complement pairs;
-// it ties for the best achievable min-distance (4) from all three existing values
-// and is balanced (popcount 4), unlike the equally-spaced 0x00/0xFF, which are
-// exactly what a stuck or floating line reads as.
-#define SYNC_NACK_REFUSED 0b10110010
-
-typedef struct _poly_sync_reply_t {
-    uint8_t ack;
-} poly_sync_reply_t;
-
-// send_to_bridge() returns the slave's reply ack byte, or SYNC_CRC32_ERR after
-// exhausting its retries. SYNC_NACK_REFUSED needs no case here — it is not an ACK,
-// so every existing "not ACK == failure" caller already treats it correctly; only a
-// caller that wants to tell a refusal from a link drop looks at it specifically.
-// ALL of SYNC_ACK / SYNC_ACK_SIG / SYNC_CRC32_ERR are
-// non-zero, so a bare truthiness test — `if(!send_to_bridge(...))` — is NOT a
-// failure check: it is false for the failure value too, so the caller would
-// treat a give-up as success and advance its global snapshot, never re-firing
-// the lost sync. Always classify the return through this helper.
-static inline bool sync_succeeded(uint8_t ack) {
-    return ack == SYNC_ACK || ack == SYNC_ACK_SIG;
-}
 
 
 typedef struct _overlay_sync_t {


### PR DESCRIPTION
## Summary

Follow-up to #209, which left this as a documented known limit. `send_to_bridge()` returns `SYNC_CRC32_ERR` both for a slave that **answered and refused** and for its own **retry give-up**, so a font-pack COMMIT could only ever report `'L'` ("unverified, retry me") for a half whose staged image was genuinely bad — and retrying a bad image just fails again.

While tracing it, `SYNC_CRC32_ERR` turned out to be **triple**-overloaded, not double, and that decides the shape of the fix:

| Context | What `0x35` means | Correct response |
|---|---|---|
| `flash_stage_begin` re-poll | **"still erasing"** — a normal state `hid_fw_up.c` counts to log erase progress | keep polling |
| `flash_stage_commit`, request CRC mismatch | "your frame arrived garbled" | retry |
| `flash_stage_commit`, finalize returned false | "I processed it and **refuse**" | re-flash |
| `send_to_bridge` retries exhausted | "no answer at all" | retry |

So repurposing `SYNC_CRC32_ERR` would break the BEGIN protocol. This **adds** a value instead:

```c
#define SYNC_NACK_REFUSED 0b10110010   // the slave answered and refused
```

`sync_succeeded()` is **unchanged** — the new value isn't an ACK, so all 14 existing "not ACK == failure" callers keep working, and only a caller that wants to tell a refusal from a link drop looks at it specifically.

Note `flash_stage_commit` had **two** `SYNC_CRC32_ERR` exits and only one is the refusal. The garbled-request exit keeps `SYNC_CRC32_ERR`, because there a retry is exactly right.

### Why `0xB2` and not any spare byte

The reply carries **no CRC**, so these bytes are deliberately Hamming-spaced (`SYNC_ACK` 0xCA and `SYNC_CRC32_ERR` 0x35 are exact complements, distance 8). Brute-forcing the fourth value against all three:

```
best achievable min-distance for a 4th value: 4
0xB2: SYNC_ACK_SIG=8  SYNC_ACK=4  SYNC_CRC32_ERR=4   popcount=4
```

`0xB2` is the complement of `SYNC_ACK_SIG`, so the set becomes two complement pairs; it ties for the best min-distance and has the best profile among the ties. It's also balanced — `0x00` and `0xFF` tie on distance but are exactly what a stuck or floating line reads as.

This is now **enforced by a test** rather than only documented (see Tests below), so a fifth value cannot silently degrade the single-bit tolerance for the whole set. An exhaustive search says 12 spare codewords preserve the distance-4 property, so there is room.

### Fallback when the refusal ack is itself lost

`fw_up_slave_refused_commit()` asks the slave over the existing read-only `FLASH_STAGE_STATUS` op.

⚠️ **`fw_up_active` is not a usable discriminator**, which is the trap in the obvious version of this: finalize clears it whether it succeeded *or* refused, so "cleared" is equally consistent with a refusal and with a **success whose ack was lost in transit** — and treating that as a refusal would turn the common lost-ack case, which a single free COMMIT retry fixes, into a full re-stream of the pack. So the slave now **records the verdict it returned** (`last_commit_ack`) and the probe reads that. It lives in `fw_staging_status_t`'s existing pad, so the struct and the RPC reply are the same size as before.

That verdict is cleared at the start of **every staging attempt**, not just at boot — `fw_staging_init()` runs once from `post_init`, so clearing it only there let a second flash in the same power cycle inherit the first one's verdict, which would have misread a later genuine link failure as a data rejection. (CodeRabbit finding, verified and fixed in `8716de2a`.)

A probe that fails, or a slave too old to record a verdict, falls back to the conservative link reading — never worse than today.

### Diagnostics

Every classification logs what it found and why, so a field log can be read without guessing:

```
FONTPACK_COMMIT: slave REFUSED (ack=0xb2) -> data failure
FONTPACK_COMMIT: slave ack=0x35 lost, but its recorded verdict is REFUSED (last_commit_ack=0xb2) -> data failure
FONTPACK_COMMIT: slave ack=0x35, recorded verdict 0x00 (active=1 next_off=38632) -> link failure, COMMIT is safe to retry
FONTPACK_COMMIT: slave ack=0x35 and the status probe failed too -> assuming link failure
```

The status probe moved to `split_fw_up.c` so both COMMIT paths share it (`hid_fw_up.c`'s static copy is gone), it now **verifies the reply's own CRC** before the result is acted on, and the logger still prints a snapshot whose CRC is bad — tagged `[CRC BAD — values suspect]` — because a corrupt snapshot is worth seeing but must never be trusted. The console outcome line now says `REJECTED (slave refused)` distinctly from `UNCONFIRMED (slave ACK lost)`.

The probe is short-circuited to the genuinely ambiguous case only: a refusal ack is self-describing, and if the master already rejected the image the status is `'R'` regardless — so no RPC is spent inside `raw_hid_receive()`, which runs on the main loop.

The firmware-update COMMIT keeps its four statuses (a fifth would need a matching host change) but now **logs** the distinction, so it is at least diagnosable.

**No host change needed.** PolyKybdHost's existing `COMMIT_REJECTED` path already declines to retry and queues a re-flash, so the `'R'` mapping is enough. Backward compatible both ways: an old master sees a non-ACK and fails as before; a new master facing an old slave falls back to today's behaviour.

## Tests (`make test:fw_up_verdict`, 21 tests, ~1 s)

The classification had **no automated coverage**, and the refusal branch is not reachable from the HIL rig (it cannot force a slave finalize refusal). PolyKybdHost has had the other end of this contract under test for a while — but those tests encode the firmware's reply bytes as **fixtures**, so they only catch the *host* misreading a status. They can never catch this end **emitting** the wrong one, which is exactly the bug #209 fixed. A fixture is not the firmware.

**Getting it testable required decoupling, and both smells were worth fixing on their own terms:**

- `split_sync.h` conflated a protocol **contract** (four ack bytes + `sync_succeeded`) with the sync payload **structs**, which need `config.h`/`state.h`/`mru.h`. So asking "is this ack a success?" pulled in the whole keyboard config — which is why `sync_succeeded()`, the helper guarding every `send_to_bridge` call site and itself the subject of a field bug, had no test for years. Moved to a dependency-free **`base/sync_ack.h`**, re-exported by `split_sync.h` so every consumer is unchanged.
- `fw_up_slave_refused_commit()` mixed RPC transport, CRC validation, the decision and `uprintf` in one function. The decision was the only part with a bug history and the only part unreachable. It is now pure in **`base/fw_up_verdict.c`**; the I/O and all four diagnostic lines stay in `split_fw_up.c` with their format strings byte-identical.

This mirrors what the host repo already does deliberately (`polyhost/core/decisions.py`, `decide_stale_bundles`, `classify_commit_reply`) — pure seams so the decisions can be tested. The firmware simply never had them.

What the tests pin:

- `sync_succeeded` is **fail-closed across all 256 bytes** — a whitelist, not a blacklist. That property is what let `SYNC_NACK_REFUSED` be introduced without touching any of the 14 existing call sites, and a blacklist implementation passes every other test in the suite.
- the ack set keeps **min pairwise Hamming distance 4**, and no value is a stuck-line reading (`0x00`/`0xFF`).
- an explicit refusal is **never** overridden by the probe, however the probe turned out.
- a **lost refusal ack** is recovered from the recorded verdict.
- a **cleared verdict** and a **recorded `SYNC_ACK`** are both retryable link failures — misreading either costs a full re-stream over the very link that just dropped a frame.
- a **failed probe** ignores the recorded byte entirely rather than reading garbage out of a zeroed struct.
- a **corrupt STATUS snapshot** is refused, not believed.
- the font-pack status byte: master rejection outranks a healthy slave, a slave refusal is `'R'` and not `'L'`, the three are distinct, and none reuses the legacy `'!'`.

**Mutation-tested against 7 deliberate breakages** — dropped `!status_ok` guard, `recorded != SYNC_ACK` as the refusal test, probe outranking an explicit refusal, `sync_succeeded` as a blacklist, a 1-bit-spaced ack value, a slave refusal reported as retryable, and a CRC check that always passes. Each was caught by the intended test. (A suite that stays green against a broken implementation measures nothing — and the first run of that harness reported all seven as "still green" because gtest's ANSI escapes defeated the grep, which is its own lesson.)

`hid_fontpack.h` drops `#include "quantum.h"` for stdint/stdbool — nothing in it needed quantum.h — so the status contract is reachable from a standalone test, and gains a pure `static inline fontpack_commit_status()`.

`base/fw_up_verdict.c` is listed in the **shared** `POLY_SRC` rather than with the other `base/*.c` in the per-variant `rules.mk`: its consumer `split_fw_up.c` is in that shared list, so a variant that forgot the line would just fail to link.

⚠️ The suite's makefile fragment is `test_rules.mk`, **not** `rules.mk`: `qmk ci-validate-keyboard-targets` globs `keyboards/**/rules.mk` and reads every hit as a keyboard (exempting only paths containing `keymaps`/`common`/`lib`), so a `rules.mk` there fails lint with *"keyboards/polykybd/base/tests::Legacy target detected"*. That step is separate from `qmk lint`, which is how it got past a local `qmk lint --strict` run — fixed in `1f5ba114`, with the reason recorded in the file and in CLAUDE.md.

## Version bump label

Patch (no label) — a split-protocol refinement, no new feature. No `PROTOCOL_VERSION` change: the HID wire format is untouched (the font-pack COMMIT status byte set is unchanged from #209; only *which* failures map to `'R'` improves).

## Testing

- [x] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`) — and `split42`
- [x] Flashed and tested on hardware — via the rig: `Build firmware` + `HIL test (split72)` passed on `e2e9ddc4` and `8716de2a`, which carry the whole functional change
- [x] If protocol changed: n/a — no `PROTOCOL_VERSION` change

Also verified:

- The full lint job locally, all four parts: `qmk ci-validate-keyboard-targets` (exit 0), `qmk ci-validate-aliases` (exit 0), `qmk lint --strict` on both variants, and no tracked-but-gitignored files.
- The **monolith** (`POLYKYBD_DOOM=yes`) — the tightest RAM flavour, which PR CI does not build — links with `.heap` at **3828 bytes**, unchanged, so this costs no heap.
- `polymod_ltr559`'s 19 tests still pass.
- A `static_assert` keeps `fw_up_status_reply_t` inside `RPC_S2M_BUFFER_SIZE`, since outgrowing it would make `transaction_rpc_exec` refuse the transfer and the probe would silently stop answering.

⚠️ **The refusal path is now unit-tested but still not exercised on real hardware** — the rig cannot force a slave finalize refusal, which would need a deliberately corrupted staged image on one half only. So: the green rig run proves the *healthy* path is unchanged (the regression risk that matters for a merge), and the unit tests pin the decision logic and both status contracts. What remains unproven end-to-end is the wiring between them on a physical link. The cheapest way to close that would be a temporary debug HID command, behind an `#ifdef`, that makes one half's next finalize return false.