### PR TITLE
Dynamic macros with keycap labels (protocol v15)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2225,6 +2225,11 @@ knowing is the parts that are NOT what you would write from scratch:
   the host's layout editor, so a user who never opens it pays nothing — and `via.c` is
   the only core dispatcher for that range, which we do not compile, so the keycodes
   are ours outright.
+- **Cost: 208 B of RAM** (the 192 B label cache + the playback state), 0 B of EEPROM
+  beyond the reclaim above. ⚠️ Verified against the **monolithic `POLYKYBD_DOOM=yes`**
+  flavour, which PR CI does not build and which is the first thing to fail on any RAM
+  growth: `.heap` 3828 → **3620 B** free. Re-measure there, not on the pack build,
+  before adding another static.
 
 ### LTR-559 light+proximity sensor (`modules/polykybd/polymod_ltr559/`) — ENTIRELY OPTIONAL
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -687,6 +687,48 @@ The firmware runs on a **Raspberry Pi RP2040** (dual-core ARM M0+) and is a heav
 
 The host software (`PolyKybdHost/`) communicates with this firmware over a custom HID report protocol (64-byte reports, v0.7.0+).
 
+### EEPROM layout: the reclaimed dynamic-keymap tail
+
+`DYNAMIC_KEYMAP_LAYER_COUNT` must stay **12** — QMK asserts it is >= the compiled
+layer count (`keymap_introspection.c`) — but only layers **0..7** are ever read or
+written from EEPROM; `_SL` and up are served straight out of flash by
+`poly_keycode_at()`. QMK's default addresses put the encoder map and the macro buffer
+after all twelve, so 640 B of keymap plus 32 B of encoder map sat there addressed by
+nothing. `config.h` rebases both on **`DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT`**:
+measured on split72, the macro region went **1787 → 2459 B (+672)**.
+
+⚠️ **The reclaim is only sound while nothing writes layers >= the cap, and QMK's own
+`dynamic_keymap_reset()` DOES.** It loops to `DYNAMIC_KEYMAP_LAYER_COUNT` through a
+bound check that is also `DYNAMIC_KEYMAP_LAYER_COUNT`, so it writes layers 8..11
+straight over both reclaimed regions. Two guards, and both are load-bearing:
+- `dynamic_keymap_reset_poly()` **no longer calls it** — it walks the cap itself,
+  resets the capped encoder map and zeroes the macro buffer.
+- `eeconfig_init_kb()` **repairs after the one call site we cannot remove**
+  (`eeconfig_init_quantum`, three lines above ours in the same function,
+  unconditional). Because that repair rewrites layers 0..7 from flash and zeroes the
+  macros, it IS the state a fresh EEPROM wants rather than a fix-up bolted on. ⚠️ The
+  override also has to replicate the weak default's `eeconfig_update_kb(0)`, which
+  replacing the body would otherwise drop silently.
+Two `_Static_assert`s in `split_sync.c` pin the addresses to the write cap, so a later
+edit to either constant fails the build instead of quietly handing the space back.
+
+The **encoder map moves**, so a board flashed over the old layout would read two
+layers' worth of keycodes as its encoder assignments — hence the
+`KEYMAP_STORAGE_RECLAIMED` bump on the existing `keymap_layers_fmt` gate (`state.h`),
+which discards the stored keymap once on the first boot after flashing.
+
+⚠️ **`DYNAMIC_KEYMAP_EEPROM_MAX_ADDR` is derived INSIDE `nvm_dynamic_keymap.c`**, i.e.
+it exists in exactly one translation unit — so anything else that needs the same number
+(here `poly_macro.c`) cannot see it. `config.h` defines it explicitly and QMK's own
+`#ifndef` picks ours up, so the two cannot disagree.
+
+**Reading the real numbers**: the addresses are macros, so they are not symbols in the
+ELF and `nm` cannot find them. Append a `const uint32_t probe[] = {…}` to a real
+firmware source, build, and read the **object file** — the linker gc's an unreferenced
+array out of the final image, but `.build/obj_*/…/<file>.o` still has it:
+`arm-none-eabi-objdump -s -j .rodata.probe <obj>`. That is how the +672 above was
+measured rather than derived.
+
 ### Key source files
 
 | File | Role |
@@ -901,6 +943,13 @@ keycode; `process_record_user()` calls it last, before `display_wakeup()`.
   setting that silently renders small. The two HIL tests assert opposite things about
   their neighbouring commands on purpose (`test_glyph_size_round_trip` /
   `test_glyph_script_expansion`). See "Keycap legend size" below.
+  **v14** adds **macros**: `MACRO_INFO` (cmd `35` / `0x23`, read-only — count, label
+  stride, capacity u16, bytes-used u16), `MACRO_BODY` (cmd `36` / `0x24`, windowed
+  read/write of the shared body buffer: `data[2]` 0 read / 1 write, `data[3..4]` offset
+  LE, `data[5]` count, `data[6..]` bytes) and `MACRO_LABEL` (cmd `37` / `0x25`,
+  `data[2]` id, `data[3]` 0xFF query else length, `data[4..]` text). All three sit
+  behind ONE host feature gate — a host that could read the info header but not the
+  bodies would render an editor over data it cannot fetch. See "Dynamic macros" below.
   **Bump `FW_VERSION` +
   `PROTOCOL_VERSION` (config.h) and `__protocol__` (PolyKybdHost `_version.py`) in
   lockstep** — the host connect gate is exact-match.
@@ -2105,6 +2154,77 @@ holding **Shift** swaps the icon to `ICON_FONT_SMALLER` and reverses the step, s
 - The legend contains a `HINT_MOVE`, so `glyph_size_remap()` bails and the key itself
   always draws at the small face. That is correct — it is a mixed icon cell, not a
   latin legend — but it means the size key does not demonstrate the setting it changes.
