### PR TITLE
Architecture review: extract testable seams, fix the base/ upward dependency, +28 unit tests

### DIFF
--- a/keyboards/polykybd/base/disp_array.c
+++ b/keyboards/polykybd/base/disp_array.c
@@ -13,7 +13,6 @@
 
 #include "fonts/base_font.h"
 #include "com.h"
-#include "../poly_keymap.h"
 
 // HINT_MID (\x16) draws the REST of the string from this standalone UI face
 // instead of the caller's array. It exists because the three standalone faces

--- a/keyboards/polykybd/base/map_codec.h
+++ b/keyboards/polykybd/base/map_codec.h
@@ -1,0 +1,62 @@
+// Copyright 2026 thpoll83
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#include <stdint.h>
+
+// Pure bit codec for the packed overlay-mapping format (HID cmd 21 fixed 10-bit,
+// cmd 33 host-chosen width, and the slave-repair bridge frames): consecutive
+// `width`-bit values packed LSB-first into a byte buffer.
+//
+// Extracted from fill_overlay.c so the encoder and decoder are ONE pair in one
+// place and unit-testable off-hardware (make test:polykybd_map_codec). Both of
+// this codec's historical bugs were in exactly this arithmetic, and neither was
+// observable from the rig — cmd 33 is silent by design, so the HIL test can only
+// assert liveness, never the decoded values:
+//   - an unconditional second-byte read ran past the last data byte at width 8
+//     (every value is one whole byte there, gcd(8,8) == 8);
+//   - a fixed `0xff >> (8 - n)` mask shifted by a negative count at the offsets
+//     only the odd widths 9/11 reach (gcd 1 walks all eight bit offsets).
+//
+// ⚠️ How many bytes a value spans depends on the width, so BOTH the second and
+// third byte accesses are conditional — a read must never touch past the last
+// data byte a value actually occupies, and the writer mirrors the reader exactly
+// so it can never dirty a byte the reader would not consume. The unit tests pin
+// this with guard bytes; verify any change there, not by eye.
+//
+// Widths up to 16 bits are representable (16 + 7 offset bits = 23 < 24); the
+// protocol bounds live in config.h (OVERLAY_MAP_WIDTH_MIN/MAX) and stay with the
+// command handlers — this codec is just the arithmetic.
+
+// Reads value `idx` of `width` bits from `buf`.
+static inline uint16_t map_codec_read(const uint8_t* buf, uint16_t idx, uint8_t width) {
+    // start_bit must be wide enough to hold idx*width (up to ~488 bits for a
+    // 61-byte report) — a uint8_t would wrap.
+    uint16_t start_bit  = (uint16_t)(idx * (uint16_t)width);
+    uint16_t start_byte = start_bit / 8;
+    uint8_t  s          = start_bit % 8;
+    uint32_t acc        = (uint32_t)buf[start_byte];
+    if (s + width > 8) {
+        acc |= (uint32_t)buf[start_byte + 1] << 8;
+    }
+    if (s + width > 16) {
+        acc |= (uint32_t)buf[start_byte + 2] << 16;
+    }
+    return (uint16_t)((acc >> s) & ((1u << width) - 1u));
+}
+
+// Writes `v` as value `idx` of `width` bits into `buf`. `buf` must be zeroed
+// first — this ORs in, so the caller can pack values in any order.
+static inline void map_codec_write(uint8_t* buf, uint16_t idx, uint16_t v, uint8_t width) {
+    uint16_t start_bit  = (uint16_t)(idx * (uint16_t)width);
+    uint16_t start_byte = start_bit / 8;
+    uint8_t  s          = start_bit % 8;
+    uint32_t shifted    = (uint32_t)(v & ((1u << width) - 1u)) << s;
+    buf[start_byte] |= (uint8_t)(shifted & 0xff);
+    if (s + width > 8) {
+        buf[start_byte + 1] |= (uint8_t)((shifted >> 8) & 0xff);
+    }
+    if (s + width > 16) {
+        buf[start_byte + 2] |= (uint8_t)((shifted >> 16) & 0xff);
+    }
+}

--- a/keyboards/polykybd/base/mode_byte.h
+++ b/keyboards/polykybd/base/mode_byte.h
@@ -1,0 +1,47 @@
+// Copyright 2026 thpoll83
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+// The one-byte "mode + known + value" EEPROM encoding shared by two persisted
+// settings in state.c: bit7 = a mode flag, bit6 = "a real value is known",
+// bits0-5 = the value (0..63). It existed as two hand-rolled copies
+// (pack/load_auto_brightness and pack/load_os_state) whose bit masks had to
+// agree by inspection; this header is the single implementation, unit-tested
+// (make test:polykybd_mode_byte).
+//
+// The POLARITY of bit7 is deliberately the caller's choice, because it is what
+// makes a zeroed byte the right default: QMK's wear levelling hands an unwritten
+// EEPROM byte back as ZERO (not 0xFF — see the latin_assign trap in CLAUDE.md),
+// so each setting picks which meaning of bit7 leaves 0 = "factory default"
+// (auto-brightness stores "auto engaged", OS state stores "manual pin").
+//
+// The KNOWN bit is load-bearing, not decorative: a mode engaged before any real
+// value arrives must not persist its placeholder as if real, or the next boot
+// snaps to it (the FULL_BRIGHT-jump family of bugs). Callers keep their own
+// range checks on the 6-bit value — this codec is just the byte layout.
+
+#define MODE_BYTE_FLAG  0x80u
+#define MODE_BYTE_KNOWN 0x40u
+#define MODE_BYTE_VALUE 0x3Fu
+
+static inline uint8_t mode_byte_pack(bool flag, bool known, uint8_t value) {
+    uint8_t b = (uint8_t)(value & MODE_BYTE_VALUE);
+    if (flag) b |= MODE_BYTE_FLAG;
+    if (known) b |= MODE_BYTE_KNOWN;
+    return b;
+}
+
+static inline bool mode_byte_flag(uint8_t packed) {
+    return (packed & MODE_BYTE_FLAG) != 0;
+}
+
+static inline bool mode_byte_known(uint8_t packed) {
+    return (packed & MODE_BYTE_KNOWN) != 0;
+}
+
+static inline uint8_t mode_byte_value(uint8_t packed) {
+    return (uint8_t)(packed & MODE_BYTE_VALUE);
+}

