### PR TITLE
ci: actually run the PolyKybd unit tests

### DIFF
--- a/.github/workflows/polykybd-unit-test.yml
+++ b/.github/workflows/polykybd-unit-test.yml
@@ -1,0 +1,100 @@
+# Runs the PolyKybd googletest suites (`make test:<name>`).
+#
+# WHY A SEPARATE WORKFLOW: upstream's `unit_test.yml` is stock QMK and its
+# `paths:` filter lists only builddefs/ quantum/ platforms/ tmk_core/ tests/ —
+# none of which a PolyKybd change touches. So every suite under
+# keyboards/polykybd/ and modules/polykybd/ was invisible to CI: 46 tests across
+# two suites had only ever been run by hand, on a repo whose PR board otherwise
+# looks comprehensively green. Editing upstream's workflow instead would just
+# conflict at the next catch-up merge.
+name: PolyKybd Unit Tests
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - PolyKybd
+      - 'PolyKybd/**'
+  pull_request:
+    paths:
+      - 'keyboards/polykybd/**'
+      - 'modules/polykybd/**'
+      # The harness registrations themselves: a suite can be silently
+      # de-registered by editing only these.
+      - 'builddefs/testlist.mk'
+      - 'builddefs/build_test.mk'
+      - '.github/workflows/polykybd-unit-test.yml'
+
+jobs:
+  test:
+    name: PolyKybd unit tests
+    runs-on: ubuntu-latest
+
+    container: ghcr.io/qmk/qmk_cli
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: pip3 install -r requirements-dev.txt
+
+      # Derived from the harness, never hardcoded: the suite names come from the
+      # `TEST_LIST +=` lines of every polykybd testlist.mk that builddefs includes.
+      # So adding a third suite needs no edit here — the same reason the split-link
+      # fault predicate refuses to enumerate its siblings: a list that must be kept
+      # in sync is a list that goes stale silently.
+      - name: Discover PolyKybd test suites
+        id: discover
+        run: |
+          set -euo pipefail
+          lists=$(grep -o '[^ ]*polykybd[^ ]*/testlist\.mk' builddefs/testlist.mk || true)
+          if [ -z "$lists" ]; then
+            echo "::error::No polykybd testlist.mk is included from builddefs/testlist.mk."
+            echo "Either the suites were de-registered, or the include path changed."
+            exit 1
+          fi
+          echo "Including:"; echo "$lists" | sed 's/^/  /'
+          names=$(grep -h 'TEST_LIST *+=' $lists | sed 's/.*+=[[:space:]]*//' | tr -d '\r' | sort -u)
+          if [ -z "$names" ]; then
+            echo "::error::Found polykybd testlist.mk files but no TEST_LIST entries in them."
+            exit 1
+          fi
+          echo "Suites:"; echo "$names" | sed 's/^/  /'
+          # Guard against a green board that ran nothing — the failure mode this
+          # whole workflow exists to remove.
+          echo "names<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$names"     >> "$GITHUB_OUTPUT"
+          echo "EOF"        >> "$GITHUB_OUTPUT"
+
+      - name: Run PolyKybd test suites
+        run: |
+          set -uo pipefail
+          failed=""
+          count=0
+          while IFS= read -r t; do
+            [ -n "$t" ] || continue
+            count=$((count + 1))
+            echo "::group::make test:$t"
+            if make "test:$t" -j "$(nproc)"; then
+              echo "::endgroup::"
+              echo "PASS $t"
+            else
+              echo "::endgroup::"
+              echo "::error::test suite '$t' failed"
+              failed="$failed $t"
+            fi
+          done <<< "${{ steps.discover.outputs.names }}"
+          echo "--- ran $count suite(s) ---"
+          if [ "$count" -eq 0 ]; then
+            echo "::error::ran zero test suites"
+            exit 1
+          fi
+          if [ -n "$failed" ]; then
+            echo "Failed:$failed"
+            exit 1
+          fi
+          echo "All $count PolyKybd test suite(s) passed."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1398,8 +1398,27 @@ backing store the way a driver test should mock its bus.
 git submodule update --init --depth 1 --no-recommend-shallow lib/googletest  # needs add_repo qmk/googletest first
 export QMK_HOME=$PWD && export PATH="/root/.qmk_venv/bin:$PATH"
 make test:polymod_ltr559          # ~1 s, 19 tests — the LTR-559 driver vs a mock I2C bus
