### PR TITLE
Report the remappable layers and their names over HID (cmd 35, protocol v14)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -901,9 +901,22 @@ keycode; `process_record_user()` calls it last, before `display_wakeup()`.
   setting that silently renders small. The two HIL tests assert opposite things about
   their neighbouring commands on purpose (`test_glyph_size_round_trip` /
   `test_glyph_script_expansion`). See "Keycap legend size" below.
+  **v14** adds `GET_LAYER_NAMES` (cmd `35` / `0x23`): a read-only reply of
+  `[total][count]` followed by `count` NUL-terminated ASCII names of at most 8 chars,
+  split across as many reports as they need (54 bytes / one report today). `total` is
+  the whole payload length, that byte included.
+  The count is deliberately the SAME `DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT` that
+  `id_dynamic_keymap_get_layer_count` already answers with — the host editor sizes
+  its tab strip from that command and labels the tabs from this one, so two counts
+  could let it draw a tab it has no name for. See "Layer names over the wire" below.
   **Bump `FW_VERSION` +
   `PROTOCOL_VERSION` (config.h) and `__protocol__` (PolyKybdHost `_version.py`) in
-  lockstep** — the host connect gate is exact-match.
+  lockstep.** ⚠️ The old note here said "the host connect gate is exact-match"; it is
+  not, and has not been for a while — the host connects to any protocol `>=
+  MIN_SUPPORTED_PROTOCOL` and gates each feature separately through
+  `FEATURE_MIN_PROTOCOL` (see `PolyKybdHost/CLAUDE.md`). So forgetting the bump no
+  longer rejects the keyboard; it silently leaves the new feature disabled, which is
+  quieter and worse.
 - **Cmd `32` = main-loop profiler control — present ONLY in a
   `POLYKYBD_LOOP_PROFILE` build, and bumps NO `PROTOCOL_VERSION`** (dispatched
   independently like cmd 31 / the fontpack commands). Sub-commands `0` RESET / `1`
