### PR TITLE
ci: add independent PR checks (Claude on demand + cppcheck) — and fix what cppcheck found

### DIFF
--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -1,0 +1,51 @@
+# Interactive Claude, triggered by mentioning @claude in a PR or issue comment.
+#
+# Companion to claude-review.yml. That one runs a full review; this one answers
+# a specific question or makes a specific change, and only when asked.
+#
+# The use it earns its keep for here is ADJUDICATING the other reviewers. Per
+# CLAUDE.md, several AI findings arrive confidently wrong (a "PACK_VERSION 3
+# needs a host change" that the host never parses; an int8_t "signed-overflow
+# UB" the cited answer contradicts), and the standing rule is verify, not
+# dismiss. This runs with the repo checked out and CLAUDE.md loaded, so:
+#
+#   @claude is CodeRabbit right that <finding>? check it against the code
+#   @claude CI is red on <check> — is that failing on the base branch too?
+#   @claude fix the trailing-comment spacing clang-format flagged
+#
+# Runs are billed to the CLAUDE_CODE_OAUTH_TOKEN owner's Claude subscription.
+# Only users with write access can trigger it, and bot accounts cannot — so a
+# rate-limit notice from another reviewer can never set this off by itself.
+#
+# NOTE: comment triggers always run the copy of this file on the DEFAULT
+# branch, so this workflow does nothing until it is merged there.
+name: Claude (@claude mention)
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude:
+    # "@claude review" belongs to claude-review.yml; excluding it here is what
+    # stops one comment from starting two runs.
+    if: >-
+      contains(github.event.comment.body, '@claude') &&
+      !contains(github.event.comment.body, '@claude review')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read      # lets Claude read CI results, incl. the HIL job logs
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -31,9 +31,11 @@ jobs:
   claude:
     # "@claude review" belongs to claude-review.yml; excluding it here is what
     # stops one comment from starting two runs.
+    # Mirrors claude-review.yml's startsWith exactly, so the two cannot both
+    # fire and no "@claude ..." comment can fall between them.
     if: >-
       contains(github.event.comment.body, '@claude') &&
-      !contains(github.event.comment.body, '@claude review')
+      !startsWith(github.event.comment.body, '@claude review')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,63 @@
+# On-demand Claude code review.
+#
+# This is a FALLBACK reviewer, deliberately never automatic: CodeRabbit and
+# Sourcery review every PR already, and a fourth always-on bot would only add
+# noise. Summon this one when the others are unavailable — CodeRabbit rate
+# limited ("Review limit reached ... next review in N minutes"), Sourcery out of
+# weekly diff-character budget (its check still goes GREEN when that happens),
+# or an upstream-merge PR over 100 changed files, which CodeRabbit skips
+# outright. See the "Code review conventions" section in CLAUDE.md.
+#
+# Two ways to run it:
+#   - comment "@claude review" on a pull request
+#   - Actions -> "Claude Review (on demand)" -> Run workflow, with the PR number
+#
+# Findings are posted as inline comments on the PR, or one summary comment when
+# it finds nothing. Runs are billed to the CLAUDE_CODE_OAUTH_TOKEN owner's
+# Claude subscription, NOT to an API key.
+#
+# NOTE: issue_comment and workflow_dispatch always run the copy of this file on
+# the DEFAULT branch, so this workflow does nothing until it is merged there.
+name: Claude Review (on demand)
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "Pull request number to review"
+        required: true
+  issue_comment:
+    types: [created]
+
+jobs:
+  review:
+    # Comment path: only on a PR, and only for the exact "@claude review"
+    # phrase, which is what keeps this from overlapping claude-mention.yml.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, '@claude review'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: claude-review-${{ github.event.issue.number || inputs.pr }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
+          plugins: "code-review@claude-code-plugins"
+          prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.issue.number || inputs.pr }}"
+          # Required even though the skill's own frontmatter names this tool:
+          # the action only starts the inline-comment MCP server when
+          # --allowedTools lists it here.
+          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -28,19 +28,29 @@ on:
         required: true
   issue_comment:
     types: [created]
