### PR TITLE
split: de-overload SYNC_CRC32_ERR with SYNC_BUSY and SYNC_GIVEUP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2707,13 +2707,22 @@ to the one number used to judge cable/baud changes.
 when the slave never answered.** It used to return a *constant* on give-up,
 discarding `reply.ack` — and that worked only by **coincidence**, because the
 constant was `SYNC_CRC32_ERR`, which happened to equal what the slave sent in every
-case that mattered. Distinguishing the failure values exposed the discard and, with
-it, **two documented behaviours that were in fact dead code** (found in review,
-2026-08-17): `hid_fw_up.c`'s erase-progress counter matches on the begin re-poll
-value, which could never arrive; and `fw_up_slave_refused_commit()`'s "a refusal is
-self-describing, so don't spend a STATUS RPC" short-circuit never triggered, so
-every refusal paid for a probe. **Generalise: a sentinel that happens to equal a
+case that mattered. Distinguishing the failure values exposed the discard, and with
+it **`fw_up_slave_refused_commit()`'s "a refusal is self-describing, so don't spend
+a STATUS RPC" short-circuit, which was dead code** — a refusal arrived as the
+give-up constant, never as `SYNC_NACK_REFUSED`, so every refusal paid for a probe
+(found in review, 2026-08-17). **Generalise: a sentinel that happens to equal a
 real value hides the fact that the real value is being thrown away.**
+- ⚠️ **The near-miss is the more instructive half, and it was initially reported
+  here as a second dead-code case — wrongly.** `hid_fw_up.c`'s erase-progress
+  counter kept firing throughout, just not for the reason it reads as: its guard
+  accepts `SYNC_BUSY` **or** `SYNC_CRC32_ERR`, a compat arm added for transiently
+  mismatched halves, and that arm also matched the give-up constant. A defensive
+  clause written for one hazard quietly covered the discard, so the counter fired
+  on a value the slave never sent. Verified on hardware 2026-08-18: it logs
+  `begin-pending` at poll 17 and 33 of a 117-sector erase — as it did before.
+  **Check a dead-code claim against the guard's OTHER arms before making it**; the
+  git history of the condition settles it in one `git show`.
 
 **Reducing `p` at the source (the real root fix), in order of leverage**:
 1. **Lower the baud** — biggest, cheapest software lever. 230400 → 115200

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2608,24 +2608,41 @@ that ring/reflect on a longer split cable.
   idempotent) or, ~1/256, into a false ACK. Low impact, but it's why a tiny
   fraction of `crc_err` counts can be reply corruption rather than payload.
   - **That missing CRC is why the ack BYTE VALUES are Hamming-spaced**, and the
-    vocabulary now lives in dependency-free **`base/sync_ack.h`** (re-exported by
-    `split_sync.h`, so consumers are unchanged) with a test enforcing it:
+    vocabulary lives in dependency-free **`base/sync_ack.h`** (re-exported by
+    `split_sync.h`, so consumers are unchanged) with tests enforcing it:
     `SyncAckTest.AckValuesStayHammingSpaced` requires min pairwise distance **4**
-    across `SYNC_ACK` / `SYNC_ACK_SIG` / `SYNC_CRC32_ERR` / `SYNC_NACK_REFUSED`.
-    ⚠️ **Adding a fifth value must keep that distance** or the single-bit tolerance
-    degrades for the *whole* set; an exhaustive search says **12 spare codewords**
-    preserve it, so there is plenty of room — but avoid `0x00`/`0xFF`, which are what
-    a stuck or floating line reads as (also asserted). `sync_succeeded()` is a
-    deliberate **whitelist** so a new failure value is a failure at all 14 existing
-    call sites with no edits; `SyncSucceededIsFailClosedAcrossEveryByte` sweeps all
-    256 bytes to pin that, because a blacklist implementation passes every other test.
-  - ⚠️ **`SYNC_CRC32_ERR` is still TRIPLE-overloaded** — "still erasing" (a normal
-    `flash_stage_begin` re-poll state), "your frame arrived garbled", and
-    "send_to_bridge gave up". Only the *refusal* case was peeled off (into
-    `SYNC_NACK_REFUSED`); the remaining three are separated by nothing but a comment.
-    The clean follow-up is a distinct `SYNC_BUSY` and a distinct give-up value, which
-    the 12 spare codewords comfortably allow — then callers could back off vs retry vs
-    escalate instead of inferring from context.
+    across all six values, `EveryAckValueIsDistinct` forbids a duplicate, and
+    `NoAckValueIsAStuckLineReading` forbids `0x00`/`0xFF` (what a stuck or floating
+    line reads as). The set is built as **complement pairs**, each balanced at
+    popcount 4: `SYNC_ACK 0xCA ↔ SYNC_CRC32_ERR 0x35`, `SYNC_ACK_SIG 0x4D ↔
+    SYNC_NACK_REFUSED 0xB2`, `SYNC_BUSY 0x1B ↔ SYNC_GIVEUP 0xE4`.
+    ⚠️ **Adding a seventh value must keep distance 4** or the single-bit tolerance
+    degrades for the *whole* set. A mutually-distance-4 code containing these six
+    extends to **16**, so 10 remain (8 excluding `0x00`/`0xFF`) — take the complement
+    of an unused one to keep the pattern. `sync_succeeded()` is a deliberate
+    **whitelist** so a new failure value is a failure at all 14 existing call sites
+    with no edits; `SyncSucceededIsFailClosedAcrossEveryByte` sweeps all 256 bytes to
+    pin that, because a blacklist implementation passes every other test.
+  - ✅ **`SYNC_CRC32_ERR` is DE-OVERLOADED — it now means exactly one thing: "the
+    frame I received did not check out".** It used to mean four: that, plus "still
+    erasing", "no answer at all", and "I refuse". Each now has its own value —
+    `SYNC_BUSY` (the `flash_stage_begin` re-poll while the deferred erase runs),
+    `SYNC_GIVEUP` (`send_to_bridge` exhausted its retries, or we never asked), and
+    `SYNC_NACK_REFUSED` (processed and declined: an unknown bundle id, a rejected
+    chunk write, an apply with no valid staged image, an unknown reset action).
+    The audit that keeps it true: **every remaining `= SYNC_CRC32_ERR` sits directly
+    on a `crc32 != …->crc32` (or magic) check** —
+    `grep -rn -B3 "ack = SYNC_CRC32_ERR" --include=*.c keyboards/polykybd/` should
+    show no exceptions.
+    - **Relabelling was behaviourally inert, which is why it was safe**: every
+      consumer tests `== SYNC_ACK` / `sync_succeeded()`, i.e. ACK-or-not, so no
+      decision changed — only what the logs and the COMMIT classifier can tell apart.
+    - ⚠️ **The one place needing a compat guard is `hid_fw_up.c`'s erase-progress
+      counter**, which matches on the begin re-poll value. It accepts **both**
+      `SYNC_BUSY` and the legacy `SYNC_CRC32_ERR`, because the two halves can
+      transiently run different firmware (a fw apply reboots the master first — the
+      2026-06-22 boot-splash hang). Mismatched halves are safe in both directions
+      *because* the functional decision is ACK-or-not.
 
 **How CRC32 + retries + noise interact** (the model that drives the retry-count
 choice). With `p` = probability a single frame is corrupted (and caught by CRC32),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,17 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
     as reviewed. There is no way to get it reviewed short of splitting the PR — so
     for a merge PR, treat the **build + HIL checks and hardware testing as the only
     real verification**, and don't count the green board as review cover.
