### PR TITLE
split: count a give-up only when the link actually failed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2695,6 +2695,25 @@ wire. **Use it to validate any link change** (baud/cable/drive/termination) by
 watching the number move, instead of by feel. `giveup` should stay ~0 with
 retries=3; if it climbs, attack `p` at the source.
 
+⚠️ **`giveup` counts only calls that ended on a LINK fault, and `nack` is EXCLUDED
+from `err%`** — both decided by the one shared predicate `sync_is_link_fault(got_reply,
+ack)` (`base/sync_ack.h`), so the two numbers can never disagree about what a bad wire
+is. A link fault is exactly *nobody answered* or *the slave says what reached it was
+corrupt* (`SYNC_CRC32_ERR`); every other byte means the wire delivered a frame and the
+slave answered with a verdict of its own.
+- ⚠️ **It is deliberately NOT an enumeration of the non-fault values.** Listing the
+  siblings (`ack == SYNC_BUSY || ack == SYNC_NACK_REFUSED || …`) is the guard shape that
+  goes stale — a seventh ack value would be misclassified until someone remembered to
+  add it. `SyncAckTest.AnUnknownReplyValueIsNotMistakenForALinkFault` sweeps all 256
+  bytes to pin that, and it fails against the enumerating implementation.
+- **Why `giveup` needed this:** the `flash_stage_begin` re-poll runs with
+  `max_retries=1`, so **every** poll of a deferred erase exhausted its retries with a
+  perfectly good `SYNC_BUSY` answer and counted as a give-up. Measured on hardware
+  (2026-08-18) a healthy font-pack sync read `nack=11 transport_fail=1 giveup=12` — one
+  real fault, twelve reported give-ups. `giveup` is read as "the link is failing", so
+  that is the same category error that had `err%` reading 6.0% on that link instead of
+  0.5%.
+
 ⚠️ **`nack` is EXCLUDED from `err%` on purpose** — it counts valid non-ACK answers
 (`SYNC_BUSY`, `SYNC_NACK_REFUSED`), where the wire worked and the slave simply said
 something other than yes. Only `crc_err` (a corrupted frame) and `transport_fail`

