### PR TITLE
docs(polykybd): capture the keycap-layout learnings from the mod-tap badge work

### DIFF
--- a/.claude/skills/update-polykybd-docs/SKILL.md
+++ b/.claude/skills/update-polykybd-docs/SKILL.md
@@ -60,6 +60,36 @@ Match the site's voice: **user-facing**, friendly, `<Aside>` callouts and tables
 no internal debugging detail. If you move/rename a page, add a `redirects` entry in
 `astro.config.mjs` for the old URL.
 
+## Images
+
+Two conventions, and they are **not** interchangeable:
+
+| Kind | Lives in | Referenced as |
+|---|---|---|
+| Stills (png/jpg) | `src/assets/<section>/` | **relative**: `![alt](../../../assets/using/foo.png)` |
+| Animations (gif) | `public/img/` | **absolute**: `![alt](/img/foo.gif)` |
+
+The stills go through Astro's image pipeline (hence the relative path from the page);
+the gifs are served as-is. Write a real descriptive `alt` — the existing pages do,
+and it is what a reader on a slow connection gets.
+
+**For anything the keyboard draws, GENERATE the image from the firmware's own
+rendering code rather than mocking it up or cropping a photo.** The keycap
+previews on the mod-tap page come from `keyboards/polykybd/.claude/skills/
+keycap-layout-preview/keycap_preview.py` plus the layout generator the firmware
+constants come from, so they show the real pixels and cannot drift into
+wishful-thinking territory. The status OLED has the same property via
+`tools/status_oled42_preview.py`. A generated image is also reproducible when the
+feature changes.
+
+⚠️ **Before repeating a "the software can't do X" claim, check it against the
+source** — these age badly and nobody re-reads them. The Keymap Editor page said
+layer-tap "may not be available from the keycode browser UI" long after it was, and
+one grep settled it: `BEHAVIORS` in `PolyKybdHost/polyhost/gui/layout_dialog/
+keycode_composer.py`, wired in at `keycode_browser.py:53`. The same goes for tray
+menus (`host.py`), `polyctl` subcommands (`polyhost/cli/polyctl.py`) and settings
+(`polyhost/settings.py`).
+
 ## Procedure
 
 1. **Get the docs repo current**: `git -C ../polykybd-docs fetch origin main &&

--- a/.claude/skills/update-polykybd-docs/SKILL.md
+++ b/.claude/skills/update-polykybd-docs/SKILL.md
@@ -73,14 +73,20 @@ The stills go through Astro's image pipeline (hence the relative path from the p
 the gifs are served as-is. Write a real descriptive `alt` — the existing pages do,
 and it is what a reader on a slow connection gets.
 
-**For anything the keyboard draws, GENERATE the image from the firmware's own
-rendering code rather than mocking it up or cropping a photo.** The keycap
-previews on the mod-tap page come from `keyboards/polykybd/.claude/skills/
-keycap-layout-preview/keycap_preview.py` plus the layout generator the firmware
-constants come from, so they show the real pixels and cannot drift into
-wishful-thinking territory. The status OLED has the same property via
-`tools/status_oled42_preview.py`. A generated image is also reproducible when the
-feature changes.
+**For anything the keyboard draws, GENERATE the image from a renderer that shares
+the firmware's own inputs rather than mocking it up or cropping a photo.** The
+keycap previews on the mod-tap page come from `keyboards/polykybd/.claude/skills/
+keycap-layout-preview/keycap_preview.py` (fed by the same generator that emits the
+firmware's position constants), and the status OLED has
+`tools/status_oled42_preview.py`. Both read the real font headers and the real
+layout values, so the image tracks the feature instead of an artist's idea of it,
+and it is reproducible when the feature changes.
+
+⚠️ These previews are Python **models** of the C, not the C — they can drift, and
+`oled_preview.py` carries a documented blind spot of exactly that kind. So a
+generated image is the right default, but for anything subtle **confirm it against
+a photo of the hardware before publishing it**, and re-check the model after a
+change to the draw path.
 
 ⚠️ **Before repeating a "the software can't do X" claim, check it against the
 source** — these age badly and nobody re-reads them. The Keymap Editor page said

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,10 +293,18 @@ inherited-upstream noise:
   ```bash
   git ls-files -c -i --exclude-from=.gitignore keyboards/polykybd/   # THIS must be empty
   ```
-  ⚠️ Which is also why **`git add -A` is the wrong way to stage a change here**: it
-  happily stages that whole build directory, and a committed ignored file is exactly
-  the thing that turns `lint` red on every later PR touching the keyboard. Stage the
-  paths you edited by name (caught while committing, 2026-08-19).
+  ⚠️ **That `-o` noise is convincing enough to cause a MISDIAGNOSIS — it did,
+  while this very note was being written (2026-08-19).** Running `git add -A` and
+  then the `-c -o -i` check printed the whole `doom/pack/build/` tree, which read as
+  "`git add -A` just staged 100 ignored files"; the first draft of this bullet said
+  exactly that. It is **false** — `git add -A` honours `.gitignore` and cannot stage
+  an ignored file without `-f` (verify in 20 s in a throwaway repo). The files were
+  listed by `-o`, as untracked, before and after the add alike. **The tell is
+  `git diff --cached --name-only`** — what is *actually* staged — not an
+  `ls-files` variant that mixes tracked and untracked in one list.
+  Still prefer staging the paths you edited by name: `-A` picks up unrelated
+  working-tree changes, and it *does* stage a modification to an ignored file that
+  is already tracked, which is the state CI fails on.
   - ⚠️ **WHICH formatter runs is decided by the changed PATHS, and clang-format does
     NOT cover `keyboards/**`.** An earlier version of this file said "the lint job runs
     `format-c` as well as `format-text`" and told you to clang-format every C file you

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,15 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
     `pull_request_read` `get_reviews` — do not infer from the check conclusion.
     (The sibling rule "a bot comment is not a review" is in `PolyKybdHost/CLAUDE.md`;
     this is the same failure with a green check instead of a long comment.)
+    - ⚠️ **CodeRabbit's COMMIT STATUS does the same thing, so "at least it renders a
+      banner" only holds for the comment.** Its status context reads `state: success`
+      with the description **"Review rate limited"** (`pull_request_read`
+      `get_status`, head `2d61653d`, 2026-08-18) — so a head that nothing read shows
+      a green CodeRabbit tick alongside the green build. The banner lives in the
+      *comment*, which a status-only view never shows, and which vanishes on a
+      re-render anyway (see the sticky-walkthrough note above). **`get_status` can
+      only ever tell you a review RAN, never that it read the current head** — pair
+      it with `get_reviews` and compare each review's `commit_id` against the head.
 
 - **Verify an AI reviewer's finding against the code before acting on it — several
   arrive confidently wrong.** Of 7 CodeRabbit findings on one PR (2026-08-01), 3
@@ -275,8 +284,19 @@ inherited-upstream noise:
   git diff --quiet -- $(git diff --name-only --diff-filter=d origin/PolyKybd...HEAD) \
       && echo "format clean"        # the job's second half: any diff = "Requires Formatting"
   ```
-  ⚠️ Drop `keyboards/polykybd/tools/__pycache__` first or it shows up as a false
-  positive in the ignored-files list (CI checks out clean, so it never sees it).
+  ⚠️ **The `-o` in that command lists UNTRACKED ignored files too, and locally that
+  is mostly your own build output** — `keyboards/polykybd/tools/__pycache__`, and
+  after a `doom/pack/build_pack.sh` run the ~100 files under
+  `keyboards/polykybd/doom/pack/build/`. CI checks out clean, so it never sees any
+  of them. **What CI actually fails on is a TRACKED ignored file**, so when the list
+  is noisy re-run it without `-o`:
+  ```bash
+  git ls-files -c -i --exclude-from=.gitignore keyboards/polykybd/   # THIS must be empty
+  ```
+  ⚠️ Which is also why **`git add -A` is the wrong way to stage a change here**: it
+  happily stages that whole build directory, and a committed ignored file is exactly
+  the thing that turns `lint` red on every later PR touching the keyboard. Stage the
+  paths you edited by name (caught while committing, 2026-08-19).
   - ⚠️ **WHICH formatter runs is decided by the changed PATHS, and clang-format does
     NOT cover `keyboards/**`.** An earlier version of this file said "the lint job runs
     `format-c` as well as `format-text`" and told you to clang-format every C file you
@@ -670,6 +690,37 @@ new ISO codes append at the next free slot; private pseudo-codes with no ISO
   render pack/flag glyphs too. **Caveat:** the preview models glyph `xOffset/yOffset`
   but NOT the `kdisp` baseline-align shift, so it won't reproduce that bug — reason
   about `fonts[0]` separately.
+- ⚠️ **`render_key()` and `to_static_text()` are a PAIR — both must normalise the
+  keycode the same way, or a key draws its chrome and NO legend.** `update_displays()`
+  consults `render_key()` exactly when `to_static_text()` returned NULL, which is
+  **every letter** (the language translation lives inside `render_key()`). So when
+  `to_static_text()` unwrapped a mod-tap keycode and `render_key()` did not,
+  `RSFT_T(KC_A)` (`0x3204`) fell through every branch there — `is_letter` is false for
+  it and `translate_keycode()` has no row — and the keycap rendered its modifier badge
+  in an otherwise **empty cell** (field, 2026-08-18). The unwrap had been in
+  `to_static_text()` for years, one function away. This is the sibling of the already-
+  documented "`render_key()` is only consulted when `to_static_text()` returns NULL"
+  (Intl-remap section): that one is about a key with a legend *bypassing* `render_key`,
+  this one is about the same seam producing *no* legend at all. Any future keycode
+  rewriting (a second wrapper class, an alias) has to land in **both**.
+- ⚠️ **A hint/overlay string is drawn OVER the legend at the SAME origin, so
+  full-size extra art ERASES it — a secondary mark belongs MOVE'd into a corner, and
+  that corner is the BOTTOM-right.** `update_displays()` draws the legend at
+  `(BUFFER_X, 23)`, sets `text = NULL`, then draws `keycode_to_disp_overlay()`'s
+  string at the *same* origin with `KDISP_CY_DEFAULT` — whose 3px courtyard clears the
+  legend underneath before the glyph even lands. That is correct for a held-modifier
+  shortcut hint (the whole keycap *means* Ctrl+C while Ctrl is down) and wrong for a
+  mark that must coexist with the legend. The bottom anchor is not taste:
+  `render_key()` draws the **shift preview in the UPPER right** (baseline 23, x from
+  `*_HOFFSET VAR_SHIFT`), so a top-anchored corner mark lands on it. Measured badge-
+  ink-on-legend-ink over all 15 modifier combinations: a letter is 0 either way
+  (en-US sets `LETTER_*_OFFSET VAR_SHIFT` to `HIDE_KEY`), but a **digit/symbol key
+  always has a preview** and went from 21 px of overlap at 2 marks (top-anchored) to
+  21 px at 4 marks only (bottom-anchored). ⚠️ **Measure that as the INTERSECTION of
+  the two ink sets** — a "how many legend pixels survived" count reads **0 damage**
+  for a real collision, because overlapping lit-on-lit loses no pixels and still reads
+  as merged (that metric hid the digit collision for a round). The
+  `keycap-layout-preview` skill wraps the whole measure-don't-eyeball loop.
 - **The per-keycap DISPLAY grid is NOT a rectangle** (split72). Only the **bottom
   row (display row 4) is a full 8-wide row**; the upper rows (0–3) have panels at
   **cols 0–6 only** — display **col 7 is a routing phantom** (a `BITMASK` entry
@@ -1400,6 +1451,16 @@ export QMK_HOME=$PWD && export PATH="/root/.qmk_venv/bin:$PATH"
 make test:polymod_ltr559          # ~1 s, 19 tests — the LTR-559 driver vs a mock I2C bus
 make test:fw_up_verdict           # ~1 s, 27 tests — the flash-staging COMMIT decision layer
 ```
+
+⚠️ **`make test:<name>` with a name that is not in `TEST_LIST` exits 0 and prints
+NOTHING** — no "unknown target", no test output, just a clean prompt. It is the same
+silent-green failure the CI workflow's zero-suites guard exists to catch, one level
+down and with nothing guarding it: `make test:os_hints` "passed" twice before the
+missing output was noticed (2026-08-18); the suite is `polykybd_os_hints`. **Judge the
+run by the `[  PASSED  ] N tests.` line, never by the exit code** — a real run always
+prints one. The registered names are `polykybd_os_hints`, `polykybd_glyph_meta`,
+`fw_up_verdict` and `polymod_ltr559`; `grep -rn "TEST_LIST +=" --include=testlist.mk .`
+is the authoritative list.
 
 ✅ **These run in CI — via `polykybd-unit-test.yml`, NOT upstream's `unit_test.yml`.**
 That distinction is the whole point: upstream's workflow filters on `builddefs/ quantum/

--- a/keyboards/polykybd/.claude/skills/keycap-layout-preview/SKILL.md
+++ b/keyboards/polykybd/.claude/skills/keycap-layout-preview/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: keycap-layout-preview
-description: Place and verify anything drawn on a PER-KEYCAP 72x40 OLED — a corner badge, a modifier mark, a status dot, a second glyph beside the legend, a repositioned hint — by rendering the real draw path in Python and MEASURING whether it collides with the legend, instead of flashing a build to look at it. Use when asked to "move the mark to the other corner", "show X on the keycap too", "does this overlap the letter", "make it smaller / put it in the corner", "give me a preview instead of another hardware round", or when a keycap render needs sign-off before a build. NOT for the STATUS OLED (that is status-oled-layout) and NOT for choosing a hint GLYPH (that is add-polykybd-shortcut-hint).
+description: Place and verify anything drawn on a PER-KEYCAP 72x40 OLED — a corner badge, a modifier mark, a status dot, a second glyph beside the legend, a repositioned hint — by rendering a faithful Python model of the firmware draw path and MEASURING whether it collides with the legend, instead of flashing a build to look at it. Use when asked to "move the mark to the other corner", "show X on the keycap too", "does this overlap the letter", "make it smaller / put it in the corner", "give me a preview instead of another hardware round", or when a keycap render needs sign-off before a build. NOT for the STATUS OLED (that is status-oled-layout) and NOT for choosing a hint GLYPH (that is add-polykybd-shortcut-hint).
 ---
 
 # Per-keycap layout changes
@@ -11,12 +11,22 @@ exists in the pixels. The two that shipped in the 2026-08-18 session were both o
 that shape — a badge drawn where the legend was, and later a badge that erased
 nothing but *merged* with the shift preview.
 
-So: **render the real draw path, then measure ink against ink.** Do not eyeball
-the PNG, and do not spend a hardware round on a placement question.
+So: **model the draw path, then measure ink against ink.** Do not eyeball the PNG,
+and do not spend a hardware round on a placement question.
 
-`keycap_preview.py` (beside this file) models `base/disp_array.c` and
-`render_key()`'s legend placement, including the parts a naive renderer misses.
-Run everything from `keyboards/polykybd/`.
+`keycap_preview.py` (beside this file) is a Python **re-implementation** of
+`base/disp_array.c` and `render_key()`'s legend placement, including the parts a
+naive renderer misses. Run everything from `keyboards/polykybd/`.
+
+⚠️ **It is a model, so it can drift from the C** — that is not hypothetical, it is
+the standing caveat on `oled_preview.py` one directory over (it models
+`xOffset`/`yOffset` but *not* the baseline-align shift, so it cannot reproduce that
+class of bug). Treat a result as evidence about **layout**, never as proof about the
+compiled firmware, and re-read the C when you touch either side: the pixel plotters
+and `KDISP_CY_DEFAULT` in `base/disp_array.c`, the legend/preview placement at the
+end of `render_key()` in `poly_keymap.c`. If a preview and the hardware ever
+disagree, the hardware is right and this file has a bug — fix it here rather than
+working around it in a caller.
 
 ## The three facts that make this necessary
 
@@ -96,7 +106,9 @@ block), emit the C **and** the preview from one script, so they cannot disagree.
 Assert the invariants there:
 
 ```python
-assert x and y, 'a zero coordinate would NUL-terminate the hint string'
+if not (x and y):        # a raise, not an assert — `python -O` strips asserts,
+    raise ValueError(    # and this one guards a silent-truncation hazard
+        'zero coordinate (%d,%d) would NUL-terminate the hint string' % (x, y))
 ```
 
 ⚠️ **A `HINT_MOVE` coordinate is a codepoint in a `U"…"` literal, so a zero byte

--- a/keyboards/polykybd/.claude/skills/keycap-layout-preview/SKILL.md
+++ b/keyboards/polykybd/.claude/skills/keycap-layout-preview/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: keycap-layout-preview
+description: Place and verify anything drawn on a PER-KEYCAP 72x40 OLED — a corner badge, a modifier mark, a status dot, a second glyph beside the legend, a repositioned hint — by rendering the real draw path in Python and MEASURING whether it collides with the legend, instead of flashing a build to look at it. Use when asked to "move the mark to the other corner", "show X on the keycap too", "does this overlap the letter", "make it smaller / put it in the corner", "give me a preview instead of another hardware round", or when a keycap render needs sign-off before a build. NOT for the STATUS OLED (that is status-oled-layout) and NOT for choosing a hint GLYPH (that is add-polykybd-shortcut-hint).
+---
+
+# Per-keycap layout changes
+
+Keycap chrome is easy to get wrong in a way that survives every check you would
+normally run: it compiles, it lints, the unit tests pass, and the defect only
+exists in the pixels. The two that shipped in the 2026-08-18 session were both of
+that shape — a badge drawn where the legend was, and later a badge that erased
+nothing but *merged* with the shift preview.
+
+So: **render the real draw path, then measure ink against ink.** Do not eyeball
+the PNG, and do not spend a hardware round on a placement question.
+
+`keycap_preview.py` (beside this file) models `base/disp_array.c` and
+`render_key()`'s legend placement, including the parts a naive renderer misses.
+Run everything from `keyboards/polykybd/`.
+
+## The three facts that make this necessary
+
+1. **A hint/overlay string is drawn OVER the legend at the same origin.**
+   `update_displays()` draws the legend at `(BUFFER_X, 23)`, sets `text = NULL`,
+   then draws `keycode_to_disp_overlay()`'s string at that *same* origin with
+   `KDISP_CY_DEFAULT` — whose 3px courtyard clears the legend before the glyph
+   lands. Fine for a held-modifier hint (the keycap *means* Ctrl+C then); fatal
+   for a mark meant to coexist with the letter.
+2. **The upper right is taken.** `render_key()` puts the shift preview there
+   (baseline 23, x from `*_HOFFSET VAR_SHIFT`). en-US HIDEs it for letters, but
+   **36 of 160 languages do not**, and *every* language shows one on the number
+   and symbol rows. Corner chrome therefore anchors **bottom-right**.
+3. **`kdisp_write_gfx_char` baseline-aligns to `fonts[0]`** (IconsFont, yAdvance
+   40). `oled_preview.py` does **not** model that shift; `keycap_preview.full_ink`
+   does.
+
+## 1. Build the ink sets
+
+```python
+import sys; sys.path.insert(0, '.claude/skills/keycap-layout-preview')
+import keycap_preview as K
+
+legend = K.legend_ink('a')                    # base glyph + shift preview, real offsets
+legend = K.legend_ink('1', shifted='!')       # non-letters: name the shifted glyph
+legend = K.legend_ink('a', lang='ar-SA')      # another language's offsets
+
+mark = K.thin_ink(0x2388, 80, 21)             # decimated (HINT_THIN)
+mark = K.half_ink(0x2387, 79, 31)             # 2x2-OR (HINT_HALF)
+mark = K.full_ink(0x90, 83, 40)               # normal draw, baseline-aligned
+```
+
+`thin_ink`/`half_ink` take the literal **ink top-left**; `full_ink` takes the
+**cursor** and applies the baseline align — that asymmetry is the firmware's, not
+the helper's.
+
+## 2. Measure — this is the step that matters
+
+```python
+K.collision(legend, mark)        # px where the two overlap        -> want 0
+K.erased(legend, mark)           # legend px a courtyard draw wipes -> want 0
+K.offscreen(legend | mark)       # ink outside x28..99 / y0..39     -> want empty
+K.extent(mark)                   # (xmin, xmax, ymin, ymax)
+```
+
+⚠️ **`collision()` is the metric — intersect, do not subtract.** A "how many
+legend pixels survived" count reads **0 damage** for a real collision, because
+lit-on-lit loses no pixels; it just reads as one merged blob. That metric hid a
+21px digit/mark collision for a full round.
+
+Sweep the cases that differ, not just the convenient one:
+
+```python
+for combo in COMBOS:                      # every state your chrome can be in
+    for ch, kw in (('a', {}), ('1', {'shifted': '!'})):   # letter AND digit
+        c = K.collision(K.legend_ink(ch, **kw), marks_for(combo))
+        if c: print(combo, ch, c)
+```
+
+A letter and a digit are genuinely different tests: the digit carries a shift
+preview in every language, the letter usually does not.
+
+## 3. Render for sign-off
+
+```python
+K.sheet([(legend | mark, 'LCTL_T(KC_A)'), …], '/tmp/deliver/preview.png')
+```
+
+Send the PNG. One row of labelled keycaps beats a paragraph, and it is what the
+user asked for when they said "give me previews instead of another hardware
+round". The same renders are docs-quality — the mod-tap page's images are these.
+
+## 4. Generate the firmware constants from the SAME source
+
+If the placement becomes `#define`d positions (`HINT_MOVE` coords, an `MTB_*`
+block), emit the C **and** the preview from one script, so they cannot disagree.
+Assert the invariants there:
+
+```python
+assert x and y, 'a zero coordinate would NUL-terminate the hint string'
+```
+
+⚠️ **A `HINT_MOVE` coordinate is a codepoint in a `U"…"` literal, so a zero byte
+is a NUL that terminates the display list.** A row placed at `y=0` truncated every
+badge to two codepoints; nothing crashed, the marks just silently vanished.
+
+## Pitfalls
+
+- **Don't eyeball the sheet.** Every defect this skill exists for was invisible
+  in the render and obvious in `collision()`.
+- **Don't test only en-US letters.** That is the one case with no shift preview.
+- **Bottom-right, not top-right**, for anything that must coexist with the legend.
+- **`oled_preview.py` is still the right tool for a plain legend** (it renders the
+  real OLED look for a whole key). This skill is for *added* chrome, where the
+  baseline-align shift and the collision question both matter.
+- **A pixel-count check on a transform∘inverse round-trip proves nothing** — the
+  same rule as the IconsFont transpose. Compare against the other artefact
+  (the legend), not against your own re-derivation.
+- If the change alters something visible on a keycap, say **which pixel** tells
+  two builds apart — that is a check the user can run with no tooling.

--- a/keyboards/polykybd/.claude/skills/keycap-layout-preview/keycap_preview.py
+++ b/keyboards/polykybd/.claude/skills/keycap-layout-preview/keycap_preview.py
@@ -1,0 +1,247 @@
+"""Model the firmware's per-keycap draw path in Python, so keycap chrome can be
+placed and MEASURED without flashing.
+
+This mirrors `base/disp_array.c` (`kdisp_write_gfx_char`'s baseline-align + its
+courtyard clear, `kdisp_draw_glyph_half_at`, `kdisp_draw_glyph_thin_at`) and the
+legend placement in `poly_keymap.c` `render_key()` (base glyph, shift preview and
+AltGr preview, using the REAL per-language offsets parsed out of `lang_lut.c`).
+
+Everything works on **ink sets** — `{(x, y), …}` of lit buffer pixels — because the
+question that matters is almost always "does this new art land on the existing
+legend", and set intersection answers it exactly. See `collision()`.
+
+Coordinates are BUFFER coordinates: the visible keycap window is
+x `BUFFER_X .. BUFFER_X+VIS_W-1` (28..99), y `0..H-1` (0..39).
+
+Usage sketch:
+
+    import keycap_preview as K
+    legend = K.legend_ink('a')                       # what render_key() draws
+    mark   = K.thin_ink(0x2388, 80, 21)              # a decimated corner mark
+    print(K.collision(legend, mark))                 # px of overlap -> 0 is clean
+    K.sheet([(legend | mark, 'LCTL_T(KC_A)')], 'out.png')
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_QMK = next(p for p in _HERE.parents if (p / 'keyboards' / 'polykybd').is_dir())
+_FONTS_DIR = _QMK / 'keyboards' / 'polykybd' / 'base' / 'fonts'
+_LANG_LUT = _QMK / 'keyboards' / 'polykybd' / 'lang' / 'lang_lut.c'
+# gfx_font.py is the host repo's parser for the generated headers — the same one
+# oled_preview.py uses. Reaching sideways is deliberate: a second parser would be
+# a second thing to keep correct.
+sys.path.insert(0, str(_QMK.parent / 'PolyKybdHost' / 'tools'))
+
+import gfx_font  # noqa: E402
+from PIL import Image, ImageDraw, ImageFont  # noqa: E402
+
+FONTS = gfx_font.load_all_fonts(str(_FONTS_DIR))
+ICONS = next(f for f in FONTS if f.name == 'IconsFont')      # g_all_fonts[0]
+
+BUFFER_X = gfx_font.BUFFER_X       # 28 — left edge of the visible window
+VIS_W, H = 72, gfx_font.OLED_H     # the keycap the user sees
+W = 128                            # the full scratch buffer row
+CY_DEFAULT = 3                     # KDISP_CY_DEFAULT
+HIDE_KEY = -128
+
+# poly_settings row order (lang/lang_lut.h `enum settings_index`) and the
+# variation order (`enum variation_index`).
+S_LETTER_H, S_LETTER_V, S_NUM_H, S_NUM_V, S_SYM_H, S_SYM_V = range(6)
+VAR_SMALL, VAR_SHIFT, VAR_CAPS, VAR_ALTGR = range(4)
+
+
+# --- glyphs ------------------------------------------------------------------
+
+def find(cp):
+    """Front-to-back lookup, exactly as kdisp_gfx_glyph_font() scans g_all_fonts."""
+    for f in FONTS:
+        if f.first <= cp <= f.last:
+            g = f.glyphs[cp - f.first]
+            if g['width'] or g['height']:      # a gap record falls through
+                return f, g
+    raise KeyError('no glyph for U+%04X' % cp)
+
+
+def lit(f, g, sx, sy):
+    """Column-native (OLED page) bit test — NOT the classic row-major layout."""
+    cb = (g['height'] + 7) // 8
+    return bool(f.bitmap[g['bitmapOffset'] + sx * cb + (sy >> 3)] & (1 << (sy & 7)))
+
+
+def full_ink(cp, cur_x, cur_y):
+    """A normal glyph draw at cursor (cur_x, cur_y).
+
+    ⚠️ Includes kdisp_write_gfx_char's baseline align to fonts[0] — the shift that
+    oled_preview.py does NOT model, and the cause of the flag gap-at-top bug.
+    """
+    f, g = find(cp)
+    y = cur_y + f.yAdvance - ICONS.yAdvance
+    x0, y0 = cur_x + g['xOffset'], y + g['yOffset']
+    return {(x0 + sx, y0 + sy)
+            for sy in range(g['height']) for sx in range(g['width'])
+            if lit(f, g, sx, sy)}
+
+
+def half_ink(cp, x, y):
+    """HINT_HALF: 2x2-OR downsample at the literal ink top-left (no baseline align)."""
+    f, g = find(cp)
+    w, h = g['width'], g['height']
+    return {(x + dx, y + dy)
+            for dy in range((h + 1) // 2) for dx in range((w + 1) // 2)
+            if any(lit(f, g, dx * 2 + ox, dy * 2 + oy)
+                   for oy in (0, 1) for ox in (0, 1)
+                   if dx * 2 + ox < w and dy * 2 + oy < h)}
+
+
+def thin_ink(cp, x, y):
+    """HINT_THIN: decimating downsample (every second pixel), same placement rule."""
+    f, g = find(cp)
+    w, h = g['width'], g['height']
+    return {(x + dx, y + dy)
+            for dy in range((h + 1) // 2) for dx in range((w + 1) // 2)
+            if lit(f, g, dx * 2, dy * 2)}
+
+
+def courtyard(ink, radius=CY_DEFAULT):
+    """The pixels a cy_radius draw CLEARS before plotting (its dilation)."""
+    return {(x + dx, y + dy) for (x, y) in ink
+            for dy in range(-radius, radius + 1)
+            for dx in range(-radius, radius + 1)}
+
+
+# --- render_key()'s legend ---------------------------------------------------
+
+def _poly_settings():
+    txt = _LANG_LUT.read_text(encoding='utf-8', errors='replace')
+    body = txt[txt.rindex('static const int8_t poly_settings'):]
+    rows = re.findall(r'/\*\s*(\S+)\*/\s*(-?\d+),(-?\d+),(-?\d+),(-?\d+)', body)
+    per = len(rows) // 6
+    out = {}
+    for block in range(6):
+        for name, *vals in rows[block * per:(block + 1) * per]:
+            out[(block, name)] = [int(v) for v in vals]
+    return out
+
+
+SETTINGS = _poly_settings()
+
+
+def setting(row, lang, var):
+    return SETTINGS[(row, lang)][var]
+
+
+def legend_ink(ch, lang='en-US', kind=None, shifted=None):
+    """What render_key() draws for a resting (unshifted) key: the base glyph plus
+    the shift preview, placed and clamped by render_key()'s own rules.
+
+    `kind` is 'letter' | 'num' | 'sym'; inferred from `ch` when omitted. `shifted`
+    is the upper view (inferred for letters). Returns one ink set.
+
+    ⚠️ The shift preview is what any corner chrome collides with — en-US HIDEs it
+    for letters, but 36 of 160 languages do not, and every language shows one on
+    the number and symbol rows.
+    """
+    if kind is None:
+        kind = 'letter' if ch.isalpha() else ('num' if ch.isdigit() else 'sym')
+    hrow, vrow = {'letter': (S_LETTER_H, S_LETTER_V),
+                  'num': (S_NUM_H, S_NUM_V),
+                  'sym': (S_SYM_H, S_SYM_V)}[kind]
+    h_small = setting(hrow, lang, VAR_SMALL)
+    v_small = setting(vrow, lang, VAR_SMALL)
+    base_x = BUFFER_X + h_small
+    ink = full_ink(ord(ch), base_x, 23 + v_small)
+
+    h_pv, v_pv = setting(hrow, lang, VAR_SHIFT), setting(vrow, lang, VAR_SHIFT)
+    if h_pv == HIDE_KEY or v_pv == HIDE_KEY:
+        return ink
+    if shifted is None:
+        if kind != 'letter':
+            return ink                      # caller must name the shifted glyph
+        shifted = ch.upper()
+    _, bg = find(ord(ch))
+    _, pg = find(ord(shifted))
+    bmax = bg['xOffset'] + bg['width'] - 1
+    pmin, pmax = pg['xOffset'], pg['xOffset'] + pg['width'] - 1
+    px = BUFFER_X + h_pv
+    if px + pmin < base_x + bmax + 2:                     # keep clear of the base
+        px = base_x + bmax + 2 - pmin
+    if px + pmax > BUFFER_X + VIS_W - 1:                  # clamp to the right edge
+        px = (BUFFER_X + VIS_W - 1) - pmax
+    return ink | full_ink(ord(shifted), px, 23 + v_pv)
+
+
+# --- measuring ---------------------------------------------------------------
+
+def collision(a, b):
+    """Pixels where two ink sets overlap.
+
+    ⚠️ THE metric. A "how many of `a`'s pixels survived after drawing `b`" count
+    reads 0 for a real collision, because lit-on-lit loses no pixels — it just
+    reads as one merged blob. Intersect, don't subtract.
+    """
+    return len(a & b)
+
+
+def erased(legend, mark_ink, radius=CY_DEFAULT):
+    """Legend pixels a courtyard-clearing draw of `mark_ink` would wipe out."""
+    return len(legend & courtyard(mark_ink, radius))
+
+
+def extent(ink):
+    """(xmin, xmax, ymin, ymax); use to check the visible window."""
+    xs = [x for x, _ in ink]
+    ys = [y for _, y in ink]
+    return min(xs), max(xs), min(ys), max(ys)
+
+
+def offscreen(ink):
+    """Ink outside the visible keycap window — must be empty."""
+    return {(x, y) for (x, y) in ink
+            if not (BUFFER_X <= x < BUFFER_X + VIS_W and 0 <= y < H)}
+
+
+# --- rendering ---------------------------------------------------------------
+
+_LIT = (222, 238, 255)      # what the OLEDs read as by eye (not the camera cyan)
+_BG = (18, 18, 22)
+_FRAME = (58, 62, 72)
+_LABEL = (176, 180, 190)
+
+
+def _cap(ink, scale):
+    img = Image.new('L', (W, H), 0)
+    px = img.load()
+    for (x, y) in ink:
+        if 0 <= x < W and 0 <= y < H:
+            px[x, y] = 255
+    crop = img.crop((BUFFER_X, 0, BUFFER_X + VIS_W, H))
+    w, h = VIS_W * scale, H * scale
+    out = Image.new('RGB', (w + 2 * scale, h + 2 * scale), _BG)
+    ImageDraw.Draw(out).rounded_rectangle(
+        [0, 0, w + 2 * scale - 1, h + 2 * scale - 1],
+        radius=scale + 2, fill=(0, 0, 0), outline=_FRAME, width=1)
+    rgb = Image.merge('RGB', tuple(crop.point(lambda v, c=c: v and c) for c in _LIT))
+    out.paste(rgb.resize((w, h), Image.NEAREST), (scale, scale))
+    return out
+
+
+def sheet(cells, path, scale=5, gap=26, pad=22):
+    """cells: [(ink_set, label)] laid out in one row. Writes a PNG."""
+    font = ImageFont.truetype(
+        '/usr/share/fonts/truetype/dejavu/DejaVuSansMono-Bold.ttf', 15)
+    caps = [_cap(ink, scale) for ink, _ in cells]
+    cw, chh = caps[0].size
+    out = Image.new('RGB', (pad * 2 + cw * len(caps) + gap * (len(caps) - 1),
+                            pad * 2 + chh + 26), _BG)
+    d = ImageDraw.Draw(out)
+    for i, (cap, (_, label)) in enumerate(zip(caps, cells)):
+        x = pad + i * (cw + gap)
+        out.paste(cap, (x, pad))
+        d.text((x + (cw - d.textlength(label, font=font)) / 2, pad + chh + 8),
+               label, font=font, fill=_LABEL)
+    out.save(path)
+    return path

