### PR TITLE
docs: the FW_VERSION-vs-CI gap, and the silent missing-PR trap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,47 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
 
 - **Give every branch a name that hints at its content** (a short descriptive slug, e.g. `claude/fix-slave-layer-after-fw-apply`, not just the auto-generated `claude/<random-scientist>-<id>`) so the branch list reads as a changelog.
 - **Always start new work on a FRESH branch cut from the updated default branch — never keep committing to a branch whose PR has already merged.** Once a PR is merged, that branch is done: `git fetch origin PolyKybd` then `git checkout -b claude/<new-slug> origin/PolyKybd` for the next change. Cherry-pick only the still-unmerged commits onto the fresh branch if needed. This keeps each PR a clean, focused diff against the current default (**`PolyKybd`** here; `main` in the host/rig repos) and avoids a new PR accidentally re-including already-merged commits.
+- ⚠️ **A cross-repo feature can leave one repo with commits PUSHED and NO PR — and
+  nothing surfaces it.** A PolyKybd feature routinely spans 4–6 repos (firmware,
+  host, docs, rig, AdafruitGFX, hardware), and every "is everything saved?" check
+  passes on the repo you forgot: the branch is committed, pushed, in sync with its
+  upstream, and `git status` is clean. Only the *absence of a PR* is wrong, and no
+  local command looks for that. On 2026-08-22 the legend-size work had four PRs open
+  and reviewed while **AdafruitGFX** sat on two pushed commits with none — one of them
+  the `fontconvert -o` sign fix that the whole `latinbig` relocation depends on. It
+  was found only because the user asked whether anything was left to open.
+  **Sweep every repo before calling cross-repo work done** — `git status` is not the
+  check; commits-ahead-of-default plus "does a PR exist for this branch" is. Run a
+  `git fetch` in each repo first (below), then confirm a PR exists for every repo that
+  prints:
+  ```bash
+  seen=0
+  for e in qmk_firmware:PolyKybd PolyKybdHost:main polykybd-docs:main \
+           polykybd-ctnd:main Adafruit-GFX-Library:master PolyKybd:master; do
+      r=/home/user/${e%%:*}; d=origin/${e##*:}
+      [ -d "$r/.git" ] || continue
+      git -C "$r" fetch origin -q
+      git -C "$r" rev-parse --verify -q "$d" >/dev/null \
+          || { echo "!! $(basename $r): $d missing"; continue; }
+      seen=$((seen+1))
+      n=$(git -C "$r" rev-list --count "$d"..HEAD)
+      [ "$n" != 0 ] && echo "$(basename $r): $n commit(s) ahead of ${d#origin/} — PR?"
+  done
+  [ "$seen" = 6 ] || echo "!! inspected only $seen/6 repos — result is NOT trustworthy"
+  ```
+  ⚠️ **Three ways the obvious version of this loop FAILS OPEN — it prints nothing,
+  which reads identically to "all clean".** All three were hit writing it (2026-08-24):
+  - **`~` is `/root`, not `/home/user`** — `$HOME` is root's in this container, so a
+    `~/qmk_firmware` path matches no repo and the loop skips all six in silence. Use
+    absolute `/home/user/...`, and keep the `seen` counter so a zero-repo sweep is
+    loud rather than reassuring.
+  - **`origin/HEAD` is UNSET in every clone**, so auto-detecting the default via
+    `git symbolic-ref refs/remotes/origin/HEAD` yields nothing and any `|| origin/main`
+    fallback silently reports 0 for the firmware (default `PolyKybd`) and AdafruitGFX
+    (`master`). Hence the explicit `repo:default` table.
+  - **Without the fetch, stale remote refs cry WOLF the other way** — right after a
+    merge, an un-fetched repo still shows the merged branch as ahead of its old
+    `origin/main`. That direction is at least visible; the first two are not.
 
 ## Building & flashing
 
@@ -181,6 +222,21 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
     takes the ambiguity away. Better still, when a change alters something **visible
     on a keycap**, say which pixel tells the builds apart — that is a check the user
     can run without any tooling.
