### PR TITLE
fw_staging: stop the DoomPack slot overlapping the EEPROM

### DIFF
--- a/keyboards/polykybd/OVERLAY_FLASH_CACHE_DESIGN.md
+++ b/keyboards/polykybd/OVERLAY_FLASH_CACHE_DESIGN.md
@@ -154,7 +154,15 @@ cache needs a flash home; finding it is the gating design question, not the tran
 | `0x200000–0x400000` | 2 MB | Firmware-update **staging** (4 KB header + staged image) | `FW_STAGING_OFFSET`, `FW_UP_MAX_SIZE 0x1FF000` |
 | `0x400000–0x600000` | 2 MB | **Font pack** — per-bundle slots | `FW_RESOURCE_OFFSET`, `fontpack_layout.h` |
 | `0x600000–0x7C0000` | 1.75 MB | **DOOM WAD** (opt-in, XIP-pinned) | `FW_DOOMWAD_SLOT_OFF/SIZE` |
-| `0x7C0000–0x800000` | 256 KB | **DOOM engine pack** (opt-in) | `FW_DOOMPACK_SLOT_OFF/SIZE` |
+| `0x7C0000–0x7FE000` | 248 KB | **DOOM engine pack** (opt-in) | `FW_DOOMPACK_SLOT_OFF/SIZE` |
+| `0x7FE000–0x800000` | 8 KB | **EEPROM** — wear-levelling backing store, *not available* | `FW_EEPROM_RESERVE_SIZE` / `WEAR_LEVELING_BACKING_SIZE` |
+
+⚠️ **The resource region is 4 MB minus that last 8 KB.** QMK's rp2040_flash
+wear-levelling driver puts the emulated EEPROM at the top of physical flash, so
+any scheme in this document that wants to claim flash must stop at `0x7FE000`,
+not `0x800000` — and note that *raising* the EEPROM size to buy room for
+runtime-configurable features (macros/combos) grows it downward into the pack
+slot, so the two proposals compete for the same bytes.
 
 ### 4.2 Candidate sources of ~1–2 MB (ranked by ease / least risk)
 1. **Shrink the staging window (best first candidate).** Staging is a full **2 MB**