+
+### Dynamic macros (`poly_macro.c`, HID cmds 35/36/37, protocol v14+)
+
+A macro is text (or a short key sequence) stored on the keyboard, typed back on one
+keypress, with a **label the keycap spells out** along its bottom edge. What is worth
+knowing is the parts that are NOT what you would write from scratch:
+
+- **Storage is QMK's own dynamic-macro buffer** — a run of NUL-terminated bodies at
+  `DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR`, macro N found by counting N terminators. We did
+  not invent a format; `dynamic_keymap_macro_get/set_buffer` already manage it.
+- **The LABELS are a separate fixed-stride array**, carved off the TOP of the same
+  region by shrinking `DYNAMIC_KEYMAP_MACRO_EEPROM_SIZE` (config.h). Deliberately not
+  inside the NUL-delimited buffer: a body is addressed by counting separators — fine
+  once per keypress, wrong for something `render_key()` reads for every macro keycap
+  on every refresh. Shrinking the QMK constant is what keeps them apart, since every
+  upstream path bounds itself on it and so cannot reach the labels.
+- ⚠️ **Playback is OURS and must stay a state machine.**
+  `dynamic_keymap_macro_send()` runs the whole macro inline and spells its delay
+  `while (ms--) wait_ms(1)`. On a single-controller board that is merely rude; here
+  the same loop scans the matrix, drives the split UART, services USB HID and pushes
+  72 SPI displays, so a macro with a half-second delay would freeze the board and drop
+  the link. `poly_macro_tick()` runs at most ONE step per housekeeping pass and treats
+  a delay as a deadline. **No time-slicing is needed** (unlike Eden): steps have to be
+  SPACED anyway for the host to see distinct events, so the pacing IS the yield.
+- **The wire format is QMK's send-string encoding, NOT Vial's extension of it** —
+  `0x01 0x01/02/03 <kc>` tap/down/up, `0x01 0x04 <ascii digits>` delay. Staying on the
+  base encoding means the buffer is still playable by `dynamic_keymap_macro_send()`, a
+  real cross-check rather than a theoretical one. Cost: 8-bit keycodes, so no mod-taps
+  or layer keys; every modifier is 0xE0..0xE7, so chords are fine.
+  - ⚠️ **The byte ENDING a delay is NOT consumed** — send_string re-reads it as the
+    next step. Consuming it silently swallows the character after every delay, which
+    presents as "the macro drops a letter sometimes".
+- **The decoding is pure in `base/macro_decode.c`** (a byte-reader callback; no
+  quantum.h, no EEPROM, no timer), the same seam as `base/fw_up_verdict.c`: the
+  arithmetic is the part with a bug history and it was only unreachable because it
+  shared a function with the I/O. `make test:polykybd_macro_decode` — 23 tests,
+  mutation-tested against 7 deliberate breaks, each caught by the intended test.
+- ⚠️ **`clear_keyboard()` on abort.** A DOWN step leaves a modifier registered, and
+  any key press aborts playback — without the clear the host auto-repeats a key
+  nothing will ever release. Same rule as the FW-2 prompt and `doom_begin()`.
+- **Swallowed in `process_record_user()`**, not left to the release edge — an `OSL()`
+  layer re-dispatches a release-edge action up to three times, which for a macro means
+  playing it two or three times over (§ "A release-edge action fires up to THREE
+  times").
+- **Labels live in a RAM cache on BOTH halves** (192 B). Partly speed, mostly
+  necessity: the host writes macros to the master, so the slave's own EEPROM never
+  sees one. The master pushes each label over the split link, ONE per housekeeping
+  pass, clearing its dirty bit only on a real ACK — so the mask is its own retry queue
+  and nothing has to detect "the link is up". ⚠️ Never inline in the HID handler:
+  sixteen bridges of up to ten retries each is seconds of dead main loop on exactly
+  the link that needed the retries.
+  - It **multiplexes onto `USER_SYNC_DYNAMIC_KEYMAP_DATA`** with a private op byte
+    (`POLY_KEYMAP_OP_MACRO_LABEL`) rather than spending one of the 32 transaction
+    slots — that handler was already op-dispatched, the same trick the MRU snapshots
+    and the doom mirror use on `USER_SYNC_OVERLAY_MAP_DATA`.
+- **The keycap draws the index above and the label below**, mirroring
+  `render_lang_flag_key`. The INDEX rather than a generic macro glyph: a generic glyph
+  is identical on all sixteen keys, so it says "this is a macro" and nothing else,
+  while the index says which one and needs no font pack.
+  - ⚠️ **Truncate by MEASURED WIDTH, never by character count.** Measured against the
+    shipped `_Nano_` face: `WWWWWWWW` is exactly 72 px (8 chars) and `iiiiiiiiiiii`
+    is 34 px (12 chars) — an estimate is wrong in both directions.
+    `PolyKybdHost/tools/macro_label_preview.py --check` renders the keycap the way
+    `render_macro_key()` composes it and counts pixels outside the 72×40 window (320
+    cells, 0 clipped). Its measurement lives in the Qt-free
+    `polyhost/services/macro_label.py` because the host editor shows the same
+    truncation while the user types, and an approximation would disagree with the key.
+- **Nothing binds `QK_MACRO_*` in the default keymap.** A macro key is assigned from
+  the host's layout editor, so a user who never opens it pays nothing — and `via.c` is
+  the only core dispatcher for that range, which we do not compile, so the keycodes
+  are ours outright.
 
 ### LTR-559 light+proximity sensor (`modules/polykybd/polymod_ltr559/`) — ENTIRELY OPTIONAL
 

--- a/keyboards/polykybd/base/macro_decode.c
+++ b/keyboards/polykybd/base/macro_decode.c
@@ -1,0 +1,94 @@
+// Copyright 2026 Thomas Pollak
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "macro_decode.h"
+
+static inline bool is_ascii_digit(uint8_t c) {
+    return c >= '0' && c <= '9';
+}
+
+uint16_t poly_macro_find(poly_macro_read_fn rd, void *ctx, uint8_t id, uint16_t end) {
+    uint16_t offset = 0;
+    while (id > 0) {
+        if (offset >= end) return end;
+        if (rd(offset, ctx) == 0) --id;
+        ++offset;
+    }
+    return offset;
+}
+
+uint16_t poly_macro_used(poly_macro_read_fn rd, void *ctx, uint16_t end) {
+    uint16_t used = 0;
+    for (uint16_t offset = 0; offset < end; ++offset) {
+        if (rd(offset, ctx) != 0) used = offset + 2; // the byte plus its terminator
+    }
+    return used > end ? end : used;
+}
+
+bool poly_macro_buffer_intact(poly_macro_read_fn rd, void *ctx, uint16_t end) {
+    if (end == 0) return false;
+    return rd(end - 1, ctx) == 0;
+}
+
+poly_macro_step_t poly_macro_decode(poly_macro_read_fn rd, void *ctx, uint16_t cursor, uint16_t end) {
+    poly_macro_step_t step = {.kind = POLY_MACRO_STEP_END, .code = 0, .ms = 0, .next = cursor};
+
+    if (cursor >= end) return step;
+
+    uint8_t c = rd(cursor, ctx);
+    if (c == 0) return step; // end of this macro
+
+    if (c != POLY_MACRO_PREFIX) {
+        step.kind = POLY_MACRO_STEP_CHAR;
+        step.code = c;
+        step.next = cursor + 1;
+        return step;
+    }
+
+    // A prefix with nothing after it is a truncated buffer, not a step.
+    if (cursor + 1 >= end) return step;
+    uint8_t op = rd(cursor + 1, ctx);
+
+    if (op == POLY_MACRO_OP_DELAY) {
+        // ASCII digits, terminated by the first non-digit -- which is NOT consumed,
+        // exactly as send_string_with_delay_impl re-reads it as the next step. Getting
+        // that wrong swallows the byte after every delay.
+        uint32_t ms  = 0;
+        uint16_t pos = cursor + 2;
+        while (pos < end) {
+            uint8_t d = rd(pos, ctx);
+            if (!is_ascii_digit(d)) break;
+            ms = ms * 10 + (uint32_t)(d - '0');
+            if (ms > 0xFFFFu) ms = 0xFFFFu; // clamp rather than wrap: a wrapped delay
+                                            // reads as "no delay" and the macro races
+            ++pos;
+        }
+        step.kind = POLY_MACRO_STEP_DELAY;
+        step.ms   = (uint16_t)ms;
+        step.next = pos;
+        return step;
+    }
+
+    // Every other op takes exactly one keycode byte.
+    if (cursor + 2 >= end) return step;
+    uint8_t code = rd(cursor + 2, ctx);
+
+    switch (op) {
+        case POLY_MACRO_OP_TAP:
+            step.kind = POLY_MACRO_STEP_TAP;
+            break;
+        case POLY_MACRO_OP_DOWN:
+            step.kind = POLY_MACRO_STEP_DOWN;
+            break;
+        case POLY_MACRO_OP_UP:
+            step.kind = POLY_MACRO_STEP_UP;
+            break;
+        default:
+            // Unknown op. Stop rather than skip: the byte after it is not known to be
+            // an argument, so resuming would type whatever the argument happened to be.
+            return step;
+    }
+    step.code = code;
+    step.next = cursor + 3;
+    return step;
+}

--- a/keyboards/polykybd/base/macro_decode.h
+++ b/keyboards/polykybd/base/macro_decode.h
@@ -1,0 +1,75 @@
+// Copyright 2026 Thomas Pollak
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// Pure decoding for the dynamic-macro buffer: where macro N starts, how much of the
+// buffer is in use, and what the next step is. Deliberately dependency-free -- no
+// quantum.h, no EEPROM, no timer -- so it links against a RAM buffer in a unit test.
+//
+// This is the same split as base/fw_up_verdict.c: the part with a bug history is the
+// arithmetic, and the arithmetic is the part that was unreachable while it lived
+// inside a function that also did I/O.
+//
+// WIRE FORMAT -- QMK's own send-string encoding, NOT Vial's extension of it.
+// A macro is a run of bytes terminated by NUL; macro N is found by skipping N NULs.
+//
+//   <printable>              type that character
+//   0x01 0x01 <kc>           tap keycode
+//   0x01 0x02 <kc>           press keycode
+//   0x01 0x03 <kc>           release keycode
+//   0x01 0x04 <ascii digits> wait N ms, terminated by the first non-digit (which is
+//                            re-read as the next step, exactly as send_string does)
+//
+// Keycodes are 8-bit, i.e. basic keycodes only. That covers every modifier
+// (KC_LCTL..KC_RGUI are 0xE0..0xE7), so chords are expressible; mod-taps and layer
+// keycodes are not, and a 16-bit extension opcode can be added if that ever bites.
+// Staying on the base encoding rather than Vial's means QMK's own
+// dynamic_keymap_macro_send() can still play the very same buffer, which is a real
+// cross-check rather than a theoretical one.
+
+#define POLY_MACRO_PREFIX    0x01
+#define POLY_MACRO_OP_TAP    0x01
+#define POLY_MACRO_OP_DOWN   0x02
+#define POLY_MACRO_OP_UP     0x03
+#define POLY_MACRO_OP_DELAY  0x04
+
+typedef enum {
+    POLY_MACRO_STEP_END = 0, // NUL, or the cursor ran past the buffer
+    POLY_MACRO_STEP_CHAR,    // type `code` as a character
+    POLY_MACRO_STEP_TAP,
+    POLY_MACRO_STEP_DOWN,
+    POLY_MACRO_STEP_UP,
+    POLY_MACRO_STEP_DELAY,   // wait `ms`
+} poly_macro_step_kind_t;
+
+typedef struct {
+    poly_macro_step_kind_t kind;
+    uint8_t                code; // CHAR / TAP / DOWN / UP
+    uint16_t               ms;   // DELAY
+    uint16_t               next; // cursor to resume from
+} poly_macro_step_t;
+
+// Reads one byte of the macro region. `end` is one past the last readable offset;
+// the decoder never calls this with an offset >= end.
+typedef uint8_t (*poly_macro_read_fn)(uint16_t offset, void *ctx);
+
+// Byte offset where macro `id` starts, or `end` when the buffer holds fewer than
+// id+1 macros. Skipping N NULs is how QMK addresses them, so an empty macro is a
+// bare NUL and still occupies a slot.
+uint16_t poly_macro_find(poly_macro_read_fn rd, void *ctx, uint8_t id, uint16_t end);
+
+// Bytes in use = the offset just past the terminator of the last non-empty macro.
+// Trailing empty slots cost nothing, so this is what a budget readout should show.
+uint16_t poly_macro_used(poly_macro_read_fn rd, void *ctx, uint16_t end);
+
+// Decode the step at `cursor`. Always returns a step whose `next` is > cursor for
+// anything other than END, so a caller cannot spin.
+poly_macro_step_t poly_macro_decode(poly_macro_read_fn rd, void *ctx, uint16_t cursor, uint16_t end);
+
+// True when the buffer looks mid-write: the last byte is not NUL, so a stream was cut
+// short. QMK refuses playback in that state and so do we -- a half-written macro can
+// otherwise type an arbitrary prefix of someone's password into the wrong window.
+bool poly_macro_buffer_intact(poly_macro_read_fn rd, void *ctx, uint16_t end);

--- a/keyboards/polykybd/base/tests/macro_decode_tests.cpp
+++ b/keyboards/polykybd/base/tests/macro_decode_tests.cpp
@@ -1,0 +1,257 @@
+// Copyright 2026 Thomas Pollak
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "macro_decode.h"
+}
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+// The decoder reads through a callback so a test can back it with RAM instead of
+// EEPROM. That indirection is the whole reason these tests can exist.
+struct Buf {
+    std::vector<uint8_t> bytes;
+};
+
+uint8_t rd(uint16_t offset, void *ctx) {
+    return static_cast<Buf *>(ctx)->bytes[offset];
+}
+
+// Builds a body buffer the way the host would: macros back to back, each terminated,
+// then zero-filled to `size` (which leaves the last byte NUL, i.e. "intact").
+Buf make(const std::vector<std::string> &macros, size_t size = 64) {
+    Buf b;
+    for (const auto &m : macros) {
+        b.bytes.insert(b.bytes.end(), m.begin(), m.end());
+        b.bytes.push_back(0);
+    }
+    b.bytes.resize(size, 0);
+    return b;
+}
+
+std::string tap(uint8_t kc) {
+    return std::string{char(POLY_MACRO_PREFIX), char(POLY_MACRO_OP_TAP), char(kc)};
+}
+std::string down(uint8_t kc) {
+    return std::string{char(POLY_MACRO_PREFIX), char(POLY_MACRO_OP_DOWN), char(kc)};
+}
+std::string up(uint8_t kc) {
+    return std::string{char(POLY_MACRO_PREFIX), char(POLY_MACRO_OP_UP), char(kc)};
+}
+std::string delay(const std::string &digits) {
+    return std::string{char(POLY_MACRO_PREFIX), char(POLY_MACRO_OP_DELAY)} + digits;
+}
+
+// Runs a whole macro and returns the steps, so a test can assert on the sequence
+// rather than on one decode at a time.
+std::vector<poly_macro_step_t> run(Buf &b, uint16_t start) {
+    std::vector<poly_macro_step_t> out;
+    uint16_t                       cursor = start;
+    for (int guard = 0; guard < 512; ++guard) {
+        poly_macro_step_t s = poly_macro_decode(rd, &b, cursor, (uint16_t)b.bytes.size());
+        if (s.kind == POLY_MACRO_STEP_END) break;
+        out.push_back(s);
+        // A step that does not advance would spin the playback tick forever.
+        EXPECT_GT(s.next, cursor);
+        cursor = s.next;
+    }
+    return out;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Addressing
+
+TEST(MacroFind, FirstMacroStartsAtZero) {
+    Buf b = make({"ab", "cd"});
+    EXPECT_EQ(poly_macro_find(rd, &b, 0, b.bytes.size()), 0);
+}
+
+TEST(MacroFind, SkipsOneTerminatorPerPrecedingMacro) {
+    Buf b = make({"ab", "cd", "e"});
+    EXPECT_EQ(poly_macro_find(rd, &b, 1, b.bytes.size()), 3); // after "ab\0"
+    EXPECT_EQ(poly_macro_find(rd, &b, 2, b.bytes.size()), 6); // after "cd\0"
+}
+
+TEST(MacroFind, AnEmptyMacroStillOccupiesASlot) {
+    Buf b = make({"", "x"});
+    EXPECT_EQ(poly_macro_find(rd, &b, 0, b.bytes.size()), 0);
+    EXPECT_EQ(poly_macro_find(rd, &b, 1, b.bytes.size()), 1);
+    EXPECT_EQ(rd(0, &b), 0); // macro 0 is empty
+    EXPECT_EQ(rd(1, &b), 'x');
+}
+
+TEST(MacroFind, IdPastTheEndReturnsEnd) {
+    // Only the trailing zero fill is left, so every later id resolves to a NUL and
+    // then, once the fill is exhausted, to `end`. It must never wrap or run off.
+    Buf b = make({"a"}, 8);
+    EXPECT_EQ(poly_macro_find(rd, &b, 200, b.bytes.size()), b.bytes.size());
+}
+
+// ---------------------------------------------------------------------------
+// Budget
+
+TEST(MacroUsed, CountsThroughTheLastTerminator) {
+    Buf b = make({"abc"}, 64);
+    EXPECT_EQ(poly_macro_used(rd, &b, b.bytes.size()), 4); // "abc\0"
+}
+
+TEST(MacroUsed, TrailingEmptyMacrosAreFree) {
+    Buf a = make({"abc"}, 64);
+    Buf c = make({"abc", "", "", ""}, 64);
+    EXPECT_EQ(poly_macro_used(rd, &a, a.bytes.size()), poly_macro_used(rd, &c, c.bytes.size()));
+}
+
+TEST(MacroUsed, LeadingEmptyMacroStillCosts) {
+    Buf b = make({"", "x"}, 64);
+    EXPECT_EQ(poly_macro_used(rd, &b, b.bytes.size()), 3); // "\0x\0"
+}
+
+TEST(MacroUsed, EmptyBufferIsZero) {
+    Buf b = make({}, 64);
+    EXPECT_EQ(poly_macro_used(rd, &b, b.bytes.size()), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Mid-write guard
+
+TEST(MacroIntact, LastByteNulMeansComplete) {
+    Buf b = make({"abc"}, 64);
+    EXPECT_TRUE(poly_macro_buffer_intact(rd, &b, b.bytes.size()));
+}
+
+TEST(MacroIntact, NonNulLastByteMeansAbortedWrite) {
+    Buf b            = make({"abc"}, 64);
+    b.bytes.back()   = 'Z';
+    EXPECT_FALSE(poly_macro_buffer_intact(rd, &b, b.bytes.size()));
+}
+
+// ---------------------------------------------------------------------------
+// Decoding
+
+TEST(MacroDecode, PlainTextIsOneCharStepPerByte) {
+    Buf  b     = make({"hi"});
+    auto steps = run(b, 0);
+    ASSERT_EQ(steps.size(), 2u);
+    EXPECT_EQ(steps[0].kind, POLY_MACRO_STEP_CHAR);
+    EXPECT_EQ(steps[0].code, 'h');
+    EXPECT_EQ(steps[1].code, 'i');
+}
+
+TEST(MacroDecode, TapDownUpCarryTheirKeycode) {
+    Buf  b     = make({tap(0x04) + down(0xE0) + up(0xE0)});
+    auto steps = run(b, 0);
+    ASSERT_EQ(steps.size(), 3u);
+    EXPECT_EQ(steps[0].kind, POLY_MACRO_STEP_TAP);
+    EXPECT_EQ(steps[0].code, 0x04);
+    EXPECT_EQ(steps[1].kind, POLY_MACRO_STEP_DOWN);
+    EXPECT_EQ(steps[1].code, 0xE0);
+    EXPECT_EQ(steps[2].kind, POLY_MACRO_STEP_UP);
+    EXPECT_EQ(steps[2].code, 0xE0);
+}
+
+TEST(MacroDecode, DelayReadsAsciiDigits) {
+    Buf  b     = make({delay("250")});
+    auto steps = run(b, 0);
+    ASSERT_EQ(steps.size(), 1u);
+    EXPECT_EQ(steps[0].kind, POLY_MACRO_STEP_DELAY);
+    EXPECT_EQ(steps[0].ms, 250);
+}
+
+// The terminator of a delay is NOT consumed -- send_string re-reads it as the next
+// step. Consuming it would silently swallow the character after every delay, which is
+// the sort of thing that only shows up as "the macro drops a letter sometimes".
+TEST(MacroDecode, TheByteEndingADelayIsNotEaten) {
+    Buf  b     = make({delay("10") + "x"});
+    auto steps = run(b, 0);
+    ASSERT_EQ(steps.size(), 2u);
+    EXPECT_EQ(steps[0].kind, POLY_MACRO_STEP_DELAY);
+    EXPECT_EQ(steps[0].ms, 10);
+    EXPECT_EQ(steps[1].kind, POLY_MACRO_STEP_CHAR);
+    EXPECT_EQ(steps[1].code, 'x');
+}
+
+TEST(MacroDecode, DelayWithNoDigitsIsZeroNotAHang) {
+    Buf  b     = make({delay("") + "x"});
+    auto steps = run(b, 0);
+    ASSERT_EQ(steps.size(), 2u);
+    EXPECT_EQ(steps[0].kind, POLY_MACRO_STEP_DELAY);
+    EXPECT_EQ(steps[0].ms, 0);
+    EXPECT_GT(steps[0].next, 0);
+}
+
+// A wrapped delay reads as "no delay" and the macro races through a wait the author
+// asked for, so the clamp is the safe direction.
+TEST(MacroDecode, AbsurdDelayClampsRatherThanWraps) {
+    Buf  b     = make({delay("999999999")});
+    auto steps = run(b, 0);
+    ASSERT_EQ(steps.size(), 1u);
+    EXPECT_EQ(steps[0].ms, 0xFFFF);
+}
+
+TEST(MacroDecode, NulEndsTheMacro) {
+    Buf               b = make({"a", "b"});
+    poly_macro_step_t s = poly_macro_decode(rd, &b, 1, b.bytes.size()); // the terminator
+    EXPECT_EQ(s.kind, POLY_MACRO_STEP_END);
+}
+
+TEST(MacroDecode, StopsAtTheBufferEnd) {
+    Buf               b = make({"a"}, 1); // no room for anything
+    poly_macro_step_t s = poly_macro_decode(rd, &b, 1, 1);
+    EXPECT_EQ(s.kind, POLY_MACRO_STEP_END);
+}
+
+// An unknown op's following byte is not known to be an argument, so resuming past it
+// would type whatever happened to be there. Stopping is the only safe reading.
+TEST(MacroDecode, UnknownOpStopsRatherThanSkipping) {
+    Buf b = make({std::string{char(POLY_MACRO_PREFIX), char(0x7F), 'X', 'Y'}});
+    poly_macro_step_t s = poly_macro_decode(rd, &b, 0, b.bytes.size());
+    EXPECT_EQ(s.kind, POLY_MACRO_STEP_END);
+}
+
+TEST(MacroDecode, TruncatedPrefixAtTheEndIsNotAStep) {
+    Buf b;
+    b.bytes = {POLY_MACRO_PREFIX};
+    poly_macro_step_t s = poly_macro_decode(rd, &b, 0, b.bytes.size());
+    EXPECT_EQ(s.kind, POLY_MACRO_STEP_END);
+}
+
+TEST(MacroDecode, TruncatedOpArgumentIsNotAStep) {
+    Buf b;
+    b.bytes = {POLY_MACRO_PREFIX, POLY_MACRO_OP_TAP}; // keycode byte missing
+    poly_macro_step_t s = poly_macro_decode(rd, &b, 0, b.bytes.size());
+    EXPECT_EQ(s.kind, POLY_MACRO_STEP_END);
+}
+
+// ---------------------------------------------------------------------------
+// A realistic body, end to end
+
+TEST(MacroDecode, ChordThenTextThenDelay) {
+    // Ctrl down, 'c', Ctrl up, wait 50 ms, type "ok"
+    Buf  b     = make({down(0xE0) + tap(0x06) + up(0xE0) + delay("50") + "ok"});
+    auto steps = run(b, 0);
+    ASSERT_EQ(steps.size(), 6u);
+    EXPECT_EQ(steps[0].kind, POLY_MACRO_STEP_DOWN);
+    EXPECT_EQ(steps[1].kind, POLY_MACRO_STEP_TAP);
+    EXPECT_EQ(steps[2].kind, POLY_MACRO_STEP_UP);
+    EXPECT_EQ(steps[3].kind, POLY_MACRO_STEP_DELAY);
+    EXPECT_EQ(steps[3].ms, 50);
+    EXPECT_EQ(steps[4].code, 'o');
+    EXPECT_EQ(steps[5].code, 'k');
+}
+
+TEST(MacroDecode, SecondMacroDecodesIndependently) {
+    Buf      b     = make({"first", "second"});
+    uint16_t start = poly_macro_find(rd, &b, 1, b.bytes.size());
+    auto     steps = run(b, start);
+    std::string got;
+    for (auto &s : steps) got.push_back(char(s.code));
+    EXPECT_EQ(got, "second");
+}

--- a/keyboards/polykybd/base/tests/test_rules.mk
+++ b/keyboards/polykybd/base/tests/test_rules.mk
@@ -31,3 +31,16 @@ polykybd_glyph_meta_SRC := \
 polykybd_glyph_meta_INC := \
 	$(POLY_BASE_PATH) \
 	keyboards/polykybd
+
+# The decoder is dependency-free by construction -- no quantum.h, no EEPROM, no timer --
+# so the suite links just it and the tests. That is the same seam as fw_up_verdict: the
+# part with the arithmetic is the part worth testing, and it only became reachable once
+# it stopped sharing a function with the I/O.
+polykybd_macro_decode_SRC := \
+	$(POLY_BASE_PATH)/macro_decode.c \
+	$(POLY_BASE_PATH)/tests/macro_decode_tests.cpp
+
+polykybd_macro_decode_INC := \
+	$(POLY_BASE_PATH) \
+	$(POLY_BASE_PATH)/tests \
+	keyboards/polykybd

--- a/keyboards/polykybd/base/tests/testlist.mk
+++ b/keyboards/polykybd/base/tests/testlist.mk
@@ -1,2 +1,3 @@
 TEST_LIST += fw_up_verdict
 TEST_LIST += polykybd_glyph_meta
+TEST_LIST += polykybd_macro_decode

--- a/keyboards/polykybd/config.h
+++ b/keyboards/polykybd/config.h
@@ -223,7 +223,7 @@
 //      only and live in the `latinbig` font-pack bundle; without it (or for a
 //      non-latin legend) the render falls back to small, so the setting is
 //      always safe to accept.
-#define PROTOCOL_VERSION 13
+#define PROTOCOL_VERSION 14
 
 #define FULL_BRIGHT 50
 #define MIN_BRIGHT 1
@@ -406,3 +406,34 @@
     (DYNAMIC_KEYMAP_EEPROM_ADDR + (DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT * MATRIX_ROWS * MATRIX_COLS * 2))
 #define DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR \
     (DYNAMIC_KEYMAP_ENCODER_EEPROM_ADDR + (DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT * NUM_ENCODERS * 2 * 2))
+
+// --- Macro labels -----------------------------------------------------------
+// The label a macro keycap spells out along its bottom edge. Stored as a FIXED-STRIDE
+// array carved off the top of the macro region, NUL-padded, deliberately NOT inside
+// the NUL-delimited body buffer: a body is addressed by counting separators from the
+// start, which is fine once per keypress and wrong for something the render path reads
+// for every keycap on every display refresh. Fixed stride makes label(n) a multiply.
+//
+// Shrinking DYNAMIC_KEYMAP_MACRO_EEPROM_SIZE is what keeps the two apart -- every QMK
+// path that touches the body bounds itself on that constant, so nothing upstream can
+// reach the labels even though they sit in the same region.
+//
+// 12 bytes is the measured average that fits the 72 px panel in the _Nano_ 10 px face
+// (8 in the worst case, all-W; 24 of narrow letters). Truncation is by PIXEL WIDTH at
+// render time, not by this length -- see poly_macro_label_fit().
+#define POLY_MACRO_LABEL_LEN   12
+#define POLY_MACRO_COUNT       16
+#define DYNAMIC_KEYMAP_MACRO_COUNT POLY_MACRO_COUNT
+#define POLY_MACRO_LABEL_BYTES (POLY_MACRO_COUNT * POLY_MACRO_LABEL_LEN)
+
+// QMK derives this inside nvm_dynamic_keymap.c, i.e. it exists in exactly one
+// translation unit. Everything below (and poly_macro.c) needs the same number, so
+// define it here -- QMK's own #ifndef then picks ours up and the two cannot disagree.
+#ifndef DYNAMIC_KEYMAP_EEPROM_MAX_ADDR
+#    define DYNAMIC_KEYMAP_EEPROM_MAX_ADDR (TOTAL_EEPROM_BYTE_COUNT - 1)
+#endif
+
+#define DYNAMIC_KEYMAP_MACRO_EEPROM_SIZE \
+    ((DYNAMIC_KEYMAP_EEPROM_MAX_ADDR - DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR + 1) - POLY_MACRO_LABEL_BYTES)
+#define POLY_MACRO_LABEL_ADDR \
+    (DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR + DYNAMIC_KEYMAP_MACRO_EEPROM_SIZE)

--- a/keyboards/polykybd/config.h
+++ b/keyboards/polykybd/config.h
@@ -424,7 +424,24 @@
 #define POLY_MACRO_LABEL_LEN   12
 #define POLY_MACRO_COUNT       16
 #define DYNAMIC_KEYMAP_MACRO_COUNT POLY_MACRO_COUNT
-#define POLY_MACRO_LABEL_BYTES (POLY_MACRO_COUNT * POLY_MACRO_LABEL_LEN)
+
+// A macro OWNS its keycap -- it cannot be folded into a modifier or a tap-hold, because
+// QMK carries the wrapped key in the low byte (MT/LT are `(kc) & 0xFF`) and a macro
+// keycode is 0x7700+. Since the whole cell is the macro's, the cell is free to be more
+// than a legend, so each record carries HOW to draw it alongside the text:
+//
+//   style  1 B   POLY_MACRO_STYLE_*
+//   icon   4 B   codepoint drawn above the caption, 0 = none. Four bytes because the
+//                interesting glyphs are emoji at 0x1F300+, well past 16 bits.
+//   text  12 B   the caption
+//
+// One record, one address, one dirty bit, one bridge -- deliberately NOT a parallel
+// array beside the labels, which is the shape that goes out of step and then needs a
+// guard to remember it (see the enumerating-guard note in CLAUDE.md). The appearance
+// cannot arrive half-applied on the slave because it never travels in two pieces.
+#define POLY_MACRO_ICON_LEN    4
+#define POLY_MACRO_LOOK_LEN    (1 + POLY_MACRO_ICON_LEN + POLY_MACRO_LABEL_LEN)
+#define POLY_MACRO_LABEL_BYTES (POLY_MACRO_COUNT * POLY_MACRO_LOOK_LEN)
 
 // QMK derives this inside nvm_dynamic_keymap.c, i.e. it exists in exactly one
 // translation unit. Everything below (and poly_macro.c) needs the same number, so

--- a/keyboards/polykybd/config.h
+++ b/keyboards/polykybd/config.h
@@ -379,3 +379,30 @@
 #define USE_CORE1
 
 #define DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT 8
+
+// Reclaim the storage QMK reserves for the layers we never store.
+//
+// DYNAMIC_KEYMAP_LAYER_COUNT must stay 12 (QMK asserts it is >= the compiled layer
+// count, keymap_introspection.c), but only layers 0..7 are ever READ or WRITTEN from
+// EEPROM -- everything from _SL up is served straight out of flash by poly_keycode_at().
+// QMK's default addresses put the encoder map and the macro buffer after all TWELVE
+// layers, so 640 B (split72) / 384 B (split42) of keymap plus a further 32 B of encoder
+// map sit there addressed by nothing. Basing both on the write cap instead hands that
+// space to the macro buffer, which is the one region sized by "whatever is left".
+//
+// The bodies are expanded at the USE site (nvm_dynamic_keymap.c), not here, so
+// MATRIX_ROWS/COLS and NUM_ENCODERS do not have to be defined yet -- exactly how QMK's
+// own defaults are written.
+//
+// WARNING: this only works because nothing writes layers >= the cap. Two guards keep
+// that true and BOTH are load-bearing: the host cannot (dynamic_keymap_set_keycode_poly
+// / _set_buffer_poly clamp to the cap), and OUR reset walks the cap rather than
+// DYNAMIC_KEYMAP_LAYER_COUNT. QMK's own dynamic_keymap_reset() does NOT -- it loops to
+// DYNAMIC_KEYMAP_LAYER_COUNT and calls nvm_dynamic_keymap_update_keycode(), whose bound
+// check is also DYNAMIC_KEYMAP_LAYER_COUNT, so it writes layers 8..11 straight over the
+// encoder map and the macro buffer. It is still reachable from eeconfig_init_quantum();
+// eeconfig_init_kb() repairs after it (see poly_keymap.c). Do not add a third call site.
+#define DYNAMIC_KEYMAP_ENCODER_EEPROM_ADDR \
+    (DYNAMIC_KEYMAP_EEPROM_ADDR + (DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT * MATRIX_ROWS * MATRIX_COLS * 2))
+#define DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR \
+    (DYNAMIC_KEYMAP_ENCODER_EEPROM_ADDR + (DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT * NUM_ENCODERS * 2 * 2))

--- a/keyboards/polykybd/hid_com.c
+++ b/keyboards/polykybd/hid_com.c
@@ -1114,10 +1114,15 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                         memcpy(&data[header], buf, want);
                         raw_hid_send(data, length);
                     } else {
-                        // A write lands mid-buffer, so a macro that is being replaced is
-                        // briefly inconsistent. poly_macro_start() refuses to play a
-                        // buffer whose last byte is not NUL, which is what the host
-                        // leaves clear until the final chunk -- same guard QMK uses.
+                        // A write lands mid-buffer, so a macro that is being replaced
+                        // is briefly inconsistent -- and an interrupted upload would
+                        // otherwise leave a playable splice of the new text and
+                        // whatever preceded it. poly_macro_start() refuses to play a
+                        // buffer whose last byte is not NUL; the HOST raises a non-zero
+                        // marker there before it streams and clears it with the final
+                        // window, so the guard is armed for exactly that window. The
+                        // marker is the host's job because only the host knows a write
+                        // has begun -- from here every window looks alike.
                         poly_macro_write(offset, (uint16_t)want, &data[header]);
                         memset(data, 0, length);
                         hid_reply(data, 0x25, true);

--- a/keyboards/polykybd/hid_com.c
+++ b/keyboards/polykybd/hid_com.c
@@ -1089,6 +1089,12 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                     data[6] = (uint8_t)(cap >> 8);
                     data[7] = (uint8_t)(used & 0xFF);
                     data[8] = (uint8_t)(used >> 8);
+                    // How many keycap styles this firmware can actually DRAW. The host
+                    // may offer more (an unknown style degrades to the index rather
+                    // than being refused), but a menu that lists only what the board
+                    // renders is the honest one -- and this costs a byte in a report
+                    // with 55 spare.
+                    data[9] = POLY_MACRO_STYLE_COUNT;
                     raw_hid_send(data, length);
                 }
                 break;
@@ -1130,13 +1136,26 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                     }
                 }
                 break;
