### PR TITLE
ci: the qmk_cli container runs sh, not bash

### DIFF
--- a/.github/workflows/polykybd-unit-test.yml
+++ b/.github/workflows/polykybd-unit-test.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Discover PolyKybd test suites
         id: discover
         run: |
-          set -euo pipefail
+          set -eu
           lists=$(grep -o '[^ ]*polykybd[^ ]*/testlist\.mk' builddefs/testlist.mk || true)
           if [ -z "$lists" ]; then
             echo "::error::No polykybd testlist.mk is included from builddefs/testlist.mk."
@@ -70,13 +70,26 @@ jobs:
           echo "$names"     >> "$GITHUB_OUTPUT"
           echo "EOF"        >> "$GITHUB_OUTPUT"
 
+      # ⚠️ The container's default shell is POSIX `sh` (dash) — `shell: sh -e {0}`.
+      # No bash-isms. Two traps, and the second is the dangerous one:
+      #   * `done <<< "$list"` is a bash HERESTRING: dash fails to parse it outright
+      #     ("Syntax error: redirection unexpected"). Loud, which is the good case.
+      #   * `printf … | while read` is the tempting POSIX fix and is WORSE: it parses,
+      #     but POSIX runs the loop body in a SUBSHELL, so `count` and `failed` are
+      #     discarded at the `done`. A failing suite would leave `failed` empty and the
+      #     job would report GREEN — the exact hole this workflow exists to close. (Here
+      #     the count-zero guard below would catch it, which is why that guard is not
+      #     redundant paranoia.)
+      # A `for` over the unquoted list is correct in every POSIX shell and keeps the
+      # accumulators in this shell. Safe because suite names are makefile identifiers:
+      # the harness rejects even a `-`, so they can never contain whitespace.
       - name: Run PolyKybd test suites
+        env:
+          SUITES: ${{ steps.discover.outputs.names }}
         run: |
-          set -uo pipefail
           failed=""
           count=0
-          while IFS= read -r t; do
-            [ -n "$t" ] || continue
+          for t in $SUITES; do
             count=$((count + 1))
             echo "::group::make test:$t"
             if make "test:$t" -j "$(nproc)"; then
@@ -87,7 +100,7 @@ jobs:
               echo "::error::test suite '$t' failed"
               failed="$failed $t"
             fi
-          done <<< "${{ steps.discover.outputs.names }}"
+          done
           echo "--- ran $count suite(s) ---"
           if [ "$count" -eq 0 ]; then
             echo "::error::ran zero test suites"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1419,6 +1419,21 @@ catch-up merge.
   the exact failure this workflow was added to remove, so it must not be able to
   recreate it one level up. The loop also continues past a failing suite, so one run
   names every broken suite rather than just the first.
+- ⚠️ **`ghcr.io/qmk/qmk_cli` runs steps under POSIX `sh` (dash), not bash** — the log
+  header says `shell: sh -e {0}`. Write every `run:` in that container POSIX-clean, and
+  **test it with `dash`, not your login shell**; `bash script.sh` passing proves nothing.
+  Two traps, and the second is the dangerous one:
+  - `done <<< "$list"` is a bash **herestring**: dash won't parse it at all —
+    `Syntax error: redirection unexpected`, exit 2. Loud, so it is the good case, but
+    it is what made this workflow's first run red.
+  - `printf … | while read` is the tempting POSIX fix and is **worse**: it parses, but
+    POSIX runs the loop body in a **subshell**, so counters and accumulators are
+    discarded at the `done`. A failing suite would leave the failure list empty and the
+    job would report **green** — which is why the count-zero guard above is not
+    redundant paranoia; it is the only thing that catches this.
+  - `for t in $LIST` (unquoted, from an `env:`) keeps state in the current shell and
+    works in every POSIX shell. Safe here because suite names are makefile identifiers
+    — the harness rejects even a `-`, so they can never contain whitespace.
 
 - **`fw_up_verdict` is the pattern for testing DECISION logic** (as opposed to
   `polymod_ltr559`, which is the pattern for a driver vs a mock bus). It covers the


