### PR TITLE
docs(ci): say that a workflow_dispatch runs BOTH opt-in rig tiers

### DIFF
--- a/.github/workflows/qmk-test.yml
+++ b/.github/workflows/qmk-test.yml
@@ -127,13 +127,13 @@ jobs:
     #   * put `[hil-extended]` in a commit message — PUSH events only
     #     (`head_commit` does not exist on a pull_request event), i.e. after a
     #     merge, which is the release-time route,
-    #   * run the workflow manually (Actions -> Run workflow) — note this also
-    #     satisfies the perf job's condition below, so a dispatch runs the extended
-    #     HIL tier AND the perf measurement. They are otherwise INDEPENDENT: the
-    #     `hil-extended` label does not trigger perf, and `perf` leaves the HIL
-    #     suite on the default tier. Dispatch is therefore the release-time "run
-    #     everything" route; `perf-test` needs `hil-test`, so the two rig jobs
-    #     never interleave their flashes.
+    #   * run the workflow manually (Actions -> Run workflow) — this also satisfies
+    #     the perf job's condition below, so one dispatch runs the extended HIL tier
+    #     AND the perf measurement. The conditions are otherwise INDEPENDENT (each
+    #     opt-in drives only its own job); asking for both at once works too — both
+    #     labels, or both markers in one commit message — dispatch simply needs no
+    #     label bookkeeping. `perf-test` needs `hil-test`, so the two rig jobs never
+    #     interleave their flashes.
     # The runner reads HIL_EXTENDED itself, so the run command stays identical
     # and the tier is visible both here and in its "[runner] suite tier:" line.
     env:
@@ -302,8 +302,9 @@ jobs:
   #     applies to pushes to PolyKybd branches (i.e. after merge),
   #   * run the workflow manually (Actions -> Run workflow) — only available
   #     once this file is on the default branch. A dispatch ALSO puts the HIL
-  #     suite on its extended tier (hil-test's HIL_EXTENDED above), so it is the
-  #     one route that runs everything.
+  #     suite on its extended tier (hil-test's HIL_EXTENDED above), so one dispatch
+  #     runs both; a push commit carrying `[perf]` AND `[hil-extended]` does the
+  #     same, as do both labels on a PR.
   #
   # It reports numbers and compares them against the baseline committed in the
   # polykybd-ctnd repo (perf/baselines/<board>.json). It deliberately NEVER fails

--- a/.github/workflows/qmk-test.yml
+++ b/.github/workflows/qmk-test.yml
@@ -127,7 +127,13 @@ jobs:
     #   * put `[hil-extended]` in a commit message — PUSH events only
     #     (`head_commit` does not exist on a pull_request event), i.e. after a
     #     merge, which is the release-time route,
-    #   * run the workflow manually (Actions -> Run workflow).
+    #   * run the workflow manually (Actions -> Run workflow) — note this also
+    #     satisfies the perf job's condition below, so a dispatch runs the extended
+    #     HIL tier AND the perf measurement. They are otherwise INDEPENDENT: the
+    #     `hil-extended` label does not trigger perf, and `perf` leaves the HIL
+    #     suite on the default tier. Dispatch is therefore the release-time "run
+    #     everything" route; `perf-test` needs `hil-test`, so the two rig jobs
+    #     never interleave their flashes.
     # The runner reads HIL_EXTENDED itself, so the run command stays identical
     # and the tier is visible both here and in its "[runner] suite tier:" line.
     env:
@@ -295,7 +301,9 @@ jobs:
   #     not exist on a pull_request event, so this does nothing on a PR; it
   #     applies to pushes to PolyKybd branches (i.e. after merge),
   #   * run the workflow manually (Actions -> Run workflow) — only available
-  #     once this file is on the default branch.
+  #     once this file is on the default branch. A dispatch ALSO puts the HIL
+  #     suite on its extended tier (hil-test's HIL_EXTENDED above), so it is the
+  #     one route that runs everything.
   #
   # It reports numbers and compares them against the baseline committed in the
   # polykybd-ctnd repo (perf/baselines/<board>.json). It deliberately NEVER fails

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,9 +268,12 @@ inherited-upstream noise:
     alone starts no perf run and `perf` alone leaves the HIL suite on its default
     tier. ⚠️ Dispatch is not the *only* way to get both: both labels on a PR, or
     **both markers in one pushed commit message** (`… [hil-extended] [perf]`), do it