@@ -1738,6 +1751,66 @@ GLYPH_IBMVGA=6, GLYPH_C64=7, GLYPH_AMIGA=8, GLYPH_APL=9, GLYPH_BRAILLE=10`.
   settings dialog; `polyctl glyph-script [standard|tengwar|runes|…|braille]`. Rig:
   `test_glyph_script_round_trip` (`min_protocol: 9`) + `test_glyph_script_expansion`
   (`min_protocol: 10`, walks values 2/6/10 + out-of-range NACK).
+
+### Layer names over the wire (`layer_names.c`, HID cmd 35, protocol v14+)
+
+The host layout editor labels its layer tabs. It used to read those labels from
+`PolyKybdHost/polyhost/res/layer_names.yaml`, a build-time artifact generated from
+this repo's `layers.h` — and that generator's default source path had been dead
+through **two** renames, so nothing regenerated it and nothing failed. The committed
+file still listed 14 layers ending `EMJ0`/`EMJ1`, a split this firmware had not had
+in a very long time (found 2026-08-26). The editor was mislabelling tabs against an
+enum that no longer existed.
+
+**A name the keyboard states itself cannot drift from the keyboard**, which is the
+whole point of cmd 35. Three things are worth knowing:
+
+- ⚠️ **The count is NOT a second opinion.** It is the same
+  `DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT` that cmd 17 already reports, echoed back so
+  the reply parses standalone. Do not "improve" it to
+  `DYNAMIC_KEYMAP_LAYER_COUNT` (12): layers at or above the write cap are served from
+  flash and have no editor tab to label, so naming them would invite the editor to
+  draw tabs it cannot write to.
+- **All three name widths live in ONE record** (`layer_names.c`). split72's status
+  OLED wants the full name, split42's 32 px panel wants ≤5 chars, and the wire wants
+  ≤8 — and before this those were three hand-kept lists, two of which carried a
+  "keep in sync with the other" comment. That is the guard shape this repo keeps
+  getting caught by, so a layout now cannot be added without giving it every form.
+  A `_Static_assert` pins the named set to exactly the remappable range;
+  mutation-checked by dropping `_UL` from the table, which fails the build with the
+  assert's own message.
+- **Names are capped at 8 chars, so "Colemak DH" ships as `ColemkDH`.** The cap is
+  the host tab label's budget; the emitter clamps rather than trusting the table, so
+  an over-long name can never run into the next record.
+- ⚠️ **The TOTAL is what makes the reply decodable, and it is why the length is not
+  in the records.** The host reads byte 0, keeps reading until it holds that many
+  bytes, and only then splits on the NULs — so termination is arithmetic rather than
+  a scan, and the report's zero fill is never examined. Two encodings were tried
+  first and shipped briefly; both are worse, and the reasons generalise:
+  - **Fixed-width 8-byte records** give the same arithmetic length but cost 65 bytes
+    and therefore a **second report**, for a command whose whole payload otherwise
+    fits one.
+  - **Terminated records with no total** force the decoder to find the end by
+    scanning, and the only way to tell a real terminator from the zero fill is "an
+    empty name means padding" — which makes an **UNNAMED layer** (`poly_layer_name_wire()`
+    returning NULL, i.e. a bare terminator) indistinguishable from the fill and
+    silently truncates the list. That is the case that decided it.
+  - ⚠️ **The claim that a terminated form is UNSAFE against truncation is FALSE, and
+    was asserted here for a while on the strength of a bad test fixture.** The fixture
+    fed the decoder a **short non-final report**, which the emit loop cannot produce —
+    a short report is always the last one. Measured across every reachable failure
+    mode (last report lost, first lost, reordered, nothing arrives), fixed-width,
+    naive-terminated and total-prefixed behave **identically**. Robustness is a wash
+    under real HID behaviour, because whole 64-byte reports arrive or nothing does;
+    the encoding choice is about size, report count, and whether an unnamed layer is
+    expressible. Don't re-derive a robustness argument here without checking which
+    scenarios the firmware can actually emit.
+- **`LAYER_NAMES_PAYLOAD_MAX` is `_Static_assert`ed to stay under 255**, since the
+  total is one byte. Mutation-checked by widening `POLY_LAYER_NAME_MAX` to 32, which
+  fails the build with the assert's own message. At 12 layers × 8 chars it is 110.
+- **Names are capped at 8 chars, so "Colemak DH" ships as `ColemkDH`.** The cap is
+  the host tab label's budget; the emitter clamps rather than trusting the table, so
+  an over-long name can never run past the buffer.
 
 ### Keycap legend size (`poly_keymap.c`, HID cmd 34, protocol v13+)
 

--- a/keyboards/polykybd/config.h
+++ b/keyboards/polykybd/config.h
@@ -223,7 +223,7 @@
 //      only and live in the `latinbig` font-pack bundle; without it (or for a
 //      non-latin legend) the render falls back to small, so the setting is
 //      always safe to accept.
-#define PROTOCOL_VERSION 13
+#define PROTOCOL_VERSION 14
 
 #define FULL_BRIGHT 50
 #define MIN_BRIGHT 1

--- a/keyboards/polykybd/hid_com.c
+++ b/keyboards/polykybd/hid_com.c
@@ -36,6 +36,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include "poly_keymap.h"
+#include "layer_names.h"
 
 
 /*[[[cog
@@ -1006,6 +1007,67 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                         uprintf("Refused glyph size %u.\n", arg);
                     }
                     raw_hid_send(data, length);
+                }
+                break;
+            case 35: //report the host-remappable layers and their names (protocol v14+)
+                {
+                    // Reply: "P\x23." then the payload
+                    //
+                    //     [0] total   whole payload length, THIS BYTE INCLUDED
+                    //     [1] count   number of layers named
+                    //     [2..] count NUL-terminated ASCII names, <= POLY_LAYER_NAME_MAX each
+                    //
+                    // split across as many reports as it needs (54 bytes / one report today).
+                    //
+                    // ⚠️ The TOTAL is what makes this decodable, and it is why the length
+                    // does not live in the records. The host reads byte 0, keeps reading
+                    // until it holds that many bytes, and only then splits on the NULs —
+                    // so termination is arithmetic rather than a scan, and the zero fill
+                    // past the payload is never examined. Two encodings were tried first
+                    // and both are worse:
+                    //   - fixed-width 8-byte records also give an arithmetic length, but
+                    //     cost 65 bytes and therefore a second report;
+                    //   - terminated records with no total force the decoder to scan for
+                    //     the end, and the only way to tell a real terminator from the
+                    //     report's zero fill is "an empty name means padding" — which
+                    //     makes an UNNAMED layer (poly_layer_name_wire returning NULL,
+                    //     i.e. a bare terminator) indistinguishable from the fill and
+                    //     silently truncates the list.
+                    //
+                    // The count is DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT — the SAME value
+                    // id_dynamic_keymap_get_layer_count already answers with, on purpose:
+                    // the editor sizes its tab strip from that command and labels the tabs
+                    // from this one, so two different counts would let it draw a tab it has
+                    // no name for. Layers at or above the cap are served from flash and
+                    // cannot be remapped, so they get no name.
+                    //
+                    // This exists because the names used to be a build-time artifact on the
+                    // host, generated from layers.h by a script whose source path had gone
+                    // stale — so the editor labelled tabs from an enum the firmware had not
+                    // had for a long time. A name the keyboard states itself cannot drift.
+                    const uint8_t count = DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT;
+                    uint8_t payload[LAYER_NAMES_PAYLOAD_MAX];
+                    uint16_t used = 2;
+                    payload[1] = count;
+                    for (uint8_t layer = 0; layer < count; layer++) {
+                        const char* name = poly_layer_name_wire(layer);
+                        // Clamp rather than trust the table: an over-long name would
+                        // otherwise run past the buffer sized from POLY_LAYER_NAME_MAX.
+                        for (uint8_t i = 0; name != NULL && name[i] != '\0' && i < POLY_LAYER_NAME_MAX; i++) {
+                            payload[used++] = (uint8_t)name[i];
+                        }
+                        payload[used++] = '\0';
+                    }
+                    payload[0] = (uint8_t)used;
+
+                    const uint16_t chunk = hid_payload_avail(length, 3);
+                    for (uint16_t off = 0; off < used; off += chunk) {
+                        const uint16_t n = (used - off < chunk) ? (uint16_t)(used - off) : chunk;
+                        memset(data, 0, length);
+                        hid_reply(data, 0x23, true);
+                        memcpy(&data[3], &payload[off], n);
+                        raw_hid_send(data, length);
+                    }
                 }
                 break;
 #ifdef POLYKYBD_LOOP_PROFILE

--- a/keyboards/polykybd/layer_names.c
+++ b/keyboards/polykybd/layer_names.c
@@ -1,0 +1,58 @@
+// Copyright 2025 thpoll83
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "layer_names.h"
+#include "layers.h"
+
+#include <stddef.h>
+#include "config.h"
+
+// One record per base layout, carrying every width budget a consumer needs.
+// ⚠️ The `wire` form is what the host layout editor prints on its layer tabs,
+// so it is capped at POLY_LAYER_NAME_MAX (8) — "Colemak DH" does not fit and is
+// spelled "ColemkDH". `short_` is capped at 5 by split42's 32 px panel.
+static const struct {
+    const uint32_t* full;    // split72 status OLED
+    const uint32_t* short_;  // split42 status OLED, <= 5 chars
+    const char*     wire;    // HID cmd 35, <= POLY_LAYER_NAME_MAX chars
+} layouts[] = {
+    { U"Qwerty",       U"Qwrty", "Qwerty"   },
+    { U"Qwerty Stag!", U"Stag!", "Stag!"    },
+    { U"Colemak DH",   U"ColDH", "ColemkDH" },
+    { U"Neo",          U"Neo",   "Neo"      },
+    { U"Workman",      U"Wkmn",  "Workman"  },
+};
+#define NUM_LAYOUTS (sizeof(layouts) / sizeof(layouts[0]))
+
+// The layers above the base layouts. Indexed by (layer - NUM_LAYOUTS), so this
+// list must stay in step with the enum in layers.h from _FL up to the write cap.
+static const char* const fixed_wire[] = {
+    "Fn",       // _FL
+    "Numpad",   // _NL
+    "Utility",  // _UL
+};
+
+// The host may only remap layers below the write cap, so anything at or above it
+// has no editor tab to label. Assert the two lists together cover exactly that
+// range: a layer added or reordered in layers.h then fails the build here rather
+// than silently reporting the name of its neighbour.
+_Static_assert(NUM_LAYOUTS + (sizeof(fixed_wire) / sizeof(fixed_wire[0]))
+                   == DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT,
+               "layer_names.c does not name exactly the host-remappable layers");
+_Static_assert(_FL == NUM_LAYOUTS, "the base layouts must be the first layers");
+
+const uint32_t* poly_layout_name(uint8_t def_layer) {
+    return (def_layer < NUM_LAYOUTS) ? layouts[def_layer].full : U"Unknown";
+}
+
+const uint32_t* poly_layout_name_short(uint8_t def_layer) {
+    return (def_layer < NUM_LAYOUTS) ? layouts[def_layer].short_ : U"Unkn";
+}
+
+const char* poly_layer_name_wire(uint8_t layer) {
+    if (layer < NUM_LAYOUTS) {
+        return layouts[layer].wire;
+    }
+    const uint8_t idx = (uint8_t)(layer - NUM_LAYOUTS);
+    return (idx < sizeof(fixed_wire) / sizeof(fixed_wire[0])) ? fixed_wire[idx] : NULL;
+}

--- a/keyboards/polykybd/layer_names.h
+++ b/keyboards/polykybd/layer_names.h
@@ -1,0 +1,37 @@
+// Copyright 2025 thpoll83
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#include <stdint.h>
+
+#include "config.h"
+
+// The ONE place that answers "what is this layer called".
+//
+// Three consumers want the same answer at three different width budgets, and
+// before this file they each carried their own copy of the table:
+//   - split72's status OLED  -> the full name  ("Qwerty Stag!")
+//   - split42's status OLED  -> <= 5 chars, its panel is 32 px wide ("Stag!")
+//   - HID cmd 35             -> <= 8 chars, what the host layout editor labels
+//                               its layer tabs with ("Stag!")
+// Keeping three lists in sync by hand is the guard shape this repo keeps getting
+// caught by, so all three forms live in ONE record per layout: a new layout
+// cannot be added without giving it every form.
+#define POLY_LAYER_NAME_MAX 8   // wire form, excluding the NUL
+
+// Worst case for HID cmd 35: a total byte, a count byte, then one full-width name
+// plus its terminator per layer. The total is reported in ONE byte, so the whole
+// payload has to stay addressable by it.
+#define LAYER_NAMES_PAYLOAD_MAX \
+    (2 + DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT * (POLY_LAYER_NAME_MAX + 1))
+_Static_assert(LAYER_NAMES_PAYLOAD_MAX <= 255,
+               "the layer-name payload no longer fits its one-byte total length");
+
+// def_layer (_L0.._L4) -> the status-OLED forms.
+const uint32_t* poly_layout_name(uint8_t def_layer);        // split72, full width
+const uint32_t* poly_layout_name_short(uint8_t def_layer);  // split42, <= 5 chars
+
+// Layer index (_L0.._UL) -> the <= POLY_LAYER_NAME_MAX ASCII name reported over
+// HID cmd 35. Layers 0..4 are the base layouts, so they answer with the wire form
+// of the table above; the rest are fixed. NULL for a layer with no name.
+const char* poly_layer_name_wire(uint8_t layer);

--- a/keyboards/polykybd/oled_helper.c
+++ b/keyboards/polykybd/oled_helper.c
@@ -1,6 +1,7 @@
 // Copyright 2025 thpoll83
 // SPDX-License-Identifier: GPL-2.0-or-later
 #include "oled_helper.h"
+#include "layer_names.h"
 
 #include "state.h"
 #include "side.h"
@@ -83,14 +84,9 @@ void hex_to_u32_string(char* buffer, uint8_t buffer_len, uint8_t value) {
 }
 
 void oled_draw_layout_name(const GFXfont* const* font, int8_t x, int8_t y, uint8_t def_layer) {
-    // Indexed by def_layer (the _L0.._L4 default-layout enum in each variant's
-    // keymaps/default/layers.h). Keep in sync with the KC_L0..KC_L4 selectors in
-    // poly_keymap.c; an out-of-range value falls back to "Unknown".
-    static const uint32_t* const names[] = {
-        U"Qwerty", U"Qwerty Stag!", U"Colemak DH", U"Neo", U"Workman",
-    };
-    const uint32_t* name = (def_layer < ARRAY_SIZE(names)) ? names[def_layer] : U"Unknown";
-    kdisp_write_gfx_text(font, 1, x, y, name);
+    // The table lives in layer_names.c, which also feeds split42's short forms and
+    // HID cmd 35 -- see the header for why all three widths share one record.
+    kdisp_write_gfx_text(font, 1, x, y, poly_layout_name(def_layer));
 }
 
 void oled_status_screen(void) {

--- a/keyboards/polykybd/rules.mk
+++ b/keyboards/polykybd/rules.mk
@@ -75,7 +75,7 @@ OS_DETECTION_ENABLE = yes
 # drift the shared keymap exists to prevent. It also gets the strict PolyKybd warning
 # flags applied below, which the per-variant base sources do not. The same argument
 # covers emoji/emoji_layer.c and hints/os_hints.c.
-POLY_SRC := poly_keymap.c boot_diag.c side.c state.c split_sync.c split_fw_up.c multicore_exec.c hid_com.c hid_fw_up.c hid_fontpack.c fill_overlay.c poly_util.c matrix_helper.c bridge_helper.c oled_helper.c keycode_helper.c mru.c lang_layer.c os_actions.c anim/startup_anim.c emoji/emoji_layer.c hints/os_hints.c base/fw_up_verdict.c
+POLY_SRC := poly_keymap.c layer_names.c boot_diag.c side.c state.c split_sync.c split_fw_up.c multicore_exec.c hid_com.c hid_fw_up.c hid_fontpack.c fill_overlay.c poly_util.c matrix_helper.c bridge_helper.c oled_helper.c keycode_helper.c mru.c lang_layer.c os_actions.c anim/startup_anim.c emoji/emoji_layer.c hints/os_hints.c base/fw_up_verdict.c
 SRC += $(POLY_SRC)
 
 # emoji/emoji_layer.c is listed here, not in a keymap's rules.mk: the keyboard-level

--- a/keyboards/polykybd/split42/status_oled.c
+++ b/keyboards/polykybd/split42/status_oled.c
@@ -1,6 +1,7 @@
 // Copyright 2025 thpoll83
 // SPDX-License-Identifier: GPL-2.0-or-later
 #include "status_oled.h"
+#include "layer_names.h"
 #include "../oled_helper.h"
 
 #include "split42.h"
@@ -176,13 +177,6 @@ static void pdraw_brightness(uint8_t contrast, int bottom_y, uint8_t* buf) {
 }
 #define P42_GAUGE_H (P42_GAUGE_MIN_H + 9)   // tallest bar == band height
 
-// split42 short layout names — must stay in sync with oled_helper.c's full-name
-// array (indexed by def_layer). Shortened so they fit the 32px-wide portrait column.
-static const uint32_t* layout_name_short(uint8_t def_layer) {
-    static const uint32_t* const names[] = { U"Qwrty", U"Stag!", U"ColDH", U"Neo", U"Wkmn" };
-    return (def_layer < ARRAY_SIZE(names)) ? names[def_layer] : U"Unkn";
-}
-
 void oled_update_buffer(void) {
     uint8_t* buf = get_scratch_buffer();
     kdisp_set_buffer(0);                            // clear the whole scratch to black
@@ -212,7 +206,7 @@ void oled_update_buffer(void) {
         // Layout name (short), Nano 10px at NATIVE size, centered. LAYOUT_NAME_BASE
         // is picked so the cap top still lands on logical row 52, exactly where the
         // old half-scale render put it.
-        pdraw_text_center(nanoFont, 1, LAYOUT_NAME_BASE, layout_name_short(get_local_layer()->def_layer), buf);
+        pdraw_text_center(nanoFont, 1, LAYOUT_NAME_BASE, poly_layout_name_short(get_local_layer()->def_layer), buf);
         pdraw_brightness(ls->contrast, 82, buf);
         // Typing speed: dial over the value
         pdraw_bitmap(wpm_gauge_bitmap, (P_W - WPM_ICON_W) / 2, 93, WPM_ICON_W, WPM_ICON_H, buf);


### PR DESCRIPTION
## Summary

The host layout editor labelled its layer tabs from `PolyKybdHost/polyhost/res/layer_names.yaml`, a build-time artifact generated from this repo's `layers.h`. That generator's default source path had died through **two** renames, so nothing regenerated it and nothing failed — the committed file still described a 14-layer enum ending `EMJ0`/`EMJ1` that the firmware had not had in a long time. **A name the keyboard states itself cannot drift from the keyboard.**

New read-only `GET_LAYER_NAMES` (cmd `35` / `0x23`), `PROTOCOL_VERSION` 13 → 14:

| Offset | Bytes | Meaning |
|---|---|---|
| `0` | 1 | **total** — the whole payload length, this byte included |
| `1` | 1 | **count** — how many layers are named |
| `2…` | rest | `count` NUL-terminated ASCII names, ≤ 8 chars each |

54 bytes today, which fits **one** 64-byte report. The host reads byte 0, keeps reading until it holds that many bytes, and only then splits on the NULs — so termination is arithmetic rather than a scan, and the report's zero fill is never examined.

The names are the ones the board already knows — `Qwerty` / `Stag!` / `ColemkDH` / `Neo` / `Workman` for the base layouts, then `Fn` / `Numpad` / `Utility` — not the enum tags the yaml carried.

### Why a total, and not fixed-width records or a bare terminator

Two encodings were built first and both are worse:

- **Fixed-width 8-byte records** give the same arithmetic length but cost 65 bytes, and therefore a *second report* for a reply that otherwise fits one.
- **Terminated records with no total** force the decoder to find the end by scanning, and the only way to separate a real terminator from the zero fill is "an empty name means padding" — which makes an **unnamed layer** (`poly_layer_name_wire()` returning `NULL`, i.e. a bare terminator) indistinguishable from the fill and silently truncates the list. That case decided it.

⚠️ A robustness argument for fixed-width was asserted during development and is **retracted** in `CLAUDE.md`. It rested on a test fixture feeding the decoder a short *non-final* report, which the emit loop cannot produce — a short report is always the last one. Measured across every reachable failure mode (last report lost, first lost, reordered, nothing arrives), all three encodings behave identically, because HID delivers whole 64-byte reports or none at all.

### The count is not a second opinion

It is the same `DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT` that `id_dynamic_keymap_get_layer_count` already answers with. The editor sizes its tab strip from that command and labels the tabs from this one, so two different counts would let it draw a tab it has no name for.

### One owner for the layout names

split72's full status-OLED names and split42's 5-char short names each lived in their own list, both carrying a "keep in sync with the other" comment — and this change would have added a third. All three widths now share one record per layout in `layer_names.c`, so a new layout cannot be added without giving it every form.

## Version bump label

`bump:protocol` — `PROTOCOL_VERSION` 13 → 14, with the matching `__protocol__` bump in [PolyKybdHost](https://github.com/thpoll83/PolyKybdHost) (see the companion PR).

## Testing

- [x] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`), plus **split42** and the monolithic `POLYKYBD_DOOM=yes` flavour
- [ ] Flashed and tested on hardware — a `.bin` for commit `12f89a46047` has been handed over for a hardware round
- [x] If protocol changed: host updated and tested together