-make test:fw_up_verdict           # ~1 s, 21 tests — the flash-staging COMMIT decision layer
+make test:fw_up_verdict           # ~1 s, 27 tests — the flash-staging COMMIT decision layer
 ```
+
+✅ **These run in CI — via `polykybd-unit-test.yml`, NOT upstream's `unit_test.yml`.**
+That distinction is the whole point: upstream's workflow filters on `builddefs/ quantum/
+platforms/ tmk_core/ tests/`, and a PolyKybd change touches none of them, so for as long
+as these suites existed **CI never ran a single one of them** — 46 tests, hand-run only,
+on a PR board that otherwise looks comprehensively green. Do **not** "fix" that by adding
+our paths to `unit_test.yml`: it is stock upstream and would conflict at the next
+catch-up merge.
+- **The suite names are DERIVED, not hardcoded.** The workflow greps every
+  `*polykybd*/testlist.mk` that `builddefs/testlist.mk` includes and reads their
+  `TEST_LIST +=` lines, so **a third suite needs no workflow edit** — register it in the
+  two builddefs files (see below) and CI picks it up. Same reasoning as
+  `sync_is_link_fault()` refusing to enumerate its siblings: a list that must be kept in
+  sync is a list that goes stale silently.
+- ⚠️ **It fails when it discovers ZERO suites**, and again if the loop runs zero. A test
+  job that quietly runs nothing and reports green is strictly worse than no job — it is
+  the exact failure this workflow was added to remove, so it must not be able to
+  recreate it one level up. The loop also continues past a failing suite, so one run
+  names every broken suite rather than just the first.
 
 - **`fw_up_verdict` is the pattern for testing DECISION logic** (as opposed to
   `polymod_ltr559`, which is the pattern for a driver vs a mock bus). It covers the


### PR DESCRIPTION
## Summary

Both googletest suites — **46 tests** across `fw_up_verdict` (27) and `polymod_ltr559`
(19) — have **never been run by CI**. Only by hand.

Upstream's `unit_test.yml` filters on `builddefs/ quantum/ platforms/ tmk_core/ tests/`,
and a PolyKybd change touches none of those. So every suite under `keyboards/polykybd/`
and `modules/polykybd/` was invisible to it, while the PR board looked comprehensively
green the whole time — `Build firmware` proves the firmware *links*, `HIL test` proves the
*device* answers, and neither runs a single assertion from either suite.

That is the worst shape for a coverage gap: nothing is red, so nothing prompts you to look.
The `fw_up_verdict` suite merged last week on the strength of local runs alone.

⚠️ **Deliberately a separate workflow, not a `paths:` edit to `unit_test.yml`.** That file
is stock upstream; adding our paths to it buys a conflict at the next catch-up merge, on a
PR that CodeRabbit already skips for being >100 files.

## The suite list is derived, not hardcoded

The job greps every `*polykybd*/testlist.mk` that `builddefs/testlist.mk` includes, and
reads their `TEST_LIST +=` lines:

```bash
lists=$(grep -o '[^ ]*polykybd[^ ]*/testlist\.mk' builddefs/testlist.mk)
names=$(grep -h 'TEST_LIST *+=' $lists | sed 's/.*+=[[:space:]]*//' | sort -u)
```

So **a third suite needs no edit to this workflow** — register it in the two `builddefs`
files as today and CI picks it up. This is the same argument `sync_is_link_fault()` makes
one directory over (#212): a list that has to be kept in sync is a list that goes stale
silently, in the component nobody re-derives. Hardcoding `fw_up_verdict polymod_ltr559`
here would mean the third suite is uncovered *and looks covered*, which is exactly the bug
being fixed.

## It has to be able to fail

Two guards, because **a test job that quietly runs nothing and reports green is strictly
worse than no job at all** — that is precisely the hole being closed, and it must not be
recreated one level up:

- discovery finding **zero** testlists, or zero `TEST_LIST` entries → `::error::` + exit 1
- the run loop executing **zero** suites → exit 1

The loop also continues past a failing suite, so one run names every broken one rather
than stopping at the first.

## Triggers

`pull_request` on `keyboards/polykybd/**`, `modules/polykybd/**`, plus
`builddefs/testlist.mk` and `builddefs/build_test.mk` — a suite can be silently
de-registered by editing only those two. Also `push` on `PolyKybd`/`PolyKybd/**`, matching
`qmk-test.yml`.

## Testing

- [x] Compiled successfully — n/a, no firmware change; both suites build and run
- [ ] Flashed and tested on hardware — n/a, CI-only change
- [x] If protocol changed: n/a

Verified by **simulating both workflow steps locally**, including the negative paths:

| Check | Result |
|---|---|
| discovery | finds exactly `fw_up_verdict` + `polymod_ltr559` |
| happy path | both pass — 27 + 19 tests |
| **can it go red?** | a deliberately broken `SYNC_BUSY` value → loop reports `FAIL fw_up_verdict`, exits non-zero, **and still runs the second suite** |
| zero-suite guard | fires and exits 1 when no testlist is found |
| YAML | parses; 4 steps, both triggers |
| lint | `ci-validate-keyboard-targets` and `ci-validate-aliases` exit 0; no tracked-and-gitignored files; no CRLF, final newline present |

The one thing I could not verify from here is the job running inside `ghcr.io/qmk/qmk_cli`
with `submodules: recursive` — the step shape is copied from upstream's `unit_test.yml`,
which is proven, but this PR's own run is the first real execution.

---
_Generated by [Claude Code](https://claude.ai/code/session_019aZAPjJZ6PRrDeJD1SEEHQ)_

## Summary by Sourcery

Run all registered PolyKybd unit-test suites in CI with coverage and execution guards.

New Features:
- Add a dedicated GitHub Actions workflow that discovers and runs all registered PolyKybd unit-test suites on relevant changes and PolyKybd branch pushes.

Bug Fixes:
- Close the CI coverage gap that allowed PolyKybd unit-test failures to go undetected.
- Fail the workflow when no suites are discovered or executed, while reporting all failing suites in a run.

Enhancements:
- Derive the suite list from the existing build definitions so newly registered PolyKybd suites are picked up automatically.

CI:
- Trigger PolyKybd unit tests for changes to PolyKybd sources, test registrations, and the workflow itself.

Documentation:
- Document that PolyKybd unit tests run through the dedicated workflow and update the documented fw_up_verdict test count.