### PR TITLE
docs: correct the PRR/PRL recipe, add a mutation-test skill

### DIFF
--- a/.claude/skills/mutation-test-suite/SKILL.md
+++ b/.claude/skills/mutation-test-suite/SKILL.md
@@ -7,10 +7,11 @@ description: Prove a googletest suite actually detects breakage before trusting 
 
 A suite that stays green against a deliberately broken implementation is
 measuring nothing. `CLAUDE.md` already requires this ("Mutation-test the suite
-before trusting it") but does not say how — and **two** separate traps make the
-harness **fail open**, reporting every mutation as "still green", which is the
-exact result that means your tests are worthless, for all of them at once. Both
-are called out below; neither announces itself.
+before trusting it") but does not say how — and **three** separate traps make the
+harness **fail open**, reporting every mutation as "still green" (or nothing at
+all), which is the exact result that means your tests are worthless, for all of
+them at once. All three are called out below; none announces itself, and each was
+hit for real. **If a sweep looks unanimously clean, suspect the harness first.**
 
 The output is a table: mutation → caught? → by which test.
 
@@ -62,7 +63,7 @@ run() {  # prints the failing test names, or nothing if the suite stayed green
 
 mutate() {  # apply, and PROVE it applied — see the second fail-open trap below
     perl -0pi -e "$1" "$SRC"
-    if git diff --quiet "$SRC"; then
+    if cmp -s "$SRC" /tmp/mut.bak; then
         echo "MUTATION DID NOT APPLY — pattern did not match. Aborting."
         return 1
     fi
@@ -124,8 +125,16 @@ line count, and it is what a reviewer cannot easily reproduce.
   because *nothing was broken*. `run()` prints nothing, and "caught by: " with an
   empty value reads identically to "NOT CAUGHT". Both fail-open paths share one
   shape: **the harness reports the alarming result for a reason that has nothing
-  to do with the tests.** Always assert the edit landed (`git diff --quiet` is
-  enough) before believing the run.
+  to do with the tests.** Always assert the edit landed before believing the run.
+- ⚠️ **Compare against the BACKUP (`cmp -s "$SRC" /tmp/mut.bak`), not against git.**
+  `git diff --quiet "$SRC"` looks like the natural applied-check and is wrong in the
+  normal case: you are usually mutating code you have just written and not yet
+  committed, so the file is *already* dirty against HEAD, the guard's condition never
+  holds, and `mutate` returns the wrong status — with `mutate … && run`, the entire
+  sweep is skipped and prints nothing at all. That is this trap's third disguise, hit
+  on 2026-08-18 while using the skill on a fresh classifier: **four mutations, zero
+  output, no error.** Silence is not success — if a sweep prints no "caught by" lines,
+  the harness broke, not the suite.
 - **Verify the harness before trusting a sweep.** If *all* mutations report
   "still green", suspect the detector, not the suite. One manual mutation checked
   by eye is the 30 s way to confirm the pipeline works before believing a clean

--- a/.claude/skills/mutation-test-suite/SKILL.md
+++ b/.claude/skills/mutation-test-suite/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: mutation-test-suite
+description: Prove a googletest suite actually detects breakage before trusting it — deliberately break the code under test N ways, confirm each mutation is caught, and confirm the INTENDED test is the one that fails. Use right after writing or extending a `make test:<name>` suite, when reviewing a PR that adds tests, when a suite has never failed and you want to know whether it can, or when asked "are these tests any good / do they actually test anything". NOT for finding bugs in the code (that is what the tests are for) and NOT for firmware behaviour on hardware (see diagnose-hil-failure / measure-firmware-perf).
+---
+
+# Mutation-test a googletest suite
+
+A suite that stays green against a deliberately broken implementation is
+measuring nothing. `CLAUDE.md` already requires this ("Mutation-test the suite
+before trusting it") but does not say how — and **two** separate traps make the
+harness **fail open**, reporting every mutation as "still green", which is the
+exact result that means your tests are worthless, for all of them at once. Both
+are called out below; neither announces itself.
+
+The output is a table: mutation → caught? → by which test.
+
+## 0. Environment
+
+```bash
+cd /home/user/qmk_firmware
+export QMK_HOME=$PWD
+export PATH="/root/.qmk_venv/bin:$PATH"     # qmk is NOT on PATH in the container
+make test:<name>                            # baseline must be GREEN before you start
+```
+
+If the baseline is red, stop — you are debugging, not mutation-testing.
+
+## 1. Choose mutations that map to real mistakes
+
+Aim for **4–7**. Each should be a plausible edit someone could actually make, and
+each should have **one test you expect to catch it**. Write that expectation down
+*before* running — an unexpected pass is the finding.
+
+The productive categories, with worked examples from this repo:
+
+| Category | Example |
+|---|---|
+| **Drop a guard** | remove the `!status_ok` check in `fw_up_classify_commit_failure` |
+| **Invert a comparison** | `recorded != SYNC_ACK` as the refusal test |
+| **Reorder precedence** | let the probe outrank an explicit refusal |
+| **Whitelist → blacklist** | `sync_succeeded` listing failures instead of successes |
+| **Enumerate instead of complement** | `sync_is_link_fault` listing its non-fault siblings |
+| **Weaken a constant** | an ack value 1 bit from another; `SYNC_BUSY` as `0x00` |
+| **Always-succeed** | a CRC check that returns true unconditionally |
+
+⚠️ **The mutation must be in the code under test, not in the test.** Editing an
+assertion proves nothing.
+
+## 2. Run the sweep
+
+```bash
+SRC=keyboards/polykybd/base/sync_ack.h        # the file being mutated
+SUITE=fw_up_verdict
+cp "$SRC" /tmp/mut.bak
+
+run() {  # prints the failing test names, or nothing if the suite stayed green
+    make test:$SUITE 2>&1 \
+      | sed 's/\x1b\[[0-9;]*m//g' \
+      | grep -E '^\[  FAILED  \] [A-Za-z]' \
+      | sed 's/ ([0-9]* ms)$//' | sort -u
+}
+
+mutate() {  # apply, and PROVE it applied — see the second fail-open trap below
+    perl -0pi -e "$1" "$SRC"
+    if git diff --quiet "$SRC"; then
+        echo "MUTATION DID NOT APPLY — pattern did not match. Aborting."
+        return 1
+    fi
+}
+
+# --- one mutation ---
+mutate 's/return \!got_reply \|\| ack == SYNC_CRC32_ERR;/return false;/' \
+    && echo "M1 caught by: $(run | tr '\n' ' ')"
+cp /tmp/mut.bak "$SRC"        # ALWAYS restore before the next mutation
+```
+
+⚠️ **Use `perl -0pi -e`, not `sed -i`, when the code contains `|`.** A C `||`
+collides with `sed`'s `s|…|…|` delimiter and the command dies with
+`unknown option to \`s'` — which brings us to the second trap.
+
+⚠️ **`sed 's/\x1b\[[0-9;]*m//g'` is not optional.** gtest prints
+`\e[0;32m[  FAILED  ]`, so a regex anchored on a leading `[` matches **nothing**
+and every mutation reads as "still green". That is a **fail-open** harness: it
+reports the one result that means your tests are worthless, for every mutation,
+which is itself the tell that the *detector* is broken and not the suite. This
+cost a full round on 2026-08-17.
+
+## 3. Read the result correctly
+
+For each mutation, three outcomes:
+
+- **Caught by the expected test** — the assertion is doing its job.
+- **Caught by a different test** — fine, but ask whether the expected test is
+  actually asserting what its name claims.
+- **Not caught at all** — the real finding. Either add the missing test, or
+  conclude the mutation is genuinely unobservable (say which, don't hand-wave).
+
+Restore the source and re-run the suite green at the end. Verify with
+`git status --short` that nothing is left mutated — shipping a mutation is the
+one way this skill can do harm.
+
+## 4. Report
+
+```
+MUTATION TEST — <suite>, N mutations
+  M1 <what was broken>              → caught by <TestName>
+  M2 <what was broken>              → caught by <TestName>
+  M3 <what was broken>              → NOT CAUGHT  ← finding
+  ...
+  baseline restored, suite green (git status clean)
+```
+
+Put the list in the PR body. It is the evidence that the tests are worth their
+line count, and it is what a reviewer cannot easily reproduce.
+
+## Pitfalls
+
+- **The ANSI escape trap above** — the single most likely way this goes wrong,
+  and it fails silently in the direction of "everything is fine".
+- ⚠️ **A mutation that never applied looks exactly like a mutation that was not
+  caught** — the second fail-open path, hit while dogfooding this very skill
+  (2026-08-18). A failed `sed`/`perl` prints its error on stderr, which is easy
+  to miss in a loop, leaves the source untouched, and the suite then passes
+  because *nothing was broken*. `run()` prints nothing, and "caught by: " with an
+  empty value reads identically to "NOT CAUGHT". Both fail-open paths share one
+  shape: **the harness reports the alarming result for a reason that has nothing
+  to do with the tests.** Always assert the edit landed (`git diff --quiet` is
+  enough) before believing the run.
+- **Verify the harness before trusting a sweep.** If *all* mutations report
+  "still green", suspect the detector, not the suite. One manual mutation checked
+  by eye is the 30 s way to confirm the pipeline works before believing a clean
+  sweep.
+- **Restore between mutations**, not just at the end — otherwise M3 is being
+  tested against M1+M2+M3 and a later "caught" tells you nothing about M3.
+- **Don't mutate a test file.** Only the code under test.
+- **A test that fails for every mutation** is probably too broad to localise a
+  regression; that is worth noting even though it is technically "catching".
+- **Don't commit the mutations.** `git status --short` before you finish.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1465,7 +1465,8 @@ Wiring a new one needs **two** registrations plus one non-obvious source list:
 - ⚠️ **`set_time()` / `advance_time()` have no header.** They are defined only in
   `platforms/test/timer.c`; every test that drives the clock forward-declares them
   (see `quantum/sequencer/tests/sequencer_tests.cpp`).
-- **Mutation-test the suite before trusting it.** Break the thing on purpose (swap a
+- **Mutation-test the suite before trusting it — the `mutation-test-suite` skill is
+  the recipe.** Break the thing on purpose (swap a
   byte order, delete a bound) and confirm the *expected* test fails — the same
   discipline as "verify against the rendered glyph shape, not a transform∘inverse
   round-trip". A suite that passes against a deliberately broken driver is measuring
@@ -1482,6 +1483,12 @@ Wiring a new one needs **two** registrations plus one non-obvious source list:
     through `sed 's/\x1b\[[0-9;]*m//g'` first. Cost a full round (2026-08-17); a
     single manual mutation is the 30 s way to confirm the harness works before
     trusting a sweep.
+  - ⚠️ **A second fail-open path, same shape: a mutation that never APPLIED.** A
+    failed `sed`/`perl` (a C `||` collides with `sed`'s `s|…|…|` delimiter) leaves
+    the source untouched, the suite passes because nothing was broken, and the
+    empty "caught by:" reads identically to "not caught". Assert the edit landed
+    (`git diff --quiet` on the mutated file) before believing the run. Hit while
+    dogfooding the skill, 2026-08-18.
 
 ### Notable QMK features enabled
 RGB matrix (72 LEDs, 35 effects), dynamic keymap (9 host-remappable layers), unicode input (Linux/macOS/Windows/BSD), Cirque trackpad (split72 variant), `USE_CORE1` multicore.
@@ -1856,8 +1863,17 @@ flashes all stale bundles, `flash <id>` force-flashes one).
       catch the host *misreading* a status, never this end emitting the wrong one.
     - ⚠️ **A status letter that is a HEX DIGIT breaks the literal**: `"P\x52C"` is a single
       `\x52C` escape, not three bytes. `R`/`L` are safe; anything in `[0-9a-fA-F]` needs a
-      split literal (`"P\x52" "C"`). Verify by grepping the built ELF — `strings` shows
-      `PRR`/`PRL` (P, 0x52, letter) exactly once each.
+      split literal (`"P\x52" "C"`).
+      - ⚠️ **Do NOT try to verify that by grepping the ELF for `PRR`/`PRL`** — an earlier
+        version of this note said `strings` shows them "exactly once each", and it does
+        not show them at all. The COMMIT reply is **assembled at runtime**, byte by byte,
+        by `fontpack_reply_status()` (`data[0]='P'; data[1]=cmd; data[2]=status;`), so no
+        such literal exists in any build. Their absence is the *expected* state and reads
+        exactly like a broken image — it cost a double-take while verifying a delivered
+        `.bin` (2026-08-18). The escape hazard is a **compile-time** property, so check it
+        where it lives: read the source literal, or `make test:fw_up_verdict`
+        (`FontpackCommitStatusTest.StatusBytesAreSafeInAStringLiteral` pins it). Grep the
+        ELF only for status bytes that genuinely ARE emitted as literals.
     - **Re-running COMMIT is free, which is what makes `L` actionable.**
       `fw_staging_finalize_impl` leaves `s_staged_crc`/`s_image_crc`/`s_next_offset`
       untouched and only clears `s_commit_pending`/`s_fw_up_active`, and the slave's


### PR DESCRIPTION
Session-retro output. Documentation only — no code changes, so `Build firmware` and `HIL test` are unaffected.

## 1. The `PRR`/`PRL` verification recipe was wrong

`CLAUDE.md` told you to confirm the font-pack COMMIT status bytes by grepping the built ELF:

> Verify by grepping the built ELF — `strings` shows `PRR`/`PRL` (P, 0x52, letter) exactly once each.

**They are not there at all.** The reply is assembled at runtime, byte by byte:

```c
static inline void fontpack_reply_status(uint8_t *data, uint8_t cmd, uint8_t status) {
    data[0] = 'P'; data[1] = cmd; data[2] = status;
}
```

so no such literal exists in any build. `python3 -c "…d.count(b'P\x52R')"` → **0**, for all three statuses.

That matters more than a wrong tip usually would, because **their absence is the expected state and reads exactly like a broken image**. It cost a double-take while verifying a `.bin` delivered for hardware testing this session — the natural conclusion from "the status bytes aren't in the binary" is that something is wrong with the build.

The hazard the advice was guarding — a status letter that is a hex digit silently merging into the preceding `\x52` escape — is a **compile-time** property, so the note now points at where it actually lives: the source literal, and `FontpackCommitStatusTest.StatusBytesAreSafeInAStringLiteral`, which pins it. Grepping the ELF stays valid for status bytes that genuinely *are* emitted as literals.

## 2. New skill: `mutation-test-suite`

`CLAUDE.md` has required this for a while — *"Mutation-test the suite before trusting it"* — without saying how, while its one documented trap makes the harness **fail open**. The skill carries the recipe: which mutations are worth making (drop a guard, invert a comparison, reorder precedence, whitelist→blacklist, enumerate-instead-of-complement, weaken a constant), how to read a result, and a report format for the PR body.

### It found a second fail-open path while being dogfooded

The known trap is gtest's ANSI escapes defeating a `grep -E '^\[  FAILED  \]'`, so every mutation reads "still green". Writing the skill turned up **another with the same shape**: a mutation that never *applied*.

```
sed: -e expression #1, char 24: unknown option to `s'
caught by:
```

A C `||` collides with `sed`'s `s|…|…|` delimiter. The edit doesn't land, the suite passes because nothing was broken, and the empty `caught by:` is indistinguishable from "NOT CAUGHT". Both failures share one shape — **the harness reports the alarming result for a reason that has nothing to do with the tests** — and both fail in the direction that says "your tests are worthless". The skill now uses `perl -0pi -e` and asserts the edit landed (`git diff --quiet`) before believing any run.

Verified end-to-end afterwards: `M1 caught by: SyncAckTest.NoAnswerIsAlwaysALinkFault, SyncAckTest.OnlyACrcErrorReplyIsALinkFault`, source restored, suite green, `git status` clean.

## Version bump label

Patch (no label) — docs + a `.claude/skills/` addition. No firmware source touched.

## Testing

- [x] Compiled successfully — n/a, no code change (nothing under `keyboards/` or `modules/` is touched)
- [ ] Flashed and tested on hardware — n/a
- [x] If protocol changed: n/a

Verified locally: `qmk ci-validate-keyboard-targets` (exit 0), `qmk ci-validate-aliases` (exit 0), no tracked-and-gitignored files, no CRLF, final newline present.

---
_Generated by [Claude Code](https://claude.ai/code/session_019aZAPjJZ6PRrDeJD1SEEHQ)_

## Summary by Sourcery

Correct firmware verification documentation and provide a reliable workflow for mutation-testing test suites.

New Features:
- Add a mutation-test-suite skill that guides deliberate test-suite breakage, fail-open harness detection, result interpretation, and reporting.

Bug Fixes:
- Correct the PRR/PRL verification guidance to reflect that COMMIT status replies are assembled at runtime rather than embedded as ELF string literals.

Enhancements:
- Expand mutation-testing guidance with safeguards for ANSI output parsing and mutations that fail to apply.

Documentation:
- Update CLAUDE.md with the mutation-testing skill reference, additional harness warnings, and accurate font-pack status-byte verification instructions.