### PR TITLE
ci: make the slow HIL checks opt-in via the hil-extended label

### DIFF
--- a/.github/workflows/qmk-test.yml
+++ b/.github/workflows/qmk-test.yml
@@ -99,6 +99,30 @@ jobs:
     name: HIL test (split72)
     needs: build
     runs-on: [self-hosted, polykybd-ctnd]
+    # --- suite tier (OPT-IN extended checks) ---------------------------------
+    # Most HIL checks cost a report or two and run on every push. A few are slow
+    # by nature — they wait out a 10 s idle fade, a ~14 s animation, a 450-frame
+    # split-link soak and a reboot power cycle — and together they add most of a
+    # minute to the gate every push pays for. Those are EXTENDED tier
+    # (station/hil_tests.py TIER_EXTENDED) and are SKIPPED unless this run asks
+    # for them. Three ways to ask, mirroring the perf job below:
+    #   * add the `hil-extended` label to a PR — for a change big enough to want
+    #     the deep checks,
+    #   * put `[hil-extended]` in a commit message — PUSH events only
+    #     (`head_commit` does not exist on a pull_request event), i.e. after a
+    #     merge, which is the release-time route,
+    #   * run the workflow manually (Actions -> Run workflow).
+    # ⚠️ Adding the label does NOT start a run: this job opts out of `labeled`
+    # events (see the `build` job's `if:`) so the auto-labeler cannot re-run the
+    # whole pipeline. Label first and push, or re-run the workflow afterwards.
+    # The runner reads HIL_EXTENDED itself, so the run command stays identical
+    # and the tier is visible both here and in its "[runner] suite tier:" line.
+    env:
+      HIL_EXTENDED: >-
+        ${{ (github.event_name == 'workflow_dispatch' ||
+        contains(github.event.pull_request.labels.*.name, 'hil-extended') ||
+        contains(github.event.head_commit.message, '[hil-extended]'))
+        && '1' || '0' }}
     # download-artifact needs actions:read; posting the diagnostics comment needs
     # pull-requests:write. Setting permissions explicitly replaces the default set,
     # so both are listed; no other scopes are granted to the job token.
@@ -169,6 +193,13 @@ jobs:
         run: |
           cd ${{ steps.ctnd.outputs.dir }}
           set -o pipefail
+          if [ "$HIL_EXTENDED" = "1" ]; then
+            echo "suite tier: EXTENDED (slow checks included)"
+          else
+            echo "suite tier: default — add the 'hil-extended' label (then push or"
+            echo "re-run), or put [hil-extended] in a commit message, to include the"
+            echo "animation / idle / split-link-soak / reboot-persistence checks"
+          fi
           # -u: unbuffered, so the log survives even if a native lib aborts the
           # process at exit (test_runner itself os._exit()s with the real code).
           venv/bin/python -u -m station.test_runner \

--- a/.github/workflows/qmk-test.yml
+++ b/.github/workflows/qmk-test.yml
@@ -196,9 +196,7 @@ jobs:
           if [ "$HIL_EXTENDED" = "1" ]; then
             echo "suite tier: EXTENDED (slow checks included)"
           else
-            echo "suite tier: default — add the 'hil-extended' label (then push or"
-            echo "re-run), or put [hil-extended] in a commit message, to include the"
-            echo "animation / idle / split-link-soak / reboot-persistence checks"
+            echo "suite tier: default (add the 'hil-extended' label, then push or re-run, for the slow checks)"
           fi
           # -u: unbuffered, so the log survives even if a native lib aborts the
           # process at exit (test_runner itself os._exit()s with the real code).

--- a/.github/workflows/qmk-test.yml
+++ b/.github/workflows/qmk-test.yml
@@ -24,10 +24,23 @@ jobs:
   build:
     name: Build firmware
     # A `labeled` event means someone (or the auto-labeler) tagged the PR; it is
-    # not a code change, so there is nothing new to build or HIL-test. Only the
-    # opt-in perf jobs below act on it. `github.event.action` is null for push /
-    # workflow_dispatch, so those still run normally.
-    if: github.event.action != 'labeled'
+    # not a code change, so there is normally nothing new to build or HIL-test,
+    # and letting every auto-label re-run this pipeline is expensive.
+    # `github.event.action` is null for push / workflow_dispatch, so those still
+    # run normally.
+    #
+    # ⚠️ ONE exception: `hil-extended`, which asks for the rig's slow tier (see
+    # the hil-test job). It has to start a run, because there is no other way to
+    # act on it — RE-RUNNING an existing run replays the ORIGINAL event payload,
+    # so a label added afterwards is invisible to `github.event.pull_request.
+    # labels` and the re-run would quietly repeat the default tier. Matching on
+    # `github.event.label.name` (the label just added) keeps every other label —
+    # the auto-labeler's path tags, `bump:*` — excluded as before. This is also
+    # what makes the `hil-extended` label behave like `perf`, whose job chain
+    # starts at `build-perf` and never had this exclusion.
+    if: >-
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'hil-extended'
     runs-on: ubuntu-latest
     outputs:
       split72: ${{ steps.names.outputs.split72 }}