--- a/keyboards/polykybd/base/tests/idle_update_tests.cpp
+++ b/keyboards/polykybd/base/tests/idle_update_tests.cpp
@@ -1,0 +1,121 @@
+// Copyright 2026 Thomas Pollak
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Tests for base/update.c — the idle-activity timestamp and overlay-burst
+// coalescing counters. This module has real bug history and had no tests: the
+// timestamp was once a signed int32 whose sign bit doubled as the "tracking
+// off" sentinel, so idle silently stopped working for the ~25 days of uptime
+// after timer_read32() set bit 31, and the host "start idle" backdate
+// underflowed in the first two minutes after boot. Both regressions are pinned
+// here against the mock clock (platforms/test/timer.c).
+
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "update.h"
+// The mock clock has no header — the pattern every timer-driving QMK test uses.
+void set_time(uint32_t t);
+void advance_time(uint32_t ms);
+}
+
+namespace {
+
+class IdleUpdateTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        set_time(0);
+        // The module's statics persist across tests in one binary; put them in
+        // a known state instead of relying on test order.
+        update_performed();
+        clear_overlay_pending();
+    }
+};
+
+TEST_F(IdleUpdateTest, UpdatePerformedEnablesTrackingAndZeroesElapsed) {
+    set_time(5000);
+    update_performed();
+    EXPECT_TRUE(is_idle_tracking());
+    EXPECT_EQ(get_time_since_last_update(), 0u);
+    advance_time(1234);
+    EXPECT_EQ(get_time_since_last_update(), 1234u);
+}
+
+TEST_F(IdleUpdateTest, DisableIdleTrackingTurnsTheGateOff) {
+    disable_idle_tracking();
+    EXPECT_FALSE(is_idle_tracking());
+    update_performed();
+    EXPECT_TRUE(is_idle_tracking());
+}
+
+TEST_F(IdleUpdateTest, LegacyNegativeSetDisablesAndNonNegativeReenables) {
+    set_last_update(-1);
+    EXPECT_FALSE(is_idle_tracking());
+    set_last_update(1000);
+    EXPECT_TRUE(is_idle_tracking());
+    EXPECT_EQ(get_last_update(), 1000u);
+}
+
+TEST_F(IdleUpdateTest, TrackingSurvivesTheSignBitOfTheTimer) {
+    // The 24.86-day regression: uptime past 2^31 ms must not disable idle or
+    // corrupt the elapsed arithmetic.
+    set_time(0x80000000u + 5000u);
+    update_performed();
+    EXPECT_TRUE(is_idle_tracking());
+    EXPECT_EQ(get_time_since_last_update(), 0u);
+    advance_time(250);
+    EXPECT_EQ(get_time_since_last_update(), 250u);
+}
+
+TEST_F(IdleUpdateTest, ElapsedIsCorrectAcrossTheTimerWrap) {
+    set_time(0xFFFFFF00u);
+    update_performed();
+    advance_time(0x200);  // wraps past 2^32
+    EXPECT_EQ(get_time_since_last_update(), 0x200u);
+}
+
+TEST_F(IdleUpdateTest, BackdateNearBootDoesNotUnderflowToJustActive) {
+    // The host "start idle" regression: backdating by FADE_OUT_TIME (120 s)
+    // when uptime is only 1 s must read as "idle for 120 s", not "just active".
+    set_time(1000);
+    backdate_last_update(120000);
+    EXPECT_TRUE(is_idle_tracking());
+    EXPECT_EQ(get_time_since_last_update(), 120000u);
+}
+
+TEST_F(IdleUpdateTest, BackdateReenablesTracking) {
+    disable_idle_tracking();
+    backdate_last_update(1);
+    EXPECT_TRUE(is_idle_tracking());
+}
+
+TEST_F(IdleUpdateTest, OverlayActivityElapsedAndPendingCount) {
+    set_time(10000);
+    note_overlay_activity();
+    note_overlay_activity();
+    EXPECT_EQ(overlay_pending_count(), 2u);
+    EXPECT_EQ(overlay_activity_elapsed(), 0u);
+    advance_time(75);
+    EXPECT_EQ(overlay_activity_elapsed(), 75u);
+    clear_overlay_pending();
+    EXPECT_EQ(overlay_pending_count(), 0u);
+}
+
+TEST_F(IdleUpdateTest, OverlayPendingSaturatesInsteadOfWrapping) {
+    // A stream longer than 65535 reports must keep reading as "a lot", not
+    // wrap back to a small number that defeats the flush threshold.
+    for (uint32_t i = 0; i < 70000u; ++i) {
+        note_overlay_activity();
+    }
+    EXPECT_EQ(overlay_pending_count(), 0xFFFFu);
+}
+
+TEST_F(IdleUpdateTest, RefreshModeRoundTrips) {
+    set_disp_refresh(DONE_ALL);
+    EXPECT_EQ(get_refresh_mode(), DONE_ALL);
+    request_disp_refresh();
+    EXPECT_EQ(get_refresh_mode(), ALL_AT_ONCE);
+    set_disp_refresh(START_FIRST_HALF);
+    EXPECT_EQ(get_refresh_mode(), START_FIRST_HALF);
+}
+
+}  // namespace

--- a/keyboards/polykybd/base/tests/layer_names_tests.cpp
+++ b/keyboards/polykybd/base/tests/layer_names_tests.cpp
@@ -1,0 +1,105 @@
+// Copyright 2026 Thomas Pollak
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Tests for the HID cmd 35 (GET_LAYER_NAMES, protocol v14+) payload encoder in
+// layer_names.c. The host decoder is mutation-tested on its side, but a host
+// fixture can only catch the host MISREADING a payload — never this end
+// emitting the wrong one (the same one-sidedness the font-pack COMMIT status
+// had). This suite pins the emitting half: [total][count] then NUL-terminated
+// names, total = whole payload length including itself, count = the write cap.
+
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "layer_names.h"
+}
+
+#include <string>
+#include <vector>
+
+namespace {
+
+std::vector<uint8_t> build() {
+    std::vector<uint8_t> payload(LAYER_NAMES_PAYLOAD_MAX, 0xEE);  // poison
+    uint16_t used = poly_layer_names_payload(payload.data());
+    EXPECT_LE(used, payload.size());
+    payload.resize(LAYER_NAMES_PAYLOAD_MAX);
+    payload.push_back((uint8_t)used);  // smuggle `used` out for the callers
+    return payload;
+}
+
+// Decode the way the host does: read byte 0, take exactly that many bytes,
+// split on NULs — termination is arithmetic, never a scan.
+std::vector<std::string> decode(const std::vector<uint8_t>& payload) {
+    std::vector<std::string> names;
+    uint8_t     total = payload[0];
+    std::string cur;
+    for (uint16_t i = 2; i < total; ++i) {
+        if (payload[i] == 0) {
+            names.push_back(cur);
+            cur.clear();
+        } else {
+            cur.push_back((char)payload[i]);
+        }
+    }
+    EXPECT_TRUE(cur.empty()) << "payload did not end on a terminator";
+    return names;
+}
+
+TEST(LayerNamesPayloadTest, TotalIsTheReturnedLengthAndFitsOneByte) {
+    auto payload = build();
+    uint16_t used = payload.back();
+    EXPECT_EQ(payload[0], used);
+    EXPECT_LE(used, 255);
+    EXPECT_LE(used, LAYER_NAMES_PAYLOAD_MAX);
+}
+
+TEST(LayerNamesPayloadTest, CountIsTheHostRemappableWriteCap) {
+    // The SAME constant id_dynamic_keymap_get_layer_count answers with — two
+    // different counts would let the editor draw a tab it has no name for.
+    auto payload = build();
+    EXPECT_EQ(payload[1], DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT);
+}
+
+TEST(LayerNamesPayloadTest, EveryLayerDecodesToItsWireName) {
+    auto payload = build();
+    auto names   = decode(payload);
+    ASSERT_EQ(names.size(), (size_t)DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT);
+    for (uint8_t layer = 0; layer < DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT; ++layer) {
+        const char* wire = poly_layer_name_wire(layer);
+        std::string expect = wire ? std::string(wire).substr(0, POLY_LAYER_NAME_MAX) : "";
+        EXPECT_EQ(names[layer], expect) << "layer " << (int)layer;
+        EXPECT_LE(names[layer].size(), (size_t)POLY_LAYER_NAME_MAX);
+    }
+}
+
+TEST(LayerNamesPayloadTest, TheBaseLayoutAndFixedLayersAreNamed) {
+    // A literal spot check so a table swap cannot slip past the self-referential
+    // comparison above: layer 0 is the Qwerty base and the write cap's last
+    // layer is the utility layer.
+    auto names = decode(build());
+    EXPECT_EQ(names.front(), "Qwerty");
+    EXPECT_EQ(names.back(), "Utility");
+}
+
+TEST(LayerNamesPayloadTest, NoNameNeedsMoreThanTheBudget) {
+    // POLY_LAYER_NAME_MAX is the host tab label's budget; the emitter clamps
+    // rather than trusting the table, so nothing may exceed it after decode.
+    for (auto& n : decode(build())) {
+        EXPECT_LE(n.size(), (size_t)POLY_LAYER_NAME_MAX);
+    }
+}
+
+TEST(LayerNamesPayloadTest, ZeroFillPastTheTotalIsNeverReadAsARecord) {
+    // The report's zero fill after the payload must not add phantom empty
+    // names — decoding stops at `total` by arithmetic. Poison vs zero fill
+    // beyond `used` must not change the decode.
+    auto payload = build();
+    uint16_t used = payload.back();
+    auto a = decode(payload);
+    for (size_t i = used; i < (size_t)LAYER_NAMES_PAYLOAD_MAX; ++i) payload[i] = 0x00;
+    auto b = decode(payload);
+    EXPECT_EQ(a, b);
+}
+
+}  // namespace