--- a/keyboards/polykybd/base/fw_staging.c
+++ b/keyboards/polykybd/base/fw_staging.c
@@ -22,6 +22,15 @@ _Static_assert(FW_UP_MAX_SIZE <= FW_STAGING_OFFSET,
 _Static_assert(FW_STAGING_DATA_OFFSET + FW_UP_MAX_SIZE <= FW_RESOURCE_OFFSET,
                "staging area overruns the resource region (FLASH_TARGET_OFFSET)");
 
+// The wear-levelling EEPROM sits at the TOP of flash, inside what the map above
+// calls the resource region, so the last resource slot has to stop short of it.
+// Two guards, because the reservation is expressed twice and they must agree:
+_Static_assert(FW_EEPROM_RESERVE_SIZE == WEAR_LEVELING_BACKING_SIZE,
+               "fw_staging.h EEPROM reservation disagrees with WEAR_LEVELING_BACKING_SIZE");
+_Static_assert(FW_RESOURCE_OFFSET + FW_DOOMPACK_SLOT_OFF + FW_DOOMPACK_SLOT_SIZE
+                   <= PICO_FLASH_SIZE_BYTES - WEAR_LEVELING_BACKING_SIZE,
+               "DoomPack slot overlaps the EEPROM backing store at the top of flash");
+
 // ---------------------------------------------------------------------------
 // Dual-core flash safety: halt core1 via PSM reset before any flash_range_*
 // call to prevent a CPU LOCKUP on core1.

--- a/keyboards/polykybd/base/fw_staging.h
+++ b/keyboards/polykybd/base/fw_staging.h
@@ -10,7 +10,15 @@
 //
 //   0x000000 .. 0x200000   running firmware         (linker flash1 XIP = 2 MB)
 //   0x200000 .. 0x400000   firmware-update staging  (4 KB header + staged image)
-//   0x400000 .. 0x800000   resource / overlay data  (FW_RESOURCE_OFFSET)
+//   0x400000 .. 0x7FE000   resource / overlay data  (FW_RESOURCE_OFFSET)
+//   0x7FE000 .. 0x800000   EEPROM  (wear-levelling backing store, NOT ours)
+//
+// ⚠️ That last row is the one nothing used to declare. QMK's rp2040_flash
+// wear-levelling driver puts the emulated EEPROM at the TOP of physical flash
+// (PICO_FLASH_SIZE_BYTES - WEAR_LEVELING_BACKING_SIZE), which lands INSIDE the
+// resource region — so the resource region is 4 MB minus that reservation, not
+// a clean 4 MB. Everything a user configures lives there: the dynamic keymap,
+// brightness, language, idle style, glyph script, the Intl assignment map.
 //
 // FW_STAGING_OFFSET is kept equal to the linker's flash1 length (2 MB — see
 // RP2040_FLASH.ld, FLASH_LEN default 2048k) so the firmware can NEVER grow into
@@ -93,18 +101,34 @@ typedef enum {
     FW_TARGET_DOOMPACK = 3,
 } fw_target_t;
 
+// Bytes at the top of flash that belong to the wear-levelling EEPROM, NOT to us.
+// Must equal WEAR_LEVELING_BACKING_SIZE (pinned in keyboards/polykybd/config.h);
+// fw_staging.c _Static_asserts the two against each other. Defined here as a
+// literal rather than referencing that macro so this header stays self-contained
+// for the host-side unit tests, which include it without QMK's config.h.
+#define FW_EEPROM_RESERVE_SIZE 0x002000UL      // 8 KB
+
 // The doom slots, expressed like fontpack slots (offsets relative to
 // FW_RESOURCE_OFFSET). The upper 2 MB of the resource region is split:
 //   flash 0x600000..0x7BFFFF (1.75 MB)  WHX game data — matches the engine's
 //                                       XIP TINY_WAD_ADDR 0x10600000; the
 //                                       current doom1.whx (1,800,344 B) fits
 //                                       with ~35 KB headroom.
-//   flash 0x7C0000..0x7FFFFF (256 KB)   DoomPack (PlyX header + engine image,
-//                                       ~230 KB measured) — XIP 0x107C0000.
+//   flash 0x7C0000..0x7FDFFF (248 KB)   DoomPack (PlyX header + engine image,
+//                                       211,384 B measured) — XIP 0x107C0000.
+//   flash 0x7FE000..0x7FFFFF ( 8 KB)    EEPROM — see FW_EEPROM_RESERVE_SIZE.
+//
+// ⚠️ The DoomPack slot STOPS SHORT of the end of flash, and that is load-bearing.
+// It used to be declared as the full 256 KB to 0x800000, which overlapped the
+// EEPROM backing store exactly. Nothing caught it because the pack is 211 KB and
+// only the sectors an image actually needs are erased — but fw_staging_finalize()
+// accepts any image up to slot_size - 64, so a pack that grew into its own
+// declared slot would have erased the user's keymap and settings as a side
+// effect, with no diagnostic. Deriving the size keeps the two provably disjoint.
 #define FW_DOOMWAD_SLOT_OFF   0x200000UL
 #define FW_DOOMWAD_SLOT_SIZE  0x1C0000UL
 #define FW_DOOMPACK_SLOT_OFF  0x3C0000UL
-#define FW_DOOMPACK_SLOT_SIZE 0x040000UL
+#define FW_DOOMPACK_SLOT_SIZE (0x040000UL - FW_EEPROM_RESERVE_SIZE)   // 248 KB
 
 // On-wire pseudo bundle ids (CMD_FONTPACK_BEGIN data[10]) selecting the
 // DOOMWAD / DOOMPACK targets — the doom installs ride the font-pack HID flow.

--- a/keyboards/polykybd/config.h
+++ b/keyboards/polykybd/config.h
@@ -357,6 +357,16 @@
 
 #define PICO_FLASH_SIZE_BYTES (8 * 1024 * 1024)
 
+// ⚠️ The wear-levelling EEPROM backing store lives at the TOP of physical flash:
+// the rp2040_flash driver places it at PICO_FLASH_SIZE_BYTES - WEAR_LEVELING_BACKING_SIZE
+// (0x7FE000..0x800000 here), i.e. INSIDE our resource region — see the flash map in
+// base/fw_staging.h, where FW_DOOMPACK_SLOT_SIZE subtracts it. It is pinned here
+// rather than inherited from the driver default so that (a) the reservation is
+// visible beside the flash size it is carved out of, and (b) changing it is a
+// deliberate act that the _Static_assert in fw_staging.c re-checks against the
+// DoomPack slot. Raising it grows the store DOWNWARD into that slot.
+#define WEAR_LEVELING_BACKING_SIZE 8192
+
 #define OLED_FONT_START	32
 #define OLED_FONT_END	126
 #define OLED_FONT_H "base/fonts/base_font.h"

--- a/keyboards/polykybd/doom/PACK_DESIGN.md
+++ b/keyboards/polykybd/doom/PACK_DESIGN.md
@@ -18,22 +18,35 @@ same engine objects re-linked at the pack address. Measured results:
 | monolithic doom (`POLYKYBD_DOOM=yes`) | 603,972 B | — |
 | **pack-flavour firmware** (`POLYKYBD_DOOM_PACK=yes`) | **398,580 B** | **−205 KB** |
 | normal (no doom) | 384,460 B | −219 KB |
-| `doom_pack_v2.plyx` (engine pack, flashed once) | 211,384 B | fits the 256 KB slot with ~50 KB headroom; engine statics 24,396 B at the pool front |
+| `doom_pack_v2.plyx` (engine pack, flashed once) | 211,384 B | fits the 248 KB slot with ~41 KB headroom; engine statics 24,396 B at the pool front |
 
 ## 1. Flash map carve-out
 
 The upper 2 MB of the resource region (`FW_RESOURCE_OFFSET` 0x400000)
 currently belongs entirely to the WHX (`FW_DOOMWAD_SLOT_*`). The pack takes
-the top 256 KB:
+the top 248 KB — **not** the top 256 KB: the last 8 KB of flash is the
+wear-levelling EEPROM (see the ⚠️ below the table).
 
 | flash offset | XIP address | size | contents |
 |---|---|---|---|
 | 0x600000 | 0x10600000 | **1.75 MB** (was 2 MB) | `doom1.whx` (`IWHX`) — engine `TINY_WAD_ADDR`; current WHX is 1,800,344 B → ~35 KB headroom |
-| 0x7C0000 | 0x107C0000 | **256 KB** | **DoomPack** (`PlyX` header + engine image); measured need ~230 KB → ~26 KB headroom |
+| 0x7C0000 | 0x107C0000 | **248 KB** | **DoomPack** (`PlyX` header + engine image); measured 211,384 B → ~41 KB headroom |
+| 0x7FE000 | 0x107FE000 | **8 KB** | **EEPROM** — wear-levelling backing store, *not* ours (`FW_EEPROM_RESERVE_SIZE`) |
+
+⚠️ **The pack slot stops at 0x7FE000 because QMK's rp2040_flash wear-levelling
+driver places the emulated EEPROM at the top of physical flash**
+(`PICO_FLASH_SIZE_BYTES - WEAR_LEVELING_BACKING_SIZE`), which lands inside our
+resource region. Until 2026-08 the slot was declared as the full 256 KB and the
+two overlapped exactly. It never bit in practice — only the sectors an image
+needs are erased, and the pack is 211 KB — but `fw_staging_finalize()` accepts an
+image up to `slot_size - 64`, so a pack that grew into its own declared slot
+would have erased the keymap, brightness, language, idle style and Intl map with
+no diagnostic. `FW_DOOMPACK_SLOT_SIZE` is now derived from the reservation and
+`_Static_assert`ed against it in `fw_staging.c`.
 
 Constants in `base/fw_staging.h`: `FW_DOOMWAD_SLOT_SIZE` shrinks
 0x200000 → 0x1C0000; new `FW_DOOMPACK_SLOT_OFF 0x3C0000` /
-`FW_DOOMPACK_SLOT_SIZE 0x40000`; new pseudo-bundle id
+`FW_DOOMPACK_SLOT_SIZE (0x40000 - FW_EEPROM_RESERVE_SIZE)`; new pseudo-bundle id
 `FONTPACK_BUNDLE_DOOMPACK 0x7E` (the WHX uses 0x7F). Static-asserted
 non-overlapping.
 

--- a/keyboards/polykybd/doom/PACK_DESIGN.md
+++ b/keyboards/polykybd/doom/PACK_DESIGN.md
@@ -22,9 +22,9 @@ same engine objects re-linked at the pack address. Measured results:
 
 ## 1. Flash map carve-out
 
-The upper 2 MB of the resource region (`FW_RESOURCE_OFFSET` 0x400000)
-currently belongs entirely to the WHX (`FW_DOOMWAD_SLOT_*`). The pack takes
-the top 248 KB — **not** the top 256 KB: the last 8 KB of flash is the
+The upper 2 MB of the resource region (`FW_RESOURCE_OFFSET` 0x400000) is the
+Doom allocation: the WHX (`FW_DOOMWAD_SLOT_*`) holds the lower 1.75 MB and the
+pack takes the top 248 KB — **not** the top 256 KB: the last 8 KB of flash is the
 wear-levelling EEPROM (see the ⚠️ below the table).
 
 | flash offset | XIP address | size | contents |

--- a/keyboards/polykybd/doom/pack/build_pack.sh
+++ b/keyboards/polykybd/doom/pack/build_pack.sh
@@ -130,7 +130,18 @@ ARCH="-mcpu=cortex-m0plus -mthumb -Os -ffunction-sections -fdata-sections"
     -I"$REPO/keyboards/polykybd/doom" \
     -c "$PACK_DIR/pack_init.c" -o "$STASH/obj/pack_init.o"
 
-sed -e "s/@RAM_BASE@/$RAM_BASE/" -e "s/@RAM_SIZE@/$RAM_SIZE/" \
+# Pack slot size is DERIVED from the firmware header, never hardcoded: the slot is
+# the top 256 KB of flash MINUS the wear-levelling EEPROM reservation that sits above
+# it (FW_EEPROM_RESERVE_SIZE — the emulated EEPROM lives at the top of physical
+# flash). Hardcoding 0x40000 is how a pack the firmware would refuse — or worse, one
+# that reaches the EEPROM and erases the user's keymap — gets built.
+EEPROM_RESERVE=$(sed -n 's/^#define FW_EEPROM_RESERVE_SIZE[[:space:]]*\(0x[0-9A-Fa-f]*\)UL.*/\1/p' \
+                 "$REPO/keyboards/polykybd/base/fw_staging.h")
+[[ -n "$EEPROM_RESERVE" ]] || { echo "build_pack: cannot read FW_EEPROM_RESERVE_SIZE from fw_staging.h" >&2; exit 1; }
+PACK_LEN=$(( 0x40000 - EEPROM_RESERVE ))
+printf '   pack slot %d B (0x%X) after the %d B EEPROM reservation\n' "$PACK_LEN" "$PACK_LEN" "$((EEPROM_RESERVE))"
+
+sed -e "s/@RAM_BASE@/$RAM_BASE/" -e "s/@RAM_SIZE@/$RAM_SIZE/" -e "s/@PACK_LEN@/$PACK_LEN/" \
     "$PACK_DIR/pack.ld.in" > "$STASH/pack.ld"
 
 "$CC" $ARCH -nostartfiles \
@@ -153,7 +164,7 @@ python3 "$PACK_DIR/mkpack.py" \
 
 echo "== 5/5 budget check =="
 IMG=$(wc -c < "$STASH/doom_pack_image.bin")
-SLOT=$((0x40000 - 64))
+SLOT=$(( PACK_LEN - 64 ))   # PACK_LEN derived above; 64 = PlyX header
 [[ "$IMG" -le "$SLOT" ]] || { echo "build_pack: image $IMG B overflows the ${SLOT} B slot" >&2; exit 1; }
 STATICS=$(( 0x$("$NM" "$STASH/doom_pack.elf" | awk '$3=="__pack_statics_end__"{print $1}') - RAM_BASE ))
 echo "   image $IMG / $SLOT B, engine statics $STATICS B of $RAM_SIZE pool"

--- a/keyboards/polykybd/doom/pack/pack.ld.in
+++ b/keyboards/polykybd/doom/pack/pack.ld.in
@@ -15,7 +15,7 @@ ENTRY(doom_pack_init)
 
 MEMORY
 {
-    PACKF (rx)  : ORIGIN = 0x107C0000 + 64, LENGTH = 0x40000 - 64
+    PACKF (rx)  : ORIGIN = 0x107C0000 + 64, LENGTH = @PACK_LEN@ - 64
     PACKR (rwx) : ORIGIN = @RAM_BASE@,      LENGTH = @RAM_SIZE@
 }
 

--- a/keyboards/polykybd/split_fw_up.c
+++ b/keyboards/polykybd/split_fw_up.c
@@ -128,7 +128,7 @@ static void flash_stage_begin(uint8_t in_len, const void* in_data, uint8_t out_l
             // The doom WHX slot is fixed (upper resource region).
             fw_staging_set_fontpack_slot(FW_DOOMWAD_SLOT_OFF, FW_DOOMWAD_SLOT_SIZE);
         } else if (msg->target == FW_TARGET_DOOMPACK) {
-            // The executable engine pack slot is fixed (top 256 KB —
+            // The executable engine pack slot is fixed (top 248 KB, below the EEPROM —
             // doom/PACK_DESIGN.md; the slave's drone runs the same pack).
             fw_staging_set_fontpack_slot(FW_DOOMPACK_SLOT_OFF, FW_DOOMPACK_SLOT_SIZE);
         }


### PR DESCRIPTION
## Summary

The DoomPack slot was declared as `0x7C0000..0x800000` (256 KB), but the QMK
`rp2040_flash` wear-levelling driver places its EEPROM backing store at
`PICO_FLASH_SIZE_BYTES - WEAR_LEVELING_BACKING_SIZE`, i.e. `0x7FE000..0x800000`.
The two overlap by exactly 8192 bytes.

Nothing has hit it yet — the current `.plyx` is 211,320 B — but
`fw_staging_finalize()` accepts a pack up to `slot_size - 64` (262,080 B), so a
pack over 248 KB would have erased the user's keymap, brightness, language, idle
style and Intl remap map with no diagnostic of any kind.

Changes:

- `config.h` pins `WEAR_LEVELING_BACKING_SIZE 8192` beside the flash size it is
  carved out of, rather than inheriting the driver default silently.
- `base/fw_staging.h` subtracts a named `FW_EEPROM_RESERVE_SIZE` from
  `FW_DOOMPACK_SLOT_SIZE` (256 KB → 248 KB) and documents the EEPROM row in the
  flash map.
- `base/fw_staging.c` adds two `_Static_assert`s: the reservation must agree with
  `WEAR_LEVELING_BACKING_SIZE`, and the slot must end at or below the store. Both
  were verified to fire against a deliberately-broken value.
- `doom/pack/build_pack.sh` + `pack.ld.in` derive the pack length from
  `FW_EEPROM_RESERVE_SIZE` instead of a hardcoded `0x40000`, so the linker script
  and the budget check cannot drift from the header.
- `split_fw_up.c` comment and the two design docs updated to match.

Four stale mirrors of the 256 KB figure existed beyond the two obvious ones; all
are now derived or corrected.

### The EEPROM does not move

Worth stating explicitly, since "pin a value that was previously a default" is
the shape of change that silently relocates a store and resets everyone's
settings. It does not here: the `rp2040_flash` driver's own default is **8192**
(`platforms/chibios/drivers/wear_leveling/wear_leveling_rp2040_flash_config.h`),
which is exactly the value pinned, so `WEAR_LEVELING_RP2040_FLASH_BASE` is
unchanged and existing EEPROM contents are read back from the same address.

## Version bump label

*(none)* — bug fix, patch bump. No protocol change, no wire-format change.

## Testing

- [x] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`)
- [x] Also `split72 -e POLYKYBD_DOOM_PACK=yes` and `split42`
- [x] `make test:fw_up_verdict` — 27/27
- [x] `qmk lint --strict` both boards, `ci-validate-keyboard-targets`, `ci-validate-aliases`
- [x] cppcheck (CI's exact invocation) exit 0
- [x] `doom/pack/build_pack.sh` — reports `pack slot 253952 B (0x3E000) after the 8192 B EEPROM reservation`, image 211,320 / 253,888 B
- [x] **Flashed and tested on hardware** — `.bin` + paired `doom_pack_v3.plyx` built from `928fa501`, flashed, working
- [ ] If protocol changed: host updated and tested together — n/a

Note the change is almost entirely a *ceiling*: a smaller `FW_DOOMPACK_SLOT_SIZE`
constant plus two compile-time asserts. The only runtime behaviour it can alter is
refusing a pack between 248 KB and 256 KB, and no such pack exists today, so no
reachable code path behaves differently.

Paired with a host-side change (thpoll83/PolyKybdHost#193) capping `DOOMPACK_MAX_SIZE`
at the same 248 KB, and a docs change (thpoll83/polykybd-docs#64) showing the EEPROM
in the public flash map.