-            case 38: //macro label get/set (protocol v15+)
+            case 38: //macro look get/set (protocol v15+)
                 {
-                    // data[2] = macro id, data[3] = 0xFF query else byte count,
-                    // data[4..] = label text. ASCII only -- poly_macro_label_set drops
-                    // anything the _Nano_ face cannot draw, so what is stored is what the
-                    // keycap will show.
-                    const uint8_t header = 4;
+                    // The whole appearance of one macro in one exchange:
+                    //   data[2]    macro id
+                    //   data[3]    0xFF query, else the caption byte count
+                    //   data[4]    style (POLY_MACRO_STYLE_*)
+                    //   data[5..8] icon codepoint, little-endian
+                    //   data[9..]  caption text
+                    // The reply mirrors the same layout.
+                    //
+                    // One command rather than three, because a macro keycap composes
+                    // the caption WITH the style and the icon -- splitting them lets a
+                    // host apply half an appearance, and the keycap then draws a
+                    // combination the user never asked for until the next write lands.
+                    //
+                    // ASCII only: poly_macro_look_set drops anything the _Nano_ face
+                    // cannot draw, so what is stored is what the keycap will show. An
+                    // unknown style is stored as STYLE_INDEX rather than refused -- see
+                    // poly_macro.h.
+                    const uint8_t header = 9;
                     uint8_t       id     = data[HID_DATA_IDX];
                     uint8_t       n      = data[3];
                     if (id >= POLY_MACRO_COUNT) {
@@ -1149,19 +1168,26 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                         const uint16_t avail = hid_payload_avail(length, header);
                         if (n > avail) n = (uint8_t)avail;
                         if (n > POLY_MACRO_LABEL_LEN) n = POLY_MACRO_LABEL_LEN;
-                        char text[POLY_MACRO_LABEL_LEN + 1];
-                        memcpy(text, &data[header], n);
-                        text[n] = '\0';
-                        poly_macro_label_set(id, text);
+                        poly_macro_look_t look;
+                        look.style = data[4];
+                        look.icon  = (uint32_t)data[5] | ((uint32_t)data[6] << 8)
+                                   | ((uint32_t)data[7] << 16) | ((uint32_t)data[8] << 24);
+                        memcpy(look.text, &data[header], n);
+                        look.text[n] = '\0';
+                        poly_macro_look_set(id, &look);
                         request_disp_refresh();
                     }
-                    char label[POLY_MACRO_LABEL_LEN + 1];
-                    poly_macro_label_get(id, label);
-                    uint8_t len = (uint8_t)strlen(label);
+                    poly_macro_look_t look;
+                    poly_macro_look_get(id, &look);
+                    uint8_t len = (uint8_t)strlen(look.text);
                     memset(data, 0, length);
                     hid_reply(data, 0x26, true);
                     data[3] = len;
-                    memcpy(&data[header], label, len);
+                    data[4] = look.style;
+                    for (uint8_t b = 0; b < POLY_MACRO_ICON_LEN; b++) {
+                        data[5 + b] = (uint8_t)((look.icon >> (8 * b)) & 0xFFu);
+                    }
+                    memcpy(&data[header], look.text, len);
                     raw_hid_send(data, length);
                 }
                 break;

--- a/keyboards/polykybd/hid_com.c
+++ b/keyboards/polykybd/hid_com.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "hid_com.h"
+#include "poly_macro.h"
 #include "hid_fw_up.h"
 #include "hid_fontpack.h"
 #include "split_fw_up.h"
@@ -1005,6 +1006,95 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                         hid_reply(data, 0x22, false);
                         uprintf("Refused glyph size %u.\n", arg);
                     }
+                    raw_hid_send(data, length);
+                }
+                break;
+            case 35: //macro info: how many, how big, how much is in use (protocol v14+)
+                {
+                    // Read-only. The host needs all four before it can lay out an editor:
+                    // the count and the label stride are compile-time, the capacity is
+                    // whatever survived the EEPROM layout, and `used` is what makes the
+                    // shared-storage bar honest -- the bodies share one buffer, so a long
+                    // macro takes room from the others and that has to be visible before
+                    // a save fails rather than after.
+                    memset(data, 0, length);
+                    hid_reply(data, 0x23, true);
+                    data[3] = POLY_MACRO_COUNT;
+                    data[4] = POLY_MACRO_LABEL_LEN;
+                    uint16_t cap  = poly_macro_capacity();
+                    uint16_t used = poly_macro_bytes_used();
+                    data[5] = (uint8_t)(cap & 0xFF);
+                    data[6] = (uint8_t)(cap >> 8);
+                    data[7] = (uint8_t)(used & 0xFF);
+                    data[8] = (uint8_t)(used >> 8);
+                    raw_hid_send(data, length);
+                }
+                break;
+            case 36: //macro body read/write, windowed (protocol v14+)
+                {
+                    // data[2] = 0 read / 1 write, data[3..4] = offset LE, data[5] = count,
+                    // data[6..] = bytes. Windowed rather than whole-macro because the
+                    // buffer is up to ~2 KB and a report holds 64 -- the host streams it
+                    // the same way it streams an overlay.
+                    const uint8_t  header = 6;
+                    uint8_t        sub    = data[HID_DATA_IDX];
+                    uint16_t       offset = (uint16_t)data[3] | ((uint16_t)data[4] << 8);
+                    uint16_t       want   = data[5];
+                    const uint16_t avail  = hid_payload_avail(length, header);
+                    if (want > avail) want = avail;
+
+                    if (sub == 0) {
+                        uint8_t buf[64];
+                        poly_macro_read(offset, (uint16_t)want, buf);
+                        memset(data, 0, length);
+                        hid_reply(data, 0x24, true);
+                        data[3] = (uint8_t)want;
+                        memcpy(&data[header], buf, want);
+                        raw_hid_send(data, length);
+                    } else {
+                        // A write lands mid-buffer, so a macro that is being replaced is
+                        // briefly inconsistent. poly_macro_start() refuses to play a
+                        // buffer whose last byte is not NUL, which is what the host
+                        // leaves clear until the final chunk -- same guard QMK uses.
+                        poly_macro_write(offset, (uint16_t)want, &data[header]);
+                        memset(data, 0, length);
+                        hid_reply(data, 0x24, true);
+                        raw_hid_send(data, length);
+                    }
+                }
+                break;
+            case 37: //macro label get/set (protocol v14+)
+                {
+                    // data[2] = macro id, data[3] = 0xFF query else byte count,
+                    // data[4..] = label text. ASCII only -- poly_macro_label_set drops
+                    // anything the _Nano_ face cannot draw, so what is stored is what the
+                    // keycap will show.
+                    const uint8_t header = 4;
+                    uint8_t       id     = data[HID_DATA_IDX];
+                    uint8_t       n      = data[3];
+                    if (id >= POLY_MACRO_COUNT) {
+                        memset(data, 0, length);
+                        hid_reply(data, 0x25, false);
+                        raw_hid_send(data, length);
+                        break;
+                    }
+                    if (n != 0xFF) {
+                        const uint16_t avail = hid_payload_avail(length, header);
+                        if (n > avail) n = (uint8_t)avail;
+                        if (n > POLY_MACRO_LABEL_LEN) n = POLY_MACRO_LABEL_LEN;
+                        char text[POLY_MACRO_LABEL_LEN + 1];
+                        memcpy(text, &data[header], n);
+                        text[n] = '\0';
+                        poly_macro_label_set(id, text);
+                        request_disp_refresh();
+                    }
+                    char label[POLY_MACRO_LABEL_LEN + 1];
+                    poly_macro_label_get(id, label);
+                    uint8_t len = (uint8_t)strlen(label);
+                    memset(data, 0, length);
+                    hid_reply(data, 0x25, true);
+                    data[3] = len;
+                    memcpy(&data[header], label, len);
                     raw_hid_send(data, length);
                 }
                 break;

--- a/keyboards/polykybd/hid_com.c
+++ b/keyboards/polykybd/hid_com.c
@@ -1119,7 +1119,7 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                         data[3] = (uint8_t)want;
                         memcpy(&data[header], buf, want);
                         raw_hid_send(data, length);
-                    } else {
+                    } else if (sub == 1) {
                         // A write lands mid-buffer, so a macro that is being replaced
                         // is briefly inconsistent -- and an interrupted upload would
                         // otherwise leave a playable splice of the new text and
@@ -1132,6 +1132,14 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                         poly_macro_write(offset, (uint16_t)want, &data[header]);
                         memset(data, 0, length);
                         hid_reply(data, 0x25, true);
+                        raw_hid_send(data, length);
+                    } else {
+                        // Anything else NACKs rather than falling into the write. The
+                        // `else` used to catch every value, so a malformed or newer
+                        // client silently modified macro EEPROM instead of being told
+                        // the sub-command means nothing here (CodeRabbit, 2026-08-27).
+                        memset(data, 0, length);
+                        hid_reply(data, 0x25, false);
                         raw_hid_send(data, length);
                     }
                 }

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -155,6 +155,7 @@ const struct display_info disp_row_3 = { POLY_DISP_ROW_3 };
 
 
 bool display_wakeup(keyrecord_t* record);
+static void render_macro_key(uint8_t id);   // defined below, used from render_key()
 void update_displays(enum refresh_mode mode);
 void set_displays(uint8_t contrast, bool idle);
 void set_selected_displays(int8_t old_value, int8_t new_value);
@@ -977,6 +978,13 @@ void housekeeping_task_user(void) {
     // so it must not be starved by a flash or by the idle machinery, and a step that
     // took the long way round would show up as uneven keystroke timing on the host.
     poly_macro_tick();
+
+    // Drain at most one queued macro label to the slave. Master-only (the slave is the
+    // receiver), and one per pass because each bridge can spend its retries -- sixteen
+    // of them back to back would be a visible stall on a link that is already unhappy.
+    if (is_keyboard_master()) {
+        poly_macro_label_sync_tick();
+    }
 
     // fw_up state machine: apply on success path, advance deferred erase.
     // Both must run regardless of fw_up_active so the slave's erase actually
@@ -2277,6 +2285,14 @@ bool render_key(uint16_t keycode, led_t state, uint8_t mods) {
         }
     }
 