@@ -107,14 +120,14 @@ jobs:
     # (station/hil_tests.py TIER_EXTENDED) and are SKIPPED unless this run asks
     # for them. Three ways to ask, mirroring the perf job below:
     #   * add the `hil-extended` label to a PR — for a change big enough to want
-    #     the deep checks,
+    #     the deep checks. This starts a run by itself (the `build` job makes a
+    #     deliberate exception for this one label — see its `if:`); do NOT try to
+    #     pick the label up by re-running an existing run, because a re-run
+    #     replays the original event payload and cannot see it,
     #   * put `[hil-extended]` in a commit message — PUSH events only
     #     (`head_commit` does not exist on a pull_request event), i.e. after a
     #     merge, which is the release-time route,
     #   * run the workflow manually (Actions -> Run workflow).
-    # ⚠️ Adding the label does NOT start a run: this job opts out of `labeled`
-    # events (see the `build` job's `if:`) so the auto-labeler cannot re-run the
-    # whole pipeline. Label first and push, or re-run the workflow afterwards.
     # The runner reads HIL_EXTENDED itself, so the run command stays identical
     # and the tier is visible both here and in its "[runner] suite tier:" line.
     env:
@@ -196,7 +209,7 @@ jobs:
           if [ "$HIL_EXTENDED" = "1" ]; then
             echo "suite tier: EXTENDED (slow checks included)"
           else
-            echo "suite tier: default (add the 'hil-extended' label, then push or re-run, for the slow checks)"
+            echo "suite tier: default (add the 'hil-extended' label for the slow checks — it starts its own run)"
           fi
           # -u: unbuffered, so the log survives even if a native lib aborts the
           # process at exit (test_runner itself os._exit()s with the real code).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,10 +246,14 @@ inherited-upstream noise:
     only when the run asks. **Ask for them on anything that touches EEPROM/persisted
     state, the split link, the idle/animation paths, or a release.** Three ways, the
     same convention as the `perf` label:
-    - the **`hil-extended`** PR label — ⚠️ **labelling alone does NOT start a run**
-      (`hil-test` needs `build`, which opts out of `labeled` events so the
-      auto-labeler cannot re-run the pipeline). Label first, then push, or re-run the
-      workflow afterwards;
+    - the **`hil-extended`** PR label — it starts its own run: `build` excludes
+      `labeled` events (so the auto-labeler cannot re-run the pipeline) with a
+      deliberate **exception for this one label**, matched on
+      `github.event.label.name`. ⚠️ **Do not try to pick the label up by re-running
+      an existing run** — a re-run replays the ORIGINAL event payload, so a label
+      added afterwards is invisible and the re-run silently repeats the default
+      tier (caught by CodeRabbit on #223; it is also why `perf` works on a label
+      and this did not until the exception was added);
     - **`[hil-extended]`** in a commit message — PUSH events only (`head_commit` does
       not exist on a `pull_request` event), i.e. after a merge / at release time;
     - a manual **`workflow_dispatch`** (default-branch copy only).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,6 +238,26 @@ inherited-upstream noise:
 - **`Build firmware`** and **`HIL test (split72)`** (the polykybd-ctnd rig) are the
   **real** checks; these are what must go green. Use the `diagnose-hil-failure` skill
   for the HIL side.