+  # Also listen on diff-hunk comments. Without this, "@claude review" typed in a
+  # review comment triggered NOTHING: this workflow did not see the event, and
+  # claude-mention.yml (which does) excludes that phrase on purpose.
+  pull_request_review_comment:
+    types: [created]
 
 jobs:
   review:
     # Comment path: only on a PR, and only for the exact "@claude review"
     # phrase, which is what keeps this from overlapping claude-mention.yml.
+    # startsWith, not contains: a comment that merely QUOTES "@claude review"
+    # (a reply, a pasted excerpt) should not spend a review. The phrase is a
+    # command, so it has to lead the comment.
     if: >-
       github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request_review_comment' &&
+       startsWith(github.event.comment.body, '@claude review')) ||
       (github.event.issue.pull_request != null &&
-       contains(github.event.comment.body, '@claude review'))
+       startsWith(github.event.comment.body, '@claude review'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     concurrency:
-      group: claude-review-${{ github.event.issue.number || inputs.pr }}
+      group: claude-review-${{ github.event.issue.number || github.event.pull_request.number || inputs.pr }}
       cancel-in-progress: true
     permissions:
       contents: read
@@ -56,7 +66,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
-          prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.issue.number || inputs.pr }}"
+          prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.issue.number || github.event.pull_request.number || inputs.pr }}"
           # Required even though the skill's own frontmatter names this tool:
           # the action only starts the inline-comment MCP server when
           # --allowedTools lists it here.

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,54 @@
+# Static analysis of the PolyKybd firmware sources with cppcheck.
+#
+# Deliberately NOT another AI reviewer. CodeRabbit, Sourcery and the on-demand
+# Claude reviewer are all LLMs trained on much the same public code, so their
+# blind spots overlap. cppcheck is dataflow analysis: it fails in entirely
+# different places, has no quota, no star threshold and no file-count limit —
+# so unlike every bot on a PR it cannot go quiet at the moment it is needed.
+# It found a real out-of-bounds read in split72.c that none of them flagged.
+#
+# CodeQL was considered for this repo and rejected: C/C++ wants a build, and it
+# would analyse the whole upstream QMK tree — thousands of findings in code this
+# fork does not maintain, the same trap as the lint-on-upstream-keyboards
+# problem in CLAUDE.md. cppcheck scoped to keyboards/polykybd is the
+# proportionate version. The host repo does run CodeQL, where Python needs no
+# build and the tree is entirely ours.
+name: cppcheck (polykybd)
+
+on:
+  push:
+    branches: [PolyKybd]
+    paths: ['keyboards/polykybd/**', 'modules/polykybd/**', '.github/workflows/cppcheck.yml']
+  pull_request:
+    paths: ['keyboards/polykybd/**', 'modules/polykybd/**', '.github/workflows/cppcheck.yml']
+  workflow_dispatch:
+
+jobs:
+  cppcheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Install cppcheck
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq cppcheck
+
+      - name: Run cppcheck
+        run: |
+          cppcheck \
+            --enable=warning,performance,portability \
+            --inline-suppr \
+            --suppressions-list=keyboards/polykybd/.cppcheck-suppressions \
+            --error-exitcode=2 \
+            -DFW_REQUIRE_SIGNATURE -DKEYBOARD_polykybd_split72 \
+            -i keyboards/polykybd/doom \
+            -i keyboards/polykybd/base/fonts \
+            -i keyboards/polykybd/base/crypto \
+            -i keyboards/polykybd/base/tests \
+            -i keyboards/polykybd/hints/tests \
+            --template='{file}:{line}: {severity}: {message} [{id}]' \
+            keyboards/polykybd modules/polykybd

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,25 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
   in `raw_hid_receive()`, worth seconds of blocked main loop) that was adopted.
   Reply to the false ones with the evidence so they are not re-raised.
 
