### PR TITLE
docs: record the YAML folded-scalar indent trap in the CI section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,8 +302,10 @@ inherited-upstream noise:
     bare key `on:` to the **boolean** `True` (YAML 1.1 truthiness), so `d["on"]` raises
     `KeyError` on every GitHub workflow. `jobs` is an ordinary string key; mixing the two
     up raises `KeyError: 'jobs'`, which is how the first version of this very snippet was
-    wrong. Same check is worth running on the `build` job's `if:`, which uses the same
-    `>-` shape.
+    wrong. **Two other blocks use the same `>-` shape and deserve the same check**:
+    the `build` job's `if:` (the `hil-extended` label exception) and `build-perf`'s
+    (the `perf` opt-in) — a folded `if:` that gains a newline evaluates to a string
+    rather than a boolean, so the job silently stops matching its trigger.
 - **`cppcheck`** (`cppcheck.yml`) also **gates**, and is the only reviewer here that
   is not an LLM — CodeRabbit, Sourcery and the on-demand Claude reviewer share
   training data and therefore blind spots, while dataflow analysis fails elsewhere.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,6 +279,31 @@ inherited-upstream noise:
     interleaving two flashes. Measured on run #805 (2026-08-20): ~3 min of rig time
     for the extended HIL suite plus ~1 min for the perf pass, inside a ~8.5 min
     wall-clock run (the two cloud builds are most of it).
+  - ⚠️ **The opt-in condition is a YAML FOLDED SCALAR (`>-`), and indenting its
+    continuation lines for readability breaks it SILENTLY.** `HIL_EXTENDED` is one
+    `${{ … }}` expression spread over four lines. A folded scalar joins lines with a
+    space **only while they share one indent level**; a line indented *deeper* than the
+    first is treated as more-indented content and keeps its **literal newline**. So the
+    prettier-looking form — first line at the block indent, the `contains(...)` clauses
+    indented under it — embeds newlines inside the expression and the value stops being
+    a valid GitHub expression. Nothing warns: the workflow still parses as YAML, the
+    step still runs, and `HIL_EXTENDED` just comes out wrong, so the run quietly executes
+    the **default** tier while the label says otherwise. Keep every continuation line at
+    the *same* indent as the first (that is why the block looks under-indented), and
+    verify rather than eyeball it:
+    ```python
+    import yaml
+    d = yaml.safe_load(open(".github/workflows/qmk-test.yml").read())
+    v = d["jobs"]["hil-test"]["env"]["HIL_EXTENDED"]
+    assert "\n" not in v, repr(v)
+    print(d[True]["pull_request"])   # the `on:` block — see the d[True] note below
+    ```
+    ⚠️ **Reading the `on:` block needs `d[True]`, not `d["on"]`** — PyYAML resolves the
+    bare key `on:` to the **boolean** `True` (YAML 1.1 truthiness), so `d["on"]` raises
+    `KeyError` on every GitHub workflow. `jobs` is an ordinary string key; mixing the two
+    up raises `KeyError: 'jobs'`, which is how the first version of this very snippet was
+    wrong. Same check is worth running on the `build` job's `if:`, which uses the same
+    `>-` shape.
 - **`cppcheck`** (`cppcheck.yml`) also **gates**, and is the only reviewer here that
   is not an LLM — CodeRabbit, Sourcery and the on-demand Claude reviewer share
   training data and therefore blind spots, while dataflow analysis fails elsewhere.


### PR DESCRIPTION
## Summary

`HIL_EXTENDED` (added in #223) is a `>-` folded scalar holding one `${{ … }}` expression across four lines. A folded scalar joins lines with a space **only while they share one indent level**; a line indented *deeper* than the first keeps its literal newline. So the prettier-looking form — first line at the block indent, the `contains(...)` clauses indented under it — embeds newlines inside the expression and it stops being a valid GitHub expression.

**Nothing warns.** The workflow still parses as YAML, the step still runs, and `HIL_EXTENDED` just comes out wrong — so the run quietly executes the **default** tier while the label says otherwise. That is the same silent-wrong-tier failure the `hil-extended` label exception in #223 exists to prevent, arriving by a different route.

The note records the same-indent rule (which is why that block looks under-indented), and a snippet to verify rather than eyeball it.

It also records a second trap found while writing that snippet: **PyYAML resolves the bare `on:` key to the boolean `True`**, not the string `"on"`, so `d["on"]` raises `KeyError` on every GitHub workflow — while `jobs` is an ordinary string key. My first draft of the snippet mixed the two up and raised `KeyError: 'jobs'`, which is exactly why it is called out rather than left as an exercise.

Docs only — no workflow or firmware behaviour changes.

## Version bump label

*(none)* — documentation-only, patch bump is right.

## Testing

- [ ] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`)
- [ ] Flashed and tested on hardware
- [ ] If protocol changed: host updated and tested together

No firmware source is touched, so neither applies. What was verified instead:

- The snippet in the note was **run against the real workflow file** and passes — `d["jobs"]["hil-test"]["env"]["HIL_EXTENDED"]` is newline-free, and `d[True]["pull_request"]` returns the `on:` block. This is the second draft; the first one raised, which is the point of quoting a snippet that has actually been executed.
- This PR is Markdown-only, so per #225 it should **not** run the build or occupy the HIL rig — a board with `Build firmware` / `HIL test (split72)` absent (not failed) is the `paths-ignore` filter working as intended, and is itself the first live test of the docs-only path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbRbFYmCjnJfkUjEtR5PZ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbRbFYmCjnJfkUjEtR5PZ7)_

## Summary by Sourcery

Document and validate YAML edge cases that can silently alter GitHub Actions workflow behavior.

Enhancements:
- Document the YAML folded-scalar indentation trap that can silently invalidate GitHub Actions expressions and cause incorrect job tiers or triggers.
- Document PyYAML’s boolean resolution of the bare `on:` key and provide a validation snippet for workflow scalar values.

Documentation:
- Add CI guidance for preserving folded-scalar indentation and verifying workflow expressions programmatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for preserving YAML indentation in GitHub Actions expressions.
  * Documented validation steps to prevent unintended default-tier execution.
  * Included a PyYAML example and recommended checking the corresponding build condition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->