-    too — and the commit-message form is the natural release-time route, since a
-    release push is a push. What dispatch buys is needing no label bookkeeping, which
-    also sidesteps the two-labels-in-one-call trap below (that fires two runs).
+    too. The commit-message form is the natural release-time route — a release push
+    is a push — but it only fires where the workflow listens for pushes at all,
+    i.e. `PolyKybd` and `PolyKybd/**`; the same marker in a commit pushed to a
+    `claude/**` branch starts nothing. What dispatch buys is needing no label
+    bookkeeping, which also sidesteps the two-labels-in-one-call trap below (that
+    fires two runs).
     Whichever route, the combination is safe: `perf-test` has `needs: [build-perf,
     hil-test]`, so the rig runs the suite first and measures afterwards rather than
     interleaving two flashes. Measured on run #805 (2026-08-20): ~3 min of rig time

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,16 +262,20 @@ inherited-upstream noise:
     the reboot/link checks, because by default it did not. Locally on the rig:
     `python -m station.test_runner --extended` (or `HIL_EXTENDED=1`), or the touch
     UI's **Extended** toggle beside Run Tests.
-  - ✅ **`workflow_dispatch` is the "give me everything" button: it runs the extended
-    HIL tier AND the perf measurement**, because it satisfies both opt-in conditions
-    at once (they are otherwise INDEPENDENT — `hil-extended` does not trigger perf,
-    and `perf` leaves the HIL suite on the default tier). That is the route to use at
-    a release, and it is safe: `perf-test` has `needs: [build-perf, hil-test]`, so the
-    rig runs the suite first and measures afterwards rather than interleaving two
-    flashes. Measured on run #805 (2026-08-20): ~3 min of rig time for the extended
-    HIL suite plus ~1 min for the perf pass, inside a ~8.5 min wall-clock run (the
-    two cloud builds are most of it). It also sidesteps the two-labels-in-one-call
-    trap below, which would otherwise fire two runs.
+  - ✅ **`workflow_dispatch` runs the extended HIL tier AND the perf measurement in
+    one action**, because it satisfies both opt-in conditions at once. The two are
+    otherwise INDEPENDENT — each opt-in drives only its own job, so `hil-extended`
+    alone starts no perf run and `perf` alone leaves the HIL suite on its default
+    tier. ⚠️ Dispatch is not the *only* way to get both: both labels on a PR, or
+    **both markers in one pushed commit message** (`… [hil-extended] [perf]`), do it
+    too — and the commit-message form is the natural release-time route, since a
+    release push is a push. What dispatch buys is needing no label bookkeeping, which
+    also sidesteps the two-labels-in-one-call trap below (that fires two runs).
+    Whichever route, the combination is safe: `perf-test` has `needs: [build-perf,
+    hil-test]`, so the rig runs the suite first and measures afterwards rather than
+    interleaving two flashes. Measured on run #805 (2026-08-20): ~3 min of rig time
+    for the extended HIL suite plus ~1 min for the perf pass, inside a ~8.5 min
+    wall-clock run (the two cloud builds are most of it).
 - **`cppcheck`** (`cppcheck.yml`) also **gates**, and is the only reviewer here that
   is not an LLM — CodeRabbit, Sourcery and the on-demand Claude reviewer share
   training data and therefore blind spots, while dataflow analysis fails elsewhere.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,6 +262,16 @@ inherited-upstream noise:
     the reboot/link checks, because by default it did not. Locally on the rig:
     `python -m station.test_runner --extended` (or `HIL_EXTENDED=1`), or the touch
     UI's **Extended** toggle beside Run Tests.
+  - ✅ **`workflow_dispatch` is the "give me everything" button: it runs the extended
+    HIL tier AND the perf measurement**, because it satisfies both opt-in conditions
+    at once (they are otherwise INDEPENDENT — `hil-extended` does not trigger perf,
+    and `perf` leaves the HIL suite on the default tier). That is the route to use at
+    a release, and it is safe: `perf-test` has `needs: [build-perf, hil-test]`, so the
+    rig runs the suite first and measures afterwards rather than interleaving two
+    flashes. Measured on run #805 (2026-08-20): ~3 min of rig time for the extended
+    HIL suite plus ~1 min for the perf pass, inside a ~8.5 min wall-clock run (the
+    two cloud builds are most of it). It also sidesteps the two-labels-in-one-call
+    trap below, which would otherwise fire two runs.
 - **`cppcheck`** (`cppcheck.yml`) also **gates**, and is the only reviewer here that
   is not an LLM — CodeRabbit, Sourcery and the on-demand Claude reviewer share
   training data and therefore blind spots, while dataflow analysis fails elsewhere.