+- **When the other reviewers are unavailable, summon Claude with `@claude review`
+  on the PR.** `.github/workflows/claude-review.yml` runs the `code-review` skill
+  on demand (never automatically — three always-on bots is already the noise
+  ceiling) and posts inline comments; `claude-mention.yml` answers a plain
+  `@claude <question>` with the repo and this file loaded, which is the cheap way
+  to **adjudicate a suspect finding** per the verify-don't-dismiss rule above.
+  Neither has an external quota, so between them they cover the three cases that
+  otherwise leave a PR genuinely unreviewed: CodeRabbit rate-limited, Sourcery's
+  green-check-but-empty weekly limit, and an upstream-merge PR over 100 files.
+  - ⚠️ **Billed to the `CLAUDE_CODE_OAUTH_TOKEN` owner's Claude SUBSCRIPTION** —
+    the same budget as an interactive session, not an API key. A 400-file merge
+    review is the case you most want it and the one that costs most.
+  - ⚠️ **Comment and `workflow_dispatch` triggers always run the copy of the
+    workflow on the DEFAULT branch**, so neither does anything until merged
+    there — you cannot test them on the PR that adds them.
+  - Only the exact phrase `@claude review` reaches the review workflow; any other
+    `@claude ...` goes to the mention one. That split is what stops a single
+    comment starting two runs.
+
 ## Branching (all PolyKybd repos)
 
 - **Give every branch a name that hints at its content** (a short descriptive slug, e.g. `claude/fix-slave-layer-after-fw-apply`, not just the auto-generated `claude/<random-scientist>-<id>`) so the branch list reads as a changelog.

--- a/keyboards/polykybd/.cppcheck-suppressions
+++ b/keyboards/polykybd/.cppcheck-suppressions
@@ -1,0 +1,42 @@
+# cppcheck suppressions for the PolyKybd firmware.
+
+# Every entry here is a finding that was READ and judged false, with the reason
+# written down — the same discipline the Sourcery `# nosemgrep` audit note in
+# CLAUDE.md describes. Do not add an id here to make the check green; if a
+# finding is real, fix it or record why it is deferred.
+
+# --- cppcheck cannot see QMK's build context -------------------------------
+# We deliberately do not hand cppcheck QMK's include tree (chibios, pico-sdk,
+# tmk_core, the generated headers). Resolving it would be a rabbit hole and
+# buys nothing: cppcheck degrades gracefully and still does its dataflow work.
+missingInclude
+missingIncludeSystem
+# Same root cause: PRODUCT, STR and SS_TAP are QMK macros that are not visible
+# without that context, so cppcheck reports "unknown macro" rather than a bug.
+unknownMacro
+# Every *_kb / *_user hook is called by QMK core, never by our own code, so
+# cppcheck sees the whole callback surface as dead.
+unusedFunction
+unmatchedSuppression
+
+# --- verified false positives ----------------------------------------------
+# fw_staging_get_own_fw_size() computes the running image size as
+#   (uint32_t)(&__flash_binary_end - &__flash_binary_start)
+# By the letter of the standard, subtracting pointers into two different
+# objects is UB — but these are LINKER-DEFINED symbols marking the ends of one
+# contiguous flash region, which is the universal embedded idiom for it (the
+# vendored doom engine does the same in i_system.c). Both are declared
+# `extern uint8_t`, so the subtraction is in BYTES and the result is correct;
+# had they been `extern uint32_t` this would have silently returned size/4,
+# which is the actual bug worth watching for here.
+comparePointers:*/base/fw_staging.c
+
+# os_hint_for_keycode() is declared `const uint32_t*` and returns U"..." char32_t
+# literals — the codebase relies on char32_t and uint32_t being the same 32-bit
+# type on this target. cppcheck reads the returned expression as an integer
+# because the hint strings are a mini DISPLAY LIST: HINT_MOVE/HINT_FRAME expand
+# to raw control-code escapes (\x0E\xHH\xHH) spliced into the literal, so the
+# concatenation no longer parses as a plain string to it. The return type is
+# genuinely compatible; see the "shortcut-hint string is a mini DISPLAY LIST"
+# note in CLAUDE.md for what those escapes are.
+CastIntegerToAddressAtReturn:*/hints/os_hints.c