### PR DESCRIPTION
> [!IMPORTANT]
> **`PolyKybd` is currently carrying a workflow that fails on every PR touching
> `keyboards/polykybd/**` or `modules/polykybd/**`.** #214 merged at 06:57 on head
> `ed836819`; the fix below was pushed to that branch minutes later, after the merge, so
> it never landed. This is that fix, cherry-picked onto a fresh branch cut from the
> updated default.
>
> An always-red check is the worst kind — people learn to scroll past it, and the next
> real failure rides in behind it. Worth merging ahead of the other open PRs.

## Summary

The first real execution of `polykybd-unit-test.yml` went red:

```
/__w/_temp/….sh: 16: Syntax error: redirection unexpected
##[error]Process completed with exit code 2.
```

with, three lines up in the log:

```
shell: sh -e {0}
```

`ghcr.io/qmk/qmk_cli` runs steps under **POSIX `sh` (dash)**, not bash. The runner loop ended with `done <<< "$names"` — a **bash herestring** — which dash cannot parse.

**Discovery itself was correct**, which is the good news: the log shows it deriving exactly the right suites from the two `testlist.mk` files, so the "derive, don't hardcode" mechanism works as designed:

```
Including:
  modules/polykybd/polymod_ltr559/tests/testlist.mk
  keyboards/polykybd/base/tests/testlist.mk
Suites:
  fw_up_verdict
  polymod_ltr559
```

## ⚠️ The obvious POSIX fix is worse than the bug

`printf … | while read` is the natural replacement and it **parses fine**. But POSIX runs the loop body of a pipeline in a **subshell**, so `count` and `failed` are discarded at the `done`. Measured under dash:

```
after pipe:  count=0 failed=''   <-- both lost (subshell)
after for:   count=2 failed=' a b'
```

A *failing* suite would therefore leave the failure list empty and the job would report **green** — the exact hole this workflow exists to close, reintroduced by its own fix. Only the count-zero guard would have caught it, which is a decent argument that the guard is not redundant paranoia.

`for t in $SUITES` over the unquoted list keeps the accumulators in the current shell and works in every POSIX shell. Safe here because suite names are makefile identifiers — the harness hard-errors on even a `-`, so whitespace is impossible. The list is passed via `env:` rather than interpolated into the script body.

Discovery also loses `pipefail`: it happened to work in this dash build, but it is not POSIX and the image is not ours to pin. `set -eu` is enough — the one pipeline that can fail already carries `|| true`.

## Testing

- [x] Compiled successfully — n/a, CI-only change
- [ ] Flashed and tested on hardware — n/a
- [x] If protocol changed: n/a

**Verified with `dash` this time, not bash** — using my login shell is exactly what let the bug through, and `bash script.sh` passing proves nothing about this container:

| check | result |
|---|---|
| discovery under dash | finds exactly `fw_up_verdict` + `polymod_ltr559`, exit 0 |
| run loop under dash | `PASS` both, `--- ran 2 suite(s) ---`, exit 0 (27 + 19 tests) |
| **can it go red?** | broken `SYNC_BUSY` → `::error::test suite 'fw_up_verdict' failed`, **still runs the second suite**, exit 1 |
| zero-suite guard | empty `$SUITES` → `::error::ran zero test suites`, exit 1 |
| the bug itself | `done <<< …` under dash → `Syntax error: redirection unexpected`, exit 2 |

`qmk ci-validate-keyboard-targets` and `qmk ci-validate-aliases` both exit 0.

CLAUDE.md gains the container-shell note, including both traps and why the piped form is the dangerous one.

---
_Generated by [Claude Code](https://claude.ai/code/session_019aZAPjJZ6PRrDeJD1SEEHQ)_

## Summary by Sourcery

Fix PolyKybd CI test execution for the container’s POSIX shell while retaining reliable reporting of failed and empty test suites.

Bug Fixes:
- Make the PolyKybd unit-test workflow compatible with the POSIX shell used by the QMK CLI container, preventing syntax failures and preserving accurate suite failure reporting.

Enhancements:
- Document the container shell constraints and the risks of shell-loop alternatives for future workflow changes.

Documentation:
- Document that QMK CLI container workflow steps must be tested with POSIX `sh`/`dash` rather than Bash.