+  - ⚠️ **A branch-built `.bin` reports a DIFFERENT `FW_VERSION` from the one CI and
+    the HIL rig show for the SAME commit — and that is normal, not a stale build.**
+    CI builds the PR *merged into* its base, so it picks up every auto-bump that has
+    landed on `PolyKybd` since the branch was cut; a local `qmk compile` builds the
+    branch alone. On 2026-08-22 the delivered image answered `0.15.7` while the rig
+    logged `Split72 0.15.10 P13` on commit `d8bb98ca` — a 12-commit base drift. It
+    reads exactly like handing over the wrong file, so **settle it by diffing, not by
+    rebuilding**:
+    ```bash
+    git log --oneline HEAD..origin/PolyKybd                    # what the branch lacks
+    git diff --stat HEAD...origin/PolyKybd -- keyboards/polykybd modules/polykybd
+    ```
+    If the only firmware delta is `config.h`'s version string, the `.bin` carries every
+    real change and just names itself older. If it is more than that, the branch is
+    genuinely behind and the test build is missing base fixes — merge before delivering.
 - **Docker is NOT usable** in the remote container (no daemon) — use the native toolchain above, not the qmk docker image.
 - The `firmware-size-diff` skill builds HEAD vs working tree and diffs sizes / `.text`.
 - ⚠️ **In the session container `qmk` is at `/root/.qmk_venv/bin/qmk` and is NOT on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,9 +153,10 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
            polykybd-ctnd:main Adafruit-GFX-Library:master PolyKybd:master; do
       r=/home/user/${e%%:*}; d=origin/${e##*:}
       [ -d "$r/.git" ] || continue
-      git -C "$r" fetch origin -q
+      git -C "$r" fetch origin -q \
+          || { echo "!! $(basename "$r"): fetch failed - NOT inspected"; continue; }
       git -C "$r" rev-parse --verify -q "$d" >/dev/null \
-          || { echo "!! $(basename $r): $d missing"; continue; }
+          || { echo "!! $(basename "$r"): $d missing"; continue; }
       seen=$((seen+1))
       n=$(git -C "$r" rev-list --count "$d"..HEAD)
       [ "$n" != 0 ] && echo "$(basename $r): $n commit(s) ahead of ${d#origin/} — PR?"
@@ -175,6 +176,13 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
   - **Without the fetch, stale remote refs cry WOLF the other way** — right after a
     merge, an un-fetched repo still shows the merged branch as ahead of its old
     `origin/main`. That direction is at least visible; the first two are not.
+    ⚠️ **A FAILED fetch is a fourth mode, and it is the one that reads as inspected.**
+    It cannot fake a clean result — measured, not reasoned: a stale `origin/<default>`
+    is *behind* the true remote, so `$d..HEAD` can only count the same or MORE, never
+    fewer (post-merge it reports 1 where a fresh ref reports 0). But the repo is then
+    compared against unknown-age data while still incrementing `seen`, which is
+    precisely what that counter exists to prevent — hence the `|| continue` on the
+    fetch, so an unreachable repo trips the `seen` guard instead of passing quietly.
 
 ## Building & flashing
 
@@ -231,12 +239,21 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
     reads exactly like handing over the wrong file, so **settle it by diffing, not by
     rebuilding**:
     ```bash
-    git log --oneline HEAD..origin/PolyKybd                    # what the branch lacks
-    git diff --stat HEAD...origin/PolyKybd -- keyboards/polykybd modules/polykybd
+    git log --oneline HEAD..origin/PolyKybd                 # what the branch lacks
+    git diff --name-only HEAD...origin/PolyKybd             # EVERY path, not just ours
+    git diff HEAD...origin/PolyKybd -- keyboards/polykybd/config.h   # only FW_VERSION?
     ```
     If the only firmware delta is `config.h`'s version string, the `.bin` carries every
     real change and just names itself older. If it is more than that, the branch is
     genuinely behind and the test build is missing base fixes — merge before delivering.
+    ⚠️ **Read the CONTENT and the UNRESTRICTED path list — `--stat` scoped to
+    `keyboards/polykybd` proves neither half of that sentence.** `--stat` reports line
+    counts, so `config.h | 2 +-` is equally consistent with a version bump and with a
+    changed `#define` beside it; and the image links `platforms/ quantum/ drivers/
+    lib/ builddefs/` too, which a PolyKybd-scoped diff hides — exactly the paths an
+    upstream catch-up merge moves when it lands on `PolyKybd`. Even then this is a
+    drift check, not proof of binary equivalence: if anything outside `config.h` shows
+    up, rebuild on the merged base rather than reasoning about whether it mattered.
 - **Docker is NOT usable** in the remote container (no daemon) — use the native toolchain above, not the qmk docker image.
 - The `firmware-size-diff` skill builds HEAD vs working tree and diffs sizes / `.text`.
 - ⚠️ **In the session container `qmk` is at `/root/.qmk_venv/bin/qmk` and is NOT on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
            polykybd-ctnd:main Adafruit-GFX-Library:master PolyKybd:master; do
       r=/home/user/${e%%:*}; d=origin/${e##*:}
       [ -d "$r/.git" ] || continue
-      git -C "$r" fetch origin -q \
+      git -C "$r" fetch -q --no-recurse-submodules origin \
           || { echo "!! $(basename "$r"): fetch failed - NOT inspected"; continue; }
       git -C "$r" rev-parse --verify -q "$d" >/dev/null \
           || { echo "!! $(basename "$r"): $d missing"; continue; }
@@ -249,9 +249,12 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
     ⚠️ **Read the CONTENT and the UNRESTRICTED path list — `--stat` scoped to
     `keyboards/polykybd` proves neither half of that sentence.** `--stat` reports line
     counts, so `config.h | 2 +-` is equally consistent with a version bump and with a
-    changed `#define` beside it; and the image links `platforms/ quantum/ drivers/
-    lib/ builddefs/` too, which a PolyKybd-scoped diff hides — exactly the paths an
-    upstream catch-up merge moves when it lands on `PolyKybd`. Even then this is a
+    changed `#define` beside it; and the image links this fork's **patched upstream
+    files** too, which a PolyKybd-scoped diff hides — `keyboards/polykybd/
+    UPSTREAM_PATCHES.md` is the maintained list of them (today `usb_descriptor.h`,
+    `usb_main.c`, `oled_driver.c`, `transport.h`, `rp2040.c`), and a catch-up merge
+    landing on `PolyKybd` is exactly what moves them. Read that file rather than
+    hardcoding the set here — it is the thing that stays current. Even then this is a
     drift check, not proof of binary equivalence: if anything outside `config.h` shows
     up, rebuild on the merged base rather than reasoning about whether it mattered.
 - **Docker is NOT usable** in the remote container (no daemon) — use the native toolchain above, not the qmk docker image.


### PR DESCRIPTION
## Summary

Two CLAUDE.md notes from the keycap-legend-size session (#227), both about things that read as a problem but are not, and one that is a problem nothing surfaces. Docs only — no firmware change.

**1. § Building & flashing — a branch-built `.bin` reports an older `FW_VERSION` than CI and the rig, and that is normal.**
CI builds the PR *merged into* its base, so it picks up every auto-bump landed on `PolyKybd` since the branch was cut; a local `qmk compile` builds the branch alone. On 2026-08-22 the delivered image answered `0.15.7` while the rig logged `Split72 0.15.10 P13` on the same commit `d8bb98ca` — a 12-commit base drift. It reads exactly like handing over the wrong file. The note gives the two `git log`/`git diff` commands that settle it by diffing rather than rebuilding: if the only firmware delta is `config.h`'s version string, the `.bin` carries every real change and just names itself older.

**2. § Branching — a cross-repo feature can leave one repo with commits PUSHED and NO PR, and no local command looks for that.**
Every "is everything saved?" check passes on the repo you forgot: committed, pushed, in sync, `git status` clean. Only the *absence of a PR* is wrong. This session had four PRs open and reviewed while **AdafruitGFX** sat on two pushed commits with none — one of them the `fontconvert -o` sign fix the whole `latinbig` relocation depends on. It was found only because the user asked whether anything was left to open.

The note ships a sweep loop, and — more useful than the loop — **the three ways the obvious version of it fails open**, all three hit while writing it:
- `~` is `/root` in this container, so `~/qmk_firmware` matches no repo and all six are skipped in silence (hence absolute paths + a `seen` counter that makes a zero-repo sweep loud).
- `origin/HEAD` is **unset** in every clone, so auto-detecting the default and falling back to `origin/main` silently reports 0 for this repo (`PolyKybd`) and AdafruitGFX (`master`) — hence the explicit `repo:default` table.
- Without a per-repo `git fetch`, stale remote refs cry wolf in the other direction right after a merge.

The committed loop is the corrected one and was run clean before committing.

## Version bump label

*(none)* — documentation only, patch bump is correct.

## Testing
- [x] Compiled successfully — n/a, no source change (`qmk-test.yml` has `paths-ignore: ['**.md']`, so the build and rig deliberately do not run on this PR)
- [x] Flashed and tested on hardware — n/a
- [x] If protocol changed: host updated and tested together — n/a, no protocol change

Verified: no CRLF, file ends in a newline (`qmk format-text`'s whole remit, and it can't run in this container — no `dos2unix`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NytprmPuKPEwg4r5ckGJDL)_

## Summary by Sourcery

Improve contributor guidance for identifying expected firmware version drift and preventing cross-repository changes from being left without pull requests.

Enhancements:
- Document how to distinguish expected firmware version drift between branch builds and CI or hardware builds by comparing branch and base changes.
- Document a cross-repository sweep for detecting pushed commits that lack pull requests, including safeguards for missing paths, default branches, stale refs, and failed fetches.

Documentation:
- Expand CLAUDE.md with guidance for diagnosing firmware version discrepancies and verifying pull-request coverage across repositories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for verifying completion across all required repositories, including branch status, pull request checks, and missing repository reporting.
  * Documented procedures for investigating firmware version differences between local builds and CI/HIL builds.
  * Added steps for reviewing missing commits and scoped changes before rebuilding or delivering firmware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->