--- a/keyboards/polykybd/hid_com.c
+++ b/keyboards/polykybd/hid_com.c
@@ -63,6 +63,7 @@ while lang_key:
 //[[[end]]]
 
 void invert_display(uint8_t r, uint8_t c, bool state);
+bool key_has_display(uint8_t r, uint8_t c);
 // Defined in the shared keyboard-level poly_keymap.c; declared here so the
 // shared HID dispatcher can drive the display-off command (case 24).
 
@@ -587,7 +588,9 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                     if(pos==POS_NOT_FOUND) {
                         pos = get_split_matrix_pos(keycode, local_layer->def_layer, &r, &c, is_left_side());
                     }
-                    if (is_on_current_side(pos)) {
+                    // key_has_display(): one key per half has no OLED, so it must
+                    // not drive a chip-select. See the split72 header.
+                    if (is_on_current_side(pos) && key_has_display(r, c)) {
                         invert_display(r, c, pressed);
                     }
 

--- a/keyboards/polykybd/split42/split42.c
+++ b/keyboards/polykybd/split42/split42.c
@@ -61,6 +61,13 @@ uint8_t get_disp_bitmask_size(void) {
     return sizeof(key_display->bitmask);
 }
 
+bool key_has_display(uint8_t r, uint8_t c) {
+    // Every split42 key has an OLED; see the header. Parameters are unused.
+    (void)r;
+    (void)c;
+    return true;
+}
+
 void invert_display(uint8_t r, uint8_t c, bool state) {
     /*
      * split42 is a symmetric CRKBD: the right-half matrix rows (4-7) carry all 6

--- a/keyboards/polykybd/split42/split42.h
+++ b/keyboards/polykybd/split42/split42.h
@@ -80,4 +80,13 @@ void invert_display(uint8_t r, uint8_t c, bool state);
 
 const uint8_t* get_key_disp_bitmask(uint8_t index);
 
+/*
+ * True when a real per-keycap OLED sits behind matrix (r,c). Every split42 key
+ * has one (42 keys, 42 OLEDs; the 6 NO_LED entries in g_led_config are matrix
+ * slots with no key at all), so this is unconditionally true here. It exists so
+ * the shared HID and split-sync call sites can guard uniformly — see the
+ * split72 header, where one key per half genuinely has no display.
+ */
+bool key_has_display(uint8_t r, uint8_t c);
+
 uint8_t get_disp_bitmask_size(void);

--- a/keyboards/polykybd/split72/split72.c
+++ b/keyboards/polykybd/split72/split72.c
@@ -31,6 +31,12 @@ uint8_t get_disp_bitmask_size(void) {
     return sizeof(key_display->bitmask);
 }
 
+bool key_has_display(uint8_t r, uint8_t c) {
+    // The inner key at (3,7) on the left half and (8,0) on the right have no
+    // OLED and no RGB LED. Every other key on both halves has both.
+    return !((r == 3 && c == 7) || (r == 8 && c == 0));
+}
+
 void invert_display(uint8_t r, uint8_t c, bool state) {
     if (r>=5 && r<=8) {
         c--; //on the right side of the slit layout the first 4 rows have no key
@@ -38,12 +44,16 @@ void invert_display(uint8_t r, uint8_t c, bool state) {
 
     r = r % MATRIX_ROWS_PER_SIDE;
     const uint8_t disp_idx = LAYOUT_TO_INDEX(r, c);
+    // Bounds guard only, matching split42 — callers screen out the keys that
+    // have no display via key_has_display(). This replaces an `if (disp_idx !=
+    // 255)` test placed AFTER the indexed read, which could therefore never
+    // prevent one, and which only ever matched r%5==0 anyway.
+    const uint8_t table_size = (uint8_t)(sizeof(key_display) / sizeof(key_display[0]));
+    if (disp_idx >= table_size) return;
     const uint8_t* bitmask = get_key_disp_bitmask(disp_idx);
     sr_shift_out_buffer_latch(bitmask, sizeof(key_display->bitmask));
 
-    if (disp_idx != 255) {
-        kdisp_invert(state);
-    }
+    kdisp_invert(state);
 }
 
 // invert displays directly when pressed (no need to do split sync)
@@ -59,11 +69,11 @@ void matrix_scan_kb(void) {
             for (uint8_t c = 0; c < MATRIX_COLS; c++) {
                 bool old     = ((last_matrix[r - first] >> c) & 1) == 1;
                 bool current = ((matrix[r] >> c) & 1) == 1;
-                if (!old && current) {
-                    invert_display(r,c,true);
-                } else if (old && !current) {
-                    invert_display(r,c,false);
+                // Unchanged, or a key with no OLED behind it (see key_has_display).
+                if (old == current || !key_has_display(r, c)) {
+                    continue;
                 }
+                invert_display(r, c, current);
             }
         }
     }

--- a/keyboards/polykybd/split72/split72.h
+++ b/keyboards/polykybd/split72/split72.h
@@ -54,5 +54,22 @@ void invert_display(uint8_t r, uint8_t c, bool state);
 
 const uint8_t* get_key_disp_bitmask(uint8_t index);
 
+/*
+ * True when a real per-keycap OLED sits behind matrix (r,c).
+ *
+ * split72 has 74 keys but only 72 OLEDs: one key per half — the inner key at
+ * matrix (3,7) on the left and (8,0) on the right — has no OLED and no RGB LED
+ * (both read NO_LED in g_led_config). Callers must consult this BEFORE
+ * invert_display() so that stays a general "invert the display at (r,c)"
+ * primitive rather than carrying this board's key geometry.
+ *
+ * Without the check, (8,0) underflows invert_display's right-half `c--` to 255
+ * and wraps to display index 23, and (3,7) indexes 31 directly; both are the
+ * phantom inner column, so each press/release latched a chip-select for a slot
+ * the key does not own. Found by cppcheck, which flagged the dead
+ * `disp_idx != 255` guard that was meant to cover exactly this.
+ */
+bool key_has_display(uint8_t r, uint8_t c);
+
 uint8_t get_disp_bitmask_size(void);
 

--- a/keyboards/polykybd/split_sync.c
+++ b/keyboards/polykybd/split_sync.c
@@ -35,6 +35,7 @@
 void rgb_matrix_update_pwm_buffers(void);
 
 void invert_display(uint8_t r, uint8_t c, bool state);
+bool key_has_display(uint8_t r, uint8_t c);
 
 #include <stddef.h>
 #include <string.h>
@@ -309,7 +310,9 @@ void user_sync_dynamic_keymap_data_handler(uint8_t in_len, const void* in_data, 
                             //actually it should be the previous layer instead of default, but it worked so far
                             pos = get_split_matrix_pos(keycode, get_local_layer()->def_layer, &r, &c, is_left_side());
                         }
-                        if (is_on_current_side(pos)) {
+                        // key_has_display(): one key per half has no OLED, so it
+                        // must not drive a chip-select. See the split72 header.
+                        if (is_on_current_side(pos) && key_has_display(r, c)) {
                             invert_display(r, c, command_data[4] == 0);
                         }
                     }


### PR DESCRIPTION
## Summary

Every reviewer on a PR here is an LLM — CodeRabbit, Sourcery, and now an on-demand Claude reviewer. They share training data, so their blind spots overlap, and each can go quiet exactly when a PR needs reading. This adds a reviewer that is **not** an LLM, and fixes the first thing it found.

### 1. cppcheck — the genuinely independent check

Dataflow analysis: different failure modes, no quota, no star threshold, no file-count limit. Scoped to `keyboards/polykybd` + `modules/polykybd`, excluding the vendored doom engine, generated font headers, vendored monocypher and the googletest sources.

Analysed with **`-DFW_REQUIRE_SIGNATURE`**, the configuration that actually ships — without it cppcheck reports a false `identicalInnerCondition` in `fw_staging.c` that the `#ifdef` itself creates.

`keyboards/polykybd/.cppcheck-suppressions` records a **written reason for every suppression**, same discipline as the Sourcery `nosemgrep` audit note. Two were read and judged false: the linker-symbol subtraction in `fw_staging.c` (both symbols are `extern uint8_t`, so it is in bytes and correct — had they been `uint32_t` it would silently return size/4, which is the real hazard there), and the `char32_t` hint literals in `os_hints.c`.

CodeQL was considered and rejected here: C/C++ wants a build, and it would analyse the whole upstream QMK tree — the lint-on-upstream-keyboards trap from `CLAUDE.md`. The host repo runs CodeQL instead ([PolyKybdHost#179](https://github.com/thpoll83/PolyKybdHost/pull/179)), where Python needs no build.

### 2. The fix — two keys were driving a chip-select they do not own

split72 has **74 keys but 72 OLEDs**. One key per half has neither an OLED nor an RGB LED (both `NO_LED` in `g_led_config`, both at y=2 on the inner edge):

| matrix | half | what happened on every press *and* release |
|---|---|---|
| **(8,0)** | right | `c--` fold underflows `c` to 255 → `LAYOUT_TO_INDEX(8%5, 255) = 279` → `uint8_t` → **23** |
| **(3,7)** | left | no fold → index **31** directly |

Both land on the phantom inner column, so each was a stray shift-register latch aimed at a slot the key does not own. The `if (disp_idx != 255)` guard was written for exactly this and could never work: it sat **after** the indexed read, and 255 is only produced when `r%5==0`, which no col-0 key satisfies.

**The check goes at the call sites**, via a new `key_has_display(r,c)`, so `invert_display()` stays a general "invert the display at matrix (r,c)" primitive rather than carrying this board's key geometry. All three callers are covered: the split72 scan loop, the HID path, and the split-sync path. split42 implements the predicate as an unconditional `true` — all 42 of its keys have OLEDs, and its 6 `NO_LED` entries are matrix slots with no key at all — so the two shared call sites guard uniformly.

Inside `invert_display` the dead 255 test is replaced by the same bounds guard split42 already carries, keeping the variants symmetric and removing a guard that reads as protection but never fired.

### 3. On-demand Claude reviewer (never automatic)

`claude-review.yml` (`@claude review`, or Actions → Run workflow with a PR number) posts inline comments; `claude-mention.yml` answers any other `@claude …` with the repo and `CLAUDE.md` loaded, which is the cheap way to adjudicate a suspect finding. Both listen on issue *and* review comments, and both test the phrase with `startsWith`, so they cannot both fire and nothing falls between them.

⚠️ Billed to the `CLAUDE_CODE_OAUTH_TOKEN` owner's **Claude subscription**, not an API key. Needs the secret + the [Claude GitHub App](https://github.com/apps/claude), and **neither workflow works until this is merged** — comment and `workflow_dispatch` triggers always run the copy on the default branch, so they cannot be tested on this PR.

## Version bump label

*(none)* → patch. No `PROTOCOL_VERSION` change, so no matching host PR is required.

## Testing

- [x] Compiled successfully — split72 and split42 both compile and link
- [x] **Flashed and tested on hardware — all OLEDs work**
- [ ] If protocol changed: host updated and tested together — **N/A**, no protocol change

CI on the head commit: `Build firmware` ✅ · `HIL test (split72)` ✅ · `PolyKybd unit tests` ✅ · `lint` ✅ · **`cppcheck` ✅** (it reported this bug before the fix, so the check and the fix verify each other).

Locally: `qmk lint --strict` passes on both keyboards; `ci-validate-keyboard-targets` and `ci-validate-aliases` exit 0; `git ls-files -c -o -i --exclude-from=.gitignore keyboards/polykybd/` clean.

**What the hardware test does and does not prove.** A build from this branch was flashed and every keycap OLED renders and inverts — so the change is confirmed free of regressions, which was the risk worth checking. It does *not* positively demonstrate the stray latch is gone: both bad indices pointed at phantom slots, so the defect was invisible before the fix and its removal is invisible after. That asymmetry is inherent to this bug, not a gap in the testing.

One gotcha for anyone editing the suppressions file: **cppcheck 2.13 rejects a bare `#` line** with `Failed to add suppression. No id.` and exits 1 *before checking anything* — a comment needs text after the hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjRpNBwkkQMnc1xV3mPW1x