+  - ⚠️ **A STACKED PR gets no automatic review at all** — *"Review skipped — Auto
+    reviews are disabled on base/target branches other than the default branch."*
+    This is a **fourth** no-review mode (alongside the rate limit, the <10-stars
+    repo, and the >100-file skip) and it is **guaranteed, not occasional**: any PR
+    whose base is another feature branch is silently unreviewed for as long as it is
+    stacked. Seen on #211 (2026-08-17), stacked on #210. Two ways out, and prefer the
+    first: **let the parent merge** — GitHub then retargets the child to `PolyKybd`
+    and auto-review applies again (confirm a review actually lands; a base change may
+    not itself trigger one). Otherwise spend a slot on `@coderabbitai review`, which
+    works on a stacked PR but costs the same org-wide budget as any other request.
+    ⚠️ Do **not** read the resulting quiet board as "no findings" — nothing read it.
   - ⚠️ **Sourcery's rate-limit is QUIETER than CodeRabbit's: the `Sourcery review`
     check run goes GREEN (`success`) while no review happened.** When its weekly
     diff-character budget is spent it submits a `COMMENTED` review whose entire body

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2687,13 +2687,33 @@ frames (count-based, no timer — the cadence follows real traffic, so it's dens
 during overlay bursts and silent when idle; gated on `debug_enable`):
 
 ```text
-Split link: 12345 tx crc_err=4 transport_fail=1 giveup=0 err=0.0%
+Split link: 12345 tx crc_err=4 nack=17 transport_fail=1 giveup=0 err=0.0%
 ```
 
 `err%` is the all-time detected-error rate over all frames — a direct read on the
 wire. **Use it to validate any link change** (baud/cable/drive/termination) by
 watching the number move, instead of by feel. `giveup` should stay ~0 with
 retries=3; if it climbs, attack `p` at the source.
+
+⚠️ **`nack` is EXCLUDED from `err%` on purpose** — it counts valid non-ACK answers
+(`SYNC_BUSY`, `SYNC_NACK_REFUSED`), where the wire worked and the slave simply said
+something other than yes. Only `crc_err` (a corrupted frame) and `transport_fail`
+(no answer) are link faults. Before the split, every non-ACK incremented
+`crc_err` — and since `SYNC_BUSY` now arrives on **every erase re-poll of a flash**,
+a single font-pack update would otherwise have added hundreds of phantom "errors"
+to the one number used to judge cable/baud changes.
+
+⚠️ **`send_to_bridge()` returns what the slave SAID; it returns `SYNC_GIVEUP` only
+when the slave never answered.** It used to return a *constant* on give-up,
+discarding `reply.ack` — and that worked only by **coincidence**, because the
+constant was `SYNC_CRC32_ERR`, which happened to equal what the slave sent in every
+case that mattered. Distinguishing the failure values exposed the discard and, with
+it, **two documented behaviours that were in fact dead code** (found in review,
+2026-08-17): `hid_fw_up.c`'s erase-progress counter matches on the begin re-poll
+value, which could never arrive; and `fw_up_slave_refused_commit()`'s "a refusal is
+self-describing, so don't spend a STATUS RPC" short-circuit never triggered, so
+every refusal paid for a probe. **Generalise: a sentinel that happens to equal a
+real value hides the fact that the real value is being thrown away.**
 
 **Reducing `p` at the source (the real root fix), in order of leverage**:
 1. **Lower the baud** — biggest, cheapest software lever. 230400 → 115200

