### PR TITLE
docs: the mutation "did it apply?" guard is itself fail-open against HEAD

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1698,6 +1698,26 @@ Wiring a new one needs **two** registrations plus one non-obvious source list:
     empty "caught by:" reads identically to "not caught". Assert the edit landed
     (`git diff --quiet` on the mutated file) before believing the run. Hit while
     dogfooding the skill, 2026-08-18.
+  - ⚠️ **…and that `git diff --quiet` guard is itself fail-open unless it
+    compares the PRE-MUTATION baseline.** Diffing against **HEAD** only works
+    while the tree is clean: mutate code you have not committed yet — the normal
+    case, since you mutation-test a suite right after writing it — and the guard
+    sees your own feature diff, reports "changed", and passes for every
+    mutation whether or not any applied. So the check meant to catch a
+    non-applied mutation is exactly the one that stops working when you need it.
+    Copy the file first and compare to the copy:
+    ```bash
+    cp path/to/src.c /tmp/base.c                      # pre-mutation baseline
+    ...apply mutation...
+    diff -q /tmp/base.c path/to/src.c >/dev/null \
+        && { echo "MUTATION DID NOT APPLY - result meaningless"; }
+    ...run suite, restore with: cp /tmp/base.c path/to/src.c
+    ```
+    Hit on the host repo 2026-08-20 (Python, same shape — the family is not
+    C-specific). The run happened to be sound because every mutation *did* apply
+    and turned the suite red, but that was luck: the guard could not have told
+    me otherwise. **A fail-open guard that is only correct on a clean tree is a
+    fail-open guard.**
 
 ### Notable QMK features enabled
 RGB matrix (72 LEDs, 35 effects), dynamic keymap (9 host-remappable layers), unicode input (Linux/macOS/Windows/BSD), Cirque trackpad (split72 variant), `USE_CORE1` multicore.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1709,10 +1709,21 @@ Wiring a new one needs **two** registrations plus one non-obvious source list:
     ```bash
     cp path/to/src.c /tmp/base.c                      # pre-mutation baseline
     ...apply mutation...
-    diff -q /tmp/base.c path/to/src.c >/dev/null \
-        && { echo "MUTATION DID NOT APPLY - result meaningless"; }
+    diff -q /tmp/base.c path/to/src.c >/dev/null; rc=$?
+    case $rc in
+      0) echo "MUTATION DID NOT APPLY - result meaningless" >&2; exit 1 ;;
+      1) ;;                                           # applied, carry on
+      *) echo "diff failed ($rc) - baseline unreadable?" >&2; exit 1 ;;
+    esac
     ...run suite, restore with: cp /tmp/base.c path/to/src.c
     ```
+    ⚠️ **The guard has to EXIT, not just print** — a third instance of the same
+    family, caught in review of this very note (CodeRabbit, #221). A bare
+    `diff … && echo "DID NOT APPLY"` returns 0 and the loop carries on to report
+    the mutation as "not caught", with the warning buried in a screen of gtest
+    output. And `diff` has **three** exit codes — `0` same, `1` differs, `2`
+    could not read a file — so `else`-ing on "not 0" silently treats a missing
+    baseline as a successful mutation. Hence the `case`.
     ⚠️ That restore **overwrites whatever is in the file**, and by this note's
     own premise the tree is uncommitted — so there is no git copy to recover
     from. Do not edit the source between mutating it and restoring it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1713,6 +1713,9 @@ Wiring a new one needs **two** registrations plus one non-obvious source list:
         && { echo "MUTATION DID NOT APPLY - result meaningless"; }
     ...run suite, restore with: cp /tmp/base.c path/to/src.c
     ```
+    ⚠️ That restore **overwrites whatever is in the file**, and by this note's
+    own premise the tree is uncommitted — so there is no git copy to recover
+    from. Do not edit the source between mutating it and restoring it.
     Hit on the host repo 2026-08-20 (Python, same shape — the family is not
     C-specific). The run happened to be sound because every mutation *did* apply
     and turned the suite red, but that was luck: the guard could not have told


### PR DESCRIPTION
## Summary

Session retro. One CLAUDE.md note — no code changes.

The mutation-testing section already records two fail-open paths, and the second one recommends:

> Assert the edit landed (`git diff --quiet` on the mutated file) before believing the run.

**That guard only works on a clean tree.** Mutate code that isn't committed yet — the normal case, since you mutation-test a suite right after writing it — and `git diff` against HEAD sees your own feature changes, reports "changed", and passes for every mutation whether or not any of them applied.

So the check that exists to catch a non-applied mutation is precisely the one that stops working in the situation it's used in. It's a third variant of the family this section already documents, and unlike the first two it was *recommended* here rather than merely possible.

### The fix

Copy the file first and compare against the copy, not against HEAD — and **exit**, don't just print:

```bash
cp path/to/src.c /tmp/base.c                      # pre-mutation baseline
...apply mutation...
diff -q /tmp/base.c path/to/src.c >/dev/null; rc=$?
case $rc in
  0) echo "MUTATION DID NOT APPLY - result meaningless" >&2; exit 1 ;;
  1) ;;                                           # applied, carry on
  *) echo "diff failed ($rc) - baseline unreadable?" >&2; exit 1 ;;
esac
...run suite, restore with: cp /tmp/base.c path/to/src.c
```

The first version of this snippet only *printed* the warning, so the loop continued and reported the mutation as "not caught" — a fourth instance of the same family, caught by CodeRabbit on this PR and fixed in 9d6b0f1. The third branch matters for the same reason as the first: `diff` returns `0` same / `1` differs / `2` unreadable, so `else`-ing on "not 0" would treat a missing baseline as a successful mutation.

### Evidence

Hit on the host repo (2026-08-20) while mutation-testing new Python tests — same shape, so the family isn't C-specific. That run happened to be **sound**: all four mutations did apply and did turn the suite red. But that was luck; the guard could not have told me either way, which is the whole problem with a fail-open check.

Companion PR in `PolyKybdHost` (#186) records four learnings from the same session.

## Version bump label

*(none)* — patch. Documentation only; no firmware source, protocol or wire format is touched.

## Testing

- [ ] Compiled successfully — **n/a**, no firmware source changed (`CLAUDE.md` only, 1 file)
- [ ] Flashed and tested on hardware — **n/a**, same reason
- [ ] If protocol changed: host updated and tested together — **n/a**, no protocol change

What *was* exercised is the shell snippet the note now ships, in all three branches:

| Case | Expected | Result |
|---|---|---|
| mutation applied | continue | continued, exit 0 |
| mutation not applied | fail closed | `MUTATION DID NOT APPLY`, exit 1 |
| baseline missing | fail closed | `diff failed (2)`, exit 1 |

Plus `dash -n` on the empty `1)` arm, since this repo's CI shells are POSIX `sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xrWzmiNmk6tnWP7pBpjvD

---
_Generated by [Claude Code](https://claude.ai/code/session_017xrWzmiNmk6tnWP7pBpjvD)_