### PR TITLE
ci: skip the build + HIL rig on Markdown-only changes

### DIFF
--- a/.github/workflows/qmk-test.yml
+++ b/.github/workflows/qmk-test.yml
@@ -3,6 +3,25 @@ name: Build and HIL Test
 on:
   push:
     branches: [PolyKybd, "PolyKybd/**"]
+    # A Markdown-only change cannot alter the firmware, so it should not occupy
+    # the HIL rig for a full flash-and-test cycle (the rig runs one job at a
+    # time, so a docs push delays every real build queued behind it).
+    #
+    # ⚠️ `paths-ignore` skips the workflow only when EVERY changed file matches,
+    # so a mixed docs+code PR still runs the gate in full — this can never hide
+    # a code change behind a README edit.
+    #
+    # ⚠️ `**.md` does NOT match this workflow file, so a change to the CI wiring
+    # itself still triggers a run and gets verified. `workflow_dispatch` has no
+    # paths filter at all, so a manual run is unaffected either way.
+    #
+    # ⚠️ If `Build firmware` / `HIL test (split72)` are ever made REQUIRED status
+    # checks in branch protection, remove this: a workflow that never runs never
+    # reports, and the merge button would deadlock on a docs-only PR (a *skipped
+    # job* satisfies a required check; a never-started workflow does not). The
+    # fix in that case is a paths-filter job feeding `if:` conditions instead.
+    paths-ignore:
+      - '**.md'
   pull_request:
     # `labeled` is NOT in GitHub's default set (opened/synchronize/reopened), and
     # without it adding the `perf` label to an open PR fires no run at all — the
@@ -11,6 +30,9 @@ on:
     # 'labeled'`) so the repo's auto-labeler can't re-run the whole expensive
     # pipeline every time it tags a PR by path.
     types: [opened, synchronize, reopened, labeled]
+    # Same reasoning as the push trigger above.
+    paths-ignore:
+      - '**.md'
   # Manual trigger for the opt-in performance measurement below (the normal
   # build + HIL test always run; perf does not). No inputs: the baseline is moved
   # by committing the run's JSON to polykybd-ctnd, not by a workflow switch — the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,6 +302,32 @@ inherited-upstream noise:
     would analyse the whole upstream QMK tree — the same trap as the
     lint-on-upstream-keyboards problem below. The host repo runs CodeQL instead,
     where Python needs no build and the tree is entirely ours.
