### PR TITLE
skills: diagnose a HIL that never ran, and strings' 4-char minimum

### DIFF
--- a/.claude/skills/deliver-test-firmware/SKILL.md
+++ b/.claude/skills/deliver-test-firmware/SKILL.md
@@ -79,6 +79,21 @@ Confirm:
 - `.heap` is non-trivially positive (free SRAM). A near-zero value means the next
   small feature will fail to link.
 - The `.bin` is a plausible size (~430 KB) and **newer than the source edit**.
+- **A string you changed is actually in the image.** ⚠️ `strings` defaults to a
+  **4-character minimum**, so short literals read as MISSING from a perfectly good
+  binary — verifying eight new layer names, `Neo` and `Fn` both came back absent
+  (2026-08-27) and it looked exactly like a broken build. Use `-n 2`, and match
+  whole lines so a substring cannot fake a hit:
+
+  ```bash
+  for s in Qwerty Neo Fn Utility; do
+      strings -n 2 "$BIN" | grep -qxF "$s" && echo "OK   $s" || echo "MISS $s"
+  done
+  ```
+
+  Only for literals the compiler actually emits. A reply **assembled byte-by-byte at
+  runtime** is absent by design and its absence proves nothing — see the `PRR`/`PRL`
+  note in `CLAUDE.md`, which cost a double-take for exactly this reason.
 
 ## 4. Send
 

--- a/.claude/skills/diagnose-hil-failure/SKILL.md
+++ b/.claude/skills/diagnose-hil-failure/SKILL.md
@@ -6,7 +6,8 @@ description: >
   check fails, a `❌ HIL test failed — rig diagnostics` comment appears, the user
   asks to "look at the HIL failure / rig test / why is CI red", or when deciding
   whether to re-run the HIL job. Classifies the failure into stale-rig-code /
-  no-enumeration / boot-burst flake / stale-rig-test / real-firmware-bug, then
+  no-enumeration / boot-burst flake / stale-rig-test / real-firmware-bug, or a
+  rig-network failure that dies in workflow setup with no log at all, then
   acts (re-run, fix the ctnd test, or flag the rig). NOT for building firmware
   (that's the build job) or for non-HIL CI.
 ---
@@ -37,6 +38,45 @@ mcp__github__actions_list  method=list_workflow_runs  resource_id=qmk-test.yml
 mcp__github__actions_list  method=list_workflow_jobs  resource_id=<run_id>  filter=all
 ```
 
+## 1.5 Did the suite RUN at all? — the no-log case
+
+⚠️ **Before step 2: if the log ends at `Prepare all required actions`, there is no
+settle line to read and NONE of the classes below apply.** The job died in workflow
+SETUP — before checkout, before the station sync, before a single `[test]` line.
+Signature (seen 3× on 2026-08-27, twice on a PR and again on the `PolyKybd` merge
+push):
+
+```
+Download action repository 'actions/download-artifact@v4'
+##[warning]Failed to download action 'https://codeload.github.com/actions/download-artifact/tar.gz/...'.
+           Error: The request was canceled due to the configured HttpClient.Timeout of 100 seconds elapsing.
+##[error]Failed to download archive ... after 3 attempts.
+```
+
+That is the **rig's own network** — not the firmware, not the rig's test code, and
+not something a re-run fixes once it has reproduced. Three things make it
+diagnosable:
+
+- **A runner being ONLINE does not mean its network is fine.** It picked the job up,
+  streamed logs and reported status, so `api.github.com` and the Actions service are
+  reachable while `codeload.github.com` is not. That is a *selective* failure, not
+  "the rig is offline" — don't go hunting for a dead runner.
+- **Rule out a GitHub incident before blaming the rig**, one call:
+  `https://www.githubstatus.com/api/v2/summary.json`. On 2026-08-27 Actions, Git
+  Operations and API Requests were all operational, which is what pinned it to the Pi.
+- ⚠️ **This is NOT the `codeload` note in `qmk_firmware/CLAUDE.md`.** That one is the
+  *dev container's* submodule fetches getting a **403** from the injected git proxy,
+  fixed with `add_repo`. This is the *rig runner* getting a **timeout** fetching a
+  GitHub Action. Same hostname, different machine, different symptom — the container
+  note's fix does not apply, and conflating them sends you to `add_repo` for nothing.
+
+**Action:** it qualifies for the one re-run (it died before any test body ran), but a
+second identical failure is real — stop re-running, say so, and keep the PR watched.
+There is **no fix to port**: nothing in a firmware PR can reach the runner's
+connectivity, and widening the PR to work around an Actions download is the wrong
+shape. Recovery is the rig's network; after that the HIL job re-runs on its own
+(it reuses the build artifact and force-syncs the station itself).
+
 ## 2. Check rig freshness FIRST — the settle line
 
 Before anything else, read this line:
@@ -60,6 +100,7 @@ Before anything else, read this line:
 | Signature in the log | Class | Meaning / action |
 |---|---|---|
 | `raw HID interfaces present: 0` + every test fails `Raw HID interface not found` | **no-enumeration** | The master never enumerated its raw HID interface. NOT a display/font/keymap change (USB inits before rendering). Rig USB/flash/boot wedged or slow → **re-run**; if it persists across re-runs the rig needs physical attention (reseat/power-cycle a half), not a code fix. |
+| **No `[test]` line at all**; log ends at `Prepare all required actions` | **rig network / setup** | The job never ran. See §1.5 — the runner cannot reach `codeload.github.com` to fetch an action. One re-run is allowed; a second identical failure is real and there is nothing in the PR to fix. |
 | An early read (e.g. `GET_ID #2`, a layer/keymap read) times out (`None`), **everything after passes** | **boot-burst flake** | The async slave-connect render burst (~5 s stall) landed on an early test. It *wanders* onto a different adjacent test pair each run. `need=15` settle usually rides past it; a lone straggler → **re-run**. |
 | One test fails on a **wrong value** (`status 0xNN != expected`, byte mismatch — a *response*, not a timeout), everything else passes | **stale rig test** | A rig-side mirror of a firmware constant/enum drifted. Compare the firmware source to the rig's mirror and fix the **ctnd** test, not the firmware. (2026-07: `POLY_OS_COUNT` was 6 on the rig but the firmware enum grew to 8 — `SET_OS(6)`=GNOME is valid, so the "invalid" probe wrongly ACKed.) |
 | Broad failures with genuinely wrong data / NACKs where ACK expected across many commands | **real firmware bug** | Investigate the PR diff. This is the rare case the HIL suite exists to catch. |
@@ -90,6 +131,8 @@ flag rig). One or two sentences per point.
 
 ## Pitfalls
 
