### PR TITLE
fix(polykybd): mod-tap hints read the wrong modifier encoding; render them as a corner badge with the keycaps' own icons

### DIFF
--- a/keyboards/polykybd/base/disp_array.c
+++ b/keyboards/polykybd/base/disp_array.c
@@ -233,6 +233,30 @@ void kdisp_draw_glyph_half_at(const GFXfont *const *fonts, uint8_t num_fonts, in
     }
 }
 
+// Decimating sibling of kdisp_draw_glyph_half_at — see the header for when each
+// is the right one. Samples the top-left pixel of every 2x2 block; no rounding
+// games are needed on the source index because (hw-1)*2 <= w-1 by construction.
+void kdisp_draw_glyph_thin_at(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, uint32_t ch) {
+    const GFXfont *font = NULL;
+    const GFXglyph *glyph = kdisp_gfx_glyph_font(fonts, num_fonts, ch, &font);
+    if (glyph == NULL || font == NULL) return;
+    const uint8_t *bitmap = pgm_read_bitmap_ptr(font);
+    uint16_t bo = glyph_bitmap_offset(glyph);
+    int16_t w = glyph_width(glyph);
+    int16_t h = glyph_height(glyph);
+    // Round up so an odd source width/height keeps its trailing column/row.
+    int16_t hw = (w + 1) / 2, hh = (h + 1) / 2;
+    const uint8_t cb = glyph_col_bytes((uint8_t)h);   // column-major page-bytes per column
+    for (int16_t dy = 0; dy < hh; ++dy) {
+        const int16_t sy = dy * 2;
+        for (int16_t dx = 0; dx < hw; ++dx) {
+            const int16_t sx = dx * 2;
+            uint8_t byte = pgm_read_byte(&bitmap[bo + (uint16_t)sx * cb + (sy >> 3)]);
+            if (byte & (1u << (sy & 7))) { SET_PIXEL_CLIPPED(x + dx, y + dy); }
+        }
+    }
+}
+
 void kdisp_draw_glyph_double_at(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, uint32_t ch) {
     const GFXfont *font = NULL;
     const GFXglyph *glyph = kdisp_gfx_glyph_font(fonts, num_fonts, ch, &font);
@@ -556,6 +580,9 @@ void kdisp_write_gfx_text_cy(const GFXfont *const *fonts, uint8_t num_fonts, int
                 break;
             case U'\x0F':   // HALF: draw the next codepoint half-scale (2x2-OR) at the cursor, no advance
                 if (text[1]) { kdisp_draw_glyph_half_at(fonts, num_fonts, x_cursor, y_cursor, text[1]); text++; }
+                break;
+            case U'\x11':   // THIN: as HALF but decimating, for icons whose gaps matter
+                if (text[1]) { kdisp_draw_glyph_thin_at(fonts, num_fonts, x_cursor, y_cursor, text[1]); text++; }
                 break;
             case U'\x12':   // FRAME: 2px nested rounded rect at the cursor (next two codepoints = w, h)
                 if (text[1] && text[2]) {

--- a/keyboards/polykybd/base/disp_array.h
+++ b/keyboards/polykybd/base/disp_array.h
@@ -55,6 +55,20 @@ const GFXglyph *kdisp_gfx_glyph_font(const GFXfont *const *fonts, uint8_t num_fo
 // Win+Ctrl+Shift+B reload 🗘 drawn into the monitor's screen cavity).
 void kdisp_draw_glyph_half_at(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, uint32_t c);
 
+// Same 2x downsample, but sampling ONE pixel per 2x2 block (decimation) instead
+// of OR-ing all four. The two are complementary and neither is better in
+// general — pick per glyph:
+//   _half_at (OR)   thickens strokes, so a thin line survives; but it CLOSES thin
+//                   gaps, which turns a glyph whose meaning is in its negative
+//                   space into a blob (the Windows logo becomes a solid square,
+//                   the Ctrl helm's spokes fill in).
+//   _thin_at (this) keeps gaps, so structured icons stay readable; but a 1px
+//                   stroke on an odd row/column is dropped entirely (measured:
+//                   the alt symbol keeps 54% of its lit pixels, the worst of the
+//                   set, which is why the mod-tap badge draws Ctrl and the OS
+//                   logos through here and Alt through _half_at).
+void kdisp_draw_glyph_thin_at(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, uint32_t c);
+
 // The mirror of the above: composite a glyph scaled 2x (nearest, each source
 // pixel becomes a 2x2 block) with its top-left at buffer coords (x,y) — again no
 // baseline align, (x,y) is the literal top-left. The keycap fonts top out at the

--- a/keyboards/polykybd/hints/os_hints.c
+++ b/keyboards/polykybd/hints/os_hints.c
@@ -325,28 +325,57 @@ const uint32_t* os_hint_for_keycode(uint16_t keycode, uint8_t mods_raw, uint8_t 
                                       ((mods & MOD_MASK_SHIFT) ? 2u : 0u) |
                                       ((mods & MOD_MASK_ALT)   ? 4u : 0u) |
                                       ((mods & MOD_MASK_GUI)   ? 8u : 0u));
-        // Marks read Ctrl ¤, Shift ⇧, Alt ¬, GUI ・ left-to-right, right-aligned into
-        // the top-right corner (see the MTB_* block in lang/named_glyphs.h for why a
-        // mod-tap gets a corner badge rather than a second full-size legend).
-        static const uint32_t* const mod_tap_badge[16] = {
-            [0]  = NULL,                                                        // MT(0, kc) — no modifier, no hint
-            [1]  = MTB_CTRL(MTB_X1),
-            [2]  = MTB_SHIFT(MTB_X1),
-            [3]  = MTB_CTRL(MTB_X2) MTB_SHIFT(MTB_X1),
-            [4]  = MTB_ALT(MTB_X1),
-            [5]  = MTB_CTRL(MTB_X2) MTB_ALT(MTB_X1),
-            [6]  = MTB_SHIFT(MTB_X2) MTB_ALT(MTB_X1),
-            [7]  = MTB_CTRL(MTB_X3) MTB_SHIFT(MTB_X2) MTB_ALT(MTB_X1),          // Meh
-            [8]  = MTB_GUI(MTB_X1),
-            [9]  = MTB_CTRL(MTB_X2) MTB_GUI(MTB_X1),
-            [10] = MTB_SHIFT(MTB_X2) MTB_GUI(MTB_X1),
-            [11] = MTB_CTRL(MTB_X3) MTB_SHIFT(MTB_X2) MTB_GUI(MTB_X1),
-            [12] = MTB_ALT(MTB_X2) MTB_GUI(MTB_X1),
-            [13] = MTB_CTRL(MTB_X3) MTB_ALT(MTB_X2) MTB_GUI(MTB_X1),
-            [14] = MTB_SHIFT(MTB_X3) MTB_ALT(MTB_X2) MTB_GUI(MTB_X1),
-            [15] = MTB_CTRL(MTB_X4) MTB_SHIFT(MTB_X3) MTB_ALT(MTB_X2) MTB_GUI(MTB_X1), // Hyper
-        };
-        return mod_tap_badge[idx];
+        // The marks are the modifier keycaps' own symbols, right-aligned into a 2x2
+        // grid in the top-right corner so a single modifier lands in the corner (the
+        // MTB_* block in lang/named_glyphs.h has the layout and the per-glyph choice
+        // of downsample). GUI follows the ACTIVE OS exactly as the GUI keycap does,
+        // so the table is generated once per OS; every other mark is OS-independent,
+        // and the compiler merges those identical string literals across the tables.
+#define MT_BADGE_TABLE(gui, gui_r1, gui_r2) {                                          \
+            [0]  = NULL,   /* MT(0, kc) — no modifier, so no hint */                   \
+            [1]  = MTB_CTRL(MTB_CTRL_R1),                                              \
+            [2]  = MTB_SHIFT(MTB_SHIFT_R1),                                            \
+            [3]  = MTB_CTRL(MTB_CTRL_L1) MTB_SHIFT(MTB_SHIFT_R1),                      \
+            [4]  = MTB_ALT(MTB_ALT_R1),                                                \
+            [5]  = MTB_CTRL(MTB_CTRL_L1) MTB_ALT(MTB_ALT_R1),                          \
+            [6]  = MTB_SHIFT(MTB_SHIFT_L1) MTB_ALT(MTB_ALT_R1),                        \
+            [7]  = MTB_CTRL(MTB_CTRL_L1) MTB_SHIFT(MTB_SHIFT_R1) MTB_ALT(MTB_ALT_R2),  \
+            [8]  = MTB_GUI(gui_r1, gui),                                               \
+            [9]  = MTB_CTRL(MTB_CTRL_L1) MTB_GUI(gui_r1, gui),                         \
+            [10] = MTB_SHIFT(MTB_SHIFT_L1) MTB_GUI(gui_r1, gui),                       \
+            [11] = MTB_CTRL(MTB_CTRL_L1) MTB_SHIFT(MTB_SHIFT_R1) MTB_GUI(gui_r2, gui), \
+            [12] = MTB_ALT(MTB_ALT_L1) MTB_GUI(gui_r1, gui),                           \
+            [13] = MTB_CTRL(MTB_CTRL_L1) MTB_ALT(MTB_ALT_R1) MTB_GUI(gui_r2, gui),     \
+            [14] = MTB_SHIFT(MTB_SHIFT_L1) MTB_ALT(MTB_ALT_R1) MTB_GUI(gui_r2, gui),   \
+            [15] = MTB_CTRL(MTB_CTRL_L1) MTB_SHIFT(MTB_SHIFT_R1)                       \
+                   MTB_ALT(MTB_ALT_L2) MTB_GUI(gui_r2, gui),                           \
+        }
+        static const uint32_t* const badge_win[16] =
+            MT_BADGE_TABLE(ICON_OS_WINDOWS, MTB_GUI_WINDOWS_R1, MTB_GUI_WINDOWS_R2);
+        static const uint32_t* const badge_mac[16] =
+            MT_BADGE_TABLE(TECHNICAL_COMMAND, MTB_GUI_MACOS_R1, MTB_GUI_MACOS_R2);
+        static const uint32_t* const badge_lnx[16] =
+            MT_BADGE_TABLE(ICON_OS_LINUX, MTB_GUI_LINUX_R1, MTB_GUI_LINUX_R2);
+        static const uint32_t* const badge_gnome[16] =
+            MT_BADGE_TABLE(ICON_OS_GNOME, MTB_GUI_GNOME_R1, MTB_GUI_GNOME_R2);
+        static const uint32_t* const badge_kde[16] =
+            MT_BADGE_TABLE(ICON_OS_KDE, MTB_GUI_KDE_R1, MTB_GUI_KDE_R2);
+        static const uint32_t* const badge_android[16] =
+            MT_BADGE_TABLE(ICON_OS_ANDROID, MTB_GUI_ANDROID_R1, MTB_GUI_ANDROID_R2);
+        static const uint32_t* const badge_other[16] =
+            MT_BADGE_TABLE(DINGBAT_BLACK_DIA_X, MTB_GUI_OTHER_R1, MTB_GUI_OTHER_R2);
+#undef MT_BADGE_TABLE
+        const uint32_t* const* badge;
+        switch (active_os) {
+            case POLY_OS_WINDOWS:     badge = badge_win;     break;
+            case POLY_OS_MACOS:       badge = badge_mac;     break;
+            case POLY_OS_LINUX:       badge = badge_lnx;     break;
+            case POLY_OS_LINUX_GNOME: badge = badge_gnome;   break;
+            case POLY_OS_LINUX_KDE:   badge = badge_kde;     break;
+            case POLY_OS_ANDROID:     badge = badge_android; break;
+            default:                  badge = badge_other;   break;
+        }
+        return badge[idx];
     }
 
     return NULL;

--- a/keyboards/polykybd/hints/os_hints.c
+++ b/keyboards/polykybd/hints/os_hints.c
@@ -326,44 +326,51 @@ const uint32_t* os_hint_for_keycode(uint16_t keycode, uint8_t mods_raw, uint8_t 
                                       ((mods & MOD_MASK_ALT)   ? 4u : 0u) |
                                       ((mods & MOD_MASK_GUI)   ? 8u : 0u));
         // The marks are the modifier keycaps' own symbols, right-aligned into a 2x2
-        // grid in the top-right corner so a single modifier lands in the corner (the
-        // MTB_* block in lang/named_glyphs.h has the layout and the per-glyph choice
-        // of downsample). GUI follows the ACTIVE OS exactly as the GUI keycap does,
-        // so the table is generated once per OS; every other mark is OS-independent,
-        // and the compiler merges those identical string literals across the tables.
-#define MT_BADGE_TABLE(gui, gui_r1, gui_r2) {                                          \
+        // grid anchored at the BOTTOM-right, so a single modifier lands in that
+        // corner and the badge grows up and left from there (the MTB_* block in
+        // lang/named_glyphs.h has the layout and the per-glyph choice of downsample).
+        // ⚠️ The bottom anchor is load-bearing, not taste: render_key() draws a key's
+        // shift preview in the UPPER right, so a top-anchored badge put its FIRST
+        // mark on top of it — measured 21 px of the '!' on a digit key. Bottom-
+        // anchored, nothing reaches row T until the 3rd modifier.
+        // Marks are placed in C,S,A,G order, so GUI is always last and therefore
+        // always takes the bottom-right cell — hence one GUI position per OS, not
+        // four. GUI follows the ACTIVE OS exactly as the GUI keycap does, so the
+        // table is generated once per OS; every other mark is OS-independent, and
+        // the compiler merges those identical string literals across the tables.
+#define MT_BADGE_TABLE(gui, gui_rb) {                                                  \
             [0]  = NULL,   /* MT(0, kc) — no modifier, so no hint */                   \
-            [1]  = MTB_CTRL(MTB_CTRL_R1),                                              \
-            [2]  = MTB_SHIFT(MTB_SHIFT_R1),                                            \
-            [3]  = MTB_CTRL(MTB_CTRL_L1) MTB_SHIFT(MTB_SHIFT_R1),                      \
-            [4]  = MTB_ALT(MTB_ALT_R1),                                                \
-            [5]  = MTB_CTRL(MTB_CTRL_L1) MTB_ALT(MTB_ALT_R1),                          \
-            [6]  = MTB_SHIFT(MTB_SHIFT_L1) MTB_ALT(MTB_ALT_R1),                        \
-            [7]  = MTB_CTRL(MTB_CTRL_L1) MTB_SHIFT(MTB_SHIFT_R1) MTB_ALT(MTB_ALT_R2),  \
-            [8]  = MTB_GUI(gui_r1, gui),                                               \
-            [9]  = MTB_CTRL(MTB_CTRL_L1) MTB_GUI(gui_r1, gui),                         \
-            [10] = MTB_SHIFT(MTB_SHIFT_L1) MTB_GUI(gui_r1, gui),                       \
-            [11] = MTB_CTRL(MTB_CTRL_L1) MTB_SHIFT(MTB_SHIFT_R1) MTB_GUI(gui_r2, gui), \
-            [12] = MTB_ALT(MTB_ALT_L1) MTB_GUI(gui_r1, gui),                           \
-            [13] = MTB_CTRL(MTB_CTRL_L1) MTB_ALT(MTB_ALT_R1) MTB_GUI(gui_r2, gui),     \
-            [14] = MTB_SHIFT(MTB_SHIFT_L1) MTB_ALT(MTB_ALT_R1) MTB_GUI(gui_r2, gui),   \
-            [15] = MTB_CTRL(MTB_CTRL_L1) MTB_SHIFT(MTB_SHIFT_R1)                       \
-                   MTB_ALT(MTB_ALT_L2) MTB_GUI(gui_r2, gui),                           \
+            [1]  = MTB_CTRL(MTB_CTRL_RB),                                              \
+            [2]  = MTB_SHIFT(MTB_SHIFT_RB),                                            \
+            [3]  = MTB_CTRL(MTB_CTRL_LB) MTB_SHIFT(MTB_SHIFT_RB),                      \
+            [4]  = MTB_ALT(MTB_ALT_RB),                                                \
+            [5]  = MTB_CTRL(MTB_CTRL_LB) MTB_ALT(MTB_ALT_RB),                          \
+            [6]  = MTB_SHIFT(MTB_SHIFT_LB) MTB_ALT(MTB_ALT_RB),                        \
+            [7]  = MTB_CTRL(MTB_CTRL_RT) MTB_SHIFT(MTB_SHIFT_LB) MTB_ALT(MTB_ALT_RB),  \
+            [8]  = MTB_GUI(gui_rb, gui),                                               \
+            [9]  = MTB_CTRL(MTB_CTRL_LB) MTB_GUI(gui_rb, gui),                         \
+            [10] = MTB_SHIFT(MTB_SHIFT_LB) MTB_GUI(gui_rb, gui),                       \
+            [11] = MTB_CTRL(MTB_CTRL_RT) MTB_SHIFT(MTB_SHIFT_LB) MTB_GUI(gui_rb, gui), \
+            [12] = MTB_ALT(MTB_ALT_LB) MTB_GUI(gui_rb, gui),                           \
+            [13] = MTB_CTRL(MTB_CTRL_RT) MTB_ALT(MTB_ALT_LB) MTB_GUI(gui_rb, gui),     \
+            [14] = MTB_SHIFT(MTB_SHIFT_RT) MTB_ALT(MTB_ALT_LB) MTB_GUI(gui_rb, gui),   \
+            [15] = MTB_CTRL(MTB_CTRL_LT) MTB_SHIFT(MTB_SHIFT_RT)                       \
+                   MTB_ALT(MTB_ALT_LB) MTB_GUI(gui_rb, gui),                           \
         }
         static const uint32_t* const badge_win[16] =
-            MT_BADGE_TABLE(ICON_OS_WINDOWS, MTB_GUI_WINDOWS_R1, MTB_GUI_WINDOWS_R2);
+            MT_BADGE_TABLE(ICON_OS_WINDOWS, MTB_GUI_WINDOWS_RB);
         static const uint32_t* const badge_mac[16] =
-            MT_BADGE_TABLE(TECHNICAL_COMMAND, MTB_GUI_MACOS_R1, MTB_GUI_MACOS_R2);
+            MT_BADGE_TABLE(TECHNICAL_COMMAND, MTB_GUI_MACOS_RB);
         static const uint32_t* const badge_lnx[16] =
-            MT_BADGE_TABLE(ICON_OS_LINUX, MTB_GUI_LINUX_R1, MTB_GUI_LINUX_R2);
+            MT_BADGE_TABLE(ICON_OS_LINUX, MTB_GUI_LINUX_RB);
         static const uint32_t* const badge_gnome[16] =
-            MT_BADGE_TABLE(ICON_OS_GNOME, MTB_GUI_GNOME_R1, MTB_GUI_GNOME_R2);
+            MT_BADGE_TABLE(ICON_OS_GNOME, MTB_GUI_GNOME_RB);
         static const uint32_t* const badge_kde[16] =
-            MT_BADGE_TABLE(ICON_OS_KDE, MTB_GUI_KDE_R1, MTB_GUI_KDE_R2);
+            MT_BADGE_TABLE(ICON_OS_KDE, MTB_GUI_KDE_RB);
         static const uint32_t* const badge_android[16] =
-            MT_BADGE_TABLE(ICON_OS_ANDROID, MTB_GUI_ANDROID_R1, MTB_GUI_ANDROID_R2);
+            MT_BADGE_TABLE(ICON_OS_ANDROID, MTB_GUI_ANDROID_RB);
         static const uint32_t* const badge_other[16] =
-            MT_BADGE_TABLE(DINGBAT_BLACK_DIA_X, MTB_GUI_OTHER_R1, MTB_GUI_OTHER_R2);
+            MT_BADGE_TABLE(DINGBAT_BLACK_DIA_X, MTB_GUI_OTHER_RB);
 #undef MT_BADGE_TABLE
         const uint32_t* const* badge;
         switch (active_os) {

--- a/keyboards/polykybd/hints/os_hints.c
+++ b/keyboards/polykybd/hints/os_hints.c
@@ -301,38 +301,52 @@ const uint32_t* os_hint_for_keycode(uint16_t keycode, uint8_t mods_raw, uint8_t 
     }
 
     if(IS_QK_MOD_TAP(keycode)) {
-        uint8_t mods = QK_MOD_TAP_GET_MODS(keycode);
-        if((mods & MOD_MASK_CSAG) == MOD_MASK_CSAG) {
-            return U"    " CURRENCY_SIGN ICON_SHIFT NOT_SIGN KATAKANA_MIDDLE_DOT;
-        } else if((mods & MOD_MASK_SAG) == MOD_MASK_SAG) {
-            return U"    " ICON_SHIFT NOT_SIGN KATAKANA_MIDDLE_DOT;
-        } else if((mods & MOD_MASK_CAG) == MOD_MASK_CAG) {
-            return U"    " CURRENCY_SIGN NOT_SIGN KATAKANA_MIDDLE_DOT;
-        } else if((mods & MOD_MASK_CSG) == MOD_MASK_CSG) {
-            return U"    " CURRENCY_SIGN ICON_SHIFT KATAKANA_MIDDLE_DOT;
-        } else if((mods & MOD_MASK_CSA) == MOD_MASK_CSA) {
-            return U"    " CURRENCY_SIGN ICON_SHIFT NOT_SIGN;
-        } else if((mods & MOD_MASK_AG) == MOD_MASK_AG) {
-            return U"    " NOT_SIGN KATAKANA_MIDDLE_DOT;
-        } else if((mods & MOD_MASK_SG) == MOD_MASK_SG) {
-            return U"    " ICON_SHIFT KATAKANA_MIDDLE_DOT;
-        } else if((mods & MOD_MASK_SA) == MOD_MASK_SA) {
-            return U"    " CURRENCY_SIGN NOT_SIGN;
-        } else if((mods & MOD_MASK_CG) == MOD_MASK_CG) {
-            return U"    " CURRENCY_SIGN KATAKANA_MIDDLE_DOT;
-        } else if((mods & MOD_MASK_CA) == MOD_MASK_CA) {
-            return U"    " CURRENCY_SIGN NOT_SIGN;
-        } else if((mods & MOD_MASK_CS) == MOD_MASK_CS) {
-            return U"    " CURRENCY_SIGN ICON_SHIFT;
-        } else if(mods & MOD_MASK_CTRL) {
-            return U"    " CURRENCY_SIGN;
-        } else if(mods & MOD_MASK_ALT) {
-            return U"    " NOT_SIGN;
-        } else if (mods & MOD_MASK_SHIFT) {
-            return U"    " ICON_SHIFT;
-        } else {
-            return U"   " KATAKANA_MIDDLE_DOT;
-        }
+        // ⚠️ QK_MOD_TAP_GET_MODS() yields QMK's *5-bit* mod form (quantum/modifiers.h
+        // `enum mods_5bit`): bits 0-3 = Ctrl/Shift/Alt/Gui and **bit 4 is the
+        // left/right flag**, not a fifth modifier. The MOD_MASK_* constants are the
+        // *8-bit paired* form (MOD_MASK_CTRL == 0x11, _SHIFT == 0x22, ...). Testing one
+        // against the other mis-read every mod-tap: RCTL_T/RSFT_T/RALT_T/RGUI_T all
+        // carry bit 4, whose 0x10 is MOD_MASK_CTRL's right-Ctrl bit, so all four drew
+        // Ctrl; LGUI_T (0x08) intersects no MOD_MASK_* at all and drew the bare-else
+        // legend. Normalise with the expression QMK itself uses in
+        // quantum/keymap_common.c (`(mod & 0x10) ? (mod & 0xF) << 4 : mod`).
+        const uint8_t mods_5bit = QK_MOD_TAP_GET_MODS(keycode);
+        const uint8_t mods = (mods_5bit & 0x10) ? (uint8_t)((mods_5bit & 0x0F) << 4)
+                                                : (uint8_t)(mods_5bit & 0x0F);
+        // ⚠️ Second, independent half of the same bug: the old chain asked
+        // `(mods & MOD_MASK_CS) == MOD_MASK_CS`, and MOD_MASK_CS is 0x33 — *both* left
+        // AND right Ctrl AND Shift. A mod-tap keycode carries one side only, so no
+        // combination test could ever hold and HYPR_T/MEH_T fell through to the bare
+        // Ctrl mark. Presence of a modifier is `(mods & MOD_MASK_x) != 0`; the pairs and
+        // triples are then just the conjunction, so index a table by the four
+        // independent bits instead of ordering eleven overlapping tests by specificity —
+        // that ordering is what let the Shift+Alt row silently carry Ctrl+Alt's glyphs.
+        const uint8_t idx = (uint8_t)(((mods & MOD_MASK_CTRL)  ? 1u : 0u) |
+                                      ((mods & MOD_MASK_SHIFT) ? 2u : 0u) |
+                                      ((mods & MOD_MASK_ALT)   ? 4u : 0u) |
+                                      ((mods & MOD_MASK_GUI)   ? 8u : 0u));
+        // Marks read Ctrl ¤, Shift ⇧, Alt ¬, GUI ・ left-to-right, right-aligned into
+        // the top-right corner (see the MTB_* block in lang/named_glyphs.h for why a
+        // mod-tap gets a corner badge rather than a second full-size legend).
+        static const uint32_t* const mod_tap_badge[16] = {
+            [0]  = NULL,                                                        // MT(0, kc) — no modifier, no hint
+            [1]  = MTB_CTRL(MTB_X1),
+            [2]  = MTB_SHIFT(MTB_X1),
+            [3]  = MTB_CTRL(MTB_X2) MTB_SHIFT(MTB_X1),
+            [4]  = MTB_ALT(MTB_X1),
+            [5]  = MTB_CTRL(MTB_X2) MTB_ALT(MTB_X1),
+            [6]  = MTB_SHIFT(MTB_X2) MTB_ALT(MTB_X1),
+            [7]  = MTB_CTRL(MTB_X3) MTB_SHIFT(MTB_X2) MTB_ALT(MTB_X1),          // Meh
+            [8]  = MTB_GUI(MTB_X1),
+            [9]  = MTB_CTRL(MTB_X2) MTB_GUI(MTB_X1),
+            [10] = MTB_SHIFT(MTB_X2) MTB_GUI(MTB_X1),
+            [11] = MTB_CTRL(MTB_X3) MTB_SHIFT(MTB_X2) MTB_GUI(MTB_X1),
+            [12] = MTB_ALT(MTB_X2) MTB_GUI(MTB_X1),
+            [13] = MTB_CTRL(MTB_X3) MTB_ALT(MTB_X2) MTB_GUI(MTB_X1),
+            [14] = MTB_SHIFT(MTB_X3) MTB_ALT(MTB_X2) MTB_GUI(MTB_X1),
+            [15] = MTB_CTRL(MTB_X4) MTB_SHIFT(MTB_X3) MTB_ALT(MTB_X2) MTB_GUI(MTB_X1), // Hyper
+        };
+        return mod_tap_badge[idx];
     }
 
     return NULL;

--- a/keyboards/polykybd/hints/tests/os_hints_tests.cpp
+++ b/keyboards/polykybd/hints/tests/os_hints_tests.cpp
@@ -286,24 +286,38 @@ TEST(OsHints, ModTapGuiOnlyIsNotTheEmptyCase) {
     EXPECT_EQ(mod_tap_hint(0x10), nullptr);
 }
 
-// The badge is a corner mark, not a second legend: every hint must position
-// itself with the MOVE op and draw each mark half-scale, so it can never be
-// mistaken for the prominent held-modifier shortcut hints.
-TEST(OsHints, ModTapBadgeIsPositionedAndHalfScale) {
+// The badge is a corner mark, not a second legend: every mark must be MOVE-
+// positioned, and a mark is drawn in exactly one of the three modes — decimated
+// (Ctrl, GUI), 2x2-OR (Alt) or full size (Shift, whose icon is already small).
+// This also pins the NUL trap: a MOVE coordinate is a codepoint, so a zero byte
+// would terminate the string and silently truncate the badge. That shipped once
+// (row 1 sat at y=0) and every badge came back two codepoints long, which is why
+// the length is asserted rather than assumed.
+TEST(OsHints, ModTapBadgeIsPositionedAndComplete) {
     for (uint8_t combo = 1; combo <= 0x0F; ++combo) {
         const uint32_t* got = mod_tap_hint(combo);
         ASSERT_NE(got, nullptr);
         EXPECT_EQ(got[0], U'\x0E') << "badge must start with a MOVE to the corner";
-        size_t moves = 0, halves = 0, marks = 0;
-        for (size_t i = 0; got[i]; ++i) {
-            if (got[i] == U'\x0E') { ++moves; i += 2; }        // MOVE consumes x,y
-            else if (got[i] == U'\x0F') { ++halves; ++marks; ++i; }  // HALF consumes the glyph
+        size_t moves = 0, marks = 0, len = 0;
+        while (got[len] != 0) {
+            const uint32_t c = got[len];
+            if (c == U'\x0E') {                 // MOVE consumes x,y
+                ASSERT_NE(got[len + 1], 0u) << "a zero MOVE x truncates the badge";
+                ASSERT_NE(got[len + 2], 0u) << "a zero MOVE y truncates the badge";
+                ++moves;
+                len += 3;
+            } else if (c == U'\x0F' || c == U'\x11') {   // HALF / THIN + its glyph
+                ++marks;
+                len += 2;
+            } else {                            // a full-size glyph (Shift)
+                ++marks;
+                len += 1;
+            }
         }
-        // One MOVE + one HALF per set modifier bit, and nothing drawn full size.
         const size_t want = static_cast<size_t>(__builtin_popcount(combo));
-        EXPECT_EQ(moves, want);
-        EXPECT_EQ(halves, want);
-        EXPECT_EQ(marks, want) << "a mark is drawn full-size for combo 0x"
+        EXPECT_EQ(moves, want) << "one MOVE per modifier, combo 0x"
+                               << std::hex << static_cast<int>(combo);
+        EXPECT_EQ(marks, want) << "one mark per modifier, combo 0x"
                                << std::hex << static_cast<int>(combo);
     }
 }

--- a/keyboards/polykybd/hints/tests/os_hints_tests.cpp
+++ b/keyboards/polykybd/hints/tests/os_hints_tests.cpp
@@ -15,6 +15,7 @@ const uint32_t* os_hint_reference(uint16_t keycode, uint8_t mods_raw, uint8_t ac
 
 #include <cstdio>   // snprintf in describe()
 #include <string>
+#include <utility>  // std::pair — badge grid-cell uniqueness
 #include <vector>
 
 namespace {
@@ -237,8 +238,12 @@ namespace {
 uint16_t mod_tap_kc(uint8_t mods_5bit) {
     return static_cast<uint16_t>(QK_MOD_TAP | (mods_5bit << 8) | KC_A);
 }
-const uint32_t* mod_tap_hint(uint8_t mods_5bit) {
-    return os_hint_for_keycode(mod_tap_kc(mods_5bit), 0, POLY_OS_WINDOWS);
+// os_hints.c builds one badge table PER OS; they differ only at the GUI-bearing
+// indices 8-15, through the MTB_GUI_<os>_R1/R2 position macros. Pinning a single
+// OS would leave a wrong position macro (or a table wired to the wrong OS) untested
+// on six of the seven, so every structural test below loops over os_values().
+const uint32_t* mod_tap_hint(uint8_t mods_5bit, uint8_t os = POLY_OS_WINDOWS) {
+    return os_hint_for_keycode(mod_tap_kc(mods_5bit), 0, os);
 }
 }  // namespace
 
@@ -247,30 +252,37 @@ const uint32_t* mod_tap_hint(uint8_t mods_5bit) {
 // the eleven combined branches were unreachable (they demanded both the left
 // AND right bit of each modifier), so HYPR_T and MEH_T drew a bare Ctrl.
 TEST(OsHints, ModTapEveryModifierCombinationIsDistinct) {
-    std::vector<std::u32string> seen;
-    for (uint8_t combo = 1; combo <= 0x0F; ++combo) {
-        const uint32_t* got = mod_tap_hint(combo);
-        ASSERT_NE(got, nullptr) << "combo 0x" << std::hex << static_cast<int>(combo);
-        std::u32string s;
-        for (size_t i = 0; got[i]; ++i) s.push_back(static_cast<char32_t>(got[i]));
-        for (size_t j = 0; j < seen.size(); ++j) {
-            EXPECT_NE(s, seen[j]) << "combo 0x" << std::hex << static_cast<int>(combo)
-                                  << " duplicates an earlier badge — the Shift+Alt row"
-                                     " carrying Ctrl+Alt's glyphs was exactly this";
+    for (uint8_t os : os_values()) {
+        std::vector<std::u32string> seen;
+        for (uint8_t combo = 1; combo <= 0x0F; ++combo) {
+            const uint32_t* got = mod_tap_hint(combo, os);
+            ASSERT_NE(got, nullptr) << "combo 0x" << std::hex << static_cast<int>(combo)
+                                    << " os " << static_cast<int>(os);
+            std::u32string s;
+            for (size_t i = 0; got[i]; ++i) s.push_back(static_cast<char32_t>(got[i]));
+            for (size_t j = 0; j < seen.size(); ++j) {
+                EXPECT_NE(s, seen[j]) << "combo 0x" << std::hex << static_cast<int>(combo)
+                                      << " os " << static_cast<int>(os)
+                                      << " duplicates an earlier badge — the Shift+Alt row"
+                                         " carrying Ctrl+Alt's glyphs was exactly this";
+            }
+            seen.push_back(s);
         }
-        seen.push_back(s);
+        EXPECT_EQ(seen.size(), 15u);
     }
-    EXPECT_EQ(seen.size(), 15u);
 }
 
 // Bit 4 is the left/right FLAG, not a modifier. Reading it as one made every
 // right-hand mod-tap (RCTL_T/RSFT_T/RALT_T/RGUI_T) collide with MOD_MASK_CTRL's
 // 0x10 bit and draw Ctrl. Both sides must now agree.
 TEST(OsHints, ModTapLeftAndRightSidesAgree) {
-    for (uint8_t combo = 1; combo <= 0x0F; ++combo) {
-        EXPECT_TRUE(same_hint(mod_tap_hint(combo),
-                              mod_tap_hint(static_cast<uint8_t>(combo | 0x10))))
-            << "left/right disagree for combo 0x" << std::hex << static_cast<int>(combo);
+    for (uint8_t os : os_values()) {
+        for (uint8_t combo = 1; combo <= 0x0F; ++combo) {
+            EXPECT_TRUE(same_hint(mod_tap_hint(combo, os),
+                                  mod_tap_hint(static_cast<uint8_t>(combo | 0x10), os)))
+                << "left/right disagree for combo 0x" << std::hex << static_cast<int>(combo)
+                << " os " << static_cast<int>(os);
+        }
     }
 }
 
@@ -294,16 +306,19 @@ TEST(OsHints, ModTapGuiOnlyIsNotTheEmptyCase) {
 // (row 1 sat at y=0) and every badge came back two codepoints long, which is why
 // the length is asserted rather than assumed.
 TEST(OsHints, ModTapBadgeIsPositionedAndComplete) {
+    for (uint8_t os : os_values()) {
     for (uint8_t combo = 1; combo <= 0x0F; ++combo) {
-        const uint32_t* got = mod_tap_hint(combo);
+        const uint32_t* got = mod_tap_hint(combo, os);
         ASSERT_NE(got, nullptr);
         EXPECT_EQ(got[0], U'\x0E') << "badge must start with a MOVE to the corner";
         size_t moves = 0, marks = 0, len = 0;
+        std::vector<std::pair<uint32_t, uint32_t>> cells;
         while (got[len] != 0) {
             const uint32_t c = got[len];
             if (c == U'\x0E') {                 // MOVE consumes x,y
                 ASSERT_NE(got[len + 1], 0u) << "a zero MOVE x truncates the badge";
                 ASSERT_NE(got[len + 2], 0u) << "a zero MOVE y truncates the badge";
+                cells.emplace_back(got[len + 1], got[len + 2]);
                 ++moves;
                 len += 3;
             } else if (c == U'\x0F' || c == U'\x11') {   // HALF / THIN + its glyph
@@ -319,6 +334,18 @@ TEST(OsHints, ModTapBadgeIsPositionedAndComplete) {
                                << std::hex << static_cast<int>(combo);
         EXPECT_EQ(marks, want) << "one mark per modifier, combo 0x"
                                << std::hex << static_cast<int>(combo);
+        // Two marks sharing a cell would draw on top of each other. The counts
+        // above cannot see that — the positions are hand-written per table row,
+        // so a copy-paste of the wrong MTB_* macro reads as a complete badge.
+        for (size_t a = 0; a + 1 < cells.size(); ++a) {
+            for (size_t b = a + 1; b < cells.size(); ++b) {
+                EXPECT_NE(cells[a], cells[b])
+                    << "two marks share grid cell (" << cells[a].first << ","
+                    << cells[a].second << "), combo 0x" << std::hex
+                    << static_cast<int>(combo) << " os " << static_cast<int>(os);
+            }
+        }
+    }
     }
 }
 

--- a/keyboards/polykybd/hints/tests/os_hints_tests.cpp
+++ b/keyboards/polykybd/hints/tests/os_hints_tests.cpp
@@ -93,6 +93,13 @@ std::string describe(uint16_t kc, uint8_t mods, uint8_t os) {
 TEST(OsHintsExtraction, MatchesPreExtractionTableExhaustively) {
     size_t compared = 0, hits = 0;
     for (uint16_t kc : interesting_keycodes()) {
+        // ⚠️ Mod-taps are DELIBERATELY excluded: their block was rewritten to fix the
+        // 5-bit/8-bit encoding bug and to render as a corner badge, so it no longer
+        // matches the reference — that is the point of the change. The reference file
+        // stays a verbatim pre-extraction copy (its value is being unedited), and the
+        // new mod-tap behaviour is pinned by the ModTap* tests at the bottom of this
+        // file instead. Everything else still has to match exactly.
+        if (IS_QK_MOD_TAP(kc)) continue;
         for (unsigned mods = 0; mods < 256; ++mods) {
             for (uint8_t os : os_values()) {
                 const uint32_t* got  = os_hint_for_keycode(kc, static_cast<uint8_t>(mods), os);
@@ -218,28 +225,86 @@ TEST(OsHints, UnknownOsBehavesAsTheNonAppleDefault) {
         << "Ctrl+A is not a macOS chord — if this changes the test above needs a new probe";
 }
 
-// The mod-tap hint block derives its glyphs from the KEYCODE's own mods, and its
-// eleven combined-modifier branches are UNREACHABLE: they test
-// `(mods & MOD_MASK_XY) == MOD_MASK_XY` where mods is the 5-bit mod-tap encoding
-// (0x00..0x1F) and MOD_MASK_* are 8-bit packed masks (MOD_MASK_CS == 0x33), so the
-// equality can never hold. Only the three single-modifier `&` tests and the final
-// else can fire — a Ctrl+Shift mod-tap shows "¤" alone, never "¤⇧".
-//
-// This is PRE-EXISTING behaviour, pinned here rather than fixed: this change set is
-// a behaviour-preserving extraction, and correcting it would alter what appears on
-// a keycap. Tracked separately; when it is fixed, this test is the one to update.
-TEST(OsHints, ModTapCombinedModifierBranchesAreCurrentlyUnreachable) {
-    for (uint8_t mt = 0; mt < 0x20; ++mt) {
-        const uint16_t kc = static_cast<uint16_t>(QK_MOD_TAP | (mt << 8) | KC_A);
-        const uint32_t* got = os_hint_for_keycode(kc, 0, POLY_OS_WINDOWS);
-        ASSERT_NE(got, nullptr) << "mod-tap always yields some hint";
-        // Every reachable answer is one of the four terminal cases, so the glyph
-        // count never exceeds one modifier symbol after the leading spaces.
-        size_t len = 0;
-        while (got[len] != 0) ++len;
-        EXPECT_LE(len, 5u) << "a combined-modifier mod-tap hint became reachable for mods=0x"
-                           << std::hex << static_cast<int>(mt)
-                           << " — the dead branches are alive, update this test";
+// ---------------------------------------------------------------------------
+// Mod-tap badge. The block derives its marks from the KEYCODE's own modifiers,
+// which arrive in QMK's 5-bit form (bits 0-3 = CSAG, bit 4 = the left/right
+// flag) while the MOD_MASK_* constants it is compared against are the 8-bit
+// paired form. These tests pin both halves of the fix and replace the earlier
+// ModTapCombinedModifierBranchesAreCurrentlyUnreachable, which pinned the bug.
+// ---------------------------------------------------------------------------
+
+namespace {
+uint16_t mod_tap_kc(uint8_t mods_5bit) {
+    return static_cast<uint16_t>(QK_MOD_TAP | (mods_5bit << 8) | KC_A);
+}
+const uint32_t* mod_tap_hint(uint8_t mods_5bit) {
+    return os_hint_for_keycode(mod_tap_kc(mods_5bit), 0, POLY_OS_WINDOWS);
+}
+}  // namespace
+
+// All fifteen non-empty modifier combinations must produce a DISTINCT badge.
+// Before the fix only four answers existed across the whole 32-value domain:
+// the eleven combined branches were unreachable (they demanded both the left
+// AND right bit of each modifier), so HYPR_T and MEH_T drew a bare Ctrl.
+TEST(OsHints, ModTapEveryModifierCombinationIsDistinct) {
+    std::vector<std::u32string> seen;
+    for (uint8_t combo = 1; combo <= 0x0F; ++combo) {
+        const uint32_t* got = mod_tap_hint(combo);
+        ASSERT_NE(got, nullptr) << "combo 0x" << std::hex << static_cast<int>(combo);
+        std::u32string s;
+        for (size_t i = 0; got[i]; ++i) s.push_back(static_cast<char32_t>(got[i]));
+        for (size_t j = 0; j < seen.size(); ++j) {
+            EXPECT_NE(s, seen[j]) << "combo 0x" << std::hex << static_cast<int>(combo)
+                                  << " duplicates an earlier badge — the Shift+Alt row"
+                                     " carrying Ctrl+Alt's glyphs was exactly this";
+        }
+        seen.push_back(s);
+    }
+    EXPECT_EQ(seen.size(), 15u);
+}
+
+// Bit 4 is the left/right FLAG, not a modifier. Reading it as one made every
+// right-hand mod-tap (RCTL_T/RSFT_T/RALT_T/RGUI_T) collide with MOD_MASK_CTRL's
+// 0x10 bit and draw Ctrl. Both sides must now agree.
+TEST(OsHints, ModTapLeftAndRightSidesAgree) {
+    for (uint8_t combo = 1; combo <= 0x0F; ++combo) {
+        EXPECT_TRUE(same_hint(mod_tap_hint(combo),
+                              mod_tap_hint(static_cast<uint8_t>(combo | 0x10))))
+            << "left/right disagree for combo 0x" << std::hex << static_cast<int>(combo);
+    }
+}
+
+// LGUI_T is 0x08, which intersects NO MOD_MASK_* value, so it used to fall to
+// the final else and draw the no-modifier legend — a blank-looking keycap.
+TEST(OsHints, ModTapGuiOnlyIsNotTheEmptyCase) {
+    const uint32_t* gui = mod_tap_hint(MOD_LGUI);
+    ASSERT_NE(gui, nullptr);
+    EXPECT_FALSE(same_hint(gui, mod_tap_hint(MOD_LCTL)))
+        << "GUI-only must not render as Ctrl";
+    // A mod-tap carrying no modifier at all is the one case with no hint.
+    EXPECT_EQ(mod_tap_hint(0), nullptr);
+    EXPECT_EQ(mod_tap_hint(0x10), nullptr);
+}
+
+// The badge is a corner mark, not a second legend: every hint must position
+// itself with the MOVE op and draw each mark half-scale, so it can never be
+// mistaken for the prominent held-modifier shortcut hints.
+TEST(OsHints, ModTapBadgeIsPositionedAndHalfScale) {
+    for (uint8_t combo = 1; combo <= 0x0F; ++combo) {
+        const uint32_t* got = mod_tap_hint(combo);
+        ASSERT_NE(got, nullptr);
+        EXPECT_EQ(got[0], U'\x0E') << "badge must start with a MOVE to the corner";
+        size_t moves = 0, halves = 0, marks = 0;
+        for (size_t i = 0; got[i]; ++i) {
+            if (got[i] == U'\x0E') { ++moves; i += 2; }        // MOVE consumes x,y
+            else if (got[i] == U'\x0F') { ++halves; ++marks; ++i; }  // HALF consumes the glyph
+        }
+        // One MOVE + one HALF per set modifier bit, and nothing drawn full size.
+        const size_t want = static_cast<size_t>(__builtin_popcount(combo));
+        EXPECT_EQ(moves, want);
+        EXPECT_EQ(halves, want);
+        EXPECT_EQ(marks, want) << "a mark is drawn full-size for combo 0x"
+                               << std::hex << static_cast<int>(combo);
     }
 }
 

--- a/keyboards/polykybd/lang/named_glyphs.h
+++ b/keyboards/polykybd/lang/named_glyphs.h
@@ -1977,6 +1977,28 @@
 #define HINT_POS_ZOOMOUT U"\x3E\x16"   // (62,22)  cursor so a base-font '-' centres in the lens
 #define HINT_POS_RUNBOX  U"\x36\x01"   // (54, 1)  Win+R run-dialog frame top-left
 #define HINT_SZ_RUNBOX   U"\x21\x1B"   // 33 x 27  Win+R run-dialog frame size
+// ---- Mod-tap badge -----------------------------------------------------------
+// A mod-tap keycap already draws its TAP legend ("A" for MT(RSFT,KC_A)) as the
+// primary text; the modifier is only what HOLDING it does. So it renders as a
+// small mark in the top-right corner rather than as a second full-size legend
+// beside the letter — the shortcut hints are prominent on purpose (holding Ctrl
+// makes the whole keycap mean "Ctrl+C"), a mod-tap badge is not.
+//
+// Four right-aligned 8px slots, X1 rightmost. HINT_HALF draws the literal ink
+// top-left with NO advance (see kdisp_write_gfx_text_cy), so every mark carries
+// its own MOVE — which is also what lets each one bake in its own y and put all
+// four bottoms on a common line at y=9 despite half-heights of 8/7/4/3.
+// Measured half sizes: ¤ 7x7, ⇧ 7x8, ¬ 7x4, ・ 3x3 (tools/gfx_font.py).
+// The top-right corner is free on a keycap whose legend sits at x28..46, y4..23.
+#define MTB_X1           U"\x5C"       // x=92, rightmost slot
+#define MTB_X2           U"\x54"       // x=84
+#define MTB_X3           U"\x4C"       // x=76
+#define MTB_X4           U"\x44"       // x=68, leftmost (4-modifier case only)
+// Each takes a slot macro; the y is per-glyph so the marks bottom-align.
+#define MTB_CTRL(x)      U"\x0E" x U"\x02" U"\x0F" CURRENCY_SIGN        // y=2, 7x7
+#define MTB_SHIFT(x)     U"\x0E" x U"\x01" U"\x0F" ICON_SHIFT           // y=1, 7x8
+#define MTB_ALT(x)       U"\x0E" x U"\x05" U"\x0F" NOT_SIGN             // y=5, 7x4
+#define MTB_GUI(x)       U"\x0E" x U"\x06" U"\x0F" KATAKANA_MIDDLE_DOT  // y=6, 3x3
 // Windows Super-chord hint glyphs (wave D), as drawn by keycode_to_disp_overlay()'s
 // win_or_unknown branch. All are display-only previews of the Win+<key> shortcut.
 // Only the Explorer folder pixmap (ICON_EXPLORER, \x9C) is a resident IconsFont

--- a/keyboards/polykybd/lang/named_glyphs.h
+++ b/keyboards/polykybd/lang/named_glyphs.h
@@ -1997,39 +1997,37 @@
 //   Shift                    -> full size. ICON_SHIFT is already a 14x16 inline
 //                               icon and matches the others' scaled size.
 //
-// Two columns x two rows, filled right-to-left then top-to-bottom, so a single
-// modifier lands in the top-right corner. A position is the literal ink top-left
-// for THIN/HALF but the baseline cursor for the full-size Shift, so they are per
-// mark and per cell; ALL of them are generated together with the preview render
-// (columns end at x97 and x74, rows start at y0 and y20) — regenerate both
-// rather than nudging one by hand. The left column's widest mark starts at x56,
-// clearing the widest tap legend ("W" ends at x52) by 4px.
-#define MTB_CTRL_L1  U"\x39\x01"   // (57, 1)
-#define MTB_CTRL_L2  U"\x39\x15"   // (57,21)
-#define MTB_CTRL_R1  U"\x50\x01"   // (80, 1)
-#define MTB_CTRL_R2  U"\x50\x15"   // (80,21)
-#define MTB_SHIFT_L1  U"\x3C\x11"   // (60,17)
-#define MTB_SHIFT_L2  U"\x3C\x28"   // (60,40)
-#define MTB_SHIFT_R1  U"\x53\x11"   // (83,17)
-#define MTB_SHIFT_R2  U"\x53\x28"   // (83,40)
-#define MTB_ALT_L1   U"\x38\x01"   // (56, 1)
-#define MTB_ALT_L2   U"\x38\x1F"   // (56,31)
-#define MTB_ALT_R1   U"\x4F\x01"   // (79, 1)
-#define MTB_ALT_R2   U"\x4F\x1F"   // (79,31)
-#define MTB_GUI_WINDOWS_R1  U"\x54\x01"   // (84, 1) ICON_OS_WINDOWS
-#define MTB_GUI_WINDOWS_R2  U"\x54\x1A"   // (84,26) ICON_OS_WINDOWS
-#define MTB_GUI_MACOS_R1  U"\x54\x01"   // (84, 1) TECHNICAL_COMMAND
-#define MTB_GUI_MACOS_R2  U"\x54\x1A"   // (84,26) TECHNICAL_COMMAND
-#define MTB_GUI_LINUX_R1  U"\x55\x01"   // (85, 1) ICON_OS_LINUX
-#define MTB_GUI_LINUX_R2  U"\x55\x15"   // (85,21) ICON_OS_LINUX
-#define MTB_GUI_GNOME_R1  U"\x56\x01"   // (86, 1) ICON_OS_GNOME
-#define MTB_GUI_GNOME_R2  U"\x56\x19"   // (86,25) ICON_OS_GNOME
-#define MTB_GUI_KDE_R1  U"\x53\x01"   // (83, 1) ICON_OS_KDE
-#define MTB_GUI_KDE_R2  U"\x53\x19"   // (83,25) ICON_OS_KDE
-#define MTB_GUI_ANDROID_R1  U"\x4E\x01"   // (78, 1) ICON_OS_ANDROID
-#define MTB_GUI_ANDROID_R2  U"\x4E\x1C"   // (78,28) ICON_OS_ANDROID
-#define MTB_GUI_OTHER_R1  U"\x4E\x01"   // (78, 1) DINGBAT_BLACK_DIA_X
-#define MTB_GUI_OTHER_R2  U"\x4E\x14"   // (78,20) DINGBAT_BLACK_DIA_X
+// Two columns x two rows, anchored BOTTOM-right: one modifier lands in the
+// bottom-right corner (cell RB) and the badge grows up and left from there. The
+// anchor is not cosmetic -- render_key() draws a key's shift preview in the
+// UPPER right (baseline 23, i.e. exactly where row T sits), so a top-anchored
+// badge put its very first mark on top of it. Bottom-anchored, only a 3rd or 4th
+// mark reaches row T, and a 3-modifier mod-tap is already exotic.
+// A position is the literal ink top-left for THIN/HALF but the baseline cursor
+// for the full-size Shift, so they are per mark and per cell; ALL of them are
+// generated together with the preview render (columns END at x97 and x74; row B
+// is bottom-aligned to the last screen row, row T top-aligned at y1) --
+// regenerate both rather than nudging one by hand. The left column's widest mark
+// starts at x56, clearing the widest tap legend ("W" ends at x52) by 4px.
+#define MTB_CTRL_LT  U"\x39\x01"   // (57, 1)
+#define MTB_CTRL_LB  U"\x39\x15"   // (57,21)
+#define MTB_CTRL_RT  U"\x50\x01"   // (80, 1)
+#define MTB_CTRL_RB  U"\x50\x15"   // (80,21)
+#define MTB_SHIFT_LT  U"\x3C\x11"   // (60,17)
+#define MTB_SHIFT_LB  U"\x3C\x28"   // (60,40)
+#define MTB_SHIFT_RT  U"\x53\x11"   // (83,17)
+#define MTB_SHIFT_RB  U"\x53\x28"   // (83,40)
+#define MTB_ALT_LT   U"\x38\x01"   // (56, 1)
+#define MTB_ALT_LB   U"\x38\x1F"   // (56,31)
+#define MTB_ALT_RT   U"\x4F\x01"   // (79, 1)
+#define MTB_ALT_RB   U"\x4F\x1F"   // (79,31)
+#define MTB_GUI_WINDOWS_RB  U"\x54\x1A"   // (84,26) ICON_OS_WINDOWS
+#define MTB_GUI_MACOS_RB  U"\x54\x1A"   // (84,26) TECHNICAL_COMMAND
+#define MTB_GUI_LINUX_RB  U"\x55\x15"   // (85,21) ICON_OS_LINUX
+#define MTB_GUI_GNOME_RB  U"\x56\x19"   // (86,25) ICON_OS_GNOME
+#define MTB_GUI_KDE_RB  U"\x53\x19"   // (83,25) ICON_OS_KDE
+#define MTB_GUI_ANDROID_RB  U"\x4E\x1C"   // (78,28) ICON_OS_ANDROID
+#define MTB_GUI_OTHER_RB  U"\x4E\x14"   // (78,20) DINGBAT_BLACK_DIA_X
 // Each takes one of the position macros above.
 #define MTB_CTRL(pos)      HINT_MOVE(pos) HINT_THIN TECHNICAL_CONTROL
 #define MTB_SHIFT(pos)     HINT_MOVE(pos) ICON_SHIFT

--- a/keyboards/polykybd/lang/named_glyphs.h
+++ b/keyboards/polykybd/lang/named_glyphs.h
@@ -1969,6 +1969,7 @@
 // Keep the op bytes in sync with the \x0E–\x12 cases in kdisp_write_gfx_text_cy().
 #define HINT_MOVE(pos)   U"\x0E" pos   // move cursor to buffer (x,y) = pos
 #define HINT_HALF        U"\x0F"       // draw the NEXT glyph half-scale (2x2-OR) at cursor
+#define HINT_THIN        U"\x11"       // as HINT_HALF but DECIMATING (see disp_array.h)
 #define HINT_FRAME(sz)   U"\x12" sz    // 2px nested rounded rect of size (w,h) = sz at cursor
 #define HINT_RESET       U"\x18"       // reset cursor to the text origin
 // Fixed buffer positions / sizes (two bytes each; decimal in the comment):
@@ -1981,24 +1982,59 @@
 // A mod-tap keycap already draws its TAP legend ("A" for MT(RSFT,KC_A)) as the
 // primary text; the modifier is only what HOLDING it does. So it renders as a
 // small mark in the top-right corner rather than as a second full-size legend
-// beside the letter — the shortcut hints are prominent on purpose (holding Ctrl
-// makes the whole keycap mean "Ctrl+C"), a mod-tap badge is not.
+// beside the letter — the held-modifier shortcut hints are prominent on purpose
+// (holding Ctrl makes the whole keycap mean "Ctrl+C"), a mod-tap badge is not.
 //
-// Four right-aligned 8px slots, X1 rightmost. HINT_HALF draws the literal ink
-// top-left with NO advance (see kdisp_write_gfx_text_cy), so every mark carries
-// its own MOVE — which is also what lets each one bake in its own y and put all
-// four bottoms on a common line at y=9 despite half-heights of 8/7/4/3.
-// Measured half sizes: ¤ 7x7, ⇧ 7x8, ¬ 7x4, ・ 3x3 (tools/gfx_font.py).
-// The top-right corner is free on a keycap whose legend sits at x28..46, y4..23.
-#define MTB_X1           U"\x5C"       // x=92, rightmost slot
-#define MTB_X2           U"\x54"       // x=84
-#define MTB_X3           U"\x4C"       // x=76
-#define MTB_X4           U"\x44"       // x=68, leftmost (4-modifier case only)
-// Each takes a slot macro; the y is per-glyph so the marks bottom-align.
-#define MTB_CTRL(x)      U"\x0E" x U"\x02" U"\x0F" CURRENCY_SIGN        // y=2, 7x7
-#define MTB_SHIFT(x)     U"\x0E" x U"\x01" U"\x0F" ICON_SHIFT           // y=1, 7x8
-#define MTB_ALT(x)       U"\x0E" x U"\x05" U"\x0F" NOT_SIGN             // y=5, 7x4
-#define MTB_GUI(x)       U"\x0E" x U"\x06" U"\x0F" KATAKANA_MIDDLE_DOT  // y=6, 3x3
+// The marks are the SAME symbols the modifier keycaps use (keycode_helper.c):
+// the Technical family plus the per-OS GUI logo. Those are drawn to fill a
+// keycap (control is 35x37), so they are downsampled 2x — and WHICH downsample
+// is per glyph, because the two fail in opposite ways (see disp_array.h):
+//   Ctrl helm + the OS logos -> HINT_THIN, or the 2x2-OR closes the gaps that
+//                               carry their meaning (the Windows logo becomes a
+//                               solid square, the helm's spokes fill in).
+//   Alt                      -> HINT_HALF; decimation costs it 46 percent of its
+//                               lit pixels, the worst of the set.
+//   Shift                    -> full size. ICON_SHIFT is already a 14x16 inline
+//                               icon and matches the others' scaled size.
+//
+// Two columns x two rows, filled right-to-left then top-to-bottom, so a single
+// modifier lands in the top-right corner. A position is the literal ink top-left
+// for THIN/HALF but the baseline cursor for the full-size Shift, so they are per
+// mark and per cell; ALL of them are generated together with the preview render
+// (columns end at x97 and x74, rows start at y0 and y20) — regenerate both
+// rather than nudging one by hand. The left column's widest mark starts at x56,
+// clearing the widest tap legend ("W" ends at x52) by 4px.
+#define MTB_CTRL_L1  U"\x39\x01"   // (57, 1)
+#define MTB_CTRL_L2  U"\x39\x15"   // (57,21)
+#define MTB_CTRL_R1  U"\x50\x01"   // (80, 1)
+#define MTB_CTRL_R2  U"\x50\x15"   // (80,21)
+#define MTB_SHIFT_L1  U"\x3C\x11"   // (60,17)
+#define MTB_SHIFT_L2  U"\x3C\x28"   // (60,40)
+#define MTB_SHIFT_R1  U"\x53\x11"   // (83,17)
+#define MTB_SHIFT_R2  U"\x53\x28"   // (83,40)
+#define MTB_ALT_L1   U"\x38\x01"   // (56, 1)
+#define MTB_ALT_L2   U"\x38\x1F"   // (56,31)
+#define MTB_ALT_R1   U"\x4F\x01"   // (79, 1)
+#define MTB_ALT_R2   U"\x4F\x1F"   // (79,31)
+#define MTB_GUI_WINDOWS_R1  U"\x54\x01"   // (84, 1) ICON_OS_WINDOWS
+#define MTB_GUI_WINDOWS_R2  U"\x54\x1A"   // (84,26) ICON_OS_WINDOWS
+#define MTB_GUI_MACOS_R1  U"\x54\x01"   // (84, 1) TECHNICAL_COMMAND
+#define MTB_GUI_MACOS_R2  U"\x54\x1A"   // (84,26) TECHNICAL_COMMAND
+#define MTB_GUI_LINUX_R1  U"\x55\x01"   // (85, 1) ICON_OS_LINUX
+#define MTB_GUI_LINUX_R2  U"\x55\x15"   // (85,21) ICON_OS_LINUX
+#define MTB_GUI_GNOME_R1  U"\x56\x01"   // (86, 1) ICON_OS_GNOME
+#define MTB_GUI_GNOME_R2  U"\x56\x19"   // (86,25) ICON_OS_GNOME
+#define MTB_GUI_KDE_R1  U"\x53\x01"   // (83, 1) ICON_OS_KDE
+#define MTB_GUI_KDE_R2  U"\x53\x19"   // (83,25) ICON_OS_KDE
+#define MTB_GUI_ANDROID_R1  U"\x4E\x01"   // (78, 1) ICON_OS_ANDROID
+#define MTB_GUI_ANDROID_R2  U"\x4E\x1C"   // (78,28) ICON_OS_ANDROID
+#define MTB_GUI_OTHER_R1  U"\x4E\x01"   // (78, 1) DINGBAT_BLACK_DIA_X
+#define MTB_GUI_OTHER_R2  U"\x4E\x14"   // (78,20) DINGBAT_BLACK_DIA_X
+// Each takes one of the position macros above.
+#define MTB_CTRL(pos)      HINT_MOVE(pos) HINT_THIN TECHNICAL_CONTROL
+#define MTB_SHIFT(pos)     HINT_MOVE(pos) ICON_SHIFT
+#define MTB_ALT(pos)       HINT_MOVE(pos) HINT_HALF TECHNICAL_ALTERNATIVE
+#define MTB_GUI(pos, icon) HINT_MOVE(pos) HINT_THIN icon
 // Windows Super-chord hint glyphs (wave D), as drawn by keycode_to_disp_overlay()'s
 // win_or_unknown branch. All are display-only previews of the Win+<key> shortcut.
 // Only the Explorer folder pixmap (ICON_EXPLORER, \x9C) is a resident IconsFont

--- a/keyboards/polykybd/lang/named_glyphs.h
+++ b/keyboards/polykybd/lang/named_glyphs.h
@@ -1981,9 +1981,11 @@
 // ---- Mod-tap badge -----------------------------------------------------------
 // A mod-tap keycap already draws its TAP legend ("A" for MT(RSFT,KC_A)) as the
 // primary text; the modifier is only what HOLDING it does. So it renders as a
-// small mark in the top-right corner rather than as a second full-size legend
+// small mark in the BOTTOM-right corner rather than as a second full-size legend
 // beside the letter — the held-modifier shortcut hints are prominent on purpose
 // (holding Ctrl makes the whole keycap mean "Ctrl+C"), a mod-tap badge is not.
+// (Bottom, not top: the shift preview owns the upper right — see the anchor note
+// on the grid below.)
 //
 // The marks are the SAME symbols the modifier keycaps use (keycode_helper.c):
 // the Technical family plus the per-OS GUI logo. Those are drawn to fill a

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -1866,6 +1866,18 @@ static const uint32_t* latin_variation(uint16_t keycode, bool upper_case) {
 }
 
 bool render_key(uint16_t keycode, led_t state, uint8_t mods) {
+    // ⚠️ A mod-tap's LEGEND is its tap keycode's legend. to_static_text() unwraps
+    // this one function away, and update_displays() consults render_key() exactly
+    // when to_static_text() returned NULL -- which is every letter, since the
+    // language translation lives down here. So without the same unwrap a
+    // RSFT_T(KC_A) fell through every branch below (is_letter is false for 0x3204,
+    // and translate_keycode() has no row for it) and the keycap drew NO letter at
+    // all: only the mod-tap hint badge, floating in an empty cell (field, 2026-08-18).
+    // The two legend producers have to agree; keep the unwrap in both.
+    if(IS_QK_MOD_TAP(keycode)) {
+        keycode = QK_MOD_TAP_GET_TAP_KEYCODE(keycode);
+    }
+
     const poly_layer_t* local_layer = get_local_layer();
 
     const bool shift = ((local_layer->mods & MOD_MASK_SHIFT) != 0);


### PR DESCRIPTION
## Summary

Five commits. The first fixes a correctness bug in the mod-tap hint block that made almost every mod-tap keycap draw the wrong modifier; the rest change how those marks are presented — using the icons the modifier keycaps themselves use, restoring the tap legend the first presentation pass had lost, and anchoring the badge where it does not collide with the shift preview. **Both presentation problems were found on hardware and fixed against a measured preview render, not by eye.**

### 1. The encoding bug (`hints/os_hints.c`)

`QK_MOD_TAP_GET_MODS()` returns QMK's **5-bit** form (`enum mods_5bit`): bits 0-3 are Ctrl/Shift/Alt/Gui and **bit 4 is the left/right flag**. The `MOD_MASK_*` constants it was tested against are the **8-bit paired** form (`MOD_MASK_CTRL == 0x11`). Two independent consequences:

* Right-side mod-taps set bit 4, whose `0x10` is `MOD_BIT_RCTRL`, so `RCTL_T`/`RSFT_T`/`RALT_T`/`RGUI_T` all matched `mods & MOD_MASK_CTRL` first and drew **Ctrl**. `LGUI_T` (`0x08`) intersects no `MOD_MASK_*` at all and fell through to the no-modifier case, drawing **nothing**.
* Every combined branch asked `(mods & MOD_MASK_CS) == MOD_MASK_CS`, i.e. *both* left AND right Ctrl AND Shift. A mod-tap carries one side only, so all eleven were unreachable **independently of** the above, and `HYPR_T`/`MEH_T` drew a bare Ctrl.

Enumerated over the 32-value domain: **11 of 15 branches dead**, and `mods & MOD_MASK_CTRL` claimed **24 of the 32** values.

The fix normalises once with the expression QMK itself uses (`quantum/keymap_common.c`: `(mod & 0x10) ? (mod & 0xF) << 4 : mod`), then indexes a 16-entry table by the four independent presence bits rather than ordering eleven overlapping tests by specificity. That ordering is what hid a third bug the enumeration turned up: the **Shift+Alt row returned Ctrl+Alt's glyphs**, a copy of the branch below it, which no test could have caught while the branch was unreachable.

### 2. The presentation (`base/disp_array.*`, `lang/named_glyphs.h`)

The hint was drawn at the same origin and size as the primary legend, so `MT(RSFT, KC_A)` rendered "A" and a full-size ⇧ side by side as if both were legends. A mod-tap's modifier is only what *holding* it does, so it now renders as a corner badge — and with the **same symbols the modifier keycaps use** (`keycode_helper.c`): helm, shift arrow, alt, and the per-OS GUI logo, instead of the previous currency-sign / not-sign / katakana-dot stand-ins.

Those Technical glyphs are drawn to fill a keycap (control is 35x37), so they are downsampled 2x. **Which** downsample is per glyph, because the two fail in opposite ways — measured on the real glyph data, not chosen by eye:

| Mark | Glyph | Draw | Why |
|---|---|---|---|
| Ctrl | ⎈ helm | **THIN** | 2x2-OR fills in the spokes |
| GUI | per-OS logo | **THIN** | 2x2-OR merges the Windows panes into a solid square |
| Alt | ⎇ | **HALF** (2x2-OR) | decimation costs it 46% of its lit pixels, worst of the ten marks compared |
| Shift | ⇧ | full size | `ICON_SHIFT` is already a 14x16 inline icon and matches the others once halved |

This adds `kdisp_draw_glyph_thin_at()` and the `HINT_THIN` (`\x11`) display-list op as a **sibling** of the existing OR-based `HINT_HALF`, not a replacement — the Win+Ctrl+Shift+B hint still uses OR.

Two other samplers were tried and rejected with numbers: reading the 2x2 diagonal and lighting on *either* pixel keeps 82-99% of OR's ink (99% on the Windows logo), i.e. it reproduces the defect; requiring *both* is sparser than plain decimation everywhere and breaks the alt stroke.

### 3. The badge drew, but the tap letter did not (`poly_keymap.c`) — found on hardware

`render_key()` never unwrapped a mod-tap keycode, and `update_displays()` consults it exactly when `to_static_text()` returns NULL — which is **every letter**, since the language translation lives inside `render_key()`. So `RSFT_T(KC_A)` (`0x3204`) fell through every branch there (`is_letter` is false for it, and `translate_keycode()` has no row for it) and the keycap drew **no letter at all**: just the badge, in an otherwise empty cell.

`to_static_text()` has had that same unwrap for years, one function away. The two legend producers have to agree, so `render_key()` now does it too.

### 4. The badge sat where the shift preview lives (`lang/named_glyphs.h`, `hints/os_hints.c`)

The 2x2 grid was filled from the **top**-right, so a single-modifier mod-tap put its one mark exactly where `render_key()` draws a key's shift preview (baseline 23, upper right). Anchoring the grid at the **bottom** instead pushes the first three marks clear of it; only a 4th reaches the top row, and a four-modifier mod-tap is not a real keymap.

Badge ink landing on legend ink, measured across all 15 modifier combinations:

| | letter `a` | digit `1` (which *does* carry a `!` preview) |
|---|---|---|
| top-anchored | 0 | 21 px, from **2 marks** up |
| bottom-anchored | 0 | 21 px at **4 marks only**, 0 below |

The grid **coordinates are unchanged** — only the fill order flipped — so every generated position is byte-identical; the cells were renamed `L1/L2/R1/R2` → `LT/LB/RT/RB`, since "row 1" reading as the top row is now backwards. Marks are placed in C,S,A,G order and GUI is last, so **GUI always lands in the bottom-right cell**: `MT_BADGE_TABLE` drops from three parameters to two and the four dead `MTB_GUI_*_R1` macros are gone.

## ⚠️ A trap worth knowing about

A `HINT_MOVE` coordinate is a **codepoint in the hint string**, so a zero byte is a NUL that **terminates the display list**. The top row initially sat at `y=0` and every badge came back two codepoints long. It is now `y=1`, and the bottom row is bottom-aligned to the last screen row — which also opens the Hyper case's left column, where the 19px helm and the alt mark would otherwise touch at a 0px gap. The layout generator asserts no coordinate is zero, and the test walks the string asserting each MOVE's x and y are non-zero.

## How this was verified

The layout constants and the preview render come from **one generator**, so the firmware and the preview cannot disagree. Checked across all 15 modifier combinations x 7 OS x the narrowest and widest tap legends: nothing exceeds the `x<=99` / `y<=39` window, the left column's widest mark clears the widest tap legend ("W" ends at x52) by 4px, and every mark clears its neighbours' 3px courtyard.

For §3 and §4 the preview additionally models `render_key()`'s own legend placement (base glyph + the shift preview, using the real en-US `poly_settings` offsets), so "does the badge damage the legend" is a measurement rather than a judgement. ⚠️ Measure it as the **intersection** of the two ink sets: a "legend pixels lost" count reads 0 for a real collision, because overlapping lit-on-lit loses no pixels and still reads as merged.

Tests (`make test:polykybd_os_hints`, 11 pass):
- `ModTapEveryModifierCombinationIsDistinct` — all 15 combinations produce distinct badges. This is what caught the NUL bug: every combo collapsed to the same 2-codepoint string.
- `ModTapLeftAndRightSidesAgree` — bit 4 is a flag, not a modifier.
- `ModTapGuiOnlyIsNotTheEmptyCase` — `LGUI_T` is no longer the blank fall-through.
- `ModTapBadgeIsPositionedAndComplete` — one MOVE and one mark per set modifier bit, with non-zero coordinates, and **no two marks sharing a grid cell**. (Replaces `ModTapCombinedModifierBranchesAreCurrentlyUnreachable`, which pinned the bug.)
- All four now loop over `os_values()` rather than pinning `POLY_OS_WINDOWS` — `os_hints.c` builds seven badge tables differing only at the GUI indices, so six were previously untested.

Mutation-tested: dropping the normalisation fails the left/right and GUI-only tests; restoring the Shift+Alt copy-paste fails the distinctness test.

`MatchesPreExtractionTableExhaustively` now **skips mod-taps**, with the reason stated inline — the reference file stays a verbatim pre-extraction copy (being unedited is its whole value) and the deliberate deviation is covered by the tests above. Everything else still matches exactly.

## Version bump label

`bump:minor` — the encoding fix alone would be a patch, but the badge is a new, user-visible rendering behaviour.

## Testing

- [x] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`)
- [x] Also `split42:default`, plus the monolith via `doom/pack/build_pack.sh` (which PR CI does not build)
- [x] `qmk lint --strict` on both keyboards, plus `qmk ci-validate-keyboard-targets` and `qmk ci-validate-aliases`
- [x] Unit tests: `polykybd_os_hints` (11), `fw_up_verdict` (27)
- [x] **Flashed and tested on hardware (split72, build `391f414e`) — reported working.** Three rounds: round 1 confirmed the badge renders correctly and surfaced §3 (the tap letter was missing); §4 followed from the observation that the corner was the wrong one; round 3 confirmed both. The head commit `2d61653d` is a comment-only change on top of the tested build. Note that neither default keymap contains a mod-tap keycode, so this is only reachable by assigning one through PolyKybdHost's layout editor (Behavior → `MT`, pick modifiers, pick the side).
- [x] If protocol changed: n/a — no protocol change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HXL2e7jiYWLBKrsnEnukK

---
_Generated by [Claude Code](https://claude.ai/code/session_015HXL2e7jiYWLBKrsnEnukK)_