### PR TITLE
Record three learnings from the function-layer and release work

### DIFF
--- a/.claude/skills/polykybd-github-release/SKILL.md
+++ b/.claude/skills/polykybd-github-release/SKILL.md
@@ -47,6 +47,18 @@ exactly as `polykybd-release-notes` does:
 State the resolved range back before drafting (e.g. "Last firmware release is
 0.9.23, tree is 0.9.42 — release notes for 0.9.24 → 0.9.42").
 
+⚠️ **Check the clone is not SHALLOW before you trust the range** — the container's
+clones are, and `git log <tag>..origin/<default>` then walks truncated history and
+returns a **plausible-looking but wrong** set with no error. Asked for 0.15.2→0.15.14 it
+returned commits from the **0.9.54** era, bump-commit boundaries and all (2026-08-26).
+The tag itself resolves fine, so "the tag exists" proves nothing.
+
+```bash
+git rev-parse --is-shallow-repository                  # true => the range below is a lie
+git fetch origin --unshallow --no-recurse-submodules   # ~45 s
+git fetch origin 'refs/tags/*:refs/tags/*'             # host clones may lack the tag
+```
+
 Gather the commits per version with the `polykybd-release-notes` mechanics (bump
 commits are the boundaries: `chore: bump firmware version to X.Y.Z [skip ci]` /
 `chore: bump host version to X.Y.Z [skip ci]`; pull commit bodies + the relevant

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,6 +292,16 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
   (see above), so a plain fetch spews `Could not access submodule 'lib/chibios'`
   and buries the real result. Once unshallowed, the merge base resolved to
   exactly the fork's own `master` — which is the sanity check that it worked.
+  - ⚠️ **It breaks a RELEASE RANGE the same way, and that one reads as plausible
+    history rather than as nonsense.** `git log <tag>..origin/PolyKybd` on a shallow
+    clone walks truncated history and returns a wrong set **with no error** — asked
+    for 0.15.2→0.15.14 it returned commits from the **0.9.54** era, complete with
+    believable bump-commit boundaries (2026-08-26). The 29,576-commit case above at
+    least screams; this one would simply have shipped release notes describing the
+    wrong versions. So the `--is-shallow-repository` check belongs in front of ANY
+    tag-anchored history question, not just merge-base reasoning — and note the tag
+    itself resolves fine (`git rev-parse <tag>` succeeds), so a tag-exists check
+    proves nothing. Unshallowing took **45 s** here; the count went 84 commits.
 - ⚠️ **When an upstream merge breaks the build, look at the vendored DOOM engine
   FIRST — a new upstream warning lands there, not on our own sources.** QMK builds
   with `-Werror`, so *any* warning upstream adds to `builddefs/common_rules.mk`
@@ -691,6 +701,67 @@ The host software (`PolyKybdHost/`) communicates with this firmware over a custo
 | `state.c` | `poly_sync_t` / `poly_layer_t` — shared state structs with CRC32, persisted via EEPROM |
 | `multicore_exec.c` | Offloads RLE decompression to RP2040 core1 via FIFO, keeping QMK's core0 responsive |
 | `lang/lang_lut.c` | 81-language lookup table (code-generated from `lang_lut.xlsx` via cog) |
+
+### ⚠️ The dynamic keymap is indexed BY LAYER NUMBER, and QMK does not version it
+
+Remove or reorder a layer and every stored layer above it silently changes meaning.
+There is no magic, no format byte, no size check in `dynamic_keymap` — the EEPROM block
+is just `layer * MATRIX_ROWS * MATRIX_COLS * 2` bytes, so dropping `_FL1` slid `_NL`
+7→6, `_UL` 8→7 and `_SL` 9→8, and a board would have come up **running the old `_FL1`
+data as its numpad layer**. No error, no log line, just wrong keys on three layers.
+
+`poly_eeconf_t.keymap_layers_fmt` is the gate: `keyboard_post_init_user` compares it to
+`KEYMAP_LAYERS_FL_MERGED` and, on a mismatch, runs `dynamic_keymap_reset_poly()` and
+stamps it. **Bump that constant whenever a layer is added, removed or reordered — never
+when a layer's CONTENTS change**, which needs no reset. Zero means "written by an older
+build", which is also what a fresh EEPROM reads (QMK's wear levelling normalises cleared
+bytes to zero — the fact that made `latin_assign` read as "every key hosts 'a'"), and
+both want the reset. The stamp is written straight through rather than via the
+suspend-only dirty-flag path, so a power cut cannot cost the user a *second* reset.
+
+⚠️ **Two hand-kept numbers move with the enum, and both are now asserted rather than
+remembered** (`state.h`): `DYNAMIC_KEYMAP_LAYER_COUNT` must cover every compiled layer,
+and the write cap **IS** the first flash-served layer, so `_SL == DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT`.
+A stale cap does not error — it just tells the host it may write to a layer
+`poly_keycode_at()` serves from flash. Mutation-checked: setting the cap back to 9 fails
+the build with the assert's own message.
+
+⚠️ **Every mutation goes through a `*_poly` wrapper in `split_sync.c`** —
+`dynamic_keymap_set_buffer_poly`, `dynamic_keymap_set_keycode_poly`, and
+`dynamic_keymap_reset_poly()` (added purely so the reset has one too). That is
+deliberate: the alternative was a list of call sites to remember to invalidate the F-row
+cache at, which is the guard shape this repo keeps getting caught by (`sync_is_link_fault()`,
+the CI suite names, the log-source registry). The invariant is "all keymap mutation goes
+through a `_poly` function", not "these four places also call the invalidator".
+
+### `poly_keycode_at()` is the ONE resolver for both the render and the key-event path
+
+`display_keycode_at()` (legend) and `keymap_key_to_keycode()` (action) both bottom out
+there, so anything derived inside it **cannot** make a keycap show one thing and type
+another. That makes it the correct — and only correct — seam for a runtime keycode
+derivation. The F-row alignment (`fl_aligned_keycode`, split72's `POLY_FL_ALIGN_FROW`)
+lives there for exactly that reason.
+
+Both callers feed it the **synced** `def_layer` from `get_local_layer()`, not live state
+for one and synced for the other. ⚠️ This is the OPPOSITE of the glyph-size key's
+deliberate asymmetry, and the difference is what changes at human speed: *modifiers*
+change within a single keypress so the action must follow the finger, while `def_layer`
+only moves on a deliberate layout switch — so the one-housekeeping-pass lag is
+irrelevant and two sources could render F6 on a keycap that types F7.
+
+⚠️ **The host layout editor CANNOT see anything derived there — it reads through
+`dynamic_keymap_get_buffer()` (`hid_com.c`), straight out of EEPROM.** So a derivation
+on a host-remappable layer would show one keycode in the editor while the board typed
+another, with nothing on screen to explain it. That constraint, not taste, is why the
+F-row alignment is **all-or-nothing and self-disabling**: it applies only while all 14
+slots still hold exactly what was compiled, and any edit hands the whole row back to the
+stored values. Two options were rejected — deriving unconditionally (fights the editor)
+and moving `_FL` above the write cap (costs remappability entirely). Any future runtime
+derivation on a remappable layer faces the same three-way choice.
+
+⚠️ **The derivation is cached** (`fl_row_is_pristine`, 14 dynamic-keymap reads) because
+`poly_keycode_at()` runs per keycap per render, not just per keypress. See the `_poly`
+wrapper invariant above for how it is invalidated.
 
 ### Keyboard variants & the shared keymap (`poly_keymap.c`)
 


### PR DESCRIPTION
## Summary

Documentation only — `CLAUDE.md` plus one skill. Three things from #230 and the v0.15.14 release that cost real time and were written down nowhere.

### 1. The dynamic keymap is indexed by layer number, and QMK does not version it

There is no magic, no format byte, no size check in `dynamic_keymap` — the EEPROM block is just `layer * MATRIX_ROWS * MATRIX_COLS * 2` bytes. Removing `_FL1` slid `_NL` 7→6, `_UL` 8→7 and `_SL` 9→8, so a board would have come up **running the old `_FL1` data as its numpad layer**: no error, no log line, wrong keys on three layers.

Records the `keymap_layers_fmt` gate and **when to bump it** — layer added, removed or reordered; *never* for a layer's contents, which needs no reset. Plus two supporting facts: the counts (`DYNAMIC_KEYMAP_LAYER_COUNT`, and the write cap which **is** `_SL`) are now `static_assert`ed against the enum instead of hand-kept, and every mutation goes through a `*_poly` wrapper — including `dynamic_keymap_reset_poly()`, added purely so the invariant reads *"all keymap mutation goes through a `_poly` function"* rather than *"these four places also call the invalidator"*. That list shape is the one this repo keeps getting caught by (`sync_is_link_fault()`, the CI suite names, the log-source registry).

### 2. `poly_keycode_at()` is the one resolver for both the render and the key-event path

Which makes it the only correct seam for a runtime keycode derivation — a keycap physically cannot show one thing and type another if the derivation lives there.

Two things worth having written down:

- **Both callers read the *synced* `def_layer`.** That's the opposite of the glyph-size key's deliberate live-vs-synced split, and the note says why the precedent doesn't transfer: modifiers change *within* a keypress so the action must follow the finger, while `def_layer` moves only on a deliberate layout switch.
- **The layout editor reads through `dynamic_keymap_get_buffer()` and cannot see a runtime derivation at all.** That constraint — not taste — is what makes the F-row alignment all-or-nothing and self-disabling. On a remappable layer the options are: derive unconditionally (fights the editor), drop remappability, or switch off on edit. The next such derivation faces the same three, so the reasoning is recorded rather than re-derived.

### 3. Shallow clones break a release range, not just `merge-base`

`CLAUDE.md` already warns that a shallow clone makes `merge-base` return an empty string. It did **not** say that `git log <tag>..origin/PolyKybd` returns *plausible-but-wrong* history: asked for 0.15.2→0.15.14 it returned **0.9.54-era commits**, complete with believable bump-commit boundaries, and no error at all.

The documented case at least screams (29,576 commits). This one would simply have shipped release notes for the wrong versions. And the tag itself resolves fine, so a tag-exists check proves nothing.

The guard is added to the **`polykybd-github-release` skill** as well as `CLAUDE.md`, since that's where it will actually fire. Unshallowing took 45 s; the real range was 84 commits.

## Version bump label

*(none)* — patch. Documentation and one skill file; no code, no build output, no protocol change.

## Testing
- [x] Compiled successfully — n/a, no source touched (Markdown only, so `qmk-test.yml`'s `paths-ignore: ['**.md']` skips the build and the rig by design)
- [x] Flashed and tested on hardware — n/a
- [x] If protocol changed: n/a

Checked: no CRLF, trailing newline present, and each added note greps back by name.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NytprmPuKPEwg4r5ckGJDL)_

## Summary by Sourcery

Record keymap compatibility, runtime keycode resolution, and shallow-clone release-history lessons in project and release-skill documentation.

Enhancements:
- Document dynamic keymap layer-number compatibility requirements, version-gate bump rules, enum-derived assertions, and the invariant that all keymap mutations use invalidating wrappers.
- Document `poly_keycode_at()` as the shared runtime keycode resolver, including synchronized layer-state handling, layout-editor limitations, and self-disabling behavior for remappable layers.
- Document shallow-clone hazards for tag-based release ranges and add a repository-depth check to the GitHub release workflow guidance.

Documentation:
- Add repository guidance covering dynamic keymap persistence, runtime keycode derivation, and reliable release-history collection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for accurately determining release commit ranges in shallow clones.
  * Documented keymap layer indexing, EEPROM format and reset behavior, layer-count safeguards, mutation wrappers, shared keycode resolution, host-editor limitations, and cached F-row handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->