+- **No settle line at all? You are in §1.5, not step 2.** Every class in the
+  table presupposes the suite ran; a setup failure produces no log to classify.
 - **Read the settle line before diagnosing.** `need=3` = stale rig; fixing the
   firmware/test is wasted effort until the rig is current.
 - **Re-running a stale rig reproduces the same red.** Get the rig current first.


### PR DESCRIPTION
## Summary

Two skill updates from the layer-names session (cmd 35 / protocol v14). Documentation only — no firmware sources touched.

**`diagnose-hil-failure` gains a §1.5** for a case none of its four classes covers: the job dying in **workflow setup**, before checkout, before the station sync, and before a single `[test]` line — so there is no settle line to read, and the skill's own "read the settle line FIRST" instruction actively misleads. Hit **three times** on 2026-08-27 (twice on #233, once on the `PolyKybd` merge push) when the rig lost outbound access to `codeload.github.com` while fetching `actions/download-artifact@v4`.

It records the three things that cost real time to work out:

- **A runner being online does not mean its network is fine.** It picked the job up, streamed logs and reported status — so `api.github.com` and the Actions service were reachable while `codeload` was not. A *selective* failure, not "the rig is offline", so there is no dead runner to go hunting for.
- **Rule out a GitHub incident before blaming the rig**, one call to `githubstatus.com/api/v2/summary.json`. Actions, Git Operations and API Requests were all operational, which is what pinned it to the Pi.
- ⚠️ **It is NOT the `codeload` note already in `CLAUDE.md`.** That one is the *dev container's* submodule fetches getting a **403** from the injected git proxy, fixed with `add_repo`. This is the *rig runner* getting a **timeout** fetching a GitHub Action. Same hostname, different machine, different remedy — conflating them sends you to `add_repo` for nothing.

Also adds the table row, a pitfall, and names the class in the frontmatter description so the skill triggers on it.

**`deliver-test-firmware`**: verifying a literal is in the image needs `strings -n 2`. The 4-character default reported `Neo` and `Fn` as **missing** from a perfectly sound binary — it reads exactly like a broken build. Cross-referenced to the existing `PRR`/`PRL` note, since a reply assembled byte-by-byte at runtime is absent by design and its absence proves nothing.

## Version bump label

*(none)* — patch. ⚠️ Worth knowing: this is a **Markdown-only** change, so `bump-version.yml` will still patch-bump `FW_VERSION` for a PR that changes no firmware. That is existing repo behaviour, flagged rather than worked around.

## Testing

- [ ] Compiled successfully — **N/A**, no C sources changed
- [ ] Flashed and tested on hardware — **N/A**
- [ ] If protocol changed: host updated and tested together — **N/A**, no protocol change

⚠️ **Expect an empty check board.** `qmk-test.yml` carries `paths-ignore: ['**.md']` on both its `push` and `pull_request` triggers, so a Markdown-only PR runs neither `Build firmware` nor the rig — by design (#225), and not a sign the checks failed to start. Verified locally instead: every fenced block balanced, and the §1.5 content renders as intended.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NytprmPuKPEwg4r5ckGJDL)_

## Summary by Sourcery

Update the firmware delivery and HIL diagnosis skills to prevent misleading build-verification results and correctly classify jobs that fail before the test suite starts.

Enhancements:
- Improve HIL failure diagnosis by covering workflow-setup failures caused by selective rig network connectivity issues, including guidance for distinguishing them from GitHub incidents and unrelated container proxy errors.
- Strengthen firmware delivery verification by checking emitted short string literals with an appropriate minimum length and distinguishing runtime-assembled responses from embedded strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added firmware verification guidance explaining how to detect short text literals in valid binaries and clarify expected runtime-assembled values.
  * Documented a hardware-in-the-loop setup failure mode caused by workflow download timeouts before tests begin.
  * Added troubleshooting guidance to distinguish infrastructure issues from development-container problems, limit retries, and report persistent failures without changing firmware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->