+  - ⚠️ **The HIL suite has TWO tiers, and the default one deliberately skips the
+    deepest checks.** The rig's slow checks — the startup animation, idle engage +
+    the Eden screensaver, a 450-frame split-link soak, and a reboot power cycle that
+    is the ONLY thing verifying user state survives a power loss — are
+    `TIER_EXTENDED` (polykybd-ctnd `station/hil_tests.py`) and add ~50 s, so they run
+    only when the run asks. **Ask for them on anything that touches EEPROM/persisted
+    state, the split link, the idle/animation paths, or a release.** Three ways, the
+    same convention as the `perf` label:
+    - the **`hil-extended`** PR label — ⚠️ **labelling alone does NOT start a run**
+      (`hil-test` needs `build`, which opts out of `labeled` events so the
+      auto-labeler cannot re-run the pipeline). Label first, then push, or re-run the
+      workflow afterwards;
+    - **`[hil-extended]`** in a commit message — PUSH events only (`head_commit` does
+      not exist on a `pull_request` event), i.e. after a merge / at release time;
+    - a manual **`workflow_dispatch`** (default-branch copy only).
+    The job log says which tier ran (`suite tier: …`), and so does the runner
+    (`[runner] suite tier: …`) — read it before concluding a green HIL board covered
+    the reboot/link checks, because by default it did not. Locally on the rig:
+    `python -m station.test_runner --extended` (or `HIL_EXTENDED=1`), or the touch
+    UI's **Extended** toggle beside Run Tests.
 - **`cppcheck`** (`cppcheck.yml`) also **gates**, and is the only reviewer here that
   is not an LLM — CodeRabbit, Sourcery and the on-demand Claude reviewer share
   training data and therefore blind spots, while dataflow analysis fails elsewhere.


### PR DESCRIPTION
## Summary

Workflow-only change (no firmware sources touched): it lets a run ask for the HIL rig's slow tier.

The rig suite gained four checks that are slow by nature — a ~14 s startup animation, a 10 s idle fade plus the Eden screensaver, a 450-frame split-link soak, and a reboot power cycle. Together they add most of a minute to the gate every push pays for, so [polykybd-ctnd#69](https://github.com/thpoll83/polykybd-ctnd/pull/69) marks them `TIER_EXTENDED` and skips them unless the run opts in.

Ask the same three ways the perf job is asked, so there is one convention for opt-in rig work:

- add the **`hil-extended`** label to a PR — for a change big enough to want the deep checks;
- put **`[hil-extended]`** in a commit message — PUSH events only (`head_commit` does not exist on a `pull_request` event), i.e. after a merge, which is the release-time route;
- run the workflow manually (Actions → Run workflow).

The runner reads `HIL_EXTENDED` itself, so this is a job-level env expression and the `station.test_runner` command line is unchanged. The step echoes which tier it is running and the runner logs its own `[runner] suite tier:` line, so the run page says which suite was executed rather than leaving you to infer it.

⚠️ **Adding the label does not start a run.** `hil-test` needs `build`, and `build` opts out of `labeled` events (`if: github.event.action != 'labeled'`) so the auto-labeler cannot re-run the whole pipeline. Label first and push, or re-run the workflow afterwards. That is documented in the job so the next person does not rediscover it.

One YAML detail worth knowing for the next edit: the continuation lines of the folded `>-` expression are kept at the **same** indent as the first. YAML only folds newlines between equally-indented lines, so a prettier extra indent would leave literal newlines inside the `${{ }}`. Verified by parsing the file and asserting the expression is a single line.

Ordering: this is inert until polykybd-ctnd#69 is merged and the rig self-updates — an older station ignores `HIL_EXTENDED` and runs exactly what it runs today. Merging it first is harmless; merging it second means the extended tier is simply never requested until then.

## Version bump label

None — default patch bump. No firmware sources changed, so the bump is cosmetic either way.

## Testing

- [x] Workflow parses and the `HIL_EXTENDED` expression folds to a single line (`yaml.safe_load` + assertion).
- [ ] Compiled successfully — **n/a**, no firmware sources touched.
- [ ] Flashed and tested on hardware — **n/a** for this change; the rig-side suite it enables is tested in polykybd-ctnd#69 (89 offline tests, plus every new check driven against a fake keyboard) and has not yet run on real hardware.
- [ ] If protocol changed: host updated and tested together — **n/a**, no protocol change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbRbFYmCjnJfkUjEtR5PZ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbRbFYmCjnJfkUjEtR5PZ7)_

## Summary by Sourcery

Make slow HIL checks opt-in while preserving the default fast suite for routine runs.

New Features:
- Add opt-in support for running the slow HIL test tier through the `hil-extended` label, commit marker, or manual workflow dispatch.

Bug Fixes:
- Ensure adding the `hil-extended` label starts a workflow while other label events remain excluded from full pipeline runs.

Enhancements:
- Expose the selected HIL suite tier in workflow and runner logs and document when extended checks are required.

CI:
- Update the HIL workflow to propagate the extended-tier selection without changing the test command.

Documentation:
- Document the HIL suite tiers, opt-in mechanisms, and label/re-run behavior.

Tests:
- Verify the workflow YAML parses and the tier expression folds correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated hardware-in-the-loop testing with configurable standard and extended test suites.
  - Extended checks can now be enabled for manual runs, designated pull requests, or commits requesting expanded validation.
  - Test output clearly indicates which suite is running and explains how to enable extended checks when using the standard tier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->