--- a/keyboards/polykybd/base/tests/map_codec_tests.cpp
+++ b/keyboards/polykybd/base/tests/map_codec_tests.cpp
@@ -21,6 +21,12 @@ extern "C" {
 #include <cstring>
 #include <vector>
 
+#if defined(__unix__) || defined(__APPLE__)
+#    include <sys/mman.h>
+#    include <unistd.h>
+#    define MAP_CODEC_HAVE_GUARD_PAGE 1
+#endif
+
 namespace {
 
 constexpr uint8_t kWidthMin = 8;   // OVERLAY_MAP_WIDTH_MIN (config.h)
@@ -82,10 +88,68 @@ TEST(MapCodecTest, WriteThenReadRoundTripsEveryWidth) {
     }
 }
 
+#ifdef MAP_CODEC_HAVE_GUARD_PAGE
+// Two mapped pages with the second one PROT_NONE: data placed flush against the
+// boundary makes any access past a value's span a deterministic SIGSEGV, with no
+// sanitizer needed. This is what actually catches the historical width-8 bug —
+// an unconditional-but-correctly-MASKED extra read returns the right value, so a
+// poison-byte comparison alone cannot see it (Sourcery's finding on this suite).
+class GuardPagedBuffer {
+   public:
+    GuardPagedBuffer() {
+        page_ = (size_t)sysconf(_SC_PAGESIZE);
+        base_ = (uint8_t*)mmap(nullptr, 2 * page_, PROT_READ | PROT_WRITE,
+                               MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        EXPECT_NE(base_, MAP_FAILED);
+        EXPECT_EQ(mprotect(base_ + page_, page_, PROT_NONE), 0);
+    }
+    ~GuardPagedBuffer() { munmap(base_, 2 * page_); }
+    // A pointer whose n-th byte is the LAST accessible one before the guard page.
+    uint8_t* ending_at_boundary(size_t n) { return base_ + page_ - n; }
+
+   private:
+    uint8_t* base_;
+    size_t   page_;
+};
+
+TEST(MapCodecTest, ReadNeverTouchesMemoryPastTheValuesSpan) {
+    GuardPagedBuffer gp;
+    for (uint8_t width = kWidthMin; width <= kWidthMax; ++width) {
+        // Every bit offset the width can produce, each with its span's last byte
+        // flush against the guard page — one byte too far faults the test.
+        for (uint16_t idx = 0; idx < 8; ++idx) {
+            size_t   span = span_end_byte(idx, width) + 1;
+            uint8_t* buf  = gp.ending_at_boundary(span);
+            for (size_t j = 0; j < span; ++j) buf[j] = (uint8_t)(0xA0 + j);
+            uint16_t got = map_codec_read(buf, idx, width);
+            EXPECT_EQ(got, reference_read(buf, idx, width))
+                << "width " << (int)width << " idx " << idx;
+        }
+    }
+}
+
+TEST(MapCodecTest, WriteNeverTouchesMemoryPastTheValuesSpan) {
+    GuardPagedBuffer gp;
+    for (uint8_t width = kWidthMin; width <= kWidthMax; ++width) {
+        uint16_t mask = (uint16_t)((1u << width) - 1u);
+        for (uint16_t idx = 0; idx < 8; ++idx) {
+            size_t   span = span_end_byte(idx, width) + 1;
+            uint8_t* buf  = gp.ending_at_boundary(span);
+            std::memset(buf, 0, span);
+            map_codec_write(buf, idx, mask, width);
+            EXPECT_EQ(map_codec_read(buf, idx, width), mask)
+                << "width " << (int)width << " idx " << idx;
+        }
+    }
+}
+#endif  // MAP_CODEC_HAVE_GUARD_PAGE
+
 TEST(MapCodecTest, ReadNeverConsultsBytesPastTheValuesSpan) {
-    // Regression pin for the width-8 OOB read: decode the same value from two
-    // buffers that differ ONLY in the bytes past the value's span. If the result
-    // differs, the codec read a byte it must not.
+    // Behavioural half of the span contract: decode the same value from two
+    // buffers that differ ONLY in the bytes past the value's span — the result
+    // must not depend on them. (The MEMORY half — no out-of-span access at all,
+    // even a correctly-masked one — is the guard-page pair above; this
+    // comparison alone cannot see a masked extra read.)
     for (uint8_t width = kWidthMin; width <= kWidthMax; ++width) {
         uint8_t a[64], b[64];
         uint32_t seed = 0xdeadbeefu;

--- a/keyboards/polykybd/base/tests/map_codec_tests.cpp
+++ b/keyboards/polykybd/base/tests/map_codec_tests.cpp
@@ -1,0 +1,170 @@
+// Copyright 2026 Thomas Pollak
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Tests for base/map_codec.h — the packed overlay-mapping bit codec (HID cmd 21
+// fixed 10-bit, cmd 33 host-chosen width, the slave-repair frames).
+//
+// Both of this codec's shipped bugs were byte-span mistakes the rig cannot see
+// (cmd 33 is silent, so the HIL test is only a liveness guard):
+//   - an unconditional second-byte read past the last data byte at width 8;
+//   - a fixed `0xff >> (8 - n)` mask that shifted by a negative count at the
+//     offsets only the odd widths reach.
+// The guard-byte tests below pin exactly those two shapes; the reference-reader
+// comparison pins the layout itself.
+
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "map_codec.h"
+}
+
+#include <cstring>
+#include <vector>
+
+namespace {
+
+constexpr uint8_t kWidthMin = 8;   // OVERLAY_MAP_WIDTH_MIN (config.h)
+constexpr uint8_t kWidthMax = 16;  // OVERLAY_MAP_WIDTH_MAX (config.h)
+
+// Slow, obviously-correct reference: read one bit at a time.
+uint16_t reference_read(const uint8_t* buf, uint16_t idx, uint8_t width) {
+    uint32_t v = 0;
+    for (uint8_t bit = 0; bit < width; ++bit) {
+        uint32_t abs_bit = (uint32_t)idx * width + bit;
+        uint8_t  byte    = buf[abs_bit / 8];
+        if (byte & (1u << (abs_bit % 8))) {
+            v |= 1u << bit;
+        }
+    }
+    return (uint16_t)v;
+}
+
+// How many bytes value `idx` at `width` actually occupies (its span).
+size_t span_end_byte(uint16_t idx, uint8_t width) {
+    uint32_t first_bit = (uint32_t)idx * width;
+    uint32_t last_bit  = first_bit + width - 1;
+    return (size_t)(last_bit / 8);
+}
+
+TEST(MapCodecTest, MatchesTheReferenceReaderAtEveryWidthAndOffset) {
+    // A deterministic pseudo-random buffer, decoded value by value at every
+    // supported width — this walks every bit offset a width can produce.
+    uint8_t buf[64];
+    uint32_t seed = 0x1234567u;
+    for (auto& b : buf) {
+        seed = seed * 1664525u + 1013904223u;
+        b    = (uint8_t)(seed >> 24);
+    }
+    for (uint8_t width = kWidthMin; width <= kWidthMax; ++width) {
+        uint16_t values = (uint16_t)(sizeof(buf) * 8 / width);
+        for (uint16_t idx = 0; idx < values; ++idx) {
+            EXPECT_EQ(map_codec_read(buf, idx, width), reference_read(buf, idx, width))
+                << "width " << (int)width << " idx " << idx;
+        }
+    }
+}
+
+TEST(MapCodecTest, WriteThenReadRoundTripsEveryWidth) {
+    for (uint8_t width = kWidthMin; width <= kWidthMax; ++width) {
+        uint8_t  buf[64] = {0};
+        uint16_t values  = (uint16_t)(sizeof(buf) * 8 / width);
+        uint16_t mask    = (uint16_t)((1u << width) - 1u);
+        for (uint16_t idx = 0; idx < values; ++idx) {
+            // A value pattern that differs per slot and exercises high bits.
+            uint16_t v = (uint16_t)((idx * 2654435761u) & mask);
+            map_codec_write(buf, idx, v, width);
+        }
+        for (uint16_t idx = 0; idx < values; ++idx) {
+            uint16_t v = (uint16_t)((idx * 2654435761u) & mask);
+            EXPECT_EQ(map_codec_read(buf, idx, width), v)
+                << "width " << (int)width << " idx " << idx;
+        }
+    }
+}
+
+TEST(MapCodecTest, ReadNeverConsultsBytesPastTheValuesSpan) {
+    // Regression pin for the width-8 OOB read: decode the same value from two
+    // buffers that differ ONLY in the bytes past the value's span. If the result
+    // differs, the codec read a byte it must not.
+    for (uint8_t width = kWidthMin; width <= kWidthMax; ++width) {
+        uint8_t a[64], b[64];
+        uint32_t seed = 0xdeadbeefu;
+        for (auto& x : a) {
+            seed = seed * 1664525u + 1013904223u;
+            x    = (uint8_t)(seed >> 24);
+        }
+        uint16_t values = (uint16_t)((sizeof(a) - 3) * 8 / width);
+        for (uint16_t idx = 0; idx < values; ++idx) {
+            std::memcpy(b, a, sizeof(a));
+            size_t end = span_end_byte(idx, width);
+            for (size_t j = end + 1; j < sizeof(b); ++j) {
+                b[j] ^= 0xFF;  // poison everything past the span
+            }
+            EXPECT_EQ(map_codec_read(a, idx, width), map_codec_read(b, idx, width))
+                << "width " << (int)width << " idx " << idx
+                << " read past its span (the historical width-8 bug shape)";
+        }
+    }
+}
+
+TEST(MapCodecTest, WriteNeverDirtiesBytesPastTheValuesSpan) {
+    for (uint8_t width = kWidthMin; width <= kWidthMax; ++width) {
+        uint16_t mask   = (uint16_t)((1u << width) - 1u);
+        uint16_t values = (uint16_t)((61 * 8) / width);  // one report's worth
+        for (uint16_t idx = 0; idx < values; ++idx) {
+            uint8_t buf[64] = {0};
+            map_codec_write(buf, idx, mask, width);  // all-ones value
+            size_t end = span_end_byte(idx, width);
+            for (size_t j = end + 1; j < sizeof(buf); ++j) {
+                EXPECT_EQ(buf[j], 0) << "width " << (int)width << " idx " << idx
+                                     << " dirtied byte " << j << " past its span";
+            }
+        }
+    }
+}
+
+TEST(MapCodecTest, OddWidthsReachAThirdByteAndDecodeCorrectly) {
+    // The negative-shift bug lived at the offsets only gcd(width,8)==1 widths
+    // reach: a 9/11-bit value starting at bit offset 7 spans three bytes. Place
+    // an all-ones value there explicitly and read it back.
+    for (uint8_t width : {9, 11, 13, 15}) {
+        uint16_t mask = (uint16_t)((1u << width) - 1u);
+        // idx 7 at width 9 starts at bit 63 → offset 7; pick the first idx whose
+        // offset is 7 for each width.
+        for (uint16_t idx = 0; idx < 8; ++idx) {
+            if (((uint32_t)idx * width) % 8 != 7) continue;
+            uint8_t buf[64] = {0};
+            map_codec_write(buf, idx, mask, width);
+            EXPECT_EQ(map_codec_read(buf, idx, width), mask)
+                << "width " << (int)width << " idx " << idx << " (3-byte span)";
+            break;
+        }
+    }
+}
+
+TEST(MapCodecTest, WidthEightIsWholeBytes) {
+    // At width 8 every value is exactly one byte at offset 0 — the identity
+    // layout the host relies on for its narrowest partition.
+    uint8_t buf[8] = {0x00, 0x11, 0x80, 0xFF, 0x5A, 0xA5, 0x01, 0xFE};
+    for (uint16_t idx = 0; idx < 8; ++idx) {
+        EXPECT_EQ(map_codec_read(buf, idx, 8), buf[idx]);
+    }
+}
+
+TEST(MapCodecTest, TenBitPairsMatchTheCmd21Layout) {
+    // The fixed 10-bit layout of cmd 21: values at bit offsets {0,2,4,6}. A
+    // hand-computed vector so a layout change (endianness, bit order) cannot
+    // slip through the self-consistent round-trip tests above.
+    uint8_t buf[5] = {0};
+    map_codec_write(buf, 0, 0x155, 10);  // 01_0101_0101
+    map_codec_write(buf, 1, 0x2AA, 10);  // 10_1010_1010
+    // value0 bits 0..9  -> buf[0]=0x55, buf[1] low 2 bits = 01
+    // value1 bits 10..19 -> buf[1] bits 2..7 = 101010(10), buf[2] bits 0..3 = 1010
+    EXPECT_EQ(buf[0], 0x55);
+    EXPECT_EQ(buf[1], (0xAA << 2 | 0x1) & 0xFF);
+    EXPECT_EQ(buf[2], 0x0A);
+    EXPECT_EQ(map_codec_read(buf, 0, 10), 0x155);
+    EXPECT_EQ(map_codec_read(buf, 1, 10), 0x2AA);
+}
+
+}  // namespace

--- a/keyboards/polykybd/base/tests/mode_byte_tests.cpp
+++ b/keyboards/polykybd/base/tests/mode_byte_tests.cpp
@@ -1,0 +1,63 @@
+// Copyright 2026 Thomas Pollak
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Tests for base/mode_byte.h — the one-byte "mode flag + known + 6-bit value"
+// EEPROM encoding shared by pack/load_auto_brightness and pack/load_os_state
+// (state.c). Before the extraction those were two hand-rolled copies of the
+// same bit layout; these tests pin the layout once for both.
+
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "mode_byte.h"
+}
+
+namespace {
+
+TEST(ModeByteTest, RoundTripsEveryCombination) {
+    for (int flag = 0; flag <= 1; ++flag) {
+        for (int known = 0; known <= 1; ++known) {
+            for (uint16_t value = 0; value <= MODE_BYTE_VALUE; ++value) {
+                uint8_t packed = mode_byte_pack(flag != 0, known != 0, (uint8_t)value);
+                EXPECT_EQ(mode_byte_flag(packed), flag != 0);
+                EXPECT_EQ(mode_byte_known(packed), known != 0);
+                EXPECT_EQ(mode_byte_value(packed), value);
+            }
+        }
+    }
+}
+
+TEST(ModeByteTest, AZeroedByteIsFlagOffUnknownValueZero) {
+    // QMK's wear levelling hands an unwritten EEPROM byte back as ZERO, so 0
+    // must decode to each setting's factory default: flag clear, nothing known.
+    EXPECT_FALSE(mode_byte_flag(0));
+    EXPECT_FALSE(mode_byte_known(0));
+    EXPECT_EQ(mode_byte_value(0), 0);
+}
+
+TEST(ModeByteTest, ValueIsMaskedToSixBits) {
+    // An out-of-range value must not bleed into the flag/known bits — that
+    // would silently flip the MODE of the setting being saved.
+    uint8_t packed = mode_byte_pack(false, false, 0xFF);
+    EXPECT_FALSE(mode_byte_flag(packed));
+    EXPECT_FALSE(mode_byte_known(packed));
+    EXPECT_EQ(mode_byte_value(packed), MODE_BYTE_VALUE);
+}
+
+TEST(ModeByteTest, TheThreeFieldsAreDisjoint) {
+    EXPECT_EQ(MODE_BYTE_FLAG & MODE_BYTE_KNOWN, 0u);
+    EXPECT_EQ(MODE_BYTE_FLAG & MODE_BYTE_VALUE, 0u);
+    EXPECT_EQ(MODE_BYTE_KNOWN & MODE_BYTE_VALUE, 0u);
+    EXPECT_EQ(MODE_BYTE_FLAG | MODE_BYTE_KNOWN | MODE_BYTE_VALUE, 0xFFu);
+}
+
+TEST(ModeByteTest, LegacyBitPositionsAreStable) {
+    // These bytes are already in field EEPROMs (auto_brightness since 2026-06,
+    // os_state since protocol 7) — the positions are an on-flash ABI, not a
+    // style choice. bit7 = flag, bit6 = known, bits0-5 = value.
+    EXPECT_EQ(mode_byte_pack(true, false, 0), 0x80);
+    EXPECT_EQ(mode_byte_pack(false, true, 0), 0x40);
+    EXPECT_EQ(mode_byte_pack(true, true, 0x2A), 0xC0 | 0x2A);
+}
+
+}  // namespace

--- a/keyboards/polykybd/base/tests/test_rules.mk
+++ b/keyboards/polykybd/base/tests/test_rules.mk
@@ -54,3 +54,12 @@ polykybd_map_codec_SRC := \
 polykybd_map_codec_INC := \
 	$(POLY_BASE_PATH) \
 	keyboards/polykybd
+
+# mode_byte.h is header-only too — the shared EEPROM byte layout behind
+# pack/load_auto_brightness and pack/load_os_state.
+polykybd_mode_byte_SRC := \
+	$(POLY_BASE_PATH)/tests/mode_byte_tests.cpp
+
+polykybd_mode_byte_INC := \
+	$(POLY_BASE_PATH) \
+	keyboards/polykybd

--- a/keyboards/polykybd/base/tests/test_rules.mk
+++ b/keyboards/polykybd/base/tests/test_rules.mk
@@ -77,3 +77,14 @@ polykybd_idle_update_SRC := \
 polykybd_idle_update_INC := \
 	$(POLY_BASE_PATH) \
 	keyboards/polykybd
+
+# layer_names.c needs only config.h + layers.h (both macro/enum-only), so the
+# HID cmd 35 wire encoder links without quantum. The keyboards/polykybd include
+# path is what resolves those two.
+polykybd_layer_names_SRC := \
+	keyboards/polykybd/layer_names.c \
+	$(POLY_BASE_PATH)/tests/layer_names_tests.cpp
+
+polykybd_layer_names_INC := \
+	$(POLY_BASE_PATH) \
+	keyboards/polykybd

--- a/keyboards/polykybd/base/tests/test_rules.mk
+++ b/keyboards/polykybd/base/tests/test_rules.mk
@@ -44,3 +44,13 @@ polykybd_macro_decode_INC := \
 	$(POLY_BASE_PATH) \
 	$(POLY_BASE_PATH)/tests \
 	keyboards/polykybd
+
+# map_codec.h is header-only (static inline), so the suite is just the tests —
+# the same shape as glyph_meta. The codec itself is what fill_overlay.c's
+# decoder and the slave-repair packer both call.
+polykybd_map_codec_SRC := \
+	$(POLY_BASE_PATH)/tests/map_codec_tests.cpp
+
+polykybd_map_codec_INC := \
+	$(POLY_BASE_PATH) \
+	keyboards/polykybd

--- a/keyboards/polykybd/base/tests/test_rules.mk
+++ b/keyboards/polykybd/base/tests/test_rules.mk
@@ -63,3 +63,17 @@ polykybd_mode_byte_SRC := \
 polykybd_mode_byte_INC := \
 	$(POLY_BASE_PATH) \
 	keyboards/polykybd
+
+# base/update.c depends only on the timer, so it links standalone against the
+# mock clock — platforms/common.mk puts the timer into SRC, which only the
+# full-keyboard harness consumes, hence both timer files listed here (the same
+# note as polymod_ltr559's rules).
+polykybd_idle_update_SRC := \
+	$(POLY_BASE_PATH)/update.c \
+	$(POLY_BASE_PATH)/tests/idle_update_tests.cpp \
+	$(PLATFORM_PATH)/timer.c \
+	$(PLATFORM_PATH)/test/timer.c
+
+polykybd_idle_update_INC := \
+	$(POLY_BASE_PATH) \
+	keyboards/polykybd

--- a/keyboards/polykybd/base/tests/testlist.mk
+++ b/keyboards/polykybd/base/tests/testlist.mk
@@ -3,3 +3,4 @@ TEST_LIST += polykybd_glyph_meta
 TEST_LIST += polykybd_macro_decode
 TEST_LIST += polykybd_map_codec
 TEST_LIST += polykybd_mode_byte
+TEST_LIST += polykybd_idle_update

--- a/keyboards/polykybd/base/tests/testlist.mk
+++ b/keyboards/polykybd/base/tests/testlist.mk
@@ -2,3 +2,4 @@ TEST_LIST += fw_up_verdict
 TEST_LIST += polykybd_glyph_meta
 TEST_LIST += polykybd_macro_decode
 TEST_LIST += polykybd_map_codec
+TEST_LIST += polykybd_mode_byte

--- a/keyboards/polykybd/base/tests/testlist.mk
+++ b/keyboards/polykybd/base/tests/testlist.mk
@@ -1,3 +1,4 @@
 TEST_LIST += fw_up_verdict
 TEST_LIST += polykybd_glyph_meta
 TEST_LIST += polykybd_macro_decode
+TEST_LIST += polykybd_map_codec

--- a/keyboards/polykybd/base/tests/testlist.mk
+++ b/keyboards/polykybd/base/tests/testlist.mk
@@ -4,3 +4,4 @@ TEST_LIST += polykybd_macro_decode
 TEST_LIST += polykybd_map_codec
 TEST_LIST += polykybd_mode_byte
 TEST_LIST += polykybd_idle_update
+TEST_LIST += polykybd_layer_names

--- a/keyboards/polykybd/fill_overlay.c
+++ b/keyboards/polykybd/fill_overlay.c
@@ -14,6 +14,7 @@
 #include "multicore_exec.h"
 #include "bridge_helper.h"
 #include "base/com.h"
+#include "base/map_codec.h"
 #include "base/overlay.h"
 #include "base/update.h"
 #include "lang/lang_lut.h"
@@ -307,25 +308,10 @@ bool set_packed_overlay_mapping(const uint8_t* mapping, uint8_t bytes, uint8_t w
     map_log[0] = '\0';
     const uint16_t values = OVERLAY_MAP_VALUES(bytes, width);
     for(uint16_t idx=0;idx<values;++idx) {
-        // start_bit must be wide enough to hold idx*width (up to ~488) — a uint8_t
-        // would wrap.
-        uint16_t start_bit = idx*(uint16_t)width;
-        uint8_t start_byte = start_bit/8;
-        uint8_t start_bit_in_byte = start_bit%8;
-        // ⚠️ How many bytes a value spans depends on the width, so BOTH the second
-        // and third byte are conditional — the load must never reach past the last
-        // data byte. At width 8 (gcd(8,8)==8) every value is one whole byte at
-        // offset 0; at 10 or 12 (gcd 2 / 4) the offset stays low enough for two;
-        // only the odd widths 9/11 (gcd 1) walk all eight offsets and reach a third.
-        uint32_t acc = (uint32_t)mapping[start_byte];
-        if (start_bit_in_byte + width > 8) {
-            acc |= (uint32_t)mapping[start_byte+1] << 8;
-        }
-        if (start_bit_in_byte + width > 16) {
-            acc |= (uint32_t)mapping[start_byte+2] << 16;
-        }
-        uint16_t to = (uint16_t)((acc >> start_bit_in_byte) &
-                                 ((1u << width) - 1u));
+        // The bit arithmetic lives in base/map_codec.h (shared with the repair
+        // packer below and unit-tested there) — the conditional byte reads are
+        // what keep a value's load inside the last data byte it occupies.
+        uint16_t to = map_codec_read(mapping, idx, width);
         if(from==UNSET_OVERLAY_MAPPING) {
             from = to;
         } else {
@@ -384,24 +370,11 @@ void note_overlay_map_sync_lost(void) {
     s_map_sync_lost = true;
 }
 
-// Inverse of the unpacking in set_packed_overlay_mapping: write `v` as `width`
-// bits at `idx`'s bit offset. `buf` must be zeroed first (this ORs in).
-// ⚠️ Mirror the decoder's conditional byte reads exactly — write the second and
-// third byte only when the value really extends there, so this can never touch a
-// byte past the last one the decoder reads. Verify any change by round-tripping
-// through the decoder, not by eye.
+// Inverse of the unpacking in set_packed_overlay_mapping — now literally the
+// same pair, base/map_codec.h, where the round-trip is unit-tested instead of
+// verified by eye.
 static void pack_map_value(uint8_t *buf, uint16_t idx, uint16_t v, uint8_t width) {
-    uint16_t start_bit = idx * (uint16_t)width;
-    uint8_t  b         = (uint8_t)(start_bit / 8);
-    uint8_t  s         = (uint8_t)(start_bit % 8);
-    uint32_t shifted   = (uint32_t)v << s;
-    buf[b] |= (uint8_t)(shifted & 0xff);
-    if (s + width > 8) {
-        buf[b + 1] |= (uint8_t)((shifted >> 8) & 0xff);
-    }
-    if (s + width > 16) {
-        buf[b + 2] |= (uint8_t)((shifted >> 16) & 0xff);
-    }
+    map_codec_write(buf, idx, v, width);
 }
 
 // Repair cursor. The walk is SPLIT ACROSS HOUSEKEEPING TICKS rather than run in

--- a/keyboards/polykybd/hid_com.c
+++ b/keyboards/polykybd/hid_com.c
@@ -1046,21 +1046,11 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                     // host, generated from layers.h by a script whose source path had gone
                     // stale — so the editor labelled tabs from an enum the firmware had not
                     // had for a long time. A name the keyboard states itself cannot drift.
-                    const uint8_t count = DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT;
-                    uint8_t payload[LAYER_NAMES_PAYLOAD_MAX];
-                    uint16_t used = 2;
-                    payload[1] = count;
-                    for (uint8_t layer = 0; layer < count; layer++) {
-                        const char* name = poly_layer_name_wire(layer);
-                        // Clamp rather than trust the table: an over-long name would
-                        // otherwise run past the buffer sized from POLY_LAYER_NAME_MAX.
-                        for (uint8_t i = 0; name != NULL && name[i] != '\0' && i < POLY_LAYER_NAME_MAX; i++) {
-                            payload[used++] = (uint8_t)name[i];
-                        }
-                        payload[used++] = '\0';
-                    }
-                    payload[0] = (uint8_t)used;
-
+                    // The payload itself is built by poly_layer_names_payload()
+                    // (layer_names.c, unit-tested) — this case only chunks it into
+                    // reports.
+                    uint8_t        payload[LAYER_NAMES_PAYLOAD_MAX];
+                    const uint16_t used  = poly_layer_names_payload(payload);
                     const uint16_t chunk = hid_payload_avail(length, 3);
                     for (uint16_t off = 0; off < used; off += chunk) {
                         const uint16_t n = (used - off < chunk) ? (uint16_t)(used - off) : chunk;

--- a/keyboards/polykybd/layer_names.c
+++ b/keyboards/polykybd/layer_names.c
@@ -56,3 +56,20 @@ const char* poly_layer_name_wire(uint8_t layer) {
     const uint8_t idx = (uint8_t)(layer - NUM_LAYOUTS);
     return (idx < sizeof(fixed_wire) / sizeof(fixed_wire[0])) ? fixed_wire[idx] : NULL;
 }
+
+uint16_t poly_layer_names_payload(uint8_t* payload) {
+    const uint8_t count = DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT;
+    uint16_t      used  = 2;
+    payload[1] = count;
+    for (uint8_t layer = 0; layer < count; layer++) {
+        const char* name = poly_layer_name_wire(layer);
+        // Clamp rather than trust the table: an over-long name would otherwise
+        // run past the buffer sized from POLY_LAYER_NAME_MAX.
+        for (uint8_t i = 0; name != NULL && name[i] != '\0' && i < POLY_LAYER_NAME_MAX; i++) {
+            payload[used++] = (uint8_t)name[i];
+        }
+        payload[used++] = '\0';
+    }
+    payload[0] = (uint8_t)used;
+    return used;
+}

--- a/keyboards/polykybd/layer_names.h
+++ b/keyboards/polykybd/layer_names.h
@@ -24,8 +24,13 @@
 // payload has to stay addressable by it.
 #define LAYER_NAMES_PAYLOAD_MAX \
     (2 + DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT * (POLY_LAYER_NAME_MAX + 1))
+#ifdef __cplusplus
+static_assert(LAYER_NAMES_PAYLOAD_MAX <= 255,
+              "the layer-name payload no longer fits its one-byte total length");
+#else
 _Static_assert(LAYER_NAMES_PAYLOAD_MAX <= 255,
                "the layer-name payload no longer fits its one-byte total length");
+#endif
 
 // def_layer (_L0.._L4) -> the status-OLED forms.
 const uint32_t* poly_layout_name(uint8_t def_layer);        // split72, full width
@@ -35,3 +40,15 @@ const uint32_t* poly_layout_name_short(uint8_t def_layer);  // split42, <= 5 cha
 // HID cmd 35. Layers 0..4 are the base layouts, so they answer with the wire form
 // of the table above; the rest are fixed. NULL for a layer with no name.
 const char* poly_layer_name_wire(uint8_t layer);
+
+// Builds the whole HID cmd 35 payload — [total][count] then `count` NUL-terminated
+// names, `total` being the payload length including itself — into `payload`, which
+// must hold LAYER_NAMES_PAYLOAD_MAX bytes. Returns the bytes used (== payload[0]).
+// Pure (no HID, no reports), so the wire encoding is unit-testable
+// (make test:polykybd_layer_names) — hid_com.c case 35 only chunks the result into
+// reports. The count is DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT on purpose: the same
+// value id_dynamic_keymap_get_layer_count answers, so the host editor can never
+// size its tab strip from one command and label it from the other. An unnamed
+// layer (poly_layer_name_wire NULL) emits a bare terminator, which the total-first
+// encoding keeps distinguishable from the report's zero fill.
+uint16_t poly_layer_names_payload(uint8_t* payload);

--- a/keyboards/polykybd/state.c
+++ b/keyboards/polykybd/state.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include "eeconfig.h"
 #include "base/com.h"   // enum poly_flag — the display-state bits guarding the auto push
+#include "base/mode_byte.h"
 
 static poly_layer_t l_layer;
 static poly_layer_t g_layer;
@@ -419,9 +420,9 @@ void note_user_brightness(uint8_t value) {
 // treat it as known and snap to it (the very FULL_BRIGHT jump get_active_brightness
 // guards against at runtime). 0 when auto is off.
 uint8_t pack_auto_brightness(void) {
-    if (!g_auto_brightness)  return 0u;       // auto off
-    if (!g_auto_value_known) return 0x80u;    // auto on, no host value yet (bit6 clear)
-    return (uint8_t)(0x80u | 0x40u | (g_last_auto_brightness & 0x3Fu));  // mode + known + value
+    if (!g_auto_brightness) return 0u;        // auto off (bit7 clear = off here)
+    return mode_byte_pack(true, g_auto_value_known,
+                          g_auto_value_known ? g_last_auto_brightness : 0u);
 }
 
 // Restore the host-auto state at boot from the packed byte. If auto was engaged
@@ -431,11 +432,11 @@ uint8_t pack_auto_brightness(void) {
 // fall back to the manual brightness (g_auto_value_known stays false). Off-state
 // leaves the manual brightness (l_state.contrast = ee.brightness) untouched.
 void load_auto_brightness(uint8_t packed) {
-    bool on = (packed & 0x80u) != 0;
+    bool on = mode_byte_flag(packed);
     g_auto_brightness = on;
     if (on) {
-        if (packed & 0x40u) {                  // a real host auto value was persisted
-            uint8_t value = packed & 0x3Fu;
+        if (mode_byte_known(packed)) {         // a real host auto value was persisted
+            uint8_t value = mode_byte_value(packed);
             if (value > FULL_BRIGHT) value = FULL_BRIGHT;
             g_last_auto_brightness = value;
             g_auto_value_known     = true;
@@ -637,20 +638,18 @@ void set_detected_os(uint8_t os) {
 // the value (the pin in manual mode, the last resolved OS in auto — stored so a
 // reboot shows the right OS immediately, before host/detection re-confirm).
 uint8_t pack_os_state(void) {
-    uint8_t b = 0;
-    uint8_t val;
-    if (!g_os_auto) { b |= 0x80u; val = g_user_os; }   // manual pin
-    else            { val = g_resolved_os; }            // auto: last resolved
-    if (g_os_known) b |= 0x40u;
-    return (uint8_t)(b | (val & 0x3Fu));
+    // bit7 here means "manual pin engaged" (the opposite polarity from
+    // pack_auto_brightness) so a zeroed byte still reads as this setting's default.
+    return mode_byte_pack(!g_os_auto, g_os_known,
+                          g_os_auto ? g_resolved_os : g_user_os);
 }
 
 // Restore the active-OS state at boot from the packed byte (0 from an old EEPROM =
 // auto, unknown — the desired default).
 void load_os_state(uint8_t packed) {
-    g_os_auto  = (packed & 0x80u) == 0;     // bit7 set => manual pin
-    g_os_known = (packed & 0x40u) != 0;
-    uint8_t val = packed & 0x3Fu;
+    g_os_auto  = !mode_byte_flag(packed);   // bit7 set => manual pin
+    g_os_known = mode_byte_known(packed);
+    uint8_t val = mode_byte_value(packed);
     if (val >= POLY_OS_COUNT) { val = POLY_OS_UNKNOWN; g_os_known = false; }
     // Migrate the retired POLY_OS_IOS (5): a protocol-7 EEPROM may still hold it
     // (pinned or last-detected). iOS is now folded into macOS, so normalise it here


### PR DESCRIPTION
## Summary

An architectural review of `keyboards/polykybd/` plus the refactors it motivated. The review looked at file sizes, dependency direction, duplication and unit-test gaps; the refactors are deliberately surgical (behaviour-identical, RAM-neutral) and each carries a new unit suite. Five commits, one change each, in bisectable order.

### Review findings → what this PR changes

1. **`base/` reached upward into the product layer — via one dead include.** `base/disp_array.c` included `../poly_keymap.h` without using a single symbol from it. Removed; `base/` now has no upward edge (`anim/` and `doom/` keep theirs — they genuinely call back into `poly_keymap`).
2. **The overlay-mapping bit codec existed as an encoder/decoder pair kept in sync by eye** (`set_packed_overlay_mapping()`'s inline decode vs `pack_map_value()`, with a comment saying "verify any change by round-tripping through the decoder"). Both of its shipped bugs (the width-8 OOB read, the negative-shift mask at odd-width offsets) were in exactly this arithmetic, and the rig can never see them — cmd 33 is silent, so the HIL test is only a liveness guard. It is now ONE pure implementation in **`base/map_codec.h`**, with `make test:polykybd_map_codec` pinning the layout against a bit-by-bit reference reader, round-trips at every width 8..16, guard-byte tests for both historical bug shapes, and a hand-computed cmd-21 10-bit vector.
3. **The EEPROM "mode + known + value" byte was hand-rolled twice** (`pack/load_auto_brightness` vs `pack/load_os_state`, identical bit layout, agreement by inspection — and the layout is an on-flash ABI). Now once in **`base/mode_byte.h`**; every packed byte is bit-identical to before. `make test:polykybd_mode_byte` pins the legacy bit positions and the zeroed-byte (wear-levelled fresh EEPROM) default.
4. **`base/update.c` had two documented field regressions and zero tests** (the 24.86-day sign-bit idle failure; the near-boot backdate underflow). **`make test:polykybd_idle_update`** now pins both against the mock clock, plus the overlay-burst counters and the `set_last_update(-1)` compat shim. No source change.
5. **The cmd 35 (GET_LAYER_NAMES) wire encoder was untested on the firmware side** — the host decoder is mutation-tested, but a host fixture can only catch the host *misreading* a payload, never this end emitting the wrong one (the same one-sidedness `fontpack_commit_status()` was extracted to fix). The payload builder moved from `hid_com.c` case 35 into **`layer_names.c` (`poly_layer_names_payload()`)**; `make test:polykybd_layer_names` decodes it the way the host does and pins total/count/name budgets, including that the count stays the host-remappable write cap.

All four new suites were **mutation-checked** (shift off-by-one, dropped third-byte read, moved flag bit, reintroduced backdate clamp, count off-by-one, short total — each caught by the intended test; the one surviving mutation, a widened name clamp, is equivalent under the shipped table since no name exceeds 8 chars).

### Review findings deferred (recorded, not changed here)

- **`poly_keymap.c` (5,124 lines) remains the oversized file.** It hosts ≥8 separable concerns (sync/housekeeping, idle jitter, Eden glue, LTR-559 policy, latin picker/remap, glyph-size planning, F-row alignment, render + key-event pipeline, boot/suspend). The repo's own precedent (poly_macro.c, layer_names.c, lang_layer.c) is gradual extraction; the next clean candidates are the LTR-559 drive policy (~110 lines, compile-gated) and the glyph-size planner (pure behind a has-glyph callback). Not done here to keep this PR reviewable.
- **`kdisp_gfx_text_bbox()` + the display-list op interpreter** in `disp_array.c` have bug history and no tests; extracting them is a bigger cut (font data + draw-path mirroring) and is the highest-value remaining gap.
- `lang/lang_lut.c` (generated) includes `../hid_com.h` sideways; `state.c` mixes persistence and policy (736 lines). Both noted, low urgency.
- No `polykybd-ctnd` change needed: the gaps closed here are exactly the ones the rig structurally cannot cover (silent commands, EEPROM byte layouts, mock-clock time travel).

### RAM headroom (measured on this branch, gcc 13.2 arm-none-eabi)

| flavour | .data | .bss | .heap free |
|---|---|---|---|
| split72 default | 11,952 | 241,480 | 8,708 B |
| split72 `POLYKYBD_DOOM_PACK` (CI/shipping) | 11,964 | 26,352 | 7,820 B |
| **split72 `POLYKYBD_DOOM` monolith** | 15,144 | 27,508 | **3,484 B** |
| split42 default | 11,844 | 238,364 | 11,928 B |

This PR is **RAM-neutral**: base vs branch monolith have byte-identical `.data`/`.bss`/`.heap`; `.text` +8 B. Note the monolith's free heap has drifted 3,620 → 3,484 B since the macro work's measurement (base-branch drift, not this PR). ~3.4 KB is workable but the monolith stays the canary — keep measuring there before adding statics.

### Flash slot layout (plyf/plyx) — reviewed, recommending NO re-arrangement

The 2 MB font-pack window is fully allotted to slots but only **32 % used** (655 KiB of 2,044 KiB): symbol 38 %, mideast 39 %, syllabic 51 %, asia 53 %, flags 50 %, emoji 28 % (215/768 KiB), fantasy 20 %, latinbig 26 % (158/604 KiB). The genuinely tight slots are in the *upper* 2 MB: the WHX slot has ~35 KB headroom (static shareware content — fine) and the DoomPack slot ~37 KB (grows only with engine changes). Re-slotting the plyf window would be a coordinated on-flash ABI change (layout version bump, full bundle re-flash, host `bundles.json`/layout reship) for zero functional gain — the slack costs nothing on otherwise-idle flash. Revisit only when a 9th bundle or a slot overflow forces it; the place to take space from then is `emoji`'s slot.

## Version bump label

*(none — patch: internal refactor, no behaviour change, no protocol change)*

## Testing
- [x] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`) — plus `POLYKYBD_DOOM_PACK=yes`, `POLYKYBD_DOOM=yes` monolith, and split42
- [x] Flashed and tested on hardware — the HIL rig flashed this PR's images to both halves and ran the **extended** tier green on head 363b6de (incl. the reboot-persistence power cycle, the right verifier for the state.c EEPROM packing)
- [x] If protocol changed: n/a (no wire change; cmd 35 bytes verified identical by the new unit suite)

All 9 unit suites green (115 tests: 87 existing + 28 new), local lint job (`qmk lint --strict` both keyboards + `ci-validate-*`) clean, CI-config cppcheck run locally clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8pW42ifgtNjFFVdrWPZ2m

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8pW42ifgtNjFFVdrWPZ2m)_

## Summary by Sourcery

Extract testable architectural seams while preserving existing firmware, persistence, and protocol behavior.

Enhancements:
- Extract shared overlay-map bit packing and unpacking into a single reusable codec.
- Centralize the persisted mode-byte encoding used by brightness and OS state.
- Extract the layer-name wire payload builder from HID command handling.
- Remove the unused base-layer dependency on the product layer.

Tests:
- Add unit coverage for overlay-map encoding boundaries, round trips, and legacy layouts.
- Add unit coverage for mode-byte compatibility and zero-initialized EEPROM defaults.
- Add unit coverage for idle timing, timer wraparound, backdating, and overlay activity tracking.
- Add firmware-side unit coverage for layer-name payload limits and host-compatible decoding.



## Summary by CodeRabbit

* **New Features**
  * Improved HID layer-name reporting with consistent payload formatting and complete layer-name support.

* **Bug Fixes**
  * Improved reliability of packed overlay mappings across supported bit widths.
  * Preserved auto-brightness and operating-system settings more consistently when stored and restored.

* **Tests**
  * Added coverage for layer-name reporting, overlay mappings, persisted settings, idle tracking, timer wraparound, and overlay activity handling.