--- a/keyboards/polykybd/base/fw_staging.h
+++ b/keyboards/polykybd/base/fw_staging.h
@@ -235,7 +235,7 @@ typedef struct _fw_staging_status_t {
     uint8_t  initialized;
     uint8_t  fw_up_active;
     uint8_t  erase_pending;
-    uint8_t  last_chunk_ack;        // last value returned from chunk handler (SYNC_ACK / SYNC_CRC32_ERR)
+    uint8_t  last_chunk_ack;        // last value returned from chunk handler (SYNC_ACK / SYNC_CRC32_ERR / SYNC_NACK_REFUSED)
     uint16_t erase_sector_next;
     uint16_t erase_sector_count;
     uint32_t next_offset;            // s_next_offset (bytes accepted)

--- a/keyboards/polykybd/base/fw_up_verdict.h
+++ b/keyboards/polykybd/base/fw_up_verdict.h
@@ -34,14 +34,17 @@ enum fw_up_commit_verdict {
 };
 
 // True when the ack byte alone settles it, so the caller must NOT spend a STATUS
-// RPC. A refusal is self-describing; SYNC_CRC32_ERR is the ambiguous one (it means
-// three different things — see sync_ack.h). Keeping this separate from the
-// classification below is what lets the caller short-circuit before doing I/O
-// inside raw_hid_receive(), which runs on the main loop.
+// RPC. Only a refusal is self-describing. SYNC_GIVEUP and SYNC_CRC32_ERR both still
+// need the probe — neither says whether the slave's finalize ran, which is the whole
+// question. Keeping this separate from the classification below is what lets the
+// caller short-circuit before doing I/O inside raw_hid_receive(), which runs on the
+// main loop.
 bool fw_up_commit_ack_is_self_describing(uint8_t slave_ack);
 
 // Classify a non-ACK COMMIT.
-//   slave_ack    — what came back (or SYNC_CRC32_ERR when send_to_bridge gave up)
+//   slave_ack    — what came back: SYNC_GIVEUP when send_to_bridge exhausted its
+//                  retries, SYNC_CRC32_ERR when the slave got a garbled frame,
+//                  SYNC_NACK_REFUSED when it answered and refused
 //   status_ok    — a CRC-VALID status snapshot was obtained from the slave
 //   recorded_ack — that snapshot's last_commit_ack (ignored when !status_ok)
 //

--- a/keyboards/polykybd/base/sync_ack.h
+++ b/keyboards/polykybd/base/sync_ack.h
@@ -20,33 +20,50 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#define SYNC_ACK_SIG    0b01001101
-#define SYNC_ACK        0b11001010
-#define SYNC_CRC32_ERR  0b00110101
-// The slave ANSWERED and refused the request (its own validation failed), as
-// opposed to SYNC_CRC32_ERR, which cannot say which of three things happened:
-//   * "still erasing"        — flash_stage_begin's re-poll state, a NORMAL state
-//                              hid_fw_up actually counts to log erase progress
-//   * "your frame arrived garbled" — a request-CRC mismatch, which SHOULD be retried
-//   * "no answer at all"     — send_to_bridge exhausting its retries
-// A refusal needs the opposite response from all three: re-flash, don't retry.
-// Collapsing it into SYNC_CRC32_ERR is why a font-pack COMMIT could tell the host
-// "retry me" for a half whose flash was genuinely bad. Do NOT repurpose
-// SYNC_CRC32_ERR for this — the begin re-poll depends on its existing meaning.
+// ── The vocabulary ──────────────────────────────────────────────────────────
+// SUCCESS (sync_succeeded() below is the only correct way to test for it):
+//   SYNC_ACK      the slave processed the request
+//   SYNC_ACK_SIG  processed, and signalling something in-band (the flash-staging
+//                 begin uses it for "erase started, keep polling")
+// FAILURE — each needs a DIFFERENT response, which is why they are separate values:
+//   SYNC_CRC32_ERR     the frame I received did not check out  -> retry, it may
+//                      well arrive intact next time
+//   SYNC_NACK_REFUSED  I processed it and the answer is NO     -> re-flash; asking
+//                      again cannot change what is in my flash
+//   SYNC_BUSY          a normal not-yet state (the flash-staging begin re-poll
+//                      while the deferred erase runs)          -> keep polling
+//   SYNC_GIVEUP        no answer was obtained at all: send_to_bridge exhausted its
+//                      retries, or we never even asked         -> retry
 //
-// The value is not arbitrary: the reply carries NO CRC (see the split-link notes in
-// CLAUDE.md), so these bytes are spaced by Hamming distance to survive a flipped
-// bit. 0xB2 is the complement of SYNC_ACK_SIG, making the set two complement pairs;
-// it ties for the best achievable min-distance (4) from all three existing values
-// and is balanced (popcount 4), unlike the equally-spaced 0x00/0xFF, which are
-// exactly what a stuck or floating line reads as.
-//
-// ⚠️ Adding a fifth value: keep the min pairwise Hamming distance at 4 or the
-// single-bit-error tolerance above degrades for the WHOLE set, silently. There are
-// 12 spare codewords that preserve it (0x00 and 0x1B among them, though avoid the
-// all-zero/all-one ones for the stuck-line reason above). SyncAckTest.
-// AckValuesStayHammingSpaced in base/tests/ enforces this — it is not advice.
+// ⚠️ SYNC_CRC32_ERR used to mean ALL FOUR of the failure cases. That is what let a
+// font-pack COMMIT tell the host "retry me" for a half whose flash was genuinely
+// bad — a refusal and a dropped frame are opposite events. SYNC_NACK_REFUSED split
+// off the refusal; SYNC_BUSY and SYNC_GIVEUP split off the other two, so the name
+// SYNC_CRC32_ERR now finally means only what it says. Do not re-overload it.
+#define SYNC_ACK_SIG      0b01001101
+#define SYNC_ACK          0b11001010
+#define SYNC_CRC32_ERR    0b00110101
 #define SYNC_NACK_REFUSED 0b10110010
+#define SYNC_BUSY         0b00011011
+#define SYNC_GIVEUP       0b11100100
+
+// ── Why these particular bytes ──────────────────────────────────────────────
+// The reply carries NO CRC (see the split-link notes in CLAUDE.md), so the values
+// are spaced by Hamming distance so a single flipped bit cannot turn one verdict
+// into another. The set is built as COMPLEMENT PAIRS, each balanced at popcount 4:
+//   SYNC_ACK 0xCA ↔ SYNC_CRC32_ERR 0x35   (distance 8)
+//   SYNC_ACK_SIG 0x4D ↔ SYNC_NACK_REFUSED 0xB2
+//   SYNC_BUSY 0x1B ↔ SYNC_GIVEUP 0xE4
+// All six sit at min pairwise distance 4. 0x00/0xFF are deliberately avoided even
+// though they are well spaced: they are exactly what a stuck or floating line reads
+// as.
+//
+// ⚠️ Adding a SEVENTH value: keep the min pairwise distance at 4, or the
+// single-bit tolerance degrades for the WHOLE set, silently. A mutually-distance-4
+// code containing these six extends to 16 values, so 10 remain (8 after excluding
+// 0x00/0xFF) — pick a complement of an unused one to keep the pattern.
+// SyncAckTest.AckValuesStayHammingSpaced in base/tests/ enforces this; it is not
+// advice, and it fails on a badly-chosen value rather than letting it ship.
 
 typedef struct _poly_sync_reply_t {
     uint8_t ack;

--- a/keyboards/polykybd/base/tests/fw_up_verdict_tests.cpp
+++ b/keyboards/polykybd/base/tests/fw_up_verdict_tests.cpp
@@ -26,7 +26,8 @@ extern "C" {
 namespace {
 
 // Every ack value the split link can put in poly_sync_reply_t.
-const uint8_t kAllAcks[] = {SYNC_ACK, SYNC_ACK_SIG, SYNC_CRC32_ERR, SYNC_NACK_REFUSED};
+const uint8_t kAllAcks[] = {SYNC_ACK, SYNC_ACK_SIG, SYNC_CRC32_ERR,
+                            SYNC_NACK_REFUSED, SYNC_BUSY, SYNC_GIVEUP};
 
 int popcount8(uint8_t v) {
     int n = 0;
@@ -52,6 +53,17 @@ TEST(SyncAckTest, SyncSucceededAcceptsExactlyTheTwoAcks) {
     EXPECT_TRUE(sync_succeeded(SYNC_ACK_SIG));
     EXPECT_FALSE(sync_succeeded(SYNC_CRC32_ERR));
     EXPECT_FALSE(sync_succeeded(SYNC_NACK_REFUSED));
+    EXPECT_FALSE(sync_succeeded(SYNC_BUSY));
+    EXPECT_FALSE(sync_succeeded(SYNC_GIVEUP));
+}
+
+// Every value must be distinct: two names for one byte would make the failures
+// indistinguishable again, which is the entire thing this vocabulary exists to fix.
+TEST(SyncAckTest, EveryAckValueIsDistinct) {
+    const size_t n = sizeof(kAllAcks) / sizeof(kAllAcks[0]);
+    for (size_t i = 0; i < n; i++)
+        for (size_t j = i + 1; j < n; j++)
+            EXPECT_NE(kAllAcks[i], kAllAcks[j]) << "duplicate ack value at " << i << "," << j;
 }
 
 // The helper must be a WHITELIST, not a blacklist of known failures. That property
@@ -95,8 +107,9 @@ TEST(SyncAckTest, NoAckValueIsAStuckLineReading) {
 
 TEST(FwUpVerdictTest, OnlyARefusalAckIsSelfDescribing) {
     EXPECT_TRUE(fw_up_commit_ack_is_self_describing(SYNC_NACK_REFUSED));
-    // SYNC_CRC32_ERR means three different things, so it settles nothing — this is
-    // what makes the caller spend a STATUS probe.
+    // SYNC_CRC32_ERR now means only "the frame I received did not check out", which
+    // still does not say whether the slave's finalize ran — so it settles nothing,
+    // and the caller must spend a STATUS probe.
     EXPECT_FALSE(fw_up_commit_ack_is_self_describing(SYNC_CRC32_ERR));
     EXPECT_FALSE(fw_up_commit_ack_is_self_describing(SYNC_ACK));
 }
@@ -150,6 +163,29 @@ TEST(FwUpVerdictTest, ASlaveThatRecordsNoVerdictDegradesToLinkFailure) {
     fw_staging_status_t old_slave = {};   // every field zero, as an older reply reads
     EXPECT_EQ(fw_up_classify_commit_failure(SYNC_CRC32_ERR, true, old_slave.last_commit_ack),
               FW_UP_COMMIT_LINK_FAILURE);
+}
+
+// send_to_bridge now reports exhaustion as SYNC_GIVEUP rather than SYNC_CRC32_ERR,
+// so that is the value the classifier actually receives on the lost-answer path.
+// It must behave exactly like the old one: still ambiguous, still probe, and the
+// recorded verdict still decides.
+TEST(FwUpVerdictTest, AGiveUpIsNotSelfDescribingAndStillConsultsTheProbe) {
+    EXPECT_FALSE(fw_up_commit_ack_is_self_describing(SYNC_GIVEUP));
+    EXPECT_EQ(fw_up_classify_commit_failure(SYNC_GIVEUP, true, SYNC_NACK_REFUSED),
+              FW_UP_COMMIT_REFUSED);
+    EXPECT_EQ(fw_up_classify_commit_failure(SYNC_GIVEUP, true, 0), FW_UP_COMMIT_LINK_FAILURE);
+    EXPECT_EQ(fw_up_classify_commit_failure(SYNC_GIVEUP, true, SYNC_ACK),
+              FW_UP_COMMIT_LINK_FAILURE);
+    EXPECT_EQ(fw_up_classify_commit_failure(SYNC_GIVEUP, false, SYNC_NACK_REFUSED),
+              FW_UP_COMMIT_LINK_FAILURE);
+}
+
+// SYNC_BUSY never reaches a COMMIT classification (it is the BEGIN re-poll state),
+// but if it ever did it must not be mistaken for a refusal — the conservative
+// reading is the safe one for any value we do not specifically recognise.
+TEST(FwUpVerdictTest, BusyIsNeverReadAsARefusal) {
+    EXPECT_FALSE(fw_up_commit_ack_is_self_describing(SYNC_BUSY));
+    EXPECT_EQ(fw_up_classify_commit_failure(SYNC_BUSY, true, 0), FW_UP_COMMIT_LINK_FAILURE);
 }
 
 // ---------------------------------------------------------------------------

--- a/keyboards/polykybd/bridge_helper.c
+++ b/keyboards/polykybd/bridge_helper.c
@@ -36,7 +36,8 @@ static enum com_state com = NOT_INITIALIZED;
 #    define LINK_STATS_LOG_EVERY 200   // emit one health line per N frames sent
 #endif
 static uint32_t ls_attempts       = 0;  // frames sent (transaction_rpc_exec calls)
-static uint32_t ls_crc_err        = 0;  // slave NACK'd / non-ACK reply → payload corrupted in flight
+static uint32_t ls_crc_err        = 0;  // reply was SYNC_CRC32_ERR → payload corrupted in flight
+static uint32_t ls_nack           = 0;  // reply was a valid non-ACK (BUSY / REFUSED) → NOT a link fault
 static uint32_t ls_transport_fail = 0;  // transport returned false (timeout / handshake / no reply)
 static uint32_t ls_call_giveup    = 0;  // send_to_bridge() calls that exhausted every retry
 static uint32_t ls_last_log       = 0;  // ls_attempts at the last emitted summary
@@ -79,15 +80,26 @@ uint8_t send_to_bridge(int8_t tid, void* buffer_with4crc_bytes, const uint8_t nu
     // debug off (debug_enable now defaults false to suppress keystroke logging).
     if ((ls_attempts - ls_last_log) >= LINK_STATS_LOG_EVERY) {
         ls_last_log = ls_attempts;
+        // err% counts only real LINK faults — a corrupted frame or no answer at
+        // all. `nack` (a valid SYNC_BUSY / SYNC_NACK_REFUSED answer) is deliberately
+        // excluded: the wire worked, the slave simply said something other than yes.
+        // Counting those would inflate the one number used to judge cable / baud /
+        // drive changes — and SYNC_BUSY arrives on EVERY erase re-poll of a flash,
+        // so a font-pack update alone would have added hundreds of phantom "errors".
         uint32_t errs    = ls_crc_err + ls_transport_fail;
         uint32_t permille = ls_attempts ? (uint32_t)(((uint64_t)errs * 1000U) / ls_attempts) : 0U;
-        uprintf("Split link: %lu tx crc_err=%lu transport_fail=%lu giveup=%lu err=%lu.%lu%%\n",
-                (unsigned long)ls_attempts, (unsigned long)ls_crc_err,
+        uprintf("Split link: %lu tx crc_err=%lu nack=%lu transport_fail=%lu giveup=%lu err=%lu.%lu%%\n",
+                (unsigned long)ls_attempts, (unsigned long)ls_crc_err, (unsigned long)ls_nack,
                 (unsigned long)ls_transport_fail, (unsigned long)ls_call_giveup,
                 (unsigned long)(permille / 10U), (unsigned long)(permille % 10U));
     }
 
     *((uint32_t *)buffer_with4crc_bytes) = crc32_1byte(&((uint8_t *)buffer_with4crc_bytes)[4], num_bytes-4, 0);
+    // What the slave ACTUALLY said, kept across retries. Returning a constant on
+    // give-up threw this away, which made every non-ACK answer indistinguishable
+    // from silence — see the note at the return below.
+    uint8_t last_ack  = SYNC_GIVEUP;
+    bool    got_reply = false;
     for(; retry<max_retries; ++retry) {
         // Reset the reply each iteration: transaction_rpc_exec() leaves it
         // untouched when transport_write/read fails, so without this the log
@@ -105,18 +117,30 @@ uint8_t send_to_bridge(int8_t tid, void* buffer_with4crc_bytes, const uint8_t nu
         loop_profile_add_bridge_us(timer_hw->timerawl - _lp_t0);
 #endif
         ls_attempts++;
+        if(sync_success) {
+            // The transport delivered an answer. Remember it even if we go on to
+            // retry, so the caller can still learn what the slave said.
+            got_reply = true;
+            last_ack  = reply.ack;
+        }
         if(sync_success && (reply.ack == SYNC_ACK || reply.ack == SYNC_ACK_SIG)) {
             // A recovered retry is a non-event — the LINK_STATS summary already
             // counts retries/errors. Announcing every success spammed the console
             // unusably during a font-pack flash (thousands of bridged frames).
             return reply.ack;
         }
-        // Failed attempt. sync_success==true means the transport delivered a
-        // reply but it wasn't an ACK → the slave rejected the frame on CRC (or
-        // the reply itself was corrupted): a payload-integrity miss. false means
-        // the transport gave up (timeout / bad handshake / no reply).
+        // Failed attempt — but classify WHY, because only some of these are link
+        // faults. A SYNC_CRC32_ERR reply is a payload-integrity miss (the frame
+        // arrived corrupted). SYNC_BUSY / SYNC_NACK_REFUSED are valid protocol
+        // answers over a perfectly good wire and must not be counted as errors.
+        // sync_success==false means the transport gave up (timeout / bad
+        // handshake / no reply).
         if(sync_success) {
-            ls_crc_err++;
+            if(reply.ack == SYNC_CRC32_ERR) {
+                ls_crc_err++;
+            } else {
+                ls_nack++;
+            }
         } else {
             ls_transport_fail++;
         }
@@ -129,12 +153,22 @@ uint8_t send_to_bridge(int8_t tid, void* buffer_with4crc_bytes, const uint8_t nu
         uprintf("Failed to sync %d bytes for transaction %s!\n", num_bytes, tid_to_str(tid));
     }
 
-    // SYNC_GIVEUP, not SYNC_CRC32_ERR: we never obtained an answer, which is a
-    // different thing from having received a frame that failed its CRC. Callers
-    // that only ask sync_succeeded() are unaffected (it is a whitelist); the ones
-    // that classify a failure can now tell "the link went quiet" from "the slave
-    // answered and refused" without a status probe.
-    return SYNC_GIVEUP;
+    // Return what the slave SAID, and SYNC_GIVEUP only when it never answered.
+    //
+    // ⚠️ This used to return a constant, discarding reply.ack — and that silently
+    // defeated the whole point of having distinct failure values. It worked before
+    // only by COINCIDENCE: the constant was SYNC_CRC32_ERR, which happened to equal
+    // what the slave sent in every case that mattered. Two documented behaviours
+    // were in fact dead code because of it:
+    //   * hid_fw_up.c's erase-progress counter matches on the begin re-poll value.
+    //     With the slave answering SYNC_BUSY and this returning a constant, that
+    //     condition could never be true and the diagnostic never fired.
+    //   * fw_up_slave_refused_commit()'s "a refusal is self-describing, so don't
+    //     spend a STATUS RPC" short-circuit never triggered, because a refusal
+    //     arrived here as the give-up constant. Every refusal paid for a probe.
+    // Callers that only ask sync_succeeded() are unaffected — it is a whitelist,
+    // and none of these values is an ACK.
+    return got_reply ? last_ack : SYNC_GIVEUP;
 }
 
 bool differ(const void* b1, const void* b2, uint8_t byte_count) {

--- a/keyboards/polykybd/bridge_helper.c
+++ b/keyboards/polykybd/bridge_helper.c
@@ -158,14 +158,20 @@ uint8_t send_to_bridge(int8_t tid, void* buffer_with4crc_bytes, const uint8_t nu
     // ⚠️ This used to return a constant, discarding reply.ack — and that silently
     // defeated the whole point of having distinct failure values. It worked before
     // only by COINCIDENCE: the constant was SYNC_CRC32_ERR, which happened to equal
-    // what the slave sent in every case that mattered. Two documented behaviours
-    // were in fact dead code because of it:
-    //   * hid_fw_up.c's erase-progress counter matches on the begin re-poll value.
-    //     With the slave answering SYNC_BUSY and this returning a constant, that
-    //     condition could never be true and the diagnostic never fired.
-    //   * fw_up_slave_refused_commit()'s "a refusal is self-describing, so don't
-    //     spend a STATUS RPC" short-circuit never triggered, because a refusal
-    //     arrived here as the give-up constant. Every refusal paid for a probe.
+    // what the slave sent in every case that mattered.
+    //
+    // fw_up_slave_refused_commit()'s "a refusal is self-describing, so don't spend
+    // a STATUS RPC" short-circuit was DEAD CODE because of it: a refusal arrived
+    // here as the give-up constant, never as SYNC_NACK_REFUSED, so every refusal
+    // paid for a probe.
+    //
+    // hid_fw_up.c's erase-progress counter is the instructive near-miss — it kept
+    // working, but not for the reason it reads as. Its guard accepts SYNC_BUSY
+    // *or* SYNC_CRC32_ERR, a compat arm added for transiently-mismatched halves,
+    // and that arm happened to match the give-up constant too. So a defensive
+    // clause written for one hazard silently covered the discard, and the counter
+    // fired on a value the slave had not sent. It now matches SYNC_BUSY because
+    // the slave actually said SYNC_BUSY.
     // Callers that only ask sync_succeeded() are unaffected — it is a whitelist,
     // and none of these values is an ACK.
     return got_reply ? last_ack : SYNC_GIVEUP;

--- a/keyboards/polykybd/bridge_helper.c
+++ b/keyboards/polykybd/bridge_helper.c
@@ -92,7 +92,9 @@ uint8_t send_to_bridge(int8_t tid, void* buffer_with4crc_bytes, const uint8_t nu
         // Reset the reply each iteration: transaction_rpc_exec() leaves it
         // untouched when transport_write/read fails, so without this the log
         // line below would print the previous successful call's ack value.
-        reply.ack = SYNC_CRC32_ERR;
+        // SYNC_GIVEUP is the honest sentinel — "no answer obtained" — so a
+        // transport failure no longer reports itself as a CRC error in the log.
+        reply.ack = SYNC_GIVEUP;
 #ifdef POLYKYBD_LOOP_PROFILE
         uint32_t _lp_t0 = timer_hw->timerawl;
 #endif
@@ -127,7 +129,12 @@ uint8_t send_to_bridge(int8_t tid, void* buffer_with4crc_bytes, const uint8_t nu
         uprintf("Failed to sync %d bytes for transaction %s!\n", num_bytes, tid_to_str(tid));
     }
 
-    return SYNC_CRC32_ERR;
+    // SYNC_GIVEUP, not SYNC_CRC32_ERR: we never obtained an answer, which is a
+    // different thing from having received a frame that failed its CRC. Callers
+    // that only ask sync_succeeded() are unaffected (it is a whitelist); the ones
+    // that classify a failure can now tell "the link went quiet" from "the slave
+    // answered and refused" without a status probe.
+    return SYNC_GIVEUP;
 }
 
 bool differ(const void* b1, const void* b2, uint8_t byte_count) {

--- a/keyboards/polykybd/hid_fontpack.c
+++ b/keyboards/polykybd/hid_fontpack.c
@@ -125,7 +125,7 @@ bool hid_fontpack_receive(uint8_t *data, uint8_t length) {
 
             uint8_t slave_ack = master_ok
                 ? send_to_bridge(USER_SYNC_FLASH_STAGE, &begin_msg, sizeof(begin_msg), 1)
-                : SYNC_CRC32_ERR;
+                : SYNC_GIVEUP;   // never asked — the master rejected the pack itself
             bool slave_ok    = (slave_ack == SYNC_ACK);
             bool master_done = !fw_staging_erase_pending();
 

--- a/keyboards/polykybd/hid_fw_up.c
+++ b/keyboards/polykybd/hid_fw_up.c
@@ -73,7 +73,7 @@ bool hid_fw_up_receive(uint8_t *data, uint8_t length) {
             // the QMK main loop advance both deferred erases between polls.
             uint8_t slave_ack = master_ok
                 ? send_to_bridge(USER_SYNC_FLASH_STAGE, &begin_msg, sizeof(begin_msg), 1)
-                : SYNC_CRC32_ERR;
+                : SYNC_GIVEUP;   // never asked — the master's own image is invalid
             bool slave_ok    = (slave_ack == SYNC_ACK);
             bool master_done = !fw_staging_erase_pending();   // master's own staging erased?
 
@@ -101,8 +101,15 @@ bool hid_fw_up_receive(uint8_t *data, uint8_t length) {
             // print a snapshot so we can see whether erase_sector_next is
             // actually advancing.  Without this the slave can be stuck and
             // the only visible signal is "slave_ack=0x35" forever.
+            // ⚠️ Accept SYNC_CRC32_ERR as well as SYNC_BUSY. The slave now answers
+            // SYNC_BUSY while erasing, but the two halves can transiently run
+            // DIFFERENT firmware (a fw apply reboots the master first — the
+            // 2026-06-22 boot-splash hang), and an older slave still sends
+            // SYNC_CRC32_ERR here. Only this progress counter cares: the functional
+            // decision above is `slave_ack == SYNC_ACK`, so every non-ACK value
+            // keeps polling regardless, in either direction of mismatch.
             static uint16_t s_pending_poll_count = 0;
-            if (!slave_ok && slave_ack == SYNC_CRC32_ERR) {
+            if (!slave_ok && (slave_ack == SYNC_BUSY || slave_ack == SYNC_CRC32_ERR)) {
                 if ((++s_pending_poll_count & 0x0F) == 0) {
                     fw_up_log_slave_status("begin-pending");
                 }
@@ -162,7 +169,7 @@ bool hid_fw_up_receive(uint8_t *data, uint8_t length) {
             // ended up one chunk behind and rejected the whole rest of the stream
             // (2026-06-10, updates dying at 6% / 83%).  A duplicate re-send of an
             // already-staged chunk has next_offset > offset and passes (idempotent).
-            uint8_t slave_ack = fw_up_relay_chunk_to_slave(offset, chunk_data, "FW_UP_CHUNK") ? SYNC_ACK : SYNC_CRC32_ERR;
+            uint8_t slave_ack = fw_up_relay_chunk_to_slave(offset, chunk_data, "FW_UP_CHUNK") ? SYNC_ACK : SYNC_GIVEUP;
             // First-failure diagnostic: when a chunk doesn't reach the slave,
             // immediately query the slave's internal state so we can tell from
             // the master serial log whether the slave is fully hung (status RPC

--- a/keyboards/polykybd/split_fw_up.c
+++ b/keyboards/polykybd/split_fw_up.c
@@ -106,22 +106,24 @@ static void flash_stage_begin(uint8_t in_len, const void* in_data, uint8_t out_l
                        msg->target == s_begun_target && msg->bundle == s_begun_bundle);
 
     if (!same_image) {
-        s_begun_size   = msg->image_size;
-        s_begun_crc    = msg->image_crc;
-        s_begun_target = msg->target;
-        s_begun_bundle = msg->bundle;
-        // FONTPACK: point the stager at this bundle's fixed slot before erasing.
+        // ⚠️ Resolve and VALIDATE the slot before recording this identity. Caching
+        // s_begun_* first meant a refused bundle was remembered as "begun", so an
+        // identical retry — and send_to_bridge does retry a non-ACK — took the
+        // same_image path below, skipped this validation entirely, found no erase
+        // pending and could ACK a bundle we had just refused, against whatever slot
+        // was last set. Pre-existing; found in review of the refusal relabel.
         if (msg->target == FW_TARGET_FONTPACK) {
             uint32_t slot_off = 0, slot_size = 0;
-            if (fontpack_slot(msg->bundle, &slot_off, &slot_size)) {
-                fw_staging_set_fontpack_slot(slot_off, slot_size);
-            } else {
+            if (!fontpack_slot(msg->bundle, &slot_off, &slot_size)) {
                 // Unknown bundle id — REFUSE (not a CRC error: the frame was fine,
                 // we understood it and will not stage to a stale slot). Retrying
-                // cannot help; the halves disagree about the bundle layout.
+                // cannot help; the halves disagree about the bundle layout. Nothing
+                // has been recorded, so a repeat request is refused again.
                 ((poly_sync_reply_t *)out_data)->ack = SYNC_NACK_REFUSED;
                 return;
             }
+            // FONTPACK: point the stager at this bundle's fixed slot before erasing.
+            fw_staging_set_fontpack_slot(slot_off, slot_size);
         } else if (msg->target == FW_TARGET_DOOMWAD) {
             // The doom WHX slot is fixed (upper resource region).
             fw_staging_set_fontpack_slot(FW_DOOMWAD_SLOT_OFF, FW_DOOMWAD_SLOT_SIZE);
@@ -130,6 +132,10 @@ static void flash_stage_begin(uint8_t in_len, const void* in_data, uint8_t out_l
             // doom/PACK_DESIGN.md; the slave's drone runs the same pack).
             fw_staging_set_fontpack_slot(FW_DOOMPACK_SLOT_OFF, FW_DOOMPACK_SLOT_SIZE);
         }
+        s_begun_size   = msg->image_size;
+        s_begun_crc    = msg->image_crc;
+        s_begun_target = msg->target;
+        s_begun_bundle = msg->bundle;
         fw_staging_begin_deferred_target(msg->image_size, msg->image_crc, msg->target);
         uprintf("slave FW_UP_BEGIN: size=%lu crc=0x%08lx target=%u started erase\n",
                 msg->image_size, msg->image_crc, msg->target);

--- a/keyboards/polykybd/split_fw_up.c
+++ b/keyboards/polykybd/split_fw_up.c
@@ -31,11 +31,11 @@ bool fw_up_relay_chunk_to_slave(uint32_t offset, const uint8_t *chunk_data, cons
     chunk_msg.offset = offset;
     memcpy(chunk_msg.data, chunk_data, FW_UP_CHUNK_SIZE);
     chunk_msg.crc32 = crc32_1byte(&((const uint8_t *)&chunk_msg)[4], sizeof(chunk_msg) - 4, 0);
-    uint8_t slave_ack = SYNC_CRC32_ERR;
+    uint8_t slave_ack = SYNC_GIVEUP;   // no answer yet
     for (uint8_t retry = 0; retry < 10; ++retry) {
         fw_up_chunk_reply_t reply;
         memset(&reply, 0, sizeof(reply));
-        reply.ack = SYNC_CRC32_ERR;
+        reply.ack = SYNC_GIVEUP;   // sentinel: transaction_rpc_exec may not write it
         bool ok_rpc = transaction_rpc_exec(USER_SYNC_FLASH_STAGE, sizeof(chunk_msg), &chunk_msg,
                                            sizeof(reply), &reply);
         if (ok_rpc && reply.ack == SYNC_ACK && reply.next_offset > offset) {
@@ -79,7 +79,7 @@ static void flash_stage_status(uint8_t in_len, const void* in_data, uint8_t out_
 //
 // Protocol:
 //   New image   : start deferred erase, return SYNC_ACK_SIG ("erase started, not ready").
-//   Re-poll     : SYNC_CRC32_ERR while erasing, SYNC_ACK once complete.
+//   Re-poll     : SYNC_BUSY while erasing, SYNC_ACK once complete.
 //                 s_begun_size/crc are NOT reset on "done" — additional polls of the
 //                 same image return SYNC_ACK without re-triggering the erase, so a
 //                 UART-missed ACK does not cause an unnecessary full re-erase cycle.
@@ -116,9 +116,10 @@ static void flash_stage_begin(uint8_t in_len, const void* in_data, uint8_t out_l
             if (fontpack_slot(msg->bundle, &slot_off, &slot_size)) {
                 fw_staging_set_fontpack_slot(slot_off, slot_size);
             } else {
-                // Unknown bundle id — NACK so we never stage to a stale slot (the
-                // master guards the same way with its slot_ok check).
-                ((poly_sync_reply_t *)out_data)->ack = SYNC_CRC32_ERR;
+                // Unknown bundle id — REFUSE (not a CRC error: the frame was fine,
+                // we understood it and will not stage to a stale slot). Retrying
+                // cannot help; the halves disagree about the bundle layout.
+                ((poly_sync_reply_t *)out_data)->ack = SYNC_NACK_REFUSED;
                 return;
             }
         } else if (msg->target == FW_TARGET_DOOMWAD) {
@@ -136,9 +137,12 @@ static void flash_stage_begin(uint8_t in_len, const void* in_data, uint8_t out_l
         return;
     }
 
-    // Re-poll: same image.
+    // Re-poll: same image. SYNC_BUSY, not SYNC_CRC32_ERR — this is a perfectly
+    // normal "not yet", and calling it a CRC error is what made that value
+    // meaningless. The master's decision here is `ack == SYNC_ACK` either way, so
+    // an old master facing this new value still just keeps polling.
     if (fw_staging_erase_pending()) {
-        ((poly_sync_reply_t *)out_data)->ack = SYNC_CRC32_ERR;
+        ((poly_sync_reply_t *)out_data)->ack = SYNC_BUSY;
         return;
     }
 
@@ -196,7 +200,10 @@ static void flash_stage_chunk(uint8_t in_len, const void* in_data, uint8_t out_l
 #else
         bool ok = fw_staging_write_chunk(msg->offset, msg->data, FW_UP_CHUNK_SIZE);
 #endif
-        ack = ok ? SYNC_ACK : SYNC_CRC32_ERR;
+        // A rejected write is a REFUSAL, not a CRC error — the frame checked out
+        // above; the stager declined the offset. (The relay still retries, and the
+        // next_offset invariant still guards a stale reply.)
+        ack = ok ? SYNC_ACK : SYNC_NACK_REFUSED;
     }
     fw_staging_note_chunk_call(msg->offset, ack);
     reply->ack         = ack;
@@ -363,9 +370,11 @@ void user_sync_reset_handler(uint8_t in_len, const void* in_data, uint8_t out_le
         return;
     }
     if (msg->action == RESET_ACTION_APPLY) {
-        // Install the staged image, then reboot — reject unless a valid image is staged.
+        // Install the staged image, then reboot — reject unless a valid image is
+        // staged. REFUSED, not a CRC error: the master must re-stage, and the log
+        // line it prints (ack=0x%02x) can now say which of the two happened.
         if (!fw_staging_has_valid_staged_image()) {
-            ((poly_sync_reply_t *)out_data)->ack = SYNC_CRC32_ERR;
+            ((poly_sync_reply_t *)out_data)->ack = SYNC_NACK_REFUSED;
             return;
         }
         fw_staging_arm_apply();    // housekeeping_task_user() → fw_staging_apply_and_reboot()
@@ -381,7 +390,7 @@ void user_sync_reset_handler(uint8_t in_len, const void* in_data, uint8_t out_le
     } else {
         // Unknown action — refuse rather than guess (magic+CRC already passed, so
         // this only happens on a genuinely malformed request).
-        ((poly_sync_reply_t *)out_data)->ack = SYNC_CRC32_ERR;
+        ((poly_sync_reply_t *)out_data)->ack = SYNC_NACK_REFUSED;
         return;
     }
     ((poly_sync_reply_t *)out_data)->ack = SYNC_ACK;


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #210** — its base is `claude/split-slave-commit-refusal-ack`, so the diff
> above shows only this change. GitHub retargets it to `PolyKybd` automatically when #210
> merges. It has to stack: the new values belong in `base/sync_ack.h` and the test that
> enforces their spacing lives in `fw_up_verdict_tests.cpp`, neither of which exists on
> `PolyKybd` yet. Cutting from `PolyKybd` instead would land new codewords with no test
> coverage plus a guaranteed conflict in both files.

## Summary

#210 peeled the **refusal** case off `SYNC_CRC32_ERR` and left the other three meanings
separated by nothing but a comment. This finishes it, so the name is finally accurate:

| Value | Means | Correct response |
|---|---|---|
| `SYNC_CRC32_ERR` 0x35 | the frame I received did not check out | retry — it may arrive intact |
| **`SYNC_BUSY` 0x1B** | a normal not-yet: the `flash_stage_begin` re-poll while the deferred erase runs | keep polling |
| **`SYNC_GIVEUP` 0xE4** | no answer obtained at all — `send_to_bridge` exhausted its retries, or we never asked | retry |
| `SYNC_NACK_REFUSED` 0xB2 | I processed it and the answer is no | re-flash; asking again cannot change my flash |

Four further sites were **refusals wearing a CRC error's name**, and are relabelled: an
unknown bundle id, a chunk write the stager declined, an apply with no valid staged image,
and an unknown reset action. Each is "I understood you and the answer is no".

**The invariant this establishes, and how to check it stays true:** every remaining
`= SYNC_CRC32_ERR` sits directly on a `crc32 != …->crc32` (or magic) check.

```bash
grep -rn -B3 "ack = SYNC_CRC32_ERR" --include=*.c keyboards/polykybd/   # no exceptions
```

I audited all 11 sites; the three in `split_sync.c` are the CRC macro and two
`if (crc32 == data->crc32) … else` branches.

### Why not an extra info byte next to the ack

That was the alternative considered, and it inverts the safety property. The reply carries
**no CRC**, which is precisely why the ack values are Hamming-spaced — a flipped bit cannot
turn one verdict into another. An adjacent reason byte gets none of that protection (enum
neighbours differ by 1–2 bits), and it would be *the field the decision reads*, so the
decision would become less trustworthy than today. Making it safe means a reply CRC or a
semantic invariant, i.e. a per-transaction reply struct — which this codebase already does
where it is warranted: `fw_up_chunk_reply_t` is literally `{ack, pad, next_offset}` made
trustworthy by the "cursor must have advanced past this offset" invariant, and
`fw_up_status_reply_t` carries its own `crc32`. Widening the *generic* 1-byte reply would
instead touch 13 handler write sites and 16 classifiers for payload that already has a home
(erase progress is in `fw_up_status_reply_t`'s `erase_sector_next`/`_count`; refusal detail
is in the four `FW_UP_COMMIT` HID statuses).

### Why `0x1B` / `0xE4`

Complements of each other, so the set stays **three complement pairs**, and both are
balanced at popcount 4:

```
SYNC_ACK 0xCA ↔ SYNC_CRC32_ERR    0x35
SYNC_ACK_SIG 0x4D ↔ SYNC_NACK_REFUSED 0xB2
SYNC_BUSY 0x1B ↔ SYNC_GIVEUP      0xE4     <- new pair
```

Both sit at distance exactly 4 from all four existing values, and all six keep min pairwise
distance 4. Six of a 16-codeword distance-4 code are now used — **10 remain** (8 excluding
`0x00`/`0xFF`, which are what a stuck or floating line reads as).

## Why this is safe

**Every consumer tests `== SYNC_ACK` or `sync_succeeded()`** — ACK-or-not. So no decision
anywhere changes; only what the logs and the COMMIT classifier can tell apart. `sync_succeeded()`
is a whitelist, so the two new failure values are failures at all 14 existing call sites with
no edits.

That also makes **mismatched halves safe in both directions**, which matters because they
demonstrably occur — a firmware apply reboots the master first (the 2026-06-22 boot-splash
hang, `err=36%`). ⚠️ The single place that *matches* on the begin re-poll value is
`hid_fw_up.c`'s erase-progress counter, and it accepts **both** `SYNC_BUSY` and the legacy
`SYNC_CRC32_ERR` for exactly that reason.

**No host or rig change.** The ack vocabulary is split-internal — the only occurrence outside
the firmware is a comment in `poly_core.py`.

## Review round (`45bd7ee5`)

Three findings, all verified against the code and all real. The root one is worth recording
because it generalises:

**`send_to_bridge()` returned a CONSTANT on give-up, discarding `reply.ack`** — and that
worked only by coincidence, because the constant was `SYNC_CRC32_ERR`, which happened to
equal what the slave sent in every case that mattered. Splitting the failure values is what
exposed the discard. It made `fw_up_slave_refused_commit()`'s "a refusal is self-describing,
so don't spend a STATUS RPC" short-circuit **dead code** — a refusal arrived as the give-up
constant, never as `SYNC_NACK_REFUSED` — so since #210 landed it, every refusal has paid for
a probe. `send_to_bridge()` now returns what the slave said, and `SYNC_GIVEUP` only when it
never answered.

The other two: `err%` counted valid non-ACK answers as CRC errors (material, because
`SYNC_BUSY` arrives on *every* erase re-poll — see the measured numbers below), now split
into a separate `nack=` field; and `flash_stage_begin` cached the image identity **before**
validating the bundle, so an identical retry of a just-refused bundle could skip validation
and ACK.

⚠️ `030365fe` corrects an overclaim I made while fixing those: I reported the erase-progress
counter as a *second* dead-code case. It was not — its guard accepts `SYNC_BUSY` **or**
`SYNC_CRC32_ERR`, a compat arm for transiently mismatched halves, and that arm also matched
the give-up constant, so it fired throughout on a value the slave had not sent. The lesson is
kept rather than deleted, since a defensive clause silently covering an unrelated hazard is
exactly how a discarded return value survives review. Comments only; the image is unchanged.

## Tests (21 → 24)

The six-value table drives the spacing and stuck-line tests, so those widened for free. Added:

- `EveryAckValueIsDistinct` — two names for one byte would make the failures indistinguishable
  again, which is the whole point of the vocabulary.
- `AGiveUpIsNotSelfDescribingAndStillConsultsTheProbe` — **`send_to_bridge` now returns
  `SYNC_GIVEUP` on exhaustion, so the classifier's real input on the lost-answer path
  changed.** `fw_up_verdict.h`'s doc comment still named the old value; both are fixed.
- `BusyIsNeverReadAsARefusal` — it should never reach a COMMIT classification, but if it did,
  the conservative reading is the safe one.

**Mutation-tested, 5 new breakages, each caught by the intended test:** `SYNC_BUSY` one bit
from `SYNC_ACK`, `SYNC_GIVEUP` duplicating `SYNC_BUSY`, `SYNC_BUSY` as `0x00`,
`sync_succeeded` whitelisting `BUSY` (which would make every caller read a mid-erase re-poll
as *success*), and `GIVEUP` treated as a self-describing refusal.

⚠️ **Emit sites are not unit-testable here** — the tests cover the pure decision layer, not
which byte a handler writes. That gap is closed by the hardware run below.

## Version bump label

Patch (no label) — a split-protocol refinement, no new feature, no `PROTOCOL_VERSION` change.

## Testing

- [x] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`) — and `split42`
- [x] Flashed and tested on hardware — see below; `Build firmware` + `HIL test (split72)` also
      green on `45bd7ee5`
- [x] If protocol changed: n/a

### Hardware verification (2026-08-18, split72, firmware flash + font-pack sync)

Captured with `tools/poly_console.py` — the host log is structurally blind during a flash, so
this is the only way to see it. All three effects are visible, and the emit sites the unit
tests cannot reach are exercised:

```
FW_UP_BEGIN: slave_ack=0xe4 slave_ok=0 new_image=1     <- SYNC_GIVEUP: no answer at all
FW_UP_BEGIN: slave_ack=0x1b slave_ok=0 new_image=0     <- SYNC_BUSY:   erase in progress
... x16 ...
slave status (begin-pending): ... erase=45/117 ... pd_advances=45
... x16 ...
slave status (begin-pending): ... erase=91/117 ... pd_advances=91
FW_UP_BEGIN: slave_ack=0xca slave_ok=1                 <- SYNC_ACK
fw_staging_process_deferred: erase complete (117 sectors), core1 restarted
```

**Both of those were `0x35` before this PR**, indistinguishable from a corrupted frame. The
`begin-pending` snapshots land at poll 17 and 33 of a 117-sector erase, matching the
every-16 counter, and show the slave's housekeeping advancing (`pd_advances` tracks `erase`).

The link-health line during a font-pack sync:

```
Split link: 200 tx crc_err=0 nack=11 transport_fail=1 giveup=12 err=0.5%
```

Self-consistent: the BEGIN re-poll uses `max_retries=1`, so 11 `SYNC_BUSY` + 1 no-answer =
the 12 exhausted calls. **Before the `err%` fix this same link would have reported 6.0%** —
a 12× overstatement on a link with one real fault, which is exactly the number people use to
judge cable/baud changes.

Also verified locally:

- The **whole** lint job: `qmk ci-validate-keyboard-targets` (exit 0), `qmk ci-validate-aliases`
  (exit 0), `qmk lint --strict` on both variants, no tracked-but-gitignored files, and line
  endings + final newline on every changed file.
- The **monolith** (`POLYKYBD_DOOM=yes`), which PR CI does not build: links with `.heap` at
  **3828 bytes, unchanged**.
- 24 + 19 tests pass (`fw_up_verdict`, `polymod_ltr559`).

## Known follow-up (deliberately not in this PR)

The hardware run shows `giveup=12` on a perfectly healthy link: an erase re-poll answers
`SYNC_BUSY`, but the call exhausts its single retry without an ACK and so counts as a
give-up. That is the same category error one layer up — `giveup` should mean "the link did
not answer", and now that `got_reply`/`last_ack` exist it can. Diagnostic-only, no behaviour
change, so it is better as its own change than as another push onto a reviewed branch.

## Left deliberately alone

- The **chunk** path's `next_offset` invariant and retry behaviour — untouched; only the
  failure *label* changed.
- A `SYNC_BUSY`-style value for the *master's* own erase state: the master reports readiness
  to the host as `~` over HID, which is already distinct. No need.

---
_Generated by [Claude Code](https://claude.ai/code/session_019aZAPjJZ6PRrDeJD1SEEHQ)_

## Summary by Sourcery

Separate synchronization CRC errors, busy responses, refusals, and transport give-ups into distinct, fault-tolerant verdicts without changing successful ACK handling.

New Features:
- Add distinct synchronization verdicts for erase-in-progress and exhausted/no-response cases.

Bug Fixes:
- Preserve and return the slave's actual response instead of replacing unanswered transactions with a CRC-error value.
- Prevent refused firmware bundles from being cached as valid begun images and incorrectly accepted on retry.
- Correct link diagnostics so valid negative responses are not counted as CRC or link errors.

Enhancements:
- Clarify synchronization acknowledgement semantics so CRC errors, refusals, busy states, and transport give-ups are distinguishable while preserving ACK-only behavior.
- Maintain compatibility with older firmware during mixed-version erase polling.

Documentation:
- Document the expanded acknowledgement vocabulary, Hamming-distance constraints, and revised link-health metrics.

Tests:
- Extend acknowledgement spacing and fail-closed tests to cover all six values.
- Add coverage for distinct values, give-up classification, and ensuring busy responses are not treated as refusals.