### PR DESCRIPTION
## Summary

Comment/docs only — no job, condition or step changed.

The extended HIL tier and the perf measurement are **independent** conditions that happen to share triggers, and nothing in the repo said so. From the two `if:` expressions:

| Route | Extended HIL | Perf measurement |
|---|---|---|
| `workflow_dispatch` | ✅ | ✅ |
| push, `… [hil-extended] [perf]` | ✅ | ✅ |
| PR, both labels | ✅ | ✅ |
| `hil-extended` label / `[hil-extended]` alone | ✅ | ❌ |
| `perf` label / `[perf]` alone | ❌ (default tier) | ✅ |

`build-perf` gates on `workflow_dispatch || perf || [perf]` and knows nothing about `hil-extended`, so each opt-in drives only its own job. **`workflow_dispatch` gets both in one action**, which is the thing you want at a release and the thing neither job's comment block mentioned — it had to be reverse-engineered from the two expressions, which is exactly the kind of question a comment should answer.

Documented in three places, each pointing at the others: the `hil-test` tier block, the `build-perf` trigger list, and the CI section of `CLAUDE.md`. The note also records the ordering guarantee that makes the combination safe — `perf-test` has `needs: [build-perf, hil-test]`, so the rig runs the suite first and measures afterwards rather than interleaving two flashes — and that dispatch needs no label bookkeeping, so it can't trip the documented two-labels-in-one-API-call trap that fires two runs.

⚠️ The commit-marker route only fires where the workflow listens for pushes at all — `PolyKybd` and `PolyKybd/**`. The same marker in a commit pushed to a `claude/**` branch starts nothing.

Timings are **measured**, from run [#805](https://github.com/thpoll83/qmk_firmware/actions/runs/32395193584), not estimated: ~3 min of rig time for the extended suite, ~1 min for the perf pass, inside a ~8.5 min wall-clock run that is mostly the two cloud builds.

## Review history — two corrections, both to this description's original claims

Recording these because the first draft of the note was wrong in the same way twice, and the corrections are the substance of the change:

1. **"Manual dispatch is the *one* route that runs everything"** — false. A push commit carrying both `[hil-extended]` and `[perf]` satisfies both conditions too (CodeRabbit), and checking it turned up a second case: a PR carrying both labels does as well. Fixed in a7d481b5; the table above is the corrected one.
2. **"~8 min of rig time"** — conflated wall clock with rig occupancy. Recomputed from run #805's job timestamps into the ~3 min + ~1 min split above.

Declined, with evidence, in [this comment](https://github.com/thpoll83/qmk_firmware/pull/224#issuecomment-5365974670) and [this one](https://github.com/thpoll83/qmk_firmware/pull/224#issuecomment-5366003547): deferring the YAML detail to CLAUDE.md (the workflow file is what you have open when editing the workflow, and the only one of the two visible from the Actions UI), generalising the measured timings back to a range (that's what produced error 2), and `afterwards` → `afterward` (this file is consistently British — `afterwards` ×4, `behaviour` ×4, `cancelled` ×2, `analyse` ×2, `colour` ×1 on the base branch, so the change would create the inconsistency the rule exists to prevent).

## Version bump label

None — default patch bump. Comments and CLAUDE.md only.

## Testing

- [x] Workflow still parses and the `HIL_EXTENDED` expression still folds to a single line (`yaml.safe_load` + assertion) — the failure mode when editing near that folded scalar.
- [x] Every routing claim checked against the merged `qmk-test.yml` on `PolyKybd`, and the branch restriction against `on.push.branches` — not from memory.
- [x] Green on `e50bc15d`: Build firmware ✅, HIL test ✅, triage ✅, Sourcery ✅, perf jobs correctly skipped.
- [x] LF endings + trailing newline on both files.
- [ ] Compiled / flashed — **n/a**, no firmware sources touched (and neither file is under `lint.yml`'s `keyboards/**` or `format.yml`'s paths).

### Note for a follow-up (not in this PR)

`qmk-test.yml` has no `paths-ignore`, so this comment-only PR has occupied the HIL rig for a full flash-and-test cycle on each of its three pushes, and burned CodeRabbit review slots doing it. `paths-ignore: ['**.md']` would stop docs PRs paying that, while still running the gate whenever the workflow file itself changes. Left alone deliberately — that's a CI policy decision, not a docs edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbRbFYmCjnJfkUjEtR5PZ7