Also run locally: `qmk lint --strict` on both keyboards, `qmk ci-validate-keyboard-targets`, `qmk ci-validate-aliases`, and `cppcheck` at the exact CI invocation — all clean.

**Two asserts mutation-checked**, each failing the build with its own message:
- dropping `_UL` from the name table → *"layer_names.c does not name exactly the host-remappable layers"*
- widening `POLY_LAYER_NAME_MAX` to 32 so the payload outgrows its one-byte total → *"the layer-name payload no longer fits its one-byte total length"*

Companion PRs: **PolyKybdHost** (decoder + editor + `polyctl`), **polykybd-ctnd** (HIL test), **polykybd-docs** (reference page — hold that one until the release ships).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NytprmPuKPEwg4r5ckGJDL)_

## Summary by Sourcery

Expose authoritative remappable layer names over HID and centralize their display representations across firmware consumers.

New Features:
- Expose host-remappable layer names through a new read-only HID command 35 payload.

Bug Fixes:
- Prevent host layer-tab labels from drifting from the firmware's current layer definitions.

Enhancements:
- Centralize full, short, and wire-format layer names in a shared validated table for OLED displays and host tooling.

Build:
- Register the shared layer-name implementation in the keyboard build and bump the firmware protocol version to 14.

Documentation:
- Document the layer-name HID protocol and its payload format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HID support for retrieving remappable layer names.
  * Layer-name data is transmitted with length and count information across HID reports.
  * Added consistent full, short, and wire-format layer labels for displays and host tools.

* **Bug Fixes**
  * Updated the protocol version to support the new layer-name capability.
  * Improved handling of unknown and oversized layer names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->