+- **A Markdown-only change does NOT run the build or the rig — `qmk-test.yml` has
+  `paths-ignore: ['**.md']`** on both its `push` and `pull_request` triggers (added
+  2026-08-21). The rig executes one job at a time, so before this a comment-only PR
+  occupied it for a full flash-and-test cycle per push and delayed every real build
+  queued behind it (#224 burned three rig runs and three review slots that way).
+  Four things follow, and the last is the one that would bite:
+  - **A mixed docs+code PR still runs the gate in full.** `paths-ignore` skips the
+    workflow only when EVERY changed file matches, so nothing can be smuggled in
+    behind a README edit.
+  - **`**.md` does not match `.github/workflows/qmk-test.yml`**, so a change to the
+    CI wiring itself still triggers a run and gets verified.
+  - **`workflow_dispatch` has no paths filter**, so a manual run — including the
+    both-tiers route above — works on any commit regardless.
+  - ⚠️ **A path-filtered `pull_request` trigger applies to `labeled` too**, so
+    adding `hil-extended` or `perf` to a docs-only PR now starts nothing at all.
+    That is the intent (there is no firmware there to measure), but it is a silent
+    no-op rather than an error.
+  - ⚠️ **This only works because neither check is a REQUIRED status check.** A
+    workflow that never runs never reports, so if `Build firmware` / `HIL test
+    (split72)` are ever added to branch protection, a docs-only PR would deadlock
+    the merge button. The fix then is a paths-filter job feeding `if:` conditions —
+    a *skipped job* satisfies a required check, a never-started workflow does not.
+    (Not verifiable from a Claude Code session: no MCP tool reads branch-protection
+    settings. The indirect evidence is that PRs report `mergeable_state: clean`
+    while their checks are still in flight, which would read `blocked` if any check
+    were required.)
 - **`PR Lint keyboards`** (job `lint`, `.github/workflows/lint.yml`) and **`Pull
   Request Labeler`** (job `triage`, `labeler.yml`, `pull_request_target`) are **stock
   upstream QMK** workflows the fork inherited. `lint` runs `qmk lint --strict` on the


### PR DESCRIPTION
## Summary

The rig executes one job at a time, so a comment-only PR occupied it for a full flash-and-test cycle **per push** and delayed every real build queued behind it. #224 was Markdown-only and burned three rig runs and three review slots that way, because `qmk-test.yml` has no paths filter.

This adds `paths-ignore: ['**.md']` to both the `push` and `pull_request` triggers, and records the reasoning in `CLAUDE.md`'s CI section.

Four properties make it safe, documented in comments at the trigger and in `CLAUDE.md`:

- **A mixed docs+code PR still runs the gate in full.** `paths-ignore` skips the workflow only when *every* changed file matches, so nothing can be smuggled in behind a README edit.
- **`**.md` does not match `.github/workflows/qmk-test.yml`**, so a change to the CI wiring itself still triggers a run and gets verified.
- **`workflow_dispatch` has no paths filter**, so a manual run — including the both-tiers (extended HIL + perf) route — works on any commit regardless.
- ⚠️ **A path-filtered `pull_request` trigger applies to `labeled` too**, so adding `hil-extended` or `perf` to a docs-only PR now starts nothing at all. That is the intent (there is no firmware there to measure), but it is a silent no-op rather than an error, so it is written down.

Precedent in-repo: `cppcheck.yml` already scopes itself with path filters.

### ⚠️ One caveat I could not verify

This only works because neither check is a **required status check** — a workflow that never runs never reports. If `Build firmware` / `HIL test (split72)` are ever added to branch protection, a docs-only PR would deadlock the merge button, and the fix would be a paths-filter job feeding `if:` conditions instead (a *skipped job* satisfies a required check; a never-started workflow does not).

I have no way to read branch-protection settings from a Claude Code session — no MCP tool exposes them. The indirect evidence that none are required today is that PRs report `mergeable_state: clean` while their checks are still in flight, which would read `blocked` otherwise. **Worth a glance at the branch-protection page before merging.**

## Version bump label

*(none)* — CI-only change, patch bump is right.

## Testing

- [ ] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`)
- [ ] Flashed and tested on hardware
- [ ] If protocol changed: host updated and tested together

No firmware source is touched, so neither build nor hardware testing applies. What was verified instead:

- `yaml.safe_load` parses the workflow, and both filters land where intended — `push: {'branches': ['PolyKybd', 'PolyKybd/**'], 'paths-ignore': ['**.md']}`, `pull_request: {'types': [...], 'paths-ignore': ['**.md']}`.
- The `HIL_EXTENDED` folded scalar added in #223 is still newline-free after the edit (asserted).
- This PR is itself the first live test of the filter: it changes a `.md` file **and** the workflow, so the gate **should** run in full. A green board here is the mixed-PR case working; a skipped one would mean the workflow-file exemption is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbRbFYmCjnJfkUjEtR5PZ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbRbFYmCjnJfkUjEtR5PZ7)_

## Summary by Sourcery

Avoid consuming the HIL rig for documentation-only changes while documenting the conditions and limitations of the new CI filtering.

Enhancements:
- Skip the firmware build and HIL workflow for Markdown-only pushes and pull requests while preserving runs for mixed documentation/code changes, workflow changes, and manual dispatches.

CI:
- Document the path-filter behavior, label-trigger caveat, and branch-protection implications for the QMK test workflow.

Documentation:
- Document the Markdown-only CI optimization and its operational caveats in the CI guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Documentation-only changes no longer automatically run firmware build and hardware-in-the-loop checks.
  * Changes that include code, workflow updates, or manual dispatches continue to trigger validation.
* **Documentation**
  * Added guidance explaining CI behavior for Markdown-only changes and required-check considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->