+    // Macro keys draw their own cell: the index, and the label along the bottom edge.
+    // Reached because to_static_text() has no case for QK_MACRO_*, which is exactly the
+    // seam update_displays() uses -- a key WITH a legend never gets here.
+    if (keycode >= QK_MACRO && keycode <= QK_MACRO_MAX) {
+        render_macro_key((uint8_t)(keycode - QK_MACRO));
+        return true;
+    }
+
     if (mods & MOD_RALT) {
         const uint32_t* letter = translate_keycode_only_altgr(local_state->lang, keycode);
         if (letter != NULL) {
@@ -2551,6 +2567,85 @@ static void render_fw_confirm_key(bool accept) {
                                (int8_t)(BUFFER_X + (SCREEN_WIDTH - lw) / 2),
                                (int8_t)((free_rows - lh) / 2),
                                letter);
+}
+
+// Compose a macro keycap: the macro's index above, its label along the bottom edge.
+//
+// Same split as render_lang_flag_key -- identity on top, a tiny _Nano_ caption below --
+// because it is the shape this board already uses for "what is this, and which one".
+// The INDEX rather than a generic macro glyph: a generic glyph would be identical on
+// all sixteen keys, so it says "this is a macro" and nothing else, while the index says
+// which one and needs no font pack (the pack glyphs are the one thing a fresh keyboard
+// might not have). When a label is set it carries the meaning and the index shrinks
+// out of the way; when it is not, the index is all there is, so it takes the cell.
+//
+// The label is truncated by MEASURED WIDTH, never by character count: in this face a
+// 'W' is about three times an 'i', so a fixed cut either clips a wide label off the
+// panel or wastes half the band on a narrow one. The host runs the same measurement in
+// its editor, so what you type is what the keycap shows.
+static void render_macro_key(uint8_t id) {
+    char label[POLY_MACRO_LABEL_LEN + 1];
+    poly_macro_label_get(id, label);
+
+    // "M12" -- built by hand rather than snprintf, which is not worth linking for two
+    // digits, and the display list wants uint32_t codepoints anyway.
+    uint32_t index_text[4];
+    uint8_t  n = 0;
+    index_text[n++] = (uint32_t)'M';
+    if (id >= 10) index_text[n++] = (uint32_t)('0' + id / 10);
+    index_text[n++] = (uint32_t)('0' + id % 10);
+    index_text[n]   = 0;
+
+    if (label[0] == '\0') {
+        // No label: centre the index in the whole cell.
+        int8_t ixmin, ixmax, iymin, iymax;
+        kdisp_gfx_text_bbox(mid_fonts, 1, index_text, &ixmin, &ixmax, &iymin, &iymax);
+        kdisp_write_gfx_text(mid_fonts, 1,
+                             (int8_t)(BUFFER_X + (SCREEN_WIDTH - (ixmax - ixmin + 1)) / 2 - ixmin),
+                             (int8_t)((SCREEN_HEIGHT - (iymax - iymin + 1)) / 2 - iymin),
+                             index_text);
+        return;
+    }
+
+    // Widen to codepoints, then drop trailing characters until the run fits the panel.
+    // Measuring after each drop rather than estimating from a per-character width is
+    // the point -- the face is proportional, so an estimate is wrong in both directions.
+    uint32_t text[POLY_MACRO_LABEL_LEN + 1];
+    uint8_t  len = 0;
+    for (; label[len] != '\0' && len < POLY_MACRO_LABEL_LEN; len++) {
+        text[len] = (uint32_t)(uint8_t)label[len];
+    }
+    text[len] = 0;
+
+    int8_t lxmin = 0, lxmax = 0, lymin = 0, lymax = 0;
+    while (len > 0) {
+        kdisp_gfx_text_bbox(lang_label_fonts, 1, text, &lxmin, &lxmax, &lymin, &lymax);
+        if ((int16_t)(lxmax - lxmin + 1) <= SCREEN_WIDTH) break;
+        text[--len] = 0;
+    }
+    if (len == 0) return;
+
+    // Pin the caption's lowest lit pixel to the last screen row, exactly as the FW-2
+    // prompt does -- the descender budget differs per string, so a fixed baseline
+    // clips whichever label happens to carry a 'y'.
+    const int8_t cap_base  = (int8_t)(SCREEN_HEIGHT - 1 - lymax);
+    const int8_t free_rows = (int8_t)(cap_base + lymin);   // rows above the caption
+
+    kdisp_write_gfx_text(lang_label_fonts, 1,
+                         (int8_t)(BUFFER_X + (SCREEN_WIDTH - (lxmax - lxmin + 1)) / 2 - lxmin),
+                         cap_base, text);
+
+    // The index, centred in whatever the caption left. Skipped rather than squeezed if
+    // a tall label leaves no room -- a clipped index is worse than none.
+    int8_t ixmin, ixmax, iymin, iymax;
+    kdisp_gfx_text_bbox(mid_fonts, 1, index_text, &ixmin, &ixmax, &iymin, &iymax);
+    const int8_t ih = (int8_t)(iymax - iymin + 1);
+    if (ih < free_rows) {
+        kdisp_write_gfx_text(mid_fonts, 1,
+                             (int8_t)(BUFFER_X + (SCREEN_WIDTH - (ixmax - ixmin + 1)) / 2 - ixmin),
+                             (int8_t)((free_rows - ih) / 2 - iymin),
+                             index_text);
+    }
 }
 
 static void render_lang_flag_key(uint8_t idx, const uint32_t* label, uint8_t current_lang) {
@@ -4414,6 +4509,16 @@ static void boot_trace(const uint32_t* digit) {
 // Initializes keyboard state after reset: enables debug, sets CPI, loads layer/unicode defaults.
 // Global variables: com
 void keyboard_post_init_user(void) {
+    // Labels live in RAM on both halves (the render path reads one per macro keycap per
+    // refresh). Each half loads its own EEPROM copy, then the master overwrites the
+    // slave's over the link -- so a role swap makes whichever half the host talks to
+    // the authority, with no handedness bookkeeping.
+    poly_macro_labels_load();
+    // Queue them all. Nothing detects "the link is up" here and nothing needs to: the
+    // sync tick only clears a label's bit on a real ACK, so the queue simply drains
+    // once the slave starts answering. Same shape as the state diff being its own
+    // retry queue.
+    poly_macro_labels_mark_all_dirty();
 #ifdef FW_UP_BOOT_TRACE
     boot_trace(U"1");
 #endif

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -77,6 +77,7 @@
 #endif
 
 #include "state.h"
+#include "poly_macro.h"
 #include "multicore_exec.h"
 #include "split_sync.h"
 #include "poly_util.h"
@@ -970,6 +971,12 @@ void housekeeping_task_user(void) {
 #endif
 
     boot_banner_housekeeping_tick();   // re-emit the boot banner for a late console
+
+    // Advance a playing macro by at most one step. Deliberately near the TOP of
+    // housekeeping and outside every fw_up/idle gate: a macro is user-visible typing,
+    // so it must not be starved by a flash or by the idle machinery, and a step that
+    // took the long way round would show up as uneven keystroke timing on the host.
+    poly_macro_tick();
 
     // fw_up state machine: apply on success path, advance deferred erase.
     // Both must run regardless of fw_up_active so the slave's erase actually
@@ -3801,6 +3808,28 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
                 fw_staging_confirm_answer(false);   // right half -> R / REJECT
             }
         }
+        return false;
+    }
+
+    // A macro is interruptible: any PRESS while one is playing stops it. That is the
+    // "make it stop" a user reaches for, and it is also what keeps a macro from
+    // interleaving its own keystrokes with live typing. The aborting key then falls
+    // through and behaves normally -- the abort is not a swallow.
+    if (poly_macro_active() && record->event.pressed) {
+        poly_macro_abort();
+    }
+
+    // Macro keycodes (QK_MACRO_0..QK_MACRO_MAX). Nothing else in the build consumes
+    // them -- via.c is the only core dispatcher and VIA_ENABLE is unset -- so they are
+    // ours, and they are SWALLOWED here rather than handled on the release edge: an
+    // OSL() layer re-dispatches a release-edge action up to three times
+    // (process_action's do_release_oneshot), which for a macro would mean playing it
+    // two or three times over.
+    if (keycode >= QK_MACRO && keycode <= QK_MACRO_MAX) {
+        if (record->event.pressed) {
+            poly_macro_start((uint8_t)(keycode - QK_MACRO));
+        }
+        display_wakeup(record);
         return false;
     }
 

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -2726,7 +2726,8 @@ static void render_macro_key(uint8_t id) {
     uint32_t             mark_text[2];
     const uint32_t*      mark = index_text;
 
-    if (look.style == POLY_MACRO_STYLE_ICON && look.icon != 0) {
+    if ((look.style == POLY_MACRO_STYLE_ICON || look.style == POLY_MACRO_STYLE_ICON_ONLY)
+        && look.icon != 0) {
         icon_glyph = kdisp_gfx_glyph_font(g_all_fonts, g_all_font_count, look.icon,
                                           &icon_font);
         if (icon_glyph != NULL) {
@@ -2739,8 +2740,17 @@ static void render_macro_key(uint8_t id) {
         }
     }
 
-    if (label[0] == '\0') {
-        // No caption: centre the mark in the whole cell.
+    // ICON_ONLY draws the icon alone, centred in the whole cell, exactly as an
+    // uncaptioned key does -- the caption is KEPT in storage so switching back does
+    // not lose it, it is simply not drawn. An icon this keyboard has no glyph for
+    // leaves icon_glyph NULL and falls through to the captioned index, which is the
+    // same fallback every other icon path takes: a keycap is never left blank.
+    const bool icon_only = (look.style == POLY_MACRO_STYLE_ICON_ONLY && icon_glyph != NULL);
+
+    if (label[0] == '\0' || icon_only) {
+        // No caption to place around: centre the mark in the whole cell. No fit check
+        // and no halving here -- the tallest pack glyph is exactly SCREEN_HEIGHT, and
+        // filling the cell is the point of this branch.
         int8_t ixmin, ixmax, iymin, iymax;
         kdisp_gfx_text_bbox(mark_fonts, mark_count, mark, &ixmin, &ixmax, &iymin, &iymax);
         kdisp_write_gfx_text(mark_fonts, mark_count,

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -4510,7 +4510,7 @@ void keyboard_post_init_user(void) {
     // user datablock and the keymap are separate blocks with separate lifetimes —
     // the keymap survives a user-data re-init, which is exactly the case that would
     // otherwise slip through.
-    if (ee.keymap_layers_fmt != KEYMAP_LAYERS_FL_MERGED) {
+    if (ee.keymap_layers_fmt != KEYMAP_STORAGE_CURRENT) {
         uprintf("Keymap layer enum changed (fmt %u) - resetting dynamic keymap\n",
                 (unsigned)ee.keymap_layers_fmt);
         dynamic_keymap_reset_poly();
@@ -4708,6 +4708,29 @@ void keyboard_pre_init_user(void) {
 #endif
 
     gpio_set_pin_input_high(I2C1_SDA_PIN);
+}
+
+// Runs immediately after QMK's own dynamic_keymap_reset() in eeconfig_init_quantum().
+//
+// That call is the ONE remaining reachable use of the unbounded reset, and with the
+// encoder/macro regions rebased on DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT (config.h) it
+// writes layers 8..11 straight over both of them. It cannot be prevented from here --
+// eeconfig.c is upstream and we deliberately do not patch it for this -- but it CAN be
+// repaired, because eeconfig_init_quantum() calls us three lines later, unconditionally,
+// in the same function. dynamic_keymap_reset_poly() rewrites layers 0..7 and the capped
+// encoder map from flash and zeroes the macro buffer, which is exactly the state a fresh
+// EEPROM should be in, so this is the normal initialisation rather than a fix-up that
+// happens to also repair.
+//
+// Nearly free despite running second: eeprom_update_byte() only writes a byte that
+// actually changed, and QMK's pass has already put the correct values in layers 0..7.
+void eeconfig_init_kb(void) {
+    // Replicate what the weak default does before adding the repair -- overriding it
+    // replaces the whole body, and dropping either half here would be silent
+    // (eeconfig.c, EECONFIG_KB_DATA_SIZE == 0 branch).
+    eeconfig_update_kb(0);
+    dynamic_keymap_reset_poly();
+    eeconfig_init_user();
 }
 
 // Initializes EEPROM configuration with default language, brightness, and latin extension settings.

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -2583,9 +2583,85 @@ static void render_fw_confirm_key(bool accept) {
 // 'W' is about three times an 'i', so a fixed cut either clips a wide label off the
 // panel or wastes half the band on a narrow one. The host runs the same measurement in
 // its editor, so what you type is what the keycap shows.
+// Draw `text` centred in the whole cell at the largest face that fits it, biggest
+// first. Returns false when even the smallest face overflows, which the caller treats
+// as "nothing to draw" rather than clipping.
+//
+// The ladder is the point: a caption alone has the entire 72x40 to spend, and the
+// _Nano_ 10 px face the bottom band uses would waste it. The two big tiers live in the
+// `latinbig` PACK bundle, so they are simply absent on a keyboard with no font pack --
+// glyph_size_remap() is all-or-nothing and returns false there, and the ladder walks
+// past them to the resident faces. That is why the resident 27 px face is on the list
+// rather than being the assumed floor.
+static bool draw_macro_caption_big(const uint32_t* text) {
+    uint32_t scratch[POLY_MACRO_LABEL_LEN + 1];
+
+    for (uint8_t tier = 0; tier < 4; tier++) {
+        const GFXfont* const* fonts = NULL;
+        uint8_t               count = 0;
+        const uint32_t*       run   = text;
+
+        switch (tier) {
+            case 0:
+            case 1:
+                // GLYPH_SIZE_L then _M, relocated into the supplementary PUA planes the
+                // latinbig entries are emitted at. Same helper the legend-size feature
+                // uses, so a caption cannot end up at a size the legends cannot reach.
+                if (!glyph_size_remap((uint8_t)(tier == 0 ? GLYPH_SIZE_L : GLYPH_SIZE_M),
+                                      text, scratch,
+                                      (uint8_t)(POLY_MACRO_LABEL_LEN + 1))) {
+                    continue;
+                }
+                run   = scratch;
+                fonts = g_all_fonts;
+                count = g_all_font_count;
+                break;
+            case 2:
+                // The resident latin face (~20 px caps). Always present.
+                fonts = g_all_fonts;
+                count = g_all_font_count;
+                break;
+            default:
+                fonts = mid_fonts;
+                count = 1;
+                break;
+        }
+
+        int8_t xmin, xmax, ymin, ymax;
+        kdisp_gfx_text_bbox(fonts, count, run, &xmin, &xmax, &ymin, &ymax);
+        const int16_t w = (int16_t)(xmax - xmin + 1);
+        const int16_t h = (int16_t)(ymax - ymin + 1);
+        if (w > SCREEN_WIDTH || h > SCREEN_HEIGHT) continue;
+
+        kdisp_write_gfx_text(fonts, count,
+                             (int8_t)(BUFFER_X + (SCREEN_WIDTH - w) / 2 - xmin),
+                             (int8_t)((SCREEN_HEIGHT - h) / 2 - ymin),
+                             run);
+        return true;
+    }
+    return false;
+}
+
 static void render_macro_key(uint8_t id) {
-    char label[POLY_MACRO_LABEL_LEN + 1];
-    poly_macro_label_get(id, label);
+    poly_macro_look_t look;
+    poly_macro_look_get(id, &look);
+    const char *label = look.text;
+
+    // Widen the caption to codepoints once -- both the big-text style and the captioned
+    // styles below need it, and the display list wants uint32_t anyway.
+    uint32_t text[POLY_MACRO_LABEL_LEN + 1];
+    uint8_t  tlen = 0;
+    for (; label[tlen] != '\0' && tlen < POLY_MACRO_LABEL_LEN; tlen++) {
+        text[tlen] = (uint32_t)(uint8_t)label[tlen];
+    }
+    text[tlen] = 0;
+
+    // Caption alone, filling the cell. Falls through to the captioned styles when the
+    // caption is empty (there would be nothing to draw) or when even the smallest face
+    // overflows -- an empty keycap is worse than the small one it replaced.
+    if (look.style == POLY_MACRO_STYLE_TEXT && tlen > 0) {
+        if (draw_macro_caption_big(text)) return;
+    }
 
     // "M12" -- built by hand rather than snprintf, which is not worth linking for two
     // digits, and the display list wants uint32_t codepoints anyway.
@@ -2596,26 +2672,46 @@ static void render_macro_key(uint8_t id) {
     index_text[n++] = (uint32_t)('0' + id % 10);
     index_text[n]   = 0;
 
+    // The mark above the caption: a chosen glyph, or the index. The icon is looked up
+    // through its OWN single-font array once found, because kdisp_write_gfx_char
+    // baseline-aligns every glyph to fonts[0] -- with g_all_fonts that is IconsFont
+    // (yAdvance 40) and a taller pack glyph is shifted down by the difference, which is
+    // exactly the language-flag gap-at-top regression. An icon this keyboard has no
+    // glyph for falls back to the index rather than drawing nothing, so a caption
+    // picked on a host with a richer font pack still names its macro here.
+    const GFXfont*       icon_font = NULL;
+    const GFXfont*       icon_arr[1];
+    const GFXfont* const* mark_fonts = mid_fonts;
+    uint8_t              mark_count  = 1;
+    uint32_t             mark_text[2];
+    const uint32_t*      mark = index_text;
+
+    if (look.style == POLY_MACRO_STYLE_ICON && look.icon != 0) {
+        if (kdisp_gfx_glyph_font(g_all_fonts, g_all_font_count, look.icon, &icon_font)) {
+            icon_arr[0]  = icon_font;
+            mark_fonts   = (const GFXfont* const*)icon_arr;
+            mark_count   = 1;
+            mark_text[0] = look.icon;
+            mark_text[1] = 0;
+            mark         = mark_text;
+        }
+    }
+
     if (label[0] == '\0') {
-        // No label: centre the index in the whole cell.
+        // No caption: centre the mark in the whole cell.
         int8_t ixmin, ixmax, iymin, iymax;
-        kdisp_gfx_text_bbox(mid_fonts, 1, index_text, &ixmin, &ixmax, &iymin, &iymax);
-        kdisp_write_gfx_text(mid_fonts, 1,
+        kdisp_gfx_text_bbox(mark_fonts, mark_count, mark, &ixmin, &ixmax, &iymin, &iymax);
+        kdisp_write_gfx_text(mark_fonts, mark_count,
                              (int8_t)(BUFFER_X + (SCREEN_WIDTH - (ixmax - ixmin + 1)) / 2 - ixmin),
                              (int8_t)((SCREEN_HEIGHT - (iymax - iymin + 1)) / 2 - iymin),
-                             index_text);
+                             mark);
         return;
     }
 
-    // Widen to codepoints, then drop trailing characters until the run fits the panel.
-    // Measuring after each drop rather than estimating from a per-character width is
-    // the point -- the face is proportional, so an estimate is wrong in both directions.
-    uint32_t text[POLY_MACRO_LABEL_LEN + 1];
-    uint8_t  len = 0;
-    for (; label[len] != '\0' && len < POLY_MACRO_LABEL_LEN; len++) {
-        text[len] = (uint32_t)(uint8_t)label[len];
-    }
-    text[len] = 0;
+    // Drop trailing characters until the caption fits the panel. Measuring after each
+    // drop rather than estimating from a per-character width is the point -- the face
+    // is proportional, so an estimate is wrong in both directions.
+    uint8_t len = tlen;
 
     int8_t lxmin = 0, lxmax = 0, lymin = 0, lymax = 0;
     while (len > 0) {
@@ -2635,16 +2731,17 @@ static void render_macro_key(uint8_t id) {
                          (int8_t)(BUFFER_X + (SCREEN_WIDTH - (lxmax - lxmin + 1)) / 2 - lxmin),
                          cap_base, text);
 
-    // The index, centred in whatever the caption left. Skipped rather than squeezed if
-    // a tall label leaves no room -- a clipped index is worse than none.
+    // The mark, centred in whatever the caption left. Skipped rather than squeezed if a
+    // tall caption leaves no room -- a clipped mark is worse than none, and that is the
+    // same call for a 40 px emoji as for a two-digit index.
     int8_t ixmin, ixmax, iymin, iymax;
-    kdisp_gfx_text_bbox(mid_fonts, 1, index_text, &ixmin, &ixmax, &iymin, &iymax);
+    kdisp_gfx_text_bbox(mark_fonts, mark_count, mark, &ixmin, &ixmax, &iymin, &iymax);
     const int8_t ih = (int8_t)(iymax - iymin + 1);
     if (ih < free_rows) {
-        kdisp_write_gfx_text(mid_fonts, 1,
+        kdisp_write_gfx_text(mark_fonts, mark_count,
                              (int8_t)(BUFFER_X + (SCREEN_WIDTH - (ixmax - ixmin + 1)) / 2 - ixmin),
                              (int8_t)((free_rows - ih) / 2 - iymin),
-                             index_text);
+                             mark);
     }
 }
 

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -2642,6 +2642,45 @@ static bool draw_macro_caption_big(const uint32_t* text) {
     return false;
 }
 
+// Draws `mark` centred in the `free_rows` a caption left above it, and reports
+// whether it landed.
+//
+// ⚠️ An ICON that overflows at its native size is HALVED rather than dropped, and
+// that is the whole point of this function existing. A pack emoji is rendered at
+// 40 px while a captioned keycap leaves about 29 rows, so the earlier
+// native-size-or-nothing rule drew NOTHING for most icons a user could pick --
+// measured over the picker's own set, four in five (field, 2026-08-27: "after
+// selecting the icon I cannot see it ... also not on the keyboard"). The failure
+// was silent on both ends because the host preview mirrors this placement.
+//
+// The 2x2-OR downsample keeps thin strokes that plain decimation loses, and half of
+// even the tallest pack glyph is ~20 px, which fits any single-line caption.
+static bool draw_macro_mark(const GFXfont* const* fonts, uint8_t count,
+                            const uint32_t* mark, int8_t free_rows,
+                            const GFXglyph* glyph, uint32_t cp) {
+    int8_t xmin, xmax, ymin, ymax;
+    kdisp_gfx_text_bbox(fonts, count, mark, &xmin, &xmax, &ymin, &ymax);
+    const int8_t h = (int8_t)(ymax - ymin + 1);
+    if (h < free_rows) {
+        kdisp_write_gfx_text(fonts, count,
+                             (int8_t)(BUFFER_X + (SCREEN_WIDTH - (xmax - xmin + 1)) / 2 - xmin),
+                             (int8_t)((free_rows - h) / 2 - ymin), mark);
+        return true;
+    }
+    if (glyph == NULL) return false;   // text marks (the index) are never rescaled
+    // ⚠️ kdisp_draw_glyph_half_at takes the literal TOP-LEFT of the ink -- no baseline
+    // align, no xOffset -- so the position comes from the glyph's own halved extents
+    // and NOT from the bbox above. Halve rounding UP, or an odd-width glyph loses its
+    // last column.
+    const int8_t hw = (int8_t)((pgm_read_byte(&glyph->width) + 1) / 2);
+    const int8_t hh = (int8_t)((pgm_read_byte(&glyph->height) + 1) / 2);
+    if (hh >= free_rows) return false;
+    kdisp_draw_glyph_half_at(fonts, count,
+                             (int8_t)(BUFFER_X + (SCREEN_WIDTH - hw) / 2),
+                             (int8_t)((free_rows - hh) / 2), cp);
+    return true;
+}
+
 static void render_macro_key(uint8_t id) {
     poly_macro_look_t look;
     poly_macro_look_get(id, &look);
@@ -2679,7 +2718,8 @@ static void render_macro_key(uint8_t id) {
     // exactly the language-flag gap-at-top regression. An icon this keyboard has no
     // glyph for falls back to the index rather than drawing nothing, so a caption
     // picked on a host with a richer font pack still names its macro here.
-    const GFXfont*       icon_font = NULL;
+    const GFXfont*       icon_font  = NULL;
+    const GFXglyph*      icon_glyph = NULL;
     const GFXfont*       icon_arr[1];
     const GFXfont* const* mark_fonts = mid_fonts;
     uint8_t              mark_count  = 1;
@@ -2687,7 +2727,9 @@ static void render_macro_key(uint8_t id) {
     const uint32_t*      mark = index_text;
 
     if (look.style == POLY_MACRO_STYLE_ICON && look.icon != 0) {
-        if (kdisp_gfx_glyph_font(g_all_fonts, g_all_font_count, look.icon, &icon_font)) {
+        icon_glyph = kdisp_gfx_glyph_font(g_all_fonts, g_all_font_count, look.icon,
+                                          &icon_font);
+        if (icon_glyph != NULL) {
             icon_arr[0]  = icon_font;
             mark_fonts   = (const GFXfont* const*)icon_arr;
             mark_count   = 1;
@@ -2731,17 +2773,13 @@ static void render_macro_key(uint8_t id) {
                          (int8_t)(BUFFER_X + (SCREEN_WIDTH - (lxmax - lxmin + 1)) / 2 - lxmin),
                          cap_base, text);
 
-    // The mark, centred in whatever the caption left. Skipped rather than squeezed if a
-    // tall caption leaves no room -- a clipped mark is worse than none, and that is the
-    // same call for a 40 px emoji as for a two-digit index.
-    int8_t ixmin, ixmax, iymin, iymax;
-    kdisp_gfx_text_bbox(mark_fonts, mark_count, mark, &ixmin, &ixmax, &iymin, &iymax);
-    const int8_t ih = (int8_t)(iymax - iymin + 1);
-    if (ih < free_rows) {
-        kdisp_write_gfx_text(mark_fonts, mark_count,
-                             (int8_t)(BUFFER_X + (SCREEN_WIDTH - (ixmax - ixmin + 1)) / 2 - ixmin),
-                             (int8_t)((free_rows - ih) / 2 - iymin),
-                             mark);
+    // The mark, centred in whatever the caption left: native size, else halved.
+    // An icon that fits at NO size falls back to the index, which always does --
+    // the same fallback a missing glyph already takes, so an icon can never leave
+    // the keycap without a mark.
+    if (!draw_macro_mark(mark_fonts, mark_count, mark, free_rows, icon_glyph, look.icon)
+        && icon_glyph != NULL) {
+        draw_macro_mark(mid_fonts, 1, index_text, free_rows, NULL, 0);
     }
 }
 

--- a/keyboards/polykybd/poly_macro.c
+++ b/keyboards/polykybd/poly_macro.c
@@ -1,0 +1,185 @@
+// Copyright 2026 Thomas Pollak
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "poly_macro.h"
+
+#include "quantum.h"
+#include "eeprom.h"
+#include "dynamic_keymap.h"
+#include "nvm_eeprom_eeconfig_internal.h"   // EECONFIG_BASE_SIZE, via the keymap base
+#include "send_string.h"
+
+#include "base/macro_decode.h"
+
+// The label array must not overlap the bodies, and both must stay inside the region
+// QMK sized. If a later edit to POLY_MACRO_LABEL_LEN or the count breaks either, the
+// build stops here rather than the labels quietly eating the last macro.
+_Static_assert(POLY_MACRO_LABEL_ADDR == DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR + DYNAMIC_KEYMAP_MACRO_EEPROM_SIZE,
+               "label array must start exactly where the body buffer ends");
+_Static_assert(POLY_MACRO_LABEL_ADDR + POLY_MACRO_LABEL_BYTES - 1 <= DYNAMIC_KEYMAP_EEPROM_MAX_ADDR,
+               "label array runs past the end of EEPROM");
+_Static_assert(DYNAMIC_KEYMAP_MACRO_EEPROM_SIZE > 256,
+               "body buffer has shrunk to the point where the feature is not worth shipping");
+_Static_assert(POLY_MACRO_COUNT <= POLY_MACRO_NONE,
+               "POLY_MACRO_NONE must not collide with a real macro id");
+
+// ---------------------------------------------------------------------------
+// EEPROM plumbing
+
+static uint8_t body_read(uint16_t offset, void *ctx) {
+    (void)ctx;
+    return eeprom_read_byte((const uint8_t *)(uintptr_t)(DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR + offset));
+}
+
+uint16_t poly_macro_capacity(void) {
+    return (uint16_t)DYNAMIC_KEYMAP_MACRO_EEPROM_SIZE;
+}
+
+uint16_t poly_macro_bytes_used(void) {
+    return poly_macro_used(body_read, NULL, poly_macro_capacity());
+}
+
+void poly_macro_read(uint16_t offset, uint16_t size, uint8_t *out) {
+    const uint16_t cap = poly_macro_capacity();
+    for (uint16_t i = 0; i < size; i++) {
+        out[i] = (offset + i < cap) ? body_read(offset + i, NULL) : 0;
+    }
+}
+
+void poly_macro_write(uint16_t offset, uint16_t size, const uint8_t *data) {
+    const uint16_t cap = poly_macro_capacity();
+    for (uint16_t i = 0; i < size; i++) {
+        if (offset + i >= cap) return;
+        eeprom_update_byte((uint8_t *)(uintptr_t)(DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR + offset + i), data[i]);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Labels
+
+void poly_macro_label_get(uint8_t id, char *out) {
+    if (id >= POLY_MACRO_COUNT) {
+        out[0] = '\0';
+        return;
+    }
+    const uint16_t base = POLY_MACRO_LABEL_ADDR + (uint16_t)id * POLY_MACRO_LABEL_LEN;
+    uint8_t        n    = 0;
+    for (; n < POLY_MACRO_LABEL_LEN; n++) {
+        uint8_t c = eeprom_read_byte((const uint8_t *)(uintptr_t)(base + n));
+        if (c == 0) break;
+        out[n] = (char)c;
+    }
+    out[n] = '\0';
+}
+
+void poly_macro_label_set(uint8_t id, const char *text) {
+    if (id >= POLY_MACRO_COUNT) return;
+    const uint16_t base = POLY_MACRO_LABEL_ADDR + (uint16_t)id * POLY_MACRO_LABEL_LEN;
+    uint8_t        n    = 0;
+    if (text != NULL) {
+        for (const char *p = text; *p && n < POLY_MACRO_LABEL_LEN; ++p) {
+            // The _Nano_ face is 0x20..0x7E. Anything else draws nothing, which on a
+            // keycap is indistinguishable from a bug -- so it never gets stored.
+            if ((uint8_t)*p < 0x20 || (uint8_t)*p > 0x7E) continue;
+            eeprom_update_byte((uint8_t *)(uintptr_t)(base + n), (uint8_t)*p);
+            n++;
+        }
+    }
+    for (; n < POLY_MACRO_LABEL_LEN; n++) {
+        eeprom_update_byte((uint8_t *)(uintptr_t)(base + n), 0);
+    }
+}
+
+void poly_macro_reset_all(void) {
+    poly_macro_abort();
+    for (uint16_t i = 0; i < (uint16_t)DYNAMIC_KEYMAP_MACRO_EEPROM_SIZE; i++) {
+        eeprom_update_byte((uint8_t *)(uintptr_t)(DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR + i), 0);
+    }
+    for (uint16_t i = 0; i < (uint16_t)POLY_MACRO_LABEL_BYTES; i++) {
+        eeprom_update_byte((uint8_t *)(uintptr_t)(POLY_MACRO_LABEL_ADDR + i), 0);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Playback
+
+static bool     s_active;
+static uint16_t s_cursor;
+static uint32_t s_resume_ref;
+static uint16_t s_resume_ms;
+
+bool poly_macro_active(void) {
+    return s_active;
+}
+
+void poly_macro_abort(void) {
+    if (!s_active) return;
+    s_active = false;
+    // Same rule as the firmware-confirm prompt and doom_begin(): anything that stops
+    // producing key events while a key may be registered has to clear the report, or
+    // the host keeps the keycode down and auto-repeats it until USB drops.
+    clear_keyboard();
+}
+
+bool poly_macro_start(uint8_t id) {
+    poly_macro_abort();
+    if (id >= POLY_MACRO_COUNT) return false;
+
+    const uint16_t cap = poly_macro_capacity();
+    // A buffer whose last byte is not NUL was cut short mid-write. Playing it would
+    // type an arbitrary prefix of whatever was being uploaded.
+    if (!poly_macro_buffer_intact(body_read, NULL, cap)) return false;
+
+    uint16_t start = poly_macro_find(body_read, NULL, id, cap);
+    if (start >= cap) return false;
+    if (body_read(start, NULL) == 0) return false; // empty macro: nothing to play
+
+    s_active     = true;
+    s_cursor     = start;
+    s_resume_ref = timer_read32();
+    s_resume_ms  = 0;
+    return true;
+}
+
+void poly_macro_tick(void) {
+    if (!s_active) return;
+    if (timer_elapsed32(s_resume_ref) < s_resume_ms) return;
+
+    poly_macro_step_t step = poly_macro_decode(body_read, NULL, s_cursor, poly_macro_capacity());
+
+    switch (step.kind) {
+        case POLY_MACRO_STEP_CHAR: {
+            // send_char() is the same translation table dynamic_keymap_macro_send()
+            // would use, so a body typed here and a body played by QMK agree.
+            char s[2] = {(char)step.code, '\0'};
+            send_string(s);
+            break;
+        }
+        case POLY_MACRO_STEP_TAP:
+            tap_code(step.code);
+            break;
+        case POLY_MACRO_STEP_DOWN:
+            register_code(step.code);
+            break;
+        case POLY_MACRO_STEP_UP:
+            unregister_code(step.code);
+            break;
+        case POLY_MACRO_STEP_DELAY:
+            // The whole reason this is a state machine: the wait is a deadline, not a
+            // busy loop, so the main loop keeps scanning while it runs.
+            s_cursor     = step.next;
+            s_resume_ref = timer_read32();
+            s_resume_ms  = step.ms;
+            return;
+        case POLY_MACRO_STEP_END:
+        default:
+            // Reached the terminator, or the body is malformed from here on. Either
+            // way stop, and release anything a DOWN step left registered.
+            poly_macro_abort();
+            return;
+    }
+
+    s_cursor     = step.next;
+    s_resume_ref = timer_read32();
+    s_resume_ms  = POLY_MACRO_STEP_MS;
+}

--- a/keyboards/polykybd/poly_macro.c
+++ b/keyboards/polykybd/poly_macro.c
@@ -10,6 +10,10 @@
 #include "send_string.h"
 
 #include "base/macro_decode.h"
+#include "split_sync.h"      // POLY_KEYMAP_OP_MACRO_LABEL, sync_succeeded()
+#include "bridge_helper.h"   // send_to_bridge()
+#include <transactions.h>    // USER_SYNC_DYNAMIC_KEYMAP_DATA
+#include "polymod_crc32.h"
 
 // The label array must not overlap the bodies, and both must stay inside the region
 // QMK sized. If a later edit to POLY_MACRO_LABEL_LEN or the count breaks either, the
@@ -57,37 +61,115 @@ void poly_macro_write(uint16_t offset, uint16_t size, const uint8_t *data) {
 // ---------------------------------------------------------------------------
 // Labels
 
+// Push ONE macro label to the slave over the dynamic-keymap transaction.
+//
+// Classified with sync_succeeded() rather than bool-tested: send_to_bridge returns the
+// byte the slave SAID, and every possible return is non-zero, so `if(!send_to_bridge())`
+// is dead code (the 2026-06-18 stuck-slave bug). Returning the verdict lets the caller
+// keep the label queued and re-send, which is what makes the dirty mask a retry queue.
+bool poly_macro_label_bridge(uint8_t id, const char *label) {
+    dynamic_keymap_sync_t msg = {0};
+    msg.commands[0] = POLY_KEYMAP_OP_MACRO_LABEL;
+    msg.commands[1] = id;
+    uint8_t n = 0;
+    for (; n < POLY_MACRO_LABEL_LEN && label[n] != '\0'; n++) {
+        msg.commands[2 + n] = (uint8_t)label[n];
+    }
+    // 2 header bytes + the full stride, so the payload size is constant and a shorter
+    // label cannot leave stale bytes from a previous send in the tail.
+    const uint8_t payload = (uint8_t)(sizeof(uint32_t) + 2 + POLY_MACRO_LABEL_LEN);
+    msg.crc32 = crc32_1byte(msg.commands, (uint8_t)(payload - sizeof(uint32_t)), 0);
+    return sync_succeeded(send_to_bridge(USER_SYNC_DYNAMIC_KEYMAP_DATA, &msg, payload, 3));
+}
+
+
+// RAM cache, on both halves. 192 B buys two things: the render path never touches
+// EEPROM (it runs for every macro keycap on every refresh), and the slave -- whose own
+// EEPROM never sees a macro -- has somewhere to put what the master pushes it.
+static char     s_labels[POLY_MACRO_COUNT][POLY_MACRO_LABEL_LEN];
+static uint16_t s_label_dirty;   // one bit per macro, master -> slave send queue
+
+_Static_assert(POLY_MACRO_COUNT <= 16, "the dirty mask is 16 bits wide");
+
+static uint16_t label_addr(uint8_t id) {
+    return (uint16_t)(POLY_MACRO_LABEL_ADDR + (uint16_t)id * POLY_MACRO_LABEL_LEN);
+}
+
+void poly_macro_labels_load(void) {
+    for (uint8_t id = 0; id < POLY_MACRO_COUNT; id++) {
+        const uint16_t base = label_addr(id);
+        for (uint8_t n = 0; n < POLY_MACRO_LABEL_LEN; n++) {
+            s_labels[id][n] = (char)eeprom_read_byte((const uint8_t *)(uintptr_t)(base + n));
+        }
+    }
+}
+
 void poly_macro_label_get(uint8_t id, char *out) {
     if (id >= POLY_MACRO_COUNT) {
         out[0] = '\0';
         return;
     }
-    const uint16_t base = POLY_MACRO_LABEL_ADDR + (uint16_t)id * POLY_MACRO_LABEL_LEN;
-    uint8_t        n    = 0;
-    for (; n < POLY_MACRO_LABEL_LEN; n++) {
-        uint8_t c = eeprom_read_byte((const uint8_t *)(uintptr_t)(base + n));
-        if (c == 0) break;
-        out[n] = (char)c;
+    uint8_t n = 0;
+    for (; n < POLY_MACRO_LABEL_LEN && s_labels[id][n] != '\0'; n++) {
+        out[n] = s_labels[id][n];
     }
     out[n] = '\0';
 }
 
-void poly_macro_label_set(uint8_t id, const char *text) {
-    if (id >= POLY_MACRO_COUNT) return;
-    const uint16_t base = POLY_MACRO_LABEL_ADDR + (uint16_t)id * POLY_MACRO_LABEL_LEN;
-    uint8_t        n    = 0;
+// Normalises into the cache: ASCII only, NUL-padded to the full stride. Shared by the
+// master (which then persists) and the slave (which does not), so the two halves can
+// never disagree about what a given label is.
+static void label_store(uint8_t id, const char *text) {
+    uint8_t n = 0;
     if (text != NULL) {
         for (const char *p = text; *p && n < POLY_MACRO_LABEL_LEN; ++p) {
             // The _Nano_ face is 0x20..0x7E. Anything else draws nothing, which on a
             // keycap is indistinguishable from a bug -- so it never gets stored.
             if ((uint8_t)*p < 0x20 || (uint8_t)*p > 0x7E) continue;
-            eeprom_update_byte((uint8_t *)(uintptr_t)(base + n), (uint8_t)*p);
-            n++;
+            s_labels[id][n++] = *p;
         }
     }
     for (; n < POLY_MACRO_LABEL_LEN; n++) {
-        eeprom_update_byte((uint8_t *)(uintptr_t)(base + n), 0);
+        s_labels[id][n] = '\0';
     }
+}
+
+void poly_macro_label_set(uint8_t id, const char *text) {
+    if (id >= POLY_MACRO_COUNT) return;
+    label_store(id, text);
+    const uint16_t base = label_addr(id);
+    for (uint8_t n = 0; n < POLY_MACRO_LABEL_LEN; n++) {
+        eeprom_update_byte((uint8_t *)(uintptr_t)(base + n), (uint8_t)s_labels[id][n]);
+    }
+    s_label_dirty |= (uint16_t)1u << id;
+}
+
+void poly_macro_label_adopt(uint8_t id, const char *text) {
+    if (id >= POLY_MACRO_COUNT) return;
+    label_store(id, text);
+}
+
+void poly_macro_labels_mark_all_dirty(void) {
+    s_label_dirty = (uint16_t)((1u << POLY_MACRO_COUNT) - 1u);
+}
+
+bool poly_macro_label_sync_tick(void) {
+    if (s_label_dirty == 0) return false;
+    for (uint8_t id = 0; id < POLY_MACRO_COUNT; id++) {
+        const uint16_t bit = (uint16_t)1u << id;
+        if (!(s_label_dirty & bit)) continue;
+        char label[POLY_MACRO_LABEL_LEN + 1];
+        poly_macro_label_get(id, label);
+        // Clear the bit only on a real ACK: send_to_bridge returns what the slave SAID,
+        // and every return value is non-zero, so it must be classified rather than
+        // bool-tested. On a give-up the bit stays set and the next pass re-sends -- the
+        // dirty mask IS the retry queue, the same shape the state diff uses.
+        if (poly_macro_label_bridge(id, label)) {
+            s_label_dirty &= (uint16_t)~bit;
+        }
+        return true;   // at most one bridge per housekeeping pass
+    }
+    return false;
 }
 
 void poly_macro_reset_all(void) {

--- a/keyboards/polykybd/poly_macro.c
+++ b/keyboards/polykybd/poly_macro.c
@@ -52,6 +52,28 @@ void poly_macro_read(uint16_t offset, uint16_t size, uint8_t *out) {
 
 void poly_macro_write(uint16_t offset, uint16_t size, const uint8_t *data) {
     const uint16_t cap = poly_macro_capacity();
+    if (cap == 0 || size == 0) return;
+
+    // A window that does NOT carry the buffer's final byte invalidates it first, so a
+    // stream that stops early reads as not-intact and poly_macro_start() refuses it.
+    // Without this, an interrupted upload leaves a playable splice of the new text and
+    // whatever preceded it -- which can promote the tail of a former macro (a password,
+    // say) into a macro of its own.
+    //
+    // ⚠️ The HOST also raises a marker before it streams, and that is NOT redundant: it
+    // is the tested half (a mocked write cannot exercise EEPROM), while this half is
+    // what makes the guarantee hold for a host that never learned to. The firmware must
+    // not depend on the host to arm its own integrity guard.
+    //
+    // The consequence to know: a deliberate PREFIX write leaves the buffer unplayable
+    // until something writes the tail. That is correct -- a partially rewritten buffer
+    // is exactly what must not play -- but it means a caller probing a prefix has to
+    // restore the final byte too.
+    if ((uint32_t)offset + size < cap) {
+        eeprom_update_byte((uint8_t *)(uintptr_t)(DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR + cap - 1),
+                           POLY_MACRO_INCOMPLETE);
+    }
+
     for (uint16_t i = 0; i < size; i++) {
         if (offset + i >= cap) return;
         eeprom_update_byte((uint8_t *)(uintptr_t)(DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR + offset + i), data[i]);
@@ -180,6 +202,13 @@ void poly_macro_reset_all(void) {
     for (uint16_t i = 0; i < (uint16_t)POLY_MACRO_LABEL_BYTES; i++) {
         eeprom_update_byte((uint8_t *)(uintptr_t)(POLY_MACRO_LABEL_ADDR + i), 0);
     }
+    // The EEPROM is only half of it: both halves RENDER from the RAM cache, so leaving
+    // it populated makes poly_macro_label_get() and render_macro_key() keep drawing the
+    // label of a macro that no longer exists -- and the pending dirty bits would then
+    // push those stale labels to the slave. Marking all dirty is what sends the cleared
+    // ones across.
+    memset(s_labels, 0, sizeof(s_labels));
+    poly_macro_labels_mark_all_dirty();
 }
 
 // ---------------------------------------------------------------------------

--- a/keyboards/polykybd/poly_macro.c
+++ b/keyboards/polykybd/poly_macro.c
@@ -83,92 +83,143 @@ void poly_macro_write(uint16_t offset, uint16_t size, const uint8_t *data) {
 // ---------------------------------------------------------------------------
 // Labels
 
-// Push ONE macro label to the slave over the dynamic-keymap transaction.
+// Push ONE macro's whole look to the slave over the dynamic-keymap transaction.
+//
+// The style, the icon and the caption travel together, so the slave can never render a
+// caption in a style the master has already replaced -- that is the reason they are one
+// record rather than three.
 //
 // Classified with sync_succeeded() rather than bool-tested: send_to_bridge returns the
 // byte the slave SAID, and every possible return is non-zero, so `if(!send_to_bridge())`
 // is dead code (the 2026-06-18 stuck-slave bug). Returning the verdict lets the caller
-// keep the label queued and re-send, which is what makes the dirty mask a retry queue.
-bool poly_macro_label_bridge(uint8_t id, const char *label) {
+// keep the look queued and re-send, which is what makes the dirty mask a retry queue.
+bool poly_macro_look_bridge(uint8_t id, const poly_macro_look_t *look) {
     dynamic_keymap_sync_t msg = {0};
     msg.commands[0] = POLY_KEYMAP_OP_MACRO_LABEL;
     msg.commands[1] = id;
+    msg.commands[2] = look->style;
+    for (uint8_t n = 0; n < POLY_MACRO_ICON_LEN; n++) {
+        msg.commands[3 + n] = (uint8_t)((look->icon >> (8 * n)) & 0xFFu);
+    }
     uint8_t n = 0;
-    for (; n < POLY_MACRO_LABEL_LEN && label[n] != '\0'; n++) {
-        msg.commands[2 + n] = (uint8_t)label[n];
+    for (; n < POLY_MACRO_LABEL_LEN && look->text[n] != '\0'; n++) {
+        msg.commands[2 + POLY_MACRO_LOOK_LEN - POLY_MACRO_LABEL_LEN + n] = (uint8_t)look->text[n];
     }
     // 2 header bytes + the full stride, so the payload size is constant and a shorter
-    // label cannot leave stale bytes from a previous send in the tail.
-    const uint8_t payload = (uint8_t)(sizeof(uint32_t) + 2 + POLY_MACRO_LABEL_LEN);
+    // caption cannot leave stale bytes from a previous send in the tail.
+    const uint8_t payload = (uint8_t)(sizeof(uint32_t) + 2 + POLY_MACRO_LOOK_LEN);
     msg.crc32 = crc32_1byte(msg.commands, (uint8_t)(payload - sizeof(uint32_t)), 0);
     return sync_succeeded(send_to_bridge(USER_SYNC_DYNAMIC_KEYMAP_DATA, &msg, payload, 3));
 }
 
 
-// RAM cache, on both halves. 192 B buys two things: the render path never touches
-// EEPROM (it runs for every macro keycap on every refresh), and the slave -- whose own
-// EEPROM never sees a macro -- has somewhere to put what the master pushes it.
-static char     s_labels[POLY_MACRO_COUNT][POLY_MACRO_LABEL_LEN];
-static uint16_t s_label_dirty;   // one bit per macro, master -> slave send queue
+// RAM cache, on both halves. It buys two things: the render path never touches EEPROM
+// (it runs for every macro keycap on every refresh), and the slave -- whose own EEPROM
+// never sees a macro -- has somewhere to put what the master pushes it.
+//
+// The caption, the style and the icon are ONE record rather than three arrays, so a
+// render can never compose a caption with a style that was written at a different
+// moment, and the whole appearance crosses the split link in a single message.
+static poly_macro_look_t s_looks[POLY_MACRO_COUNT];
+static uint16_t          s_label_dirty;   // one bit per macro, master -> slave queue
 
 _Static_assert(POLY_MACRO_COUNT <= 16, "the dirty mask is 16 bits wide");
 
 static uint16_t label_addr(uint8_t id) {
-    return (uint16_t)(POLY_MACRO_LABEL_ADDR + (uint16_t)id * POLY_MACRO_LABEL_LEN);
+    return (uint16_t)(POLY_MACRO_LABEL_ADDR + (uint16_t)id * POLY_MACRO_LOOK_LEN);
+}
+
+// A style this build does not know draws as INDEX rather than as nothing. The index is
+// the one style that needs neither a font pack nor a stored icon, so it is the safe
+// floor -- the same reasoning as the glyph script falling back to the normal legend.
+static uint8_t style_or_default(uint8_t style) {
+    return style < POLY_MACRO_STYLE_COUNT ? style : (uint8_t)POLY_MACRO_STYLE_INDEX;
 }
 
 void poly_macro_labels_load(void) {
     for (uint8_t id = 0; id < POLY_MACRO_COUNT; id++) {
         const uint16_t base = label_addr(id);
-        for (uint8_t n = 0; n < POLY_MACRO_LABEL_LEN; n++) {
-            s_labels[id][n] = (char)eeprom_read_byte((const uint8_t *)(uintptr_t)(base + n));
+        uint8_t raw[POLY_MACRO_LOOK_LEN];
+        for (uint8_t n = 0; n < POLY_MACRO_LOOK_LEN; n++) {
+            raw[n] = eeprom_read_byte((const uint8_t *)(uintptr_t)(base + n));
         }
+        s_looks[id].style = style_or_default(raw[0]);
+        // Little-endian, matching the wire. An unwritten record reads as all-zero
+        // (QMK's wear levelling normalises a cleared byte to 0, NOT 0xFF -- the fact
+        // that made latin_assign read as "every key hosts 'a'"), which is exactly the
+        // default look, so no migration sentinel is needed here.
+        s_looks[id].icon = (uint32_t)raw[1] | ((uint32_t)raw[2] << 8)
+                         | ((uint32_t)raw[3] << 16) | ((uint32_t)raw[4] << 24);
+        for (uint8_t n = 0; n < POLY_MACRO_LABEL_LEN; n++) {
+            s_looks[id].text[n] = (char)raw[1 + POLY_MACRO_ICON_LEN + n];
+        }
+        s_looks[id].text[POLY_MACRO_LABEL_LEN] = '\0';
     }
 }
 
-void poly_macro_label_get(uint8_t id, char *out) {
+void poly_macro_look_get(uint8_t id, poly_macro_look_t *out) {
+    if (out == NULL) return;
     if (id >= POLY_MACRO_COUNT) {
-        out[0] = '\0';
+        out->style = POLY_MACRO_STYLE_INDEX;
+        out->icon  = 0;
+        out->text[0] = '\0';
         return;
     }
+    *out = s_looks[id];
+    out->text[POLY_MACRO_LABEL_LEN] = '\0';
+}
+
+void poly_macro_label_get(uint8_t id, char *out) {
+    poly_macro_look_t look;
+    poly_macro_look_get(id, &look);
     uint8_t n = 0;
-    for (; n < POLY_MACRO_LABEL_LEN && s_labels[id][n] != '\0'; n++) {
-        out[n] = s_labels[id][n];
+    for (; n < POLY_MACRO_LABEL_LEN && look.text[n] != '\0'; n++) {
+        out[n] = look.text[n];
     }
     out[n] = '\0';
 }
 
-// Normalises into the cache: ASCII only, NUL-padded to the full stride. Shared by the
-// master (which then persists) and the slave (which does not), so the two halves can
-// never disagree about what a given label is.
-static void label_store(uint8_t id, const char *text) {
+// Normalises into the cache: ASCII only, NUL-padded to the full stride, style bounded.
+// Shared by the master (which then persists) and the slave (which does not), so the two
+// halves can never disagree about what a given macro looks like.
+static void look_store(uint8_t id, const poly_macro_look_t *look) {
+    s_looks[id].style = style_or_default(look != NULL ? look->style
+                                                      : (uint8_t)POLY_MACRO_STYLE_INDEX);
+    s_looks[id].icon  = look != NULL ? look->icon : 0u;
     uint8_t n = 0;
-    if (text != NULL) {
-        for (const char *p = text; *p && n < POLY_MACRO_LABEL_LEN; ++p) {
+    if (look != NULL) {
+        for (const char *p = look->text; *p && n < POLY_MACRO_LABEL_LEN; ++p) {
             // The _Nano_ face is 0x20..0x7E. Anything else draws nothing, which on a
             // keycap is indistinguishable from a bug -- so it never gets stored.
             if ((uint8_t)*p < 0x20 || (uint8_t)*p > 0x7E) continue;
-            s_labels[id][n++] = *p;
+            s_looks[id].text[n++] = *p;
         }
     }
-    for (; n < POLY_MACRO_LABEL_LEN; n++) {
-        s_labels[id][n] = '\0';
+    for (; n <= POLY_MACRO_LABEL_LEN; n++) {
+        s_looks[id].text[n] = '\0';
     }
 }
 
-void poly_macro_label_set(uint8_t id, const char *text) {
+void poly_macro_look_set(uint8_t id, const poly_macro_look_t *look) {
     if (id >= POLY_MACRO_COUNT) return;
-    label_store(id, text);
+    look_store(id, look);
     const uint16_t base = label_addr(id);
+    const uint32_t icon = s_looks[id].icon;
+    eeprom_update_byte((uint8_t *)(uintptr_t)(base + 0), s_looks[id].style);
+    for (uint8_t n = 0; n < POLY_MACRO_ICON_LEN; n++) {
+        eeprom_update_byte((uint8_t *)(uintptr_t)(base + 1 + n),
+                           (uint8_t)((icon >> (8 * n)) & 0xFFu));
+    }
     for (uint8_t n = 0; n < POLY_MACRO_LABEL_LEN; n++) {
-        eeprom_update_byte((uint8_t *)(uintptr_t)(base + n), (uint8_t)s_labels[id][n]);
+        eeprom_update_byte((uint8_t *)(uintptr_t)(base + 1 + POLY_MACRO_ICON_LEN + n),
+                           (uint8_t)s_looks[id].text[n]);
     }
     s_label_dirty |= (uint16_t)1u << id;
 }
 
-void poly_macro_label_adopt(uint8_t id, const char *text) {
+void poly_macro_look_adopt(uint8_t id, const poly_macro_look_t *look) {
     if (id >= POLY_MACRO_COUNT) return;
-    label_store(id, text);
+    look_store(id, look);
 }
 
 void poly_macro_labels_mark_all_dirty(void) {
@@ -180,13 +231,13 @@ bool poly_macro_label_sync_tick(void) {
     for (uint8_t id = 0; id < POLY_MACRO_COUNT; id++) {
         const uint16_t bit = (uint16_t)1u << id;
         if (!(s_label_dirty & bit)) continue;
-        char label[POLY_MACRO_LABEL_LEN + 1];
-        poly_macro_label_get(id, label);
+        poly_macro_look_t look;
+        poly_macro_look_get(id, &look);
         // Clear the bit only on a real ACK: send_to_bridge returns what the slave SAID,
         // and every return value is non-zero, so it must be classified rather than
         // bool-tested. On a give-up the bit stays set and the next pass re-sends -- the
         // dirty mask IS the retry queue, the same shape the state diff uses.
-        if (poly_macro_label_bridge(id, label)) {
+        if (poly_macro_look_bridge(id, &look)) {
             s_label_dirty &= (uint16_t)~bit;
         }
         return true;   // at most one bridge per housekeeping pass
@@ -203,11 +254,11 @@ void poly_macro_reset_all(void) {
         eeprom_update_byte((uint8_t *)(uintptr_t)(POLY_MACRO_LABEL_ADDR + i), 0);
     }
     // The EEPROM is only half of it: both halves RENDER from the RAM cache, so leaving
-    // it populated makes poly_macro_label_get() and render_macro_key() keep drawing the
-    // label of a macro that no longer exists -- and the pending dirty bits would then
-    // push those stale labels to the slave. Marking all dirty is what sends the cleared
+    // it populated makes poly_macro_look_get() and render_macro_key() keep drawing the
+    // look of a macro that no longer exists -- and the pending dirty bits would then
+    // push those stale looks to the slave. Marking all dirty is what sends the cleared
     // ones across.
-    memset(s_labels, 0, sizeof(s_labels));
+    memset(s_looks, 0, sizeof(s_looks));
     poly_macro_labels_mark_all_dirty();
 }
 

--- a/keyboards/polykybd/poly_macro.h
+++ b/keyboards/polykybd/poly_macro.h
@@ -41,6 +41,11 @@ void poly_macro_read(uint16_t offset, uint16_t size, uint8_t *out);
 void poly_macro_write(uint16_t offset, uint16_t size, const uint8_t *data);
 
 // Zero every body and every label.
+// Written into the buffer's last byte while a body write is in flight. Any non-zero
+// value works -- poly_macro_buffer_intact() only asks "is the final byte NUL" -- and it
+// is the same marker the host raises before it streams.
+#define POLY_MACRO_INCOMPLETE 0xFF
+
 void poly_macro_reset_all(void);
 
 // ---------------------------------------------------------------------------

--- a/keyboards/polykybd/poly_macro.h
+++ b/keyboards/polykybd/poly_macro.h
@@ -46,14 +46,37 @@ void poly_macro_reset_all(void);
 // ---------------------------------------------------------------------------
 // Labels
 
+// Labels live in a RAM cache on BOTH halves, not just in EEPROM. Two reasons, and the
+// second is the binding one: the render path reads a label for every macro keycap on
+// every refresh, and the slave has no other way to know them at all -- the host writes
+// macros to the master, and the slave's own EEPROM never sees them.
+//
 // Copies macro `id`'s label into `out` as a NUL-terminated string. `out` must hold at
 // least POLY_MACRO_LABEL_LEN + 1 bytes. An empty label yields "".
 void poly_macro_label_get(uint8_t id, char *out);
 
-// Stores up to POLY_MACRO_LABEL_LEN bytes, NUL-padded. Non-ASCII bytes are dropped:
-// the _Nano_ face covers 0x20..0x7E only, so anything else would render as nothing and
-// read as a bug. Rejecting at the door means what is stored is what is drawable.
+// Stores up to POLY_MACRO_LABEL_LEN bytes, NUL-padded, and queues it for the slave.
+// Non-ASCII bytes are dropped: the _Nano_ face covers 0x20..0x7E only, so anything else
+// would render as nothing and read as a bug. Rejecting at the door means what is stored
+// is what is drawable.
 void poly_macro_label_set(uint8_t id, const char *text);
+
+// Fill the RAM cache from EEPROM. Master only -- called once at boot.
+void poly_macro_labels_load(void);
+
+// Slave side: adopt a label pushed over the split link. RAM only; the slave never
+// persists a label, because the master is authoritative and re-pushes every boot.
+void poly_macro_label_adopt(uint8_t id, const char *text);
+
+// Master side: push at most ONE queued label to the slave. Call from housekeeping --
+// never inline in the HID handler, where sixteen bridges of up to ten retries each
+// would be seconds of dead main loop on exactly the bad link that needed the retries.
+// Returns true when it sent something, so the caller can see the queue draining.
+bool poly_macro_label_sync_tick(void);
+
+// Queue every label for the slave. Used at boot, once the link is up: the slave comes
+// up with an empty cache and nothing else would ever fill it.
+void poly_macro_labels_mark_all_dirty(void);
 
 // ---------------------------------------------------------------------------
 // Playback

--- a/keyboards/polykybd/poly_macro.h
+++ b/keyboards/polykybd/poly_macro.h
@@ -49,37 +49,66 @@ void poly_macro_write(uint16_t offset, uint16_t size, const uint8_t *data);
 void poly_macro_reset_all(void);
 
 // ---------------------------------------------------------------------------
-// Labels
+// Look: the caption, and how the keycap draws it
 
-// Labels live in a RAM cache on BOTH halves, not just in EEPROM. Two reasons, and the
-// second is the binding one: the render path reads a label for every macro keycap on
+// How a macro's keycap is composed. A macro owns its whole cell (it cannot ride a
+// modifier -- see config.h), so the cell can be more than a legend.
+enum poly_macro_style {
+    POLY_MACRO_STYLE_INDEX = 0,  // "M3" above the caption. The default, and the only
+                                 // one that needs no font pack and no decision.
+    POLY_MACRO_STYLE_ICON  = 1,  // a chosen glyph above the caption
+    POLY_MACRO_STYLE_TEXT  = 2,  // the caption alone, at the largest face that fits
+    POLY_MACRO_STYLE_COUNT
+};
+
+// The whole appearance of one macro, in one value. Passed by pointer rather than
+// assembled from three getters so a caller cannot read a caption and a style that came
+// from different moments -- the render path reads this per keycap per refresh.
+// Field order is for PADDING, not taste: icon first puts the 4-byte member on the
+// natural alignment, so the record is 20 B rather than the 24 B a leading uint8_t
+// forces -- 64 B of RAM across the sixteen, on a board whose tightest flavour has
+// about 3.5 KB of heap left.
+typedef struct {
+    uint32_t icon;                           // codepoint for STYLE_ICON, 0 = none
+    uint8_t  style;                          // enum poly_macro_style
+    char     text[POLY_MACRO_LABEL_LEN + 1]; // NUL-terminated caption
+} poly_macro_look_t;
+
+// Looks live in a RAM cache on BOTH halves, not just in EEPROM. Two reasons, and the
+// second is the binding one: the render path reads one for every macro keycap on
 // every refresh, and the slave has no other way to know them at all -- the host writes
 // macros to the master, and the slave's own EEPROM never sees them.
 //
-// Copies macro `id`'s label into `out` as a NUL-terminated string. `out` must hold at
-// least POLY_MACRO_LABEL_LEN + 1 bytes. An empty label yields "".
+// Fills `out` for macro `id`. An unknown id yields the default look (index style, no
+// icon, empty caption) rather than leaving the caller's struct untouched.
+void poly_macro_look_get(uint8_t id, poly_macro_look_t *out);
+
+// Convenience for the callers that only want the caption. `out` must hold at least
+// POLY_MACRO_LABEL_LEN + 1 bytes.
 void poly_macro_label_get(uint8_t id, char *out);
 
-// Stores up to POLY_MACRO_LABEL_LEN bytes, NUL-padded, and queues it for the slave.
-// Non-ASCII bytes are dropped: the _Nano_ face covers 0x20..0x7E only, so anything else
-// would render as nothing and read as a bug. Rejecting at the door means what is stored
-// is what is drawable.
-void poly_macro_label_set(uint8_t id, const char *text);
+// Stores the look and queues it for the slave. The caption keeps up to
+// POLY_MACRO_LABEL_LEN bytes, NUL-padded; non-ASCII bytes are dropped, because the
+// _Nano_ face covers 0x20..0x7E only and anything else would render as nothing, which
+// on a keycap is indistinguishable from a bug. An out-of-range style falls back to
+// STYLE_INDEX rather than being refused: it is the style that always draws something,
+// so a keyboard that does not know a style a newer host offers still shows the macro.
+void poly_macro_look_set(uint8_t id, const poly_macro_look_t *look);
 
 // Fill the RAM cache from EEPROM. Master only -- called once at boot.
 void poly_macro_labels_load(void);
 
-// Slave side: adopt a label pushed over the split link. RAM only; the slave never
-// persists a label, because the master is authoritative and re-pushes every boot.
-void poly_macro_label_adopt(uint8_t id, const char *text);
+// Slave side: adopt a look pushed over the split link. RAM only; the slave never
+// persists one, because the master is authoritative and re-pushes every boot.
+void poly_macro_look_adopt(uint8_t id, const poly_macro_look_t *look);
 
-// Master side: push at most ONE queued label to the slave. Call from housekeeping --
+// Master side: push at most ONE queued look to the slave. Call from housekeeping --
 // never inline in the HID handler, where sixteen bridges of up to ten retries each
 // would be seconds of dead main loop on exactly the bad link that needed the retries.
 // Returns true when it sent something, so the caller can see the queue draining.
 bool poly_macro_label_sync_tick(void);
 
-// Queue every label for the slave. Used at boot, once the link is up: the slave comes
+// Queue every look for the slave. Used at boot, once the link is up: the slave comes
 // up with an empty cache and nothing else would ever fill it.
 void poly_macro_labels_mark_all_dirty(void);
 

--- a/keyboards/polykybd/poly_macro.h
+++ b/keyboards/polykybd/poly_macro.h
@@ -1,0 +1,71 @@
+// Copyright 2026 Thomas Pollak
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// Dynamic macros with a keycap legend.
+//
+// Storage is QMK's own dynamic-macro buffer (a run of NUL-terminated bodies at
+// DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR) plus a fixed-stride label array carved off the top
+// of the same region -- see config.h for why the two are separate structures rather
+// than one.
+//
+// Playback is OURS, not QMK's. dynamic_keymap_macro_send() runs the whole macro inline
+// and implements its delay as `while (ms--) wait_ms(1)`. On a single-controller board
+// that is merely rude; here the same loop scans the matrix, drives the split UART to
+// the other half, services USB HID and pushes 72 SPI displays, so a macro with a half-
+// second delay would freeze the board, drop the split link and stall the keycaps
+// mid-render. poly_macro_tick() executes at most one step per housekeeping pass.
+
+#define POLY_MACRO_NONE 0xFF
+
+// Spacing between steps. TAP_CODE_DELAY is 0 on this board, which would run steps
+// back-to-back -- still one per main-loop pass, so still yielding, but fast enough that
+// some hosts drop events. 8 ms is comfortably above USB polling without being felt.
+#ifndef POLY_MACRO_STEP_MS
+#    define POLY_MACRO_STEP_MS 8
+#endif
+
+// ---------------------------------------------------------------------------
+// Bodies
+
+// Total body bytes available (labels excluded) and how many are in use.
+uint16_t poly_macro_capacity(void);
+uint16_t poly_macro_bytes_used(void);
+
+// Read/write a window of the body buffer. Both clamp to the body region, so neither
+// can reach the labels.
+void poly_macro_read(uint16_t offset, uint16_t size, uint8_t *out);
+void poly_macro_write(uint16_t offset, uint16_t size, const uint8_t *data);
+
+// Zero every body and every label.
+void poly_macro_reset_all(void);
+
+// ---------------------------------------------------------------------------
+// Labels
+
+// Copies macro `id`'s label into `out` as a NUL-terminated string. `out` must hold at
+// least POLY_MACRO_LABEL_LEN + 1 bytes. An empty label yields "".
+void poly_macro_label_get(uint8_t id, char *out);
+
+// Stores up to POLY_MACRO_LABEL_LEN bytes, NUL-padded. Non-ASCII bytes are dropped:
+// the _Nano_ face covers 0x20..0x7E only, so anything else would render as nothing and
+// read as a bug. Rejecting at the door means what is stored is what is drawable.
+void poly_macro_label_set(uint8_t id, const char *text);
+
+// ---------------------------------------------------------------------------
+// Playback
+
+// Start macro `id`. Returns false when the id is out of range, the macro is empty, or
+// the buffer looks mid-write. Aborts any macro already running.
+bool poly_macro_start(uint8_t id);
+
+// Stop immediately and release everything the macro registered.
+void poly_macro_abort(void);
+
+bool poly_macro_active(void);
+
+// Advance at most one step. Call from housekeeping on the master.
+void poly_macro_tick(void);

--- a/keyboards/polykybd/poly_macro.h
+++ b/keyboards/polykybd/poly_macro.h
@@ -58,6 +58,7 @@ enum poly_macro_style {
                                  // one that needs no font pack and no decision.
     POLY_MACRO_STYLE_ICON  = 1,  // a chosen glyph above the caption
     POLY_MACRO_STYLE_TEXT  = 2,  // the caption alone, at the largest face that fits
+    POLY_MACRO_STYLE_ICON_ONLY = 3,  // the icon alone, centred in the whole cell
     POLY_MACRO_STYLE_COUNT
 };
 

--- a/keyboards/polykybd/rules.mk
+++ b/keyboards/polykybd/rules.mk
@@ -75,7 +75,7 @@ OS_DETECTION_ENABLE = yes
 # drift the shared keymap exists to prevent. It also gets the strict PolyKybd warning
 # flags applied below, which the per-variant base sources do not. The same argument
 # covers emoji/emoji_layer.c and hints/os_hints.c.
-POLY_SRC := poly_keymap.c boot_diag.c side.c state.c split_sync.c split_fw_up.c multicore_exec.c hid_com.c hid_fw_up.c hid_fontpack.c fill_overlay.c poly_util.c matrix_helper.c bridge_helper.c oled_helper.c keycode_helper.c mru.c lang_layer.c os_actions.c anim/startup_anim.c emoji/emoji_layer.c hints/os_hints.c base/fw_up_verdict.c
+POLY_SRC := poly_keymap.c boot_diag.c side.c state.c split_sync.c split_fw_up.c multicore_exec.c hid_com.c hid_fw_up.c hid_fontpack.c fill_overlay.c poly_util.c matrix_helper.c bridge_helper.c oled_helper.c keycode_helper.c mru.c lang_layer.c os_actions.c anim/startup_anim.c emoji/emoji_layer.c hints/os_hints.c base/fw_up_verdict.c poly_macro.c base/macro_decode.c
 SRC += $(POLY_SRC)
 
 # emoji/emoji_layer.c is listed here, not in a keymap's rules.mk: the keyboard-level

--- a/keyboards/polykybd/split_sync.c
+++ b/keyboards/polykybd/split_sync.c
@@ -280,6 +280,13 @@ _Static_assert(DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR >
                    DYNAMIC_KEYMAP_EEPROM_ADDR +
                        (DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT * MATRIX_ROWS * MATRIX_COLS * 2),
                "macro buffer must start above the capped keymap region");
+// The label array is carved off the TOP of the macro region by subtraction, which on
+// unsigned arithmetic wraps to a vast size instead of erroring. Pin it here rather than
+// in config.h: that header is also read by the C++ test harness, where `_Static_assert`
+// is not the spelling.
+_Static_assert(DYNAMIC_KEYMAP_EEPROM_MAX_ADDR - DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR + 1 >
+                   POLY_MACRO_LABEL_BYTES,
+               "macro label carve-out does not fit the reclaimed macro region");
 
 // Writes data to EEPROM at specified offset within the dynamic keymap region with bounds checking.
 void dynamic_keymap_set_buffer_poly(uint16_t offset, uint16_t size, const uint8_t *data) {

--- a/keyboards/polykybd/split_sync.c
+++ b/keyboards/polykybd/split_sync.c
@@ -284,6 +284,12 @@ _Static_assert(DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR >
 // unsigned arithmetic wraps to a vast size instead of erroring. Pin it here rather than
 // in config.h: that header is also read by the C++ test harness, where `_Static_assert`
 // is not the spelling.
+// Order first: the subtraction below is only meaningful once the region is known to
+// start inside the EEPROM at all. Whether a reversed pair would wrap or go negative
+// depends on the promoted type of two macros defined three headers apart, which is not
+// a thing to leave to inspection.
+_Static_assert(DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR <= DYNAMIC_KEYMAP_EEPROM_MAX_ADDR,
+               "macro region starts beyond the end of EEPROM");
 _Static_assert(DYNAMIC_KEYMAP_EEPROM_MAX_ADDR - DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR + 1 >
                    POLY_MACRO_LABEL_BYTES,
                "macro label carve-out does not fit the reclaimed macro region");
@@ -371,6 +377,13 @@ void user_sync_dynamic_keymap_data_handler(uint8_t in_len, const void* in_data, 
                     // RAM only on this side. The slave never persists a look: the
                     // master owns the EEPROM copy and re-pushes every one at boot,
                     // so a slave-side write would only be a second thing to go stale.
+                    //
+                    // The length check is this op's own, because the CRC does not pin
+                    // it: the slave computes it over `in_len - 4`, so a short frame
+                    // validates against its own truncated payload. This op reads the
+                    // most of any here -- a whole POLY_MACRO_LOOK_LEN record -- and a
+                    // short one would install a caption built from stale buffer bytes.
+                    if (in_len < sizeof(uint32_t) + 2 + POLY_MACRO_LOOK_LEN) break;
                     {
                         poly_macro_look_t look;
                         look.style = command_data[1];

--- a/keyboards/polykybd/split_sync.c
+++ b/keyboards/polykybd/split_sync.c
@@ -368,14 +368,20 @@ void user_sync_dynamic_keymap_data_handler(uint8_t in_len, const void* in_data, 
                     break;
                 }
                 case POLY_KEYMAP_OP_MACRO_LABEL:
-                    // RAM only on this side. The slave never persists a label: the
-                    // master owns the EEPROM copy and re-pushes every label at boot,
+                    // RAM only on this side. The slave never persists a look: the
+                    // master owns the EEPROM copy and re-pushes every one at boot,
                     // so a slave-side write would only be a second thing to go stale.
                     {
-                        char label[POLY_MACRO_LABEL_LEN + 1];
-                        memcpy(label, &command_data[1], POLY_MACRO_LABEL_LEN);
-                        label[POLY_MACRO_LABEL_LEN] = '\0';
-                        poly_macro_label_adopt(command_data[0], label);
+                        poly_macro_look_t look;
+                        look.style = command_data[1];
+                        look.icon  = (uint32_t)command_data[2]
+                                   | ((uint32_t)command_data[3] << 8)
+                                   | ((uint32_t)command_data[4] << 16)
+                                   | ((uint32_t)command_data[5] << 24);
+                        memcpy(look.text, &command_data[2 + POLY_MACRO_ICON_LEN],
+                               POLY_MACRO_LABEL_LEN);
+                        look.text[POLY_MACRO_LABEL_LEN] = '\0';
+                        poly_macro_look_adopt(command_data[0], &look);
                         request_disp_refresh();
                     }
                     break;

--- a/keyboards/polykybd/split_sync.c
+++ b/keyboards/polykybd/split_sync.c
@@ -16,6 +16,7 @@
 #include "eeprom.h"
 #include "nvm_eeprom_eeconfig_internal.h"
 #include "dynamic_keymap.h"
+#include "keymap_introspection.h"   // keycode_at_keymap_location_raw() for the capped reset
 #include "poly_keymap.h"   // poly_fl_row_cache_invalidate()
 #include "base/com.h"
 #include "base/disp_array.h"
@@ -266,6 +267,19 @@ void user_sync_roi_data_handler(uint8_t in_len, const void* in_data, uint8_t out
 
 _Static_assert(DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT <= DYNAMIC_KEYMAP_LAYER_COUNT, "Maximum cannot exceed DYNAMIC_KEYMAP_LAYER_COUNT");
 
+// The reclaim in config.h is only sound while the encoder/macro regions really do sit
+// at the WRITE CAP rather than at DYNAMIC_KEYMAP_LAYER_COUNT. Pin both, so a future
+// edit to either constant fails the build instead of silently handing the macro buffer
+// back to storage nothing reads.
+_Static_assert(DYNAMIC_KEYMAP_ENCODER_EEPROM_ADDR ==
+                   DYNAMIC_KEYMAP_EEPROM_ADDR +
+                       (DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT * MATRIX_ROWS * MATRIX_COLS * 2),
+               "encoder map must be based on the write cap, not DYNAMIC_KEYMAP_LAYER_COUNT");
+_Static_assert(DYNAMIC_KEYMAP_MACRO_EEPROM_ADDR >
+                   DYNAMIC_KEYMAP_EEPROM_ADDR +
+                       (DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT * MATRIX_ROWS * MATRIX_COLS * 2),
+               "macro buffer must start above the capped keymap region");
+
 // Writes data to EEPROM at specified offset within the dynamic keymap region with bounds checking.
 void dynamic_keymap_set_buffer_poly(uint16_t offset, uint16_t size, const uint8_t *data) {
     uint16_t max = DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT * MATRIX_ROWS * MATRIX_COLS * 2;
@@ -288,8 +302,36 @@ void dynamic_keymap_set_keycode_poly(uint8_t layer, uint8_t row, uint8_t column,
 // function and none can forget the cache invalidation. Deliberately a wrapper rather
 // than a list of "remember to also call this here" call sites — that is the guard
 // shape this codebase keeps getting caught by.
+//
+// ⚠️ This deliberately does NOT call QMK's dynamic_keymap_reset(). That one loops to
+// DYNAMIC_KEYMAP_LAYER_COUNT (12) and writes through nvm_dynamic_keymap_update_keycode(),
+// whose bound check is the same 12 — so with the encoder/macro regions rebased on the
+// 8-layer offset (config.h) it writes layers 8..11 straight over them. Walking the write
+// cap instead is also what the reclaim is FOR: those four layers are served from flash
+// by poly_keycode_at(), so storing them was only ever paying rent on unread bytes.
+//
+// The encoder map is reset over the same capped range for the same reason. The macro
+// buffer is zeroed because a keymap reset is exactly when a stale macro body would
+// otherwise survive — and because this is the repair path for QMK's unbounded reset
+// (eeconfig_init_kb, poly_keymap.c).
 void dynamic_keymap_reset_poly(void) {
-    dynamic_keymap_reset();
+    for (uint8_t layer = 0; layer < DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT; layer++) {
+        for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
+            for (uint8_t col = 0; col < MATRIX_COLS; col++) {
+                dynamic_keymap_set_keycode(layer, row, col,
+                                           keycode_at_keymap_location_raw(layer, row, col));
+            }
+        }
+#ifdef ENCODER_MAP_ENABLE
+        for (uint8_t enc = 0; enc < NUM_ENCODERS; enc++) {
+            dynamic_keymap_set_encoder(layer, enc, true,
+                                       keycode_at_encodermap_location_raw(layer, enc, true));
+            dynamic_keymap_set_encoder(layer, enc, false,
+                                       keycode_at_encodermap_location_raw(layer, enc, false));
+        }
+#endif
+    }
+    dynamic_keymap_macro_reset();
     poly_fl_row_cache_invalidate();
 }
 

--- a/keyboards/polykybd/split_sync.c
+++ b/keyboards/polykybd/split_sync.c
@@ -18,6 +18,7 @@
 #include "dynamic_keymap.h"
 #include "keymap_introspection.h"   // keycode_at_keymap_location_raw() for the capped reset
 #include "poly_keymap.h"   // poly_fl_row_cache_invalidate()
+#include "poly_macro.h"
 #include "base/com.h"
 #include "base/disp_array.h"
 #include "base/update.h"
@@ -331,7 +332,8 @@ void dynamic_keymap_reset_poly(void) {
         }
 #endif
     }
-    dynamic_keymap_macro_reset();
+    poly_macro_reset_all();   // bodies AND labels — a stale label on a cleared macro
+                             // is worse than no label, it names something that is gone
     poly_fl_row_cache_invalidate();
 }
 

--- a/keyboards/polykybd/split_sync.c
+++ b/keyboards/polykybd/split_sync.c
@@ -360,6 +360,18 @@ void user_sync_dynamic_keymap_data_handler(uint8_t in_len, const void* in_data, 
                     request_disp_refresh();
                     break;
                 }
+                case POLY_KEYMAP_OP_MACRO_LABEL:
+                    // RAM only on this side. The slave never persists a label: the
+                    // master owns the EEPROM copy and re-pushes every label at boot,
+                    // so a slave-side write would only be a second thing to go stale.
+                    {
+                        char label[POLY_MACRO_LABEL_LEN + 1];
+                        memcpy(label, &command_data[1], POLY_MACRO_LABEL_LEN);
+                        label[POLY_MACRO_LABEL_LEN] = '\0';
+                        poly_macro_label_adopt(command_data[0], label);
+                        request_disp_refresh();
+                    }
+                    break;
                 case id_custom_save: //handle the same way
                 case 'P':
                     if(command_data[0]==14) {

--- a/keyboards/polykybd/split_sync.h
+++ b/keyboards/polykybd/split_sync.h
@@ -95,6 +95,21 @@ void dynamic_keymap_set_buffer_poly(uint16_t offset, uint16_t size, const uint8_
 void dynamic_keymap_set_keycode_poly(uint8_t layer, uint8_t row, uint8_t column, uint16_t keycode);
 void dynamic_keymap_reset_poly(void);
 
+// Macro labels ride the DYNAMIC KEYMAP transaction rather than spending one of the 32
+// split-transaction slots (config.h explains how close to the cap that table is). That
+// handler is already op-dispatched on commands[0], so a private op costs nothing --
+// this is the same multiplexing the MRU snapshots and the doom mirror do on
+// USER_SYNC_OVERLAY_MAP_DATA.
+//
+// The value sits well clear of every VIA id the handler already matches
+// (id_dynamic_keymap_set_keycode 0x05, _reset 0x06, id_custom_save 0x09,
+// _set_buffer 0x13, plus the private 'P' 0x50) and below id_unhandled 0xFF.
+#define POLY_KEYMAP_OP_MACRO_LABEL 0xB1
+
+// Push one macro label to the slave. Returns true only on a real ACK -- callers use
+// that to decide whether to keep the label queued.
+bool poly_macro_label_bridge(uint8_t id, const char *label);
+
 void user_sync_dynamic_keymap_data_handler(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data);
 
 // Handles incoming overlay mapping data on bridge with CRC32 validation.

--- a/keyboards/polykybd/split_sync.h
+++ b/keyboards/polykybd/split_sync.h
@@ -12,6 +12,9 @@
 // config this file needs for the structs below. Re-exported here, so every
 // existing `#include "split_sync.h"` consumer is unaffected.
 #include "base/sync_ack.h"
+// poly_macro_look_t crosses this link, so the declaration below needs the type. It is
+// a plain POD header (stdint/stdbool + config.h), so this costs nothing.
+#include "poly_macro.h"
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -106,9 +109,9 @@ void dynamic_keymap_reset_poly(void);
 // _set_buffer 0x13, plus the private 'P' 0x50) and below id_unhandled 0xFF.
 #define POLY_KEYMAP_OP_MACRO_LABEL 0xB1
 
-// Push one macro label to the slave. Returns true only on a real ACK -- callers use
-// that to decide whether to keep the label queued.
-bool poly_macro_label_bridge(uint8_t id, const char *label);
+// Push one macro's whole look to the slave. Returns true only on a real ACK -- callers
+// use that to decide whether to keep it queued.
+bool poly_macro_look_bridge(uint8_t id, const poly_macro_look_t *look);
 
 void user_sync_dynamic_keymap_data_handler(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data);
 

--- a/keyboards/polykybd/state.c
+++ b/keyboards/polykybd/state.c
@@ -241,7 +241,7 @@ void save_user_latin(void) {
 // been reset by the time this is called, so losing the stamp to a power cut would cost
 // the user a SECOND reset on the next boot.
 void stamp_keymap_layers_fmt(void) {
-    const uint8_t marker = KEYMAP_LAYERS_FL_MERGED;
+    const uint8_t marker = KEYMAP_STORAGE_CURRENT;
     eeconfig_update_user_datablock(&marker, offsetof(poly_eeconf_t, keymap_layers_fmt),
                                    sizeof(marker));
 }

--- a/keyboards/polykybd/state.h
+++ b/keyboards/polykybd/state.h
@@ -432,7 +432,17 @@ typedef struct _poly_eeconf_t {
 // Layer-enum revision the stored dynamic keymap matches. Bump this ONLY when a layer
 // is added, removed or reordered — not when a layer's CONTENTS change, which needs no
 // reset. Anything else (0 included) means "written against a different enum, discard".
-#define KEYMAP_LAYERS_FL_MERGED 0x71 // single _FL; _NL/_UL/_SL shifted down one
+// Format versions for the stored dynamic keymap, oldest first. Anything that changes
+// what a stored byte MEANS -- the layer enum shifting, or the region moving -- gets a
+// new value here, and load_user_eeconf() discards the keymap once when it does not
+// match KEYMAP_STORAGE_CURRENT. Same shape as the LATIN_PICK_* list below.
+#define KEYMAP_LAYERS_FL_MERGED  0x71 // single _FL; _NL/_UL/_SL shifted down one
+#define KEYMAP_STORAGE_RECLAIMED 0x72 // ...and the encoder map + macro buffer moved down
+                                      // to the 8-layer offset (config.h). The keymap
+                                      // itself did not move, but the ENCODER map did, so
+                                      // a board flashed over 0x71 would read two layers'
+                                      // worth of keycodes as its encoder assignments.
+#define KEYMAP_STORAGE_CURRENT   KEYMAP_STORAGE_RECLAIMED
 // ⚠️ 0xC3 is deliberately NOT the current version. The build that introduced it
 // assumed an unwritten EEPROM reads 0xFF, so it copied the assignment map straight
 // out of a block that had never held one — read back as all-zero, i.e. "every key


### PR DESCRIPTION
## Summary

Store text (or a short key sequence) on the keyboard and type it back with one key —
with a short **label the keycap spells out** along its bottom edge, so a row of macro
keys reads `push`, `work mail`, `sign off` rather than M0, M1, M2. Every keyboard with
macros has the first half; the legend is the part that is ours.

Three commands behind one feature gate — `MACRO_INFO` (`0x24`/36), `MACRO_BODY`
(`0x25`/37), `MACRO_LABEL` (`0x26`/38), **protocol v15**. Splitting the gate would let a
host read the macro list from a keyboard that cannot serve the bodies, and draw an
editor over data it cannot fetch.

Paired with thpoll83/PolyKybdHost#196 and thpoll83/polykybd-ctnd#74. **Merge the ctnd PR
first** — the rig force-syncs to its `main`, so this PR's HIL check cannot run a test
that only exists on a branch.

### It cost no EEPROM

`DYNAMIC_KEYMAP_LAYER_COUNT` must stay 12 (QMK asserts it covers the compiled layers),
but only layers 0–7 are ever read or written — `_SL` and up are served from flash. QMK's
default addresses put the encoder map and the macro buffer after all twelve, so 640 B of
keymap plus 32 B of encoder map sat there addressed by nothing. Both are rebased on
`DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT`; **measured** on split72 the macro region went
1787 → 2459 B (+672), which is where the macros live.

Measured, not derived: the addresses are macros, so they are not symbols in the ELF.
A `const uint32_t probe[]` appended to a real TU, built, and read back out of
`.build/obj_*/split_sync.o` — the linker gc's it from the image but the object file
still has it.

⚠️ The reclaim is only sound while nothing writes layers ≥ the cap, and QMK's own
`dynamic_keymap_reset()` **does** — it loops to `DYNAMIC_KEYMAP_LAYER_COUNT` through a
bound check that is also `DYNAMIC_KEYMAP_LAYER_COUNT`, straight over both reclaimed
regions. Two guards, both load-bearing: `dynamic_keymap_reset_poly()` no longer calls
it, and `eeconfig_init_kb()` repairs after the one call site that cannot be removed
(`eeconfig_init_quantum`, three lines above ours, unconditional). Two `_Static_assert`s
pin the addresses to the write cap so a later edit fails the build instead of quietly
handing the space back.

The encoder map moves, so a board flashed over the old layout would read two layers of
keycodes as its encoder assignments — hence the `KEYMAP_STORAGE_RECLAIMED` bump on the
existing `keymap_layers_fmt` gate, which discards the stored keymap once on the first
boot after flashing.

## Design notes worth reading before reviewing

- **Storage is QMK's own dynamic-macro buffer** — NUL-terminated bodies, macro N found
  by counting terminators. Nothing new was invented. The **labels** are a separate
  fixed-stride array carved off the top of the same region by shrinking
  `DYNAMIC_KEYMAP_MACRO_EEPROM_SIZE`: a body is addressed by counting separators, which
  is fine once per keypress and wrong for something `render_key()` reads for every macro
  keycap on every refresh. Shrinking the QMK constant is what keeps them apart, since
  every upstream path bounds itself on it.

- **Playback is ours and is a state machine.** `dynamic_keymap_macro_send()` runs the
  whole macro inline and spells its delay `while (ms--) wait_ms(1)`. On a single-
  controller board that is rude; here the same loop scans the matrix, drives the split
  UART, services USB and pushes 72 SPI displays. `poly_macro_tick()` runs at most one
  step per housekeeping pass and treats a delay as a deadline. No time-slicing is needed
  — steps have to be spaced anyway for the host to see distinct events, so the pacing
  *is* the yield.

- **The wire format is QMK's send-string encoding, not Vial's extension of it.** Staying
  on the base encoding means the buffer is still playable by
  `dynamic_keymap_macro_send()` — a real cross-check rather than a theoretical one. Cost:
  8-bit keycodes, so no mod-taps or layer keys; every modifier is 0xE0..0xE7 so chords
  are fine.

- **Swallowed in `process_record_user()`**, not left to the release edge — an `OSL()`
  layer re-dispatches a release-edge action up to three times, which for a macro means
  playing it two or three times over.

- **`clear_keyboard()` on abort.** A DOWN step leaves a modifier registered and any
  keypress aborts playback; without the clear the host auto-repeats a key nothing will
  ever release. Same rule as the FW-2 prompt and `doom_begin()`.

- **Labels live in a RAM cache on both halves** (192 B). Partly speed, mostly necessity:
  the host writes macros to the master, so the slave's EEPROM never sees one. The master
  pushes one label per housekeeping pass and clears its dirty bit only on a real ACK, so
  the mask is its own retry queue and nothing has to detect "the link is up". It
  multiplexes onto `USER_SYNC_DYNAMIC_KEYMAP_DATA` with a private op byte rather than
  spending one of the 32 transaction slots.

- **The keycap draws the index above and the label below.** The index rather than a
  generic macro glyph: a generic glyph is identical on all sixteen keys, so it says
  "this is a macro" and nothing else. Truncation is by **measured width**, never
  character count — `WWWWWWWW` is exactly 72 px at eight characters and
  `iiiiiiiiiiii` is 34 px at twelve.

## Testing

- [x] Compiled successfully — `polykybd/split72` and `polykybd/split42`
- [x] Monolith `POLYKYBD_DOOM=yes` built (PR CI does not): `.heap` 3828 → **3620 B**
      free, i.e. the feature costs 208 B of RAM
- [x] `make test:polykybd_macro_decode` — 23 tests, mutation-tested against 7
      deliberate breaks, each caught by the intended test
- [x] `qmk lint --strict` both boards; `ci-validate-keyboard-targets` / `-aliases` clean
- [ ] Flashed and tested on hardware — a `.bin` is with the author; **not tested by me**
- [x] Protocol changed: host and rig PRs are open and move in lockstep

The decoder is pure in `base/macro_decode.c` (a byte-reader callback; no `quantum.h`, no
EEPROM, no timer) for the same reason as `base/fw_up_verdict.c`: the arithmetic is the
part with a bug history and it was only unreachable because it shared a function with
the I/O. One subtlety it pins — **the byte ending a delay is not consumed**, since
send_string re-reads it as the next step; consuming it silently swallows the character
after every delay, which presents as "the macro drops a letter sometimes".

## Version bump label

`bump:minor`. Deliberately **not** `bump:protocol`: `PROTOCOL_VERSION` is already
bumped in-source (14 → 15), and the label would double-bump it.

Nothing binds `QK_MACRO_*` in the default keymap — a macro key is assigned from the
host's layout editor, so a user who never opens it pays nothing. Happy to add a few if
you would rather they were there out of the box.

## Summary by Sourcery

Add protocol v15 dynamic macros with persistent playback, configurable keycap legends, split synchronization, and reclaimed EEPROM storage.

New Features:
- Add host-configurable dynamic macros with persistent bodies, keycap labels, icons, and display styles.
- Expose protocol v15 commands for macro metadata, body transfer, and combined keycap appearance management.
- Play stored macros incrementally with delays, key actions, abort handling, and synchronization of labels to the split half.

Bug Fixes:
- Prevent incomplete or malformed macro buffers from being played and safely release keys when playback is aborted.
- Prevent stale dynamic-keymap reset behavior from overwriting reclaimed macro and encoder storage.

Enhancements:
- Reclaim unused dynamic-keymap EEPROM space for macro storage and add migration safeguards for the relocated encoder map.
- Render macro keycaps with measured-width labels and graceful icon/style fallbacks.

Documentation:
- Document the reclaimed EEPROM layout, protocol additions, macro format, playback behavior, synchronization, rendering, and resource costs.

Tests:
- Add dependency-free macro decoding tests covering addressing, usage accounting, integrity checks, delays, malformed input, and realistic key sequences.

Chores:
- Bump the firmware protocol version from 14 to 15 and update the stored keymap format marker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added programmable dynamic macros with tap, hold, release, delay, and text playback.
  * Added 16 customizable macro keycap appearances with captions, icons, and display styles.
  * Added host controls for reading, writing, monitoring, and customizing macros.
  * Macro playback remains non-blocking and synchronizes across split keyboard halves.

* **Bug Fixes**
  * Invalid, incomplete, or interrupted macro uploads now stop safely and release held keys.
  * Improved storage reset and recovery for macro data.

* **Documentation**
  * Documented macro behavior, appearance settings, storage limits, and host protocol updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->