--- a/keyboards/polykybd/base/sync_ack.h
+++ b/keyboards/polykybd/base/sync_ack.h
@@ -85,3 +85,21 @@ typedef struct _poly_sync_reply_t {
 static inline bool sync_succeeded(uint8_t ack) {
     return ack == SYNC_ACK || ack == SYNC_ACK_SIG;
 }
+
+// Was this exchange a LINK fault — a bad wire — as opposed to a verdict the
+// slave deliberately sent? Both the err% numerator and the give-up counter ask
+// this, so sharing one predicate keeps them from ever disagreeing about what a
+// bad link is.
+//
+// `got_reply` is whether the transport delivered a reply at all.
+//
+// ⚠️ Deliberately NOT an enumeration of the failure values. A link fault is
+// exactly two things: nobody answered, or the slave says what reached it was
+// corrupt. Any OTHER byte means the wire delivered a frame and the slave
+// answered with a verdict of its own — so a seventh ack value is classified
+// correctly here with no edit. A guard that instead listed its siblings
+// (`ack == SYNC_BUSY || ack == SYNC_NACK_REFUSED || …`) would need updating for
+// every new value, and would silently misclassify until someone remembered.
+static inline bool sync_is_link_fault(bool got_reply, uint8_t ack) {
+    return !got_reply || ack == SYNC_CRC32_ERR;
+}

--- a/keyboards/polykybd/base/tests/fw_up_verdict_tests.cpp
+++ b/keyboards/polykybd/base/tests/fw_up_verdict_tests.cpp
@@ -15,6 +15,8 @@
 
 #include "gtest/gtest.h"
 
+#include <ios>
+
 extern "C" {
 #include "sync_ack.h"
 #include "fw_staging.h"
@@ -98,6 +100,42 @@ TEST(SyncAckTest, NoAckValueIsAStuckLineReading) {
     for (uint8_t ack : kAllAcks) {
         EXPECT_NE(ack, 0x00);
         EXPECT_NE(ack, 0xFF);
+    }
+}
+
+// sync_is_link_fault() decides both the err% numerator and the give-up counter,
+// so a mistake here silently corrupts the one number used to judge cable / baud /
+// drive changes. A link fault is "nobody answered" or "the slave says what
+// reached it was corrupt" — nothing else.
+TEST(SyncAckTest, NoAnswerIsAlwaysALinkFault) {
+    // The ack byte is meaningless when nothing was received, so it must not be
+    // consulted: every possible value still reads as a fault.
+    for (int b = 0; b <= 0xFF; ++b) {
+        EXPECT_TRUE(sync_is_link_fault(false, static_cast<uint8_t>(b)))
+            << "no reply, but ack 0x" << std::hex << b << " read as a clean link";
+    }
+}
+
+TEST(SyncAckTest, OnlyACrcErrorReplyIsALinkFault) {
+    EXPECT_TRUE(sync_is_link_fault(true, SYNC_CRC32_ERR));
+    // Everything the slave can deliberately say is a verdict, not a bad wire —
+    // most importantly SYNC_BUSY, which arrives on EVERY erase re-poll of a flash.
+    EXPECT_FALSE(sync_is_link_fault(true, SYNC_BUSY));
+    EXPECT_FALSE(sync_is_link_fault(true, SYNC_NACK_REFUSED));
+    EXPECT_FALSE(sync_is_link_fault(true, SYNC_ACK));
+    EXPECT_FALSE(sync_is_link_fault(true, SYNC_ACK_SIG));
+}
+
+// The predicate must NOT enumerate the non-fault values: a seventh ack value has
+// to classify correctly with no edit, or the counter goes stale the way an
+// enumerating guard always does. A delivered reply is by construction proof the
+// wire worked, so every byte except SYNC_CRC32_ERR is a verdict.
+TEST(SyncAckTest, AnUnknownReplyValueIsNotMistakenForALinkFault) {
+    for (int b = 0; b <= 0xFF; ++b) {
+        const uint8_t ack = static_cast<uint8_t>(b);
+        if (ack == SYNC_CRC32_ERR) continue;
+        EXPECT_FALSE(sync_is_link_fault(true, ack))
+            << "a delivered reply of 0x" << std::hex << b << " read as a link fault";
     }
 }
 

--- a/keyboards/polykybd/bridge_helper.c
+++ b/keyboards/polykybd/bridge_helper.c
@@ -39,7 +39,9 @@ static uint32_t ls_attempts       = 0;  // frames sent (transaction_rpc_exec cal
 static uint32_t ls_crc_err        = 0;  // reply was SYNC_CRC32_ERR → payload corrupted in flight
 static uint32_t ls_nack           = 0;  // reply was a valid non-ACK (BUSY / REFUSED) → NOT a link fault
 static uint32_t ls_transport_fail = 0;  // transport returned false (timeout / handshake / no reply)
-static uint32_t ls_call_giveup    = 0;  // send_to_bridge() calls that exhausted every retry
+static uint32_t ls_call_giveup    = 0;  // calls that exhausted every retry on a LINK fault
+                                        // (not counted when the slave answered BUSY/REFUSED —
+                                        //  see the note where it is incremented)
 static uint32_t ls_last_log       = 0;  // ls_attempts at the last emitted summary
 
 void set_com_state(enum com_state state) {
@@ -135,20 +137,31 @@ uint8_t send_to_bridge(int8_t tid, void* buffer_with4crc_bytes, const uint8_t nu
         // answers over a perfectly good wire and must not be counted as errors.
         // sync_success==false means the transport gave up (timeout / bad
         // handshake / no reply).
-        if(sync_success) {
-            if(reply.ack == SYNC_CRC32_ERR) {
-                ls_crc_err++;
-            } else {
-                ls_nack++;
-            }
-        } else {
+        if(!sync_success) {
             ls_transport_fail++;
+        } else if(sync_is_link_fault(true, reply.ack)) {
+            ls_crc_err++;
+        } else {
+            ls_nack++;
         }
         if(debug_enable) {
             uprintf("Bridge sync retry %d (tid: %s, success: %d, ack: %d, bytes: %d)\n", retry, tid_to_str(tid), sync_success, reply.ack, num_bytes);
         }
     }
-    ls_call_giveup++;
+    // Count a give-up only when the call ended on a LINK fault. A call whose last
+    // answer was a protocol verdict — SYNC_BUSY above all — did not give up on
+    // anything: the slave answered, and the answer was simply not yes.
+    //
+    // This matters because it is the COMMON case, not an edge one. The
+    // flash_stage_begin re-poll runs with max_retries=1, so EVERY poll of a
+    // deferred erase used to land here: a healthy font-pack sync measured
+    // `nack=11 transport_fail=1 giveup=12` on hardware (2026-08-18) — a link with
+    // one real fault reporting twelve give-ups. `giveup` is read as "the link is
+    // failing", so inflating it with normal polling is the same category error
+    // that made err% read 6.0% on that link instead of 0.5%.
+    if(sync_is_link_fault(got_reply, last_ack)) {
+        ls_call_giveup++;
+    }
     if(debug_enable) {
         uprintf("Failed to sync %d bytes for transaction %s!\n", num_bytes, tid_to_str(tid));
     }


### PR DESCRIPTION
> [!NOTE]
> Was stacked on #211 (itself on #210). **Both merged 2026-08-18**, and GitHub retargeted
> this to `PolyKybd` and rebased the branch, so it now carries exactly one commit with no
> duplicated history. Auto-review applies again — the stacked-PR skip no longer holds.

## Summary

Found by reading a real hardware log from #211's build, which is the only reason it was
visible at all — the ack values had to be distinct before a verdict could be told from
silence.

`ls_call_giveup` counted every `send_to_bridge()` call that exhausted its retries without
an ACK. But the `flash_stage_begin` re-poll runs with **`max_retries=1`**, so *every* poll
of a deferred erase landed there — having been answered, correctly, with `SYNC_BUSY`. A
healthy font-pack sync therefore reported twelve give-ups on a link with one real fault
(hardware, 2026-08-18):

```
Split link: 200 tx crc_err=0 nack=11 transport_fail=1 giveup=12 err=0.5%
                          └─ 11 BUSY + 1 no-answer = the 12 "give-ups"
```

`giveup` is read as *"the link is failing"*. Inflating it with normal polling is the same
category error that had `err%` reading **6.0%** on that link instead of 0.5% — one layer
up.

## The fix, and why it is shaped this way

Both questions — *is this frame an error?* and *did this call give up?* — are now decided
by one shared predicate, so they can never disagree about what a bad wire is:

```c
static inline bool sync_is_link_fault(bool got_reply, uint8_t ack) {
    return !got_reply || ack == SYNC_CRC32_ERR;
}
```

A link fault is exactly two things: **nobody answered**, or **the slave says what reached
it was corrupt**. Every other byte means the transport delivered a frame and the slave
answered with a verdict of its own.

⚠️ **That framing is the point, not an implementation detail.** The obvious version lists
the non-fault values — `ack == SYNC_BUSY || ack == SYNC_NACK_REFUSED || …` — and that is
the guard shape which goes stale: a seventh ack value would be misclassified until someone
remembered to add it, silently, in a counter nobody re-derives. The sibling host repo has
this exact failure written up (`find_matching_entry`, where a matcher enumerated two of its
three siblings and one overlay set had *never once rendered*). Testing the complement is
what makes it stable — a delivered reply is by construction proof the wire worked.

## Why this is safe

**Diagnostics only.** No decision anywhere reads these counters; they exist to measure the
link so cable / baud / drive changes can be judged by a number instead of by feel. Every
caller's behaviour is byte-for-byte identical.

## Tests (24 → 27)

- `NoAnswerIsAlwaysALinkFault` — sweeps all 256 bytes with `got_reply=false`. The ack byte
  is meaningless when nothing arrived, so it must not be consulted.
- `OnlyACrcErrorReplyIsALinkFault` — `SYNC_BUSY` above all must not count, since it arrives
  on *every* erase re-poll of a flash.
- `AnUnknownReplyValueIsNotMistakenForALinkFault` — sweeps all 256 bytes except
  `SYNC_CRC32_ERR`. **This is the test that forbids the enumerating implementation**, and
  it is the one that fails against it.

**Mutation-tested against 4 deliberate breakages, each caught by the intended test:** the
enumerating form (caught by the unknown-value sweep), ignoring `got_reply`, `SYNC_BUSY`
classified as a fault, and "never a fault".

## Version bump label

Patch (no label) — a diagnostics correction. No `PROTOCOL_VERSION` change, no wire change.

## Testing

- [x] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`) — and `split42`
- [ ] Flashed and tested on hardware — **not yet**; the rig runs on push. The change is
      counter-only, and the log excerpt above is the evidence for the behaviour it corrects.
- [x] If protocol changed: n/a

Also verified locally:

- The **whole** lint job: `qmk ci-validate-keyboard-targets` (exit 0), `qmk ci-validate-aliases`
  (exit 0), `qmk lint --strict` on both variants, no tracked-and-gitignored files, and line
  endings + final newline on every changed file.
- The **monolith** (`POLYKYBD_DOOM=yes`), which PR CI does not build: links with `.heap` at
  **3828 bytes, unchanged**.
- 27 tests pass (`make test:fw_up_verdict`).

---
_Generated by [Claude Code](https://claude.ai/code/session_019aZAPjJZ6PRrDeJD1SEEHQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected link health statistics to count only missing responses and CRC failures as link faults.
  * Prevented valid slave responses, including `BUSY` and `REFUSED`, from inflating error or give-up counters.
  * Improved handling of unknown response values so they are treated as valid protocol verdicts.

* **Tests**
  * Added coverage for missing, CRC-error, valid, and unknown response classifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->