--- a/keyboards/polykybd/.claude/skills/keycap-layout-preview/keycap_preview.py
+++ b/keyboards/polykybd/.claude/skills/keycap-layout-preview/keycap_preview.py
@@ -229,10 +229,24 @@ def _cap(ink, scale):
     return out
 
 
+def _label_font(size=15):
+    """A mono label face if the host has one, else PIL's built-in bitmap font.
+
+    Only the caption under each keycap uses this — the keycap itself is drawn from
+    the firmware's own font headers — so a fallback costs nothing but looks.
+    """
+    for name in ('DejaVuSansMono-Bold.ttf', 'DejaVuSansMono.ttf',
+                 'LiberationMono-Bold.ttf', 'Menlo.ttc', 'consolab.ttf'):
+        try:
+            return ImageFont.truetype(name, size)      # PIL searches the font dirs
+        except OSError:
+            continue
+    return ImageFont.load_default()
+
+
 def sheet(cells, path, scale=5, gap=26, pad=22):
     """cells: [(ink_set, label)] laid out in one row. Writes a PNG."""
-    font = ImageFont.truetype(
-        '/usr/share/fonts/truetype/dejavu/DejaVuSansMono-Bold.ttf', 15)
+    font = _label_font()
     caps = [_cap(ink, scale) for ink, _ in cells]
     cw, chh = caps[0].size
     out = Image.new('RGB', (pad * 2 + cw * len(caps) + gap * (len(caps) - 1),


### PR DESCRIPTION
## Summary

Session retro for **#217** (merged). Documentation and tooling only — **no firmware source is touched**, so nothing here can change a build.

Each item points at something that actually cost a round in that session, not at a general principle.

### `CLAUDE.md` → per-keycap rendering gotchas

- **`render_key()` and `to_static_text()` are a PAIR** — both must normalise the keycode the same way, or a key draws its chrome and *no legend*. `update_displays()` consults `render_key()` exactly when `to_static_text()` returned NULL, which is every letter, so when only one of them unwrapped a mod-tap the keycap rendered its badge in an empty cell. Written as the sibling of the existing "`render_key()` is only consulted when `to_static_text()` returns NULL" note, which describes the *other* direction of the same seam.
- **A hint string is drawn OVER the legend at the same origin**, and its `KDISP_CY_DEFAULT` courtyard erases the legend before the glyph lands — correct for a held-modifier hint, wrong for a mark meant to coexist. So a coexisting mark is MOVE'd into a corner, and that corner is the **bottom-right**, because `render_key()` owns the upper right with the shift preview. Includes the measured table (letters 0 either way because en-US HIDEs their preview; a digit went 21 px @ 2 marks → 21 px @ 4 marks only) and the method note that **a "legend pixels lost" count reads 0 for a real collision** — intersect the ink sets instead.

### `CLAUDE.md` → unit tests

- **`make test:<unregistered-name>` exits 0 and prints nothing.** `make test:os_hints` "passed" twice before the missing output was noticed; the suite is `polykybd_os_hints`. Judge a run by its `[  PASSED  ] N tests.` line, never the exit code.

### `CLAUDE.md` → code review conventions

- **CodeRabbit's *commit status* also goes green while rate-limited** (`state: success`, description "Review rate limited"), so the existing "CodeRabbit at least renders a warning banner" holds only for the comment — which a status-only view never shows and which vanishes on a re-render. `get_status` can never tell you a review read the *current head*; compare each review's `commit_id`.

### `CLAUDE.md` → the local lint recipe

- The ignored-files check's `-o` lists **untracked** ignored files, which locally is mostly your own build output (~100 files after a `doom/pack/build_pack.sh` run). CI checks out clean and only fails on a **tracked** ignored file, so the noisy case has a tracked-only form. And `git add -A` is the wrong way to stage here — **it staged that entire `doom/pack/build/` tree while committing this very PR**, which is precisely what turns `lint` red on every later PR touching the keyboard.

### New skill: `keycap-layout-preview`

Model the real per-keycap draw path in Python, place chrome, and **measure ink-set collisions** rather than flashing a build to look at it. `keycap_preview.py` models what a naive renderer misses:

- `kdisp_write_gfx_char`'s **baseline-align to `fonts[0]`** — the shift `oled_preview.py` explicitly does not model;
- `render_key()`'s legend placement including the **shift preview**, using the real per-language offsets parsed out of `lang_lut.c` (so "does this collide" can be asked for `ar-SA` as easily as `en-US`);
- the three draw modes (`full` / `HINT_HALF` 2×2-OR / `HINT_THIN` decimate) with the firmware's own asymmetry — half/thin take the ink top-left, full takes the cursor.

Used five times in the session it came from (badge variants, the downsample study, the missing-legend check, the bottom-anchor check, and the docs images). Sibling precedent: `status-oled-layout` does exactly this for the status panel. Smoke-tested against the session's own numbers — it reproduces the 21 px digit collision and the 0 px letter result.

### `update-polykybd-docs` skill

Adds an **Images** section: the two asset conventions (`src/assets/<section>/` stills referenced relatively vs `public/img/` gifs referenced absolutely — not interchangeable), a push to **generate** keyboard renders from the firmware's own code rather than mocking them up, and a note to check any "the software can't do X" claim against the host source before repeating it. The Keymap Editor page carried a stale one for months; one grep of `BEHAVIORS` settled it.

## Version bump label

*(none)* — patch. Documentation and developer tooling only; no firmware source, no protocol change.

## Testing

- [x] Compiled successfully — n/a, but verified nothing compiled changed: the diff is `CLAUDE.md`, two `SKILL.md`s and one Python helper under `.claude/`
- [x] `qmk lint --strict` on `polykybd/split72`, plus `qmk ci-validate-keyboard-targets` and `qmk ci-validate-aliases`
- [x] Tracked-ignored-files check clean (`git ls-files -c -i --exclude-from=.gitignore keyboards/polykybd/` → empty)
- [x] Line endings + trailing newlines checked by hand on all four files (`qmk format-text` needs `dos2unix`, absent in the container)
- [x] `keycap_preview.py` compiles and reproduces the session's measurements
- [ ] Flashed and tested on hardware — n/a, no firmware change
- [x] If protocol changed: n/a

Companion docs PR for the same feature: **[polykybd-docs#56](https://github.com/thpoll83/polykybd-docs/pull/56)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HXL2e7jiYWLBKrsnEnukK

---
_Generated by [Claude Code](https://claude.ai/code/session_015HXL2e7jiYWLBKrsnEnukK)_

## Summary by Sourcery

Capture keycap rendering and development-workflow lessons from the mod-tap badge work in contributor guidance and reusable preview tooling.

New Features:
- Add a keycap layout preview skill that models firmware rendering and measures legend collisions across languages and draw modes.

Enhancements:
- Document keycap rendering seams, overlay placement, unit-test invocation, ignored-file checks, and review-status verification practices in CLAUDE.md.

Documentation:
- Document image asset conventions, firmware-derived image generation, model validation, and source verification for capability claims in the documentation-update skill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for storing and referencing still images and GIFs, writing descriptive alt text, and verifying visual sources.
  - Expanded development guidance for reliable status checks, tracked files, rendering consistency, and test validation.
  - Documented a workflow for previewing keyboard layouts across languages, glyph styles, and display conditions.

- **Tools**
  - Added a preview utility that generates labeled keyboard-rendering sheets and detects legend collisions, erased pixels, and off-screen content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->