### PR TITLE
Extract the LTR-559 drive policy and the legend-size planner out of poly_keymap.c

### DIFF
--- a/keyboards/polykybd/base/legend_plan.c
+++ b/keyboards/polykybd/base/legend_plan.c
@@ -1,0 +1,120 @@
+// Copyright 2026 thpoll83
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "legend_plan.h"
+
+#include <stddef.h>
+
+// The two bigger faces are the SAME latin repertoire rendered larger, so they
+// cannot be looked up by their natural codepoints: g_all_fonts is scanned
+// front-to-back and the resident 27 px `latin` font is always in front, so a
+// second 'a' at 0x61 could never be reached. fonts.yaml therefore emits each
+// tier at a fixed offset into supplementary private-use plane 15 (fontconvert
+// -o), and the render path adds the same offset before the lookup. Keep these
+// bases identical to the `offset:` values in the fonts.yaml `latinbig` entries.
+//
+// The spacing (0x3000) exceeds the highest source codepoint the latin category
+// covers (0x2116, the numero sign), so the tiers can never overlap.
+static const uint32_t glyph_size_base[LEGEND_PLAN_SIZE_COUNT] = {
+    [LEGEND_PLAN_SIZE_S] = 0u,          // the resident face, at its natural codepoints
+    [LEGEND_PLAN_SIZE_M] = 0xF0000u,
+    [LEGEND_PLAN_SIZE_L] = 0xF3000u,
+};
+
+// ⚠️ All-or-nothing on purpose. A partial hit would mix two faces in one legend,
+// which is the "keep every glyph of a multi-glyph legend in ONE font" rule broken
+// the worst possible way: kdisp_write_gfx_char baseline-aligns per font, so the
+// halves would also sit at different heights. Falling back whole means a keyboard
+// with no `latinbig` bundle, or a CJK/Arabic/Indic legend that this latin-only
+// feature does not cover, simply keeps drawing what it always drew.
+bool legend_plan_remap(const legend_plan_env_t* env, uint8_t size, const uint32_t* text,
+                       uint32_t* out, uint8_t out_cap) {
+    if (size == LEGEND_PLAN_SIZE_S || size >= LEGEND_PLAN_SIZE_COUNT || text == NULL) return false;
+    const uint32_t base = glyph_size_base[size];
+    uint8_t n = 0;
+    for (uint8_t i = 0; text[i] != 0; ++i) {
+        // A control code is a display-list op, not a glyph. The five zero-argument
+        // cursor nudges are DROPPED; every other op bails, because HINT_MOVE /
+        // HINT_FRAME (0x0E/0x12) consume the two codepoints after them — which we
+        // would then relocate as if they were glyphs — and HINT_HALF/HINT_THIN
+        // rescale the next glyph. Neither occurs in a language legend: measured
+        // across all 160 layouts every op present is one of these five, and every
+        // one of them LEADS the legend (0x0C x150, 0x0B x8, 0x06 x9, 0x08 x1,
+        // 0x05 x1; not one after a glyph).
+        //
+        // ⚠️ DROPPED, not carried, and that is not a preference — kdisp_gfx_text_bbox
+        // and the draw disagree about these ops. `\f` is `y = y > 1 ? y - 2 : 0`
+        // applied to the cursor, and bbox runs it from y = 0 (relative to the
+        // baseline) where it saturates to 0, while the draw runs it from the real
+        // baseline where it genuinely lifts 2px. Carrying the op therefore moves the
+        // glyph by an amount legend_plan_main's clamp cannot see, and the accent
+        // clips off the top (measured: 6-8 px lost on `é è à` at M/L). Dropped, the
+        // measured bbox IS what gets drawn and the clamp is exact — and the nudge is
+        // no loss, having been hand-tuned for the small face's fixed baseline.
+        //
+        // ⚠️ This is what makes the French number row scale at all: `é è ç à` are
+        // spelled `\f\f <letter>`, so refusing every control code outright left half
+        // of AZERTY's number row on the small face while the other half grew (found
+        // by rendering the row, 2026-08-21).
+        if (text[i] < 0x20) {
+            switch (text[i]) {
+                case 0x05: case 0x06: case 0x08:
+                case 0x0B: case 0x0C:
+                    continue;                               // a small-face nudge
+                default:
+                    return false;
+            }
+        }
+        if (n + 1 >= out_cap) return false;                 // too long to relocate
+        const uint32_t cp = base + text[i];
+        if (!env->has_glyph(cp, env->ctx)) return false;
+        out[n++] = cp;
+    }
+    if (n == 0) return false;                               // ops alone draw nothing
+    out[n] = 0;
+    return true;
+}
+
+// Nominal baseline for each size, chosen so the cap height sits where the small
+// face's does (top of a capital ~1 px below the top of the panel): cap 20 -> 21,
+// 24 -> 25, 27 -> 28. The caller then draws at the CLAMPED baseline this planner
+// returns, so a tall accent stack or a deep descender shifts to fit instead of
+// clipping — the nominal value is what keeps every ordinary letter on a shared
+// baseline.
+static const int8_t glyph_size_baseline[LEGEND_PLAN_SIZE_COUNT] = {
+    [LEGEND_PLAN_SIZE_S] = 21, [LEGEND_PLAN_SIZE_M] = 25, [LEGEND_PLAN_SIZE_L] = 28,
+};
+
+void legend_plan_main(const legend_plan_env_t* env, uint8_t size, const uint32_t* text,
+                      int8_t small_x, int8_t small_y,
+                      uint32_t* scratch, uint8_t scratch_cap, main_legend_t* out) {
+    int8_t xmin = 0, xmax = 0;
+    int8_t ymin = 0, ymax = 0;
+    if (legend_plan_remap(env, size, text, scratch, scratch_cap)) {
+        env->bbox(scratch, &xmin, &xmax, &ymin, &ymax, env->ctx);
+        // Keep the language's own horizontal origin — centring instead would eat the
+        // space the shift preview lives in — but clamp both edges into the window,
+        // since a big glyph runs up to 43 px wide.
+        int8_t x = small_x;
+        if (x + xmax > env->win_x1) x = (int8_t)(env->win_x1 - xmax);
+        if (x + xmin < env->win_x0) x = (int8_t)(env->win_x0 - xmin);
+        // The tier's nominal baseline, clamped so the ink stays on the panel. The
+        // nominal is what keeps ordinary letters on a shared baseline; the clamp is
+        // what stops a tall accent stack or a deep descender from clipping.
+        int8_t y = glyph_size_baseline[size];
+        if (y + ymin < 0)           y = (int8_t)(-ymin);
+        if (y + ymax > env->win_y1) y = (int8_t)(env->win_y1 - ymax);
+        out->text = scratch;
+        out->x = x; out->y = y;
+        out->ink_min = (int8_t)(x + xmin);
+        out->ink_max = (int8_t)(x + xmax);
+        out->big = true;
+        return;
+    }
+    env->bbox(text, &xmin, &xmax, &ymin, &ymax, env->ctx);
+    out->text = text;
+    out->x = small_x; out->y = small_y;
+    out->ink_min = (int8_t)(small_x + xmin);
+    out->ink_max = (int8_t)(small_x + xmax);
+    out->big = false;
+}

--- a/keyboards/polykybd/base/legend_plan.c
+++ b/keyboards/polykybd/base/legend_plan.c
@@ -65,7 +65,11 @@ bool legend_plan_remap(const legend_plan_env_t* env, uint8_t size, const uint32_
                     return false;
             }
         }
-        if (n + 1 >= out_cap) return false;                 // too long to relocate
+        // The glyph-count contract (GLYPH_SIZE_MAX_LEN) is enforced independently
+        // of the caller's buffer: the firmware always passes a MAX_LEN+1 buffer,
+        // where the two limits coincide, but the pure function must not let a
+        // larger buffer relocate a longer legend than the header promises.
+        if (n >= GLYPH_SIZE_MAX_LEN || n + 1 >= out_cap) return false;   // too long to relocate
         const uint32_t cp = base + text[i];
         if (!env->has_glyph(cp, env->ctx)) return false;
         out[n++] = cp;

--- a/keyboards/polykybd/base/legend_plan.h
+++ b/keyboards/polykybd/base/legend_plan.h
@@ -1,0 +1,67 @@
+// Copyright 2026 thpoll83
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+// The keycap MAIN-legend size planner (HID cmd 34 / enum poly_glyph_size),
+// extracted from poly_keymap.c as a PURE seam: the codepoint relocation into the
+// latinbig tiers and the origin/baseline clamping are exactly the arithmetic that
+// shipped subtle bugs (the dropped-vs-carried cursor ops, the clamp-vs-bbox
+// disagreement), and none of it is observable from the rig — so it is
+// unit-testable here (make test:polykybd_legend_plan) behind two callbacks
+// instead of depending on g_all_fonts and the kdisp measurement directly.
+//
+// poly_keymap.c binds the callbacks to kdisp_gfx_glyph / kdisp_gfx_text_bbox and
+// keeps thin wrappers with the old signatures, so the render path is unchanged.
+//
+// Size indices are the poly_glyph_size values (state.h). This header deliberately
+// does not include state.h — poly_keymap.c _Static_asserts the two stay equal, so
+// the planner remains includable from a standalone test with no keyboard config.
+#define LEGEND_PLAN_SIZE_S 0
+#define LEGEND_PLAN_SIZE_M 1
+#define LEGEND_PLAN_SIZE_L 2
+#define LEGEND_PLAN_SIZE_COUNT 3
+
+// Longest legend the size override will relocate. A main legend is normally ONE
+// glyph; a couple of codepoints covers the composed forms, and anything longer is
+// not the kind of thing that wants to be drawn large anyway.
+#define GLYPH_SIZE_MAX_LEN 4
+
+// Everything the planner needs from the outside world. `has_glyph` answers "can
+// the assembled font set draw this codepoint"; `bbox` measures a NUL-terminated
+// legend the way the draw lays it out (kdisp_gfx_text_bbox semantics: x/y are
+// relative to the draw origin/baseline). `win_x0..win_x1` are the visible window
+// columns and `win_y1` the last visible row (rows are 0..win_y1).
+typedef struct {
+    bool (*has_glyph)(uint32_t cp, void* ctx);
+    void (*bbox)(const uint32_t* text, int8_t* xmin, int8_t* xmax, int8_t* ymin, int8_t* ymax, void* ctx);
+    void*  ctx;
+    int8_t win_x0;
+    int8_t win_x1;
+    int8_t win_y1;
+} legend_plan_env_t;
+
+// A planned main legend: what to draw, where, and how much room it takes.
+typedef struct {
+    const uint32_t* text;      // the legend, relocated to the bigger face when big
+    int8_t x, y;               // draw origin (y is the baseline)
+    int8_t ink_min, ink_max;   // leftmost / rightmost lit pixel, in buffer coords
+    bool   big;                // a bigger face was selected
+} main_legend_t;
+
+// Rewrites `text` into `out` at the requested size, returning false — leaving the
+// caller on the normal face — if the size is S, the legend is too long, or ANY of
+// its glyphs is missing at that size. All-or-nothing on purpose; see the comment
+// on the implementation.
+bool legend_plan_remap(const legend_plan_env_t* env, uint8_t size, const uint32_t* text,
+                       uint32_t* out, uint8_t out_cap);
+
+// Works out how a key's MAIN legend should be drawn at `size`, WITHOUT drawing it.
+// `small_x`/`small_y` are the origin the small face has always used (the
+// per-language offsets), taken verbatim when no bigger face applies. `scratch`
+// must outlive the returned plan: it holds the relocated codepoints.
+void legend_plan_main(const legend_plan_env_t* env, uint8_t size, const uint32_t* text,
+                      int8_t small_x, int8_t small_y,
+                      uint32_t* scratch, uint8_t scratch_cap, main_legend_t* out);

--- a/keyboards/polykybd/base/tests/legend_plan_tests.cpp
+++ b/keyboards/polykybd/base/tests/legend_plan_tests.cpp
@@ -160,14 +160,28 @@ TEST(LegendPlanRemapTest, OpsAloneDrawNothing) {
 TEST(LegendPlanRemapTest, ATooLongLegendFallsBack) {
     FakeFonts f   = latin_world();
     auto      env = env_for(&f);
-    // GLYPH_SIZE_MAX_LEN glyphs fit a cap of GLYPH_SIZE_MAX_LEN + 1; one more must not.
+    // The buffer is deliberately LARGER than GLYPH_SIZE_MAX_LEN + 1, so this pins
+    // the glyph-count contract itself, not the caller's buffer bound: a five-glyph
+    // legend must fall back even when the output has room for it.
     std::vector<uint32_t> text(GLYPH_SIZE_MAX_LEN, 'a');
     text.push_back(0);
-    uint32_t out[GLYPH_SIZE_MAX_LEN + 1];
-    EXPECT_TRUE(legend_plan_remap(&env, LEGEND_PLAN_SIZE_M, text.data(), out, GLYPH_SIZE_MAX_LEN + 1));
+    uint32_t out[GLYPH_SIZE_MAX_LEN + 4];
+    EXPECT_TRUE(legend_plan_remap(&env, LEGEND_PLAN_SIZE_M, text.data(), out, GLYPH_SIZE_MAX_LEN + 4));
     text.back() = 'a';
     text.push_back(0);
-    EXPECT_FALSE(legend_plan_remap(&env, LEGEND_PLAN_SIZE_M, text.data(), out, GLYPH_SIZE_MAX_LEN + 1));
+    EXPECT_FALSE(legend_plan_remap(&env, LEGEND_PLAN_SIZE_M, text.data(), out, GLYPH_SIZE_MAX_LEN + 4));
+}
+
+TEST(LegendPlanRemapTest, ATightBufferStillBounds) {
+    FakeFonts f   = latin_world();
+    auto      env = env_for(&f);
+    // The out_cap half of the guard: a legend within the glyph-count contract
+    // must still be refused when the caller's buffer cannot hold it + terminator.
+    std::vector<uint32_t> text(2, 'a');
+    text.push_back(0);
+    uint32_t out[GLYPH_SIZE_MAX_LEN + 1];
+    EXPECT_FALSE(legend_plan_remap(&env, LEGEND_PLAN_SIZE_M, text.data(), out, 2));
+    EXPECT_TRUE(legend_plan_remap(&env, LEGEND_PLAN_SIZE_M, text.data(), out, 3));
 }
 
 TEST(LegendPlanMainTest, BigUsesTheTiersNominalBaseline) {

--- a/keyboards/polykybd/base/tests/legend_plan_tests.cpp
+++ b/keyboards/polykybd/base/tests/legend_plan_tests.cpp
@@ -1,0 +1,253 @@
+// Copyright 2026 Thomas Pollak
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Tests for base/legend_plan.c — the keycap MAIN-legend size planner (HID cmd 34).
+//
+// The planner's two shipped hazards are pinned here off-hardware:
+//   - the cursor-op handling (the five zero-argument nudges are DROPPED, every
+//     other display-list op bails) — getting this wrong silently halved the
+//     AZERTY number row once, and the rig cannot see it;
+//   - the origin/baseline clamping, whose whole job is keeping a 43 px glyph or
+//     a tall accent stack on the 72×40 panel.
+
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "legend_plan.h"
+}
+
+#include <set>
+#include <vector>
+
+namespace {
+
+// The split72/split42 visible window the firmware binds: columns 28..99, rows 0..39.
+constexpr int8_t kWinX0 = 28;
+constexpr int8_t kWinX1 = 99;
+constexpr int8_t kWinY1 = 39;
+
+// Fake font world: a set of drawable codepoints plus a deterministic measurer —
+// each glyph 10 px wide advancing from x 0, inking ymin..ymax as configured.
+struct FakeFonts {
+    std::set<uint32_t> glyphs;
+    int8_t             ymin = -20;  // above the baseline, like a capital
+    int8_t             ymax = 0;
+};
+
+bool fake_has_glyph(uint32_t cp, void* ctx) {
+    return static_cast<FakeFonts*>(ctx)->glyphs.count(cp) != 0;
+}
+
+void fake_bbox(const uint32_t* text, int8_t* xmin, int8_t* xmax, int8_t* ymin, int8_t* ymax, void* ctx) {
+    auto* f = static_cast<FakeFonts*>(ctx);
+    int   n = 0;
+    while (text[n] != 0) n++;
+    *xmin = 0;
+    *xmax = static_cast<int8_t>(n > 0 ? n * 10 - 1 : 0);
+    *ymin = f->ymin;
+    *ymax = f->ymax;
+}
+
+legend_plan_env_t env_for(FakeFonts* f) {
+    legend_plan_env_t env{};
+    env.has_glyph = fake_has_glyph;
+    env.bbox      = fake_bbox;
+    env.ctx       = f;
+    env.win_x0    = kWinX0;
+    env.win_x1    = kWinX1;
+    env.win_y1    = kWinY1;
+    return env;
+}
+
+// A fake world where both bigger tiers can draw 'a'..'z'.
+FakeFonts latin_world() {
+    FakeFonts f;
+    for (uint32_t c = 'a'; c <= 'z'; ++c) {
+        f.glyphs.insert(0xF0000u + c);
+        f.glyphs.insert(0xF3000u + c);
+    }
+    return f;
+}
+
+TEST(LegendPlanRemapTest, SmallSizeAlwaysFallsBack) {
+    FakeFonts f   = latin_world();
+    auto      env = env_for(&f);
+    const uint32_t text[] = {'a', 0};
+    uint32_t       out[GLYPH_SIZE_MAX_LEN + 1];
+    EXPECT_FALSE(legend_plan_remap(&env, LEGEND_PLAN_SIZE_S, text, out, GLYPH_SIZE_MAX_LEN + 1));
+}
+
+TEST(LegendPlanRemapTest, UnknownSizeFallsBack) {
+    // The closed-range contract: a size the firmware does not know renders small
+    // (cmd 34 NACKs it on the wire; this is the render-side belt to that brace).
+    FakeFonts f   = latin_world();
+    auto      env = env_for(&f);
+    const uint32_t text[] = {'a', 0};
+    uint32_t       out[GLYPH_SIZE_MAX_LEN + 1];
+    EXPECT_FALSE(legend_plan_remap(&env, LEGEND_PLAN_SIZE_COUNT, text, out, GLYPH_SIZE_MAX_LEN + 1));
+    EXPECT_FALSE(legend_plan_remap(&env, 0xFF, text, out, GLYPH_SIZE_MAX_LEN + 1));
+    EXPECT_FALSE(legend_plan_remap(&env, LEGEND_PLAN_SIZE_M, nullptr, out, GLYPH_SIZE_MAX_LEN + 1));
+}
+
+TEST(LegendPlanRemapTest, RelocationAddsExactlyTheTierBase) {
+    // Pin the PUA plane-15 bases: fonts.yaml's latinbig `offset:` values are
+    // 0xF0000 (M) and 0xF3000 (L), and the two must stay identical or every
+    // legend silently renders the wrong tier's glyphs.
+    FakeFonts f   = latin_world();
+    auto      env = env_for(&f);
+    const uint32_t text[] = {'a', 'b', 0};
+    uint32_t       out[GLYPH_SIZE_MAX_LEN + 1];
+    ASSERT_TRUE(legend_plan_remap(&env, LEGEND_PLAN_SIZE_M, text, out, GLYPH_SIZE_MAX_LEN + 1));
+    EXPECT_EQ(out[0], 0xF0000u + 'a');
+    EXPECT_EQ(out[1], 0xF0000u + 'b');
+    EXPECT_EQ(out[2], 0u);
+    ASSERT_TRUE(legend_plan_remap(&env, LEGEND_PLAN_SIZE_L, text, out, GLYPH_SIZE_MAX_LEN + 1));
+    EXPECT_EQ(out[0], 0xF3000u + 'a');
+    EXPECT_EQ(out[1], 0xF3000u + 'b');
+}
+
+TEST(LegendPlanRemapTest, OneMissingGlyphFailsTheWholeLegend) {
+    // All-or-nothing: a partial hit would mix two faces (and two baselines) in
+    // one legend.
+    FakeFonts f = latin_world();
+    f.glyphs.erase(0xF0000u + 'b');
+    auto env = env_for(&f);
+    const uint32_t text[] = {'a', 'b', 0};
+    uint32_t       out[GLYPH_SIZE_MAX_LEN + 1];
+    EXPECT_FALSE(legend_plan_remap(&env, LEGEND_PLAN_SIZE_M, text, out, GLYPH_SIZE_MAX_LEN + 1));
+    // The same legend still relocates at the tier that has every glyph.
+    EXPECT_TRUE(legend_plan_remap(&env, LEGEND_PLAN_SIZE_L, text, out, GLYPH_SIZE_MAX_LEN + 1));
+}
+
+TEST(LegendPlanRemapTest, TheFiveCursorNudgesAreDroppedNotRelocated) {
+    // The AZERTY case: `é è ç à` are spelled `\f\f <letter>` (0x0C 0x0C <cp>).
+    // Dropping the nudges — never relocating them as if they were glyphs — is
+    // what lets those keys scale at all.
+    FakeFonts f   = latin_world();
+    auto      env = env_for(&f);
+    for (uint32_t op : {0x05u, 0x06u, 0x08u, 0x0Bu, 0x0Cu}) {
+        const uint32_t text[] = {op, op, 'e', 0};
+        uint32_t       out[GLYPH_SIZE_MAX_LEN + 1];
+        ASSERT_TRUE(legend_plan_remap(&env, LEGEND_PLAN_SIZE_M, text, out, GLYPH_SIZE_MAX_LEN + 1))
+            << "op 0x" << std::hex << op;
+        EXPECT_EQ(out[0], 0xF0000u + 'e');
+        EXPECT_EQ(out[1], 0u);
+    }
+}
+
+TEST(LegendPlanRemapTest, EveryOtherDisplayListOpBails) {
+    // HINT_MOVE/HINT_FRAME consume the two codepoints after them, HINT_HALF /
+    // HINT_SMALL / HINT_MID rescale or re-font what follows — relocating any of
+    // that as glyph data would draw garbage, so the whole legend stays small.
+    FakeFonts f   = latin_world();
+    auto      env = env_for(&f);
+    for (uint32_t op : {0x01u, 0x0Eu, 0x0Fu, 0x10u, 0x12u, 0x13u, 0x16u, 0x1Fu}) {
+        const uint32_t text[] = {op, 'e', 0};
+        uint32_t       out[GLYPH_SIZE_MAX_LEN + 1];
+        EXPECT_FALSE(legend_plan_remap(&env, LEGEND_PLAN_SIZE_M, text, out, GLYPH_SIZE_MAX_LEN + 1))
+            << "op 0x" << std::hex << op;
+    }
+}
+
+TEST(LegendPlanRemapTest, OpsAloneDrawNothing) {
+    FakeFonts f   = latin_world();
+    auto      env = env_for(&f);
+    const uint32_t text[] = {0x0C, 0x0C, 0};
+    uint32_t       out[GLYPH_SIZE_MAX_LEN + 1];
+    EXPECT_FALSE(legend_plan_remap(&env, LEGEND_PLAN_SIZE_M, text, out, GLYPH_SIZE_MAX_LEN + 1));
+}
+
+TEST(LegendPlanRemapTest, ATooLongLegendFallsBack) {
+    FakeFonts f   = latin_world();
+    auto      env = env_for(&f);
+    // GLYPH_SIZE_MAX_LEN glyphs fit a cap of GLYPH_SIZE_MAX_LEN + 1; one more must not.
+    std::vector<uint32_t> text(GLYPH_SIZE_MAX_LEN, 'a');
+    text.push_back(0);
+    uint32_t out[GLYPH_SIZE_MAX_LEN + 1];
+    EXPECT_TRUE(legend_plan_remap(&env, LEGEND_PLAN_SIZE_M, text.data(), out, GLYPH_SIZE_MAX_LEN + 1));
+    text.back() = 'a';
+    text.push_back(0);
+    EXPECT_FALSE(legend_plan_remap(&env, LEGEND_PLAN_SIZE_M, text.data(), out, GLYPH_SIZE_MAX_LEN + 1));
+}
+
+TEST(LegendPlanMainTest, BigUsesTheTiersNominalBaseline) {
+    // One 10 px glyph at x 40 needs no clamp: x stays put and y is the tier's
+    // nominal baseline (M 25, L 28 — chosen so cap height matches the small face).
+    FakeFonts f   = latin_world();
+    auto      env = env_for(&f);
+    const uint32_t text[] = {'a', 0};
+    uint32_t       scratch[GLYPH_SIZE_MAX_LEN + 1];
+    main_legend_t  plan{};
+    legend_plan_main(&env, LEGEND_PLAN_SIZE_M, text, 40, 23, scratch, GLYPH_SIZE_MAX_LEN + 1, &plan);
+    EXPECT_TRUE(plan.big);
+    EXPECT_EQ(plan.text, scratch);
+    EXPECT_EQ(plan.x, 40);
+    EXPECT_EQ(plan.y, 25);
+    EXPECT_EQ(plan.ink_min, 40);
+    EXPECT_EQ(plan.ink_max, 49);
+    legend_plan_main(&env, LEGEND_PLAN_SIZE_L, text, 40, 23, scratch, GLYPH_SIZE_MAX_LEN + 1, &plan);
+    EXPECT_EQ(plan.y, 28);
+}
+
+TEST(LegendPlanMainTest, HorizontalClampKeepsTheInkInTheWindow) {
+    FakeFonts f   = latin_world();
+    auto      env = env_for(&f);
+    // Three glyphs = ink 0..29 relative to the origin. Placed at x 90 the right
+    // edge would ink to 119; the clamp pulls it back so the last pixel is win_x1.
+    const uint32_t text[] = {'a', 'b', 'c', 0};
+    uint32_t       scratch[GLYPH_SIZE_MAX_LEN + 1];
+    main_legend_t  plan{};
+    legend_plan_main(&env, LEGEND_PLAN_SIZE_M, text, 90, 23, scratch, GLYPH_SIZE_MAX_LEN + 1, &plan);
+    EXPECT_EQ(plan.ink_max, kWinX1);
+    EXPECT_EQ(plan.x, kWinX1 - 29);
+    // Placed left of the window the left clamp wins.
+    legend_plan_main(&env, LEGEND_PLAN_SIZE_M, text, 10, 23, scratch, GLYPH_SIZE_MAX_LEN + 1, &plan);
+    EXPECT_EQ(plan.ink_min, kWinX0);
+    EXPECT_EQ(plan.x, kWinX0);
+}
+
+TEST(LegendPlanMainTest, VerticalClampShiftsTallAccentsAndDeepDescenders) {
+    FakeFonts f = latin_world();
+    // A tall accent stack: 30 px of ink above the baseline. At the M nominal
+    // baseline 25 the top row would be -5, so the baseline shifts down to 30.
+    f.ymin = -30;
+    f.ymax = 0;
+    auto env = env_for(&f);
+    const uint32_t text[] = {'a', 0};
+    uint32_t       scratch[GLYPH_SIZE_MAX_LEN + 1];
+    main_legend_t  plan{};
+    legend_plan_main(&env, LEGEND_PLAN_SIZE_M, text, 40, 23, scratch, GLYPH_SIZE_MAX_LEN + 1, &plan);
+    EXPECT_EQ(plan.y, 30);
+    // A deep descender: 15 px below the L nominal baseline 28 overshoots row 39,
+    // so the baseline lifts to 24.
+    f.ymin = -20;
+    f.ymax = 15;
+    legend_plan_main(&env, LEGEND_PLAN_SIZE_L, text, 40, 23, scratch, GLYPH_SIZE_MAX_LEN + 1, &plan);
+    EXPECT_EQ(plan.y, kWinY1 - 15);
+}
+
+TEST(LegendPlanMainTest, SmallPathKeepsTheLanguagesOwnOrigin) {
+    // No bigger face (S, or nothing relocatable): the per-language origin is taken
+    // verbatim — the planner must not clamp or re-place what the small face has
+    // always drawn — and the ink extents still come from the measurement.
+    FakeFonts f   = latin_world();
+    auto      env = env_for(&f);
+    const uint32_t text[] = {'a', 'b', 0};
+    uint32_t       scratch[GLYPH_SIZE_MAX_LEN + 1];
+    main_legend_t  plan{};
+    legend_plan_main(&env, LEGEND_PLAN_SIZE_S, text, 33, 23, scratch, GLYPH_SIZE_MAX_LEN + 1, &plan);
+    EXPECT_FALSE(plan.big);
+    EXPECT_EQ(plan.text, text);
+    EXPECT_EQ(plan.x, 33);
+    EXPECT_EQ(plan.y, 23);
+    EXPECT_EQ(plan.ink_min, 33);
+    EXPECT_EQ(plan.ink_max, 33 + 19);
+    // A legend the tiers cannot draw (missing glyph) takes the same small path.
+    FakeFonts empty;
+    auto      env2 = env_for(&empty);
+    legend_plan_main(&env2, LEGEND_PLAN_SIZE_M, text, 33, 23, scratch, GLYPH_SIZE_MAX_LEN + 1, &plan);
+    EXPECT_FALSE(plan.big);
+    EXPECT_EQ(plan.text, text);
+}
+
+}  // namespace

--- a/keyboards/polykybd/base/tests/test_rules.mk
+++ b/keyboards/polykybd/base/tests/test_rules.mk
@@ -88,3 +88,13 @@ polykybd_layer_names_SRC := \
 polykybd_layer_names_INC := \
 	$(POLY_BASE_PATH) \
 	keyboards/polykybd
+# legend_plan.c is pure by construction — the font lookup and the bbox
+# measurement arrive through callbacks — so the size planner links with no fonts,
+# no display and no keyboard config. The firmware binding lives in poly_keymap.c.
+polykybd_legend_plan_SRC := \
+	$(POLY_BASE_PATH)/legend_plan.c \
+	$(POLY_BASE_PATH)/tests/legend_plan_tests.cpp
+
+polykybd_legend_plan_INC := \
+	$(POLY_BASE_PATH) \
+	keyboards/polykybd

--- a/keyboards/polykybd/base/tests/testlist.mk
+++ b/keyboards/polykybd/base/tests/testlist.mk
@@ -5,3 +5,4 @@ TEST_LIST += polykybd_map_codec
 TEST_LIST += polykybd_mode_byte
 TEST_LIST += polykybd_idle_update
 TEST_LIST += polykybd_layer_names
+TEST_LIST += polykybd_legend_plan

--- a/keyboards/polykybd/ltr559_policy.c
+++ b/keyboards/polykybd/ltr559_policy.c
@@ -1,0 +1,227 @@
+// Copyright 2026 thpoll83
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "ltr559_policy.h"
+
+#ifdef POLYKYBD_LTR559_DRIVE
+
+#    include "quantum.h"
+#    include <transactions.h>
+#    include <string.h>
+
+#    include "print.h"
+#    include "state.h"
+#    include "bridge_helper.h"    // is_usb_host_side()
+#    include "poly_keymap.h"      // reset_idle_jitter()
+#    include "base/com.h"         // STATUS_DISP_ON / DISP_IDLE flags
+#    include "base/update.h"      // update_performed() / request_disp_refresh()
+#    include "doom/doom_mode.h"   // screensaver teardown (inline no-ops without POLYKYBD_DOOM)
+
+#    ifdef COMMUNITY_MODULE_POLYMOD_LTR559_ENABLE
+#        include "polymod_ltr559.h"
+#    endif
+
+// --- LTR-559 auto-brightness + idle-inhibit (opt-in; needs hardware tuning) -----
+//
+// The sensor is just another SOURCE feeding the existing auto-brightness path:
+// the 5 s-average lux is mapped to a contrast and pushed through
+// set_auto_brightness_value() — exactly the volatile/host-auto channel the PC
+// host uses — so the resulting contrast reaches the slave over the existing
+// poly_sync_t brightness transport.
+//
+// Brightness and idle are master-authoritative, so the decision runs on the
+// master. The sensor lives on the RIGHT half, so:
+//   * master IS the right half  -> read the sensor locally
+//   * master is the LEFT half   -> pull {avg lux, proximity} from the slave over
+//     the generic USER_SYNC_SLAVE_DATA channel (kind = SLAVE_DATA_SENSOR) — the
+//     split slot freed by the FW_UP transaction consolidation.
+// Either way driving works regardless of which half USB is plugged into.
+// All tunables below are first-cut guesses to be dialled in against the OLED.
+// Proximity (0..2047) that counts as "close" -> wake / inhibit idle. Measured on
+// hardware: hand at ~5 cm 400, ~1 cm 1000, hole fully covered ~2000 (saturated).
+// The resting (nothing near) baseline depends on the housing: ~129 on the open
+// bench, ~325 once mounted in the enclosure (its walls reflect IR back). 350 was
+// kept as the wake point (wakes as a hand comes within ~5-6 cm). NOTE: with the
+// housed ~325 baseline the margin is only ~25 counts — raise toward 400 if the
+// mounted sensor ever self-triggers; lower toward the baseline for an earlier wake.
+#    define LTR559_NEAR_THRESHOLD 350
+#    define LTR559_DRIVE_MS 500         // how often the master samples + applies
+#    define LTR559_LUX_FULL_REF 100     // avg lux mapped to FULL_BRIGHT (ceiling)
+                                        // Tuned on hardware: a ~28 lux office reads
+                                        // B≈26 (was B≈19 at 200), matching the level
+                                        // the user set by hand. Curve (sqrt): ~4 in a
+                                        // dark room, 26 @ 28 lux, 35 @ 50 lux, full @ 100+.
+#    define LTR559_MIN_CONTRAST 4       // auto-brightness floor — the sensor never
+                                        // drives below this. 4 = a dim but visible
+                                        // night level; still clear of the near-off
+                                        // B=1/DISP_OFF. (The power-on dark-screen was a
+                                        // separate boot transient, fixed by the
+                                        // don't-engage-until-first-reading guard below.)
+
+// USER_SYNC_SLAVE_DATA is a GENERIC op-dispatched slave->master pull channel (see
+// config.h): the master's request is a 1-byte `kind` selecting which slave-side
+// payload to return. Append a new kind + a case below to carry other data over
+// the same one split slot — no new transaction needed. Both halves run the same
+// firmware image, so the per-kind payload structs can change freely (no split
+// versioning); the handler just bounds every copy by out_len.
+enum slave_data_kind {
+    SLAVE_DATA_SENSOR = 0,  // ltr559_sync_t: {avg lux, proximity}
+    // SLAVE_DATA_xxx = 1, ...  // future slave-side data reuses this slot
+};
+
+typedef struct {
+    uint16_t lux;   // 5 s-average lux
+    uint16_t prox;  // latest raw proximity (0..2047)
+} ltr559_sync_t;
+
+// Slave side: answer the master's pull for the requested `kind`. Registered on
+// both halves; only ever runs on the slave (the master initiates the exec).
+static void user_sync_slave_data_handler(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data) {
+    uint8_t kind = (in_len >= 1) ? ((const uint8_t*)in_data)[0] : SLAVE_DATA_SENSOR;
+    switch (kind) {
+        case SLAVE_DATA_SENSOR: {
+            ltr559_sync_t s = { ltr559_avg_lux(), ltr559_prox() };
+            if (out_len >= sizeof(s)) {
+                memcpy(out_data, &s, sizeof(s));
+            }
+            break;
+        }
+        default:
+            break;  // unknown kind: leave the reply buffer as-is
+    }
+}
+
+void poly_ltr559_register_split_handler(void) {
+    transaction_register_rpc(USER_SYNC_SLAVE_DATA, user_sync_slave_data_handler);
+}
+
+// Master-side: mirror the HID cmd-15 stop-idle path to force the displays awake.
+// Logged because this is the ONLY wake with no user-visible trigger — a proximity
+// wake used to restart the whole idle countdown silently, so the console showed a
+// second "Transition to idle" with nothing explaining the first one ending.
+static void poly_force_wake(void) {
+    poly_sync_t* local_state = access_local_state();
+    // The DOOM attract screensaver (IDLE_STYLE_IDDQD) runs with STATUS_DISP_ON SET
+    // and DISP_IDLE CLEARED — it owns the keycaps at active brightness via
+    // doom_tick(), not through the DISP_IDLE pulse path. So it matches NEITHER
+    // branch below, and proximity would be a silent no-op over it while pulse /
+    // jitter / eden (all DISP_IDLE) and full suspend wake normally — the reported
+    // "doom idle doesn't react to the proximity sensor, the other idle modes do".
+    // Tear it down exactly like a keypress does (doom_exit restores the legends and
+    // stamps a fresh last_update); only the screensaver, never an active game.
+    if (doom_mode_screensaver()) {
+        uprint("Wake by proximity (from doom screensaver)\n");
+        doom_screensaver_stop();
+        update_performed();
+        return;
+    }
+    if ((local_state->flags & (STATUS_DISP_ON | DISP_IDLE)) == 0) {
+        uprint("Wake by proximity (from suspend)\n");
+        suspend_wakeup_init_kb();   // fully suspended -> full wake
+    } else if (local_state->flags & DISP_IDLE) {
+        uprint("Wake by proximity (from idle)\n");
+        local_state->contrast = get_active_brightness();
+        local_state->flags &= ~((uint8_t)DISP_IDLE);
+        local_state->flags |= STATUS_DISP_ON;
+        reset_idle_jitter();
+        request_disp_refresh();
+        update_performed();
+    }
+}
+
+static uint32_t isqrt32(uint32_t x) {
+    uint32_t r = 0, b = 1UL << 30;
+    while (b > x) b >>= 2;
+    while (b) {
+        if (x >= r + b) { x -= r + b; r = (r >> 1) + b; }
+        else            { r >>= 1; }
+        b >>= 2;
+    }
+    return r;
+}
+
+static uint8_t lux_to_contrast(uint16_t lux) {
+    // Perceptual (sqrt) curve: brightness rises quickly out of the dark and eases
+    // toward the ceiling, so ordinary indoor light already gives a usable level
+    // instead of the near-off B=2 a linear map produced. LTR559_LUX_FULL_REF is
+    // the lux that reaches FULL_BRIGHT. (×100 before the sqrt for resolution.)
+    uint32_t sref = isqrt32((uint32_t)LTR559_LUX_FULL_REF * 100u);
+    uint32_t slux = isqrt32((uint32_t)lux * 100u);
+    if (slux >= sref) {
+        return FULL_BRIGHT;
+    }
+    uint32_t c = MIN_BRIGHT + ((uint32_t)(FULL_BRIGHT - MIN_BRIGHT) * slux) / sref;
+    if (c < LTR559_MIN_CONTRAST) c = LTR559_MIN_CONTRAST;  // never near-off
+    if (c > FULL_BRIGHT) c = FULL_BRIGHT;
+    return (uint8_t)c;
+}
+
+void poly_ltr559_drive(void) {
+    static uint32_t last        = 0;
+    static bool     engaged     = false;
+    static uint8_t  last_logged = 0xFF;   // last brightness announced to the console
+    if (!is_usb_host_side()) {
+        return;   // decisions are master-only (the slave just serves reads)
+    }
+    if (timer_elapsed32(last) < LTR559_DRIVE_MS) {
+        return;
+    }
+    last = timer_read32();
+
+    // Brightness/idle decisions are master-only; the sensor is auto-detected on
+    // whichever half it's soldered to.
+    uint16_t lux, prox;
+    if (ltr559_available()) {
+        // The master itself has the sensor — read locally.
+        lux  = ltr559_avg_lux();
+        prox = ltr559_prox();
+    } else {
+        // Sensor is on the slave (right) half — pull its latest values up over the
+        // generic slave->master channel (kind = SLAVE_DATA_SENSOR), so driving
+        // works in either USB orientation.
+        uint8_t       kind = SLAVE_DATA_SENSOR;
+        ltr559_sync_t s;
+        if (!transaction_rpc_exec(USER_SYNC_SLAVE_DATA, sizeof(kind), &kind, sizeof(s), &s)) {
+            return;   // slave busy this round; try again next tick
+        }
+        lux  = s.lux;
+        prox = s.prox;
+    }
+
+    // Auto-brightness from the 5 s average lux, via the same volatile/host-auto
+    // path the host uses (keeps the manual brightness untouched).
+    //
+    // Don't engage until the sensor has produced a real reading: for the first
+    // ~1 s after boot the 5 s average is still 0 (no samples), and engaging then
+    // would yank the displays down to the floor. Hold at the manual/restored
+    // brightness until the first non-zero average, then engage. Once engaged we
+    // keep applying — a genuine dark-room 0 is floored by lux_to_contrast (never
+    // off), so a momentary 0 can't blank the keys.
+    if (!engaged) {
+        if (lux == 0) {
+            return;
+        }
+        set_brightness_auto_mode(true);
+        engaged = true;
+        uprintf("LTR-559: auto-brightness engaged (avg lux %u)\n", lux);
+    }
+
+    // Announce every brightness the sensor drives — but only when it actually
+    // changes: this runs every LTR559_DRIVE_MS (500 ms), so an unconditional print
+    // would drown the console. Without it a sensor-driven brightness move is
+    // indistinguishable from a key/host change (or from a bug) in the log.
+    const uint8_t target = lux_to_contrast(lux);
+    if (target != last_logged) {
+        last_logged = target;
+        uprintf("LTR-559: auto brightness -> %u (avg lux %u)%s\n", target, lux,
+                get_brightness_auto_mode() ? "" : " [auto off, not applied]");
+    }
+    set_auto_brightness_value(target);
+
+    // Proximity: something is close -> defer idle (and wake if already idle).
+    if (prox > LTR559_NEAR_THRESHOLD) {
+        poly_force_wake();
+        update_performed();
+    }
+}
+#endif  // POLYKYBD_LTR559_DRIVE

--- a/keyboards/polykybd/ltr559_policy.h
+++ b/keyboards/polykybd/ltr559_policy.h
@@ -1,0 +1,26 @@
+// Copyright 2026 thpoll83
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+// LTR-559 auto-brightness + idle-inhibit POLICY. The DRIVER is the
+// polykybd/polymod_ltr559 community module (it probes and polls the part from
+// its own hooks); everything here is the PolyKybd-side decision layer on top of
+// it — mapping the 5 s average lux onto the volatile/host-auto brightness path
+// and turning a near proximity reading into a display wake. Extracted from
+// poly_keymap.c so the policy is one findable unit; behaviour is unchanged.
+//
+// Everything is gated on POLYKYBD_LTR559_DRIVE, exactly as it was in
+// poly_keymap.c — a board can carry the driver module without this policy.
+
+#ifdef POLYKYBD_LTR559_DRIVE
+// Registers the generic slave->master pull channel (USER_SYNC_SLAVE_DATA) whose
+// slave-side handler serves {avg lux, proximity}. Call once from
+// keyboard_post_init_user(), alongside the other transaction registrations —
+// the handler stays private to ltr559_policy.c, the same way every other
+// user_sync_* handler stays private to the file that owns its data.
+void poly_ltr559_register_split_handler(void);
+
+// Master-side auto-brightness + idle-inhibit; call every housekeeping pass
+// (it self-limits to one decision per LTR559_DRIVE_MS).
+void poly_ltr559_drive(void);
+#endif

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -58,6 +58,7 @@
 #include "base/text_helper.h"
 #include "base/fonts/gfx_used_fonts.h"
 #include "base/fontpack.h"                // g_all_fonts/g_all_font_count + loader
+#include "base/legend_plan.h"            // the pure keycap legend-SIZE planner
 // Country flags (NotoColorEmoji_Regular_LangFlags, codepoints FLAG_CP_BASE+idx)
 // now ship in the external-flash font pack, resolved via g_all_fonts — they are
 // NOT compiled in. The tiny label font stays resident (no-pack fallback label).
@@ -1562,139 +1563,43 @@ static uint32_t glyph_script_codepoint(uint8_t script, uint16_t keycode) {
 
 // ── Keycap legend SIZE (enum poly_glyph_size, HID cmd 34) ────────────────────
 //
-// The two bigger faces are the SAME latin repertoire rendered larger, so they
-// cannot be looked up by their natural codepoints: g_all_fonts is scanned
-// front-to-back and the resident 27 px `latin` font is always in front, so a
-// second 'a' at 0x61 could never be reached. fonts.yaml therefore emits each
-// tier at a fixed offset into supplementary private-use plane 15 (fontconvert
-// -o), and the render path adds the same offset before the lookup. Keep these
-// bases identical to the `offset:` values in the fonts.yaml `latinbig` entries.
-//
-// The spacing (0x3000) exceeds the highest source codepoint the latin category
-// covers (0x2116, the numero sign), so the tiers can never overlap.
-static const uint32_t glyph_size_base[GLYPH_SIZE_COUNT] = {
-    [GLYPH_SIZE_S] = 0u,          // the resident face, at its natural codepoints
-    [GLYPH_SIZE_M] = 0xF0000u,
-    [GLYPH_SIZE_L] = 0xF3000u,
-};
+// The relocation + placement arithmetic is the PURE planner in base/legend_plan.c
+// (unit-tested: make test:polykybd_legend_plan); the wrappers below bind it to the
+// assembled font set and this variant's visible window, keeping the signatures the
+// render path has always called.
+_Static_assert(LEGEND_PLAN_SIZE_COUNT == GLYPH_SIZE_COUNT,
+               "legend_plan's size table no longer covers poly_glyph_size");
+_Static_assert(LEGEND_PLAN_SIZE_S == GLYPH_SIZE_S && LEGEND_PLAN_SIZE_M == GLYPH_SIZE_M &&
+               LEGEND_PLAN_SIZE_L == GLYPH_SIZE_L,
+               "legend_plan's size indices drifted from poly_glyph_size");
 
-// Longest legend the size override will relocate. A main legend is normally ONE
-// glyph; a couple of codepoints covers the composed forms, and anything longer is
-// not the kind of thing that wants to be drawn large anyway.
-#define GLYPH_SIZE_MAX_LEN 4
-
-// Rewrites `text` into `out` at the requested size, returning false — leaving the
-// caller on the normal face — if the size is S, the legend is too long, or ANY of
-// its glyphs is missing at that size.
-//
-// ⚠️ All-or-nothing on purpose. A partial hit would mix two faces in one legend,
-// which is the "keep every glyph of a multi-glyph legend in ONE font" rule broken
-// the worst possible way: kdisp_write_gfx_char baseline-aligns per font, so the
-// halves would also sit at different heights. Falling back whole means a keyboard
-// with no `latinbig` bundle, or a CJK/Arabic/Indic legend that this latin-only
-// feature does not cover, simply keeps drawing what it always drew.
-static bool glyph_size_remap(uint8_t size, const uint32_t* text,
-                             uint32_t* out, uint8_t out_cap) {
-    if (size == GLYPH_SIZE_S || size >= GLYPH_SIZE_COUNT || text == NULL) return false;
-    const uint32_t base = glyph_size_base[size];
-    uint8_t n = 0;
-    for (uint8_t i = 0; text[i] != 0; ++i) {
-        // A control code is a display-list op, not a glyph. The five zero-argument
-        // cursor nudges are DROPPED; every other op bails, because HINT_MOVE /
-        // HINT_FRAME (0x0E/0x12) consume the two codepoints after them — which we
-        // would then relocate as if they were glyphs — and HINT_HALF/HINT_THIN
-        // rescale the next glyph. Neither occurs in a language legend: measured
-        // across all 160 layouts every op present is one of these five, and every
-        // one of them LEADS the legend (0x0C x150, 0x0B x8, 0x06 x9, 0x08 x1,
-        // 0x05 x1; not one after a glyph).
-        //
-        // ⚠️ DROPPED, not carried, and that is not a preference — kdisp_gfx_text_bbox
-        // and the draw disagree about these ops. `\f` is `y = y > 1 ? y - 2 : 0`
-        // applied to the cursor, and bbox runs it from y = 0 (relative to the
-        // baseline) where it saturates to 0, while the draw runs it from the real
-        // baseline where it genuinely lifts 2px. Carrying the op therefore moves the
-        // glyph by an amount plan_main_legend's clamp cannot see, and the accent
-        // clips off the top (measured: 6-8 px lost on `é è à` at M/L). Dropped, the
-        // measured bbox IS what gets drawn and the clamp is exact — and the nudge is
-        // no loss, having been hand-tuned for the small face's fixed baseline.
-        //
-        // ⚠️ This is what makes the French number row scale at all: `é è ç à` are
-        // spelled `\f\f <letter>`, so refusing every control code outright left half
-        // of AZERTY's number row on the small face while the other half grew (found
-        // by rendering the row, 2026-08-21).
-        if (text[i] < 0x20) {
-            switch (text[i]) {
-                case 0x05: case 0x06: case 0x08:
-                case 0x0B: case 0x0C:
-                    continue;                               // a small-face nudge
-                default:
-                    return false;
-            }
-        }
-        if (n + 1 >= out_cap) return false;                 // too long to relocate
-        const uint32_t cp = base + text[i];
-        if (kdisp_gfx_glyph(g_all_fonts, g_all_font_count, cp) == NULL) return false;
-        out[n++] = cp;
-    }
-    if (n == 0) return false;                               // ops alone draw nothing
-    out[n] = 0;
-    return true;
+static bool legend_has_glyph_cb(uint32_t cp, void* ctx) {
+    (void)ctx;
+    return kdisp_gfx_glyph(g_all_fonts, g_all_font_count, cp) != NULL;
 }
 
-// Nominal baseline for each size, chosen so the cap height sits where the small
-// face's does (top of a capital ~1 px below the top of the panel): cap 20 -> 21,
-// 24 -> 25, 27 -> 28. render_key() then CLAMPS it against the legend's own ink box,
-// so a tall accent stack or a deep descender shifts to fit instead of clipping —
-// the nominal value is what keeps every ordinary letter on a shared baseline.
-static const int8_t glyph_size_baseline[GLYPH_SIZE_COUNT] = {
-    [GLYPH_SIZE_S] = 21, [GLYPH_SIZE_M] = 25, [GLYPH_SIZE_L] = 28,
+static void legend_bbox_cb(const uint32_t* text, int8_t* xmin, int8_t* xmax, int8_t* ymin, int8_t* ymax, void* ctx) {
+    (void)ctx;
+    kdisp_gfx_text_bbox(g_all_fonts, g_all_font_count, text, xmin, xmax, ymin, ymax);
+}
+
+static const legend_plan_env_t legend_plan_env = {
+    .has_glyph = legend_has_glyph_cb,
+    .bbox      = legend_bbox_cb,
+    .ctx       = NULL,
+    .win_x0    = BUFFER_X,
+    .win_x1    = BUFFER_X + SCREEN_WIDTH - 1,
+    .win_y1    = SCREEN_HEIGHT - 1,
 };
 
-// A planned main legend: what to draw, where, and how much room it takes.
-typedef struct {
-    const uint32_t* text;      // the legend, relocated to the bigger face when big
-    int8_t x, y;               // draw origin (y is the baseline)
-    int8_t ink_min, ink_max;   // leftmost / rightmost lit pixel, in buffer coords
-    bool   big;                // a bigger face was selected
-} main_legend_t;
+static bool glyph_size_remap(uint8_t size, const uint32_t* text, uint32_t* out, uint8_t out_cap) {
+    return legend_plan_remap(&legend_plan_env, size, text, out, out_cap);
+}
 
-// Works out how a key's MAIN legend should be drawn at the active size, WITHOUT
-// drawing it — the shift-preview layout below needs the base glyph's extent before
-// anything lands on the buffer. `small_x`/`small_y` are the origin the small face
-// has always used (the per-language offsets), taken verbatim at GLYPH_SIZE_S.
-// `scratch` must outlive the returned plan: it holds the relocated codepoints.
 static void plan_main_legend(const uint32_t* text, int8_t small_x, int8_t small_y,
                              uint32_t* scratch, uint8_t scratch_cap, main_legend_t* out) {
-    const uint8_t size = get_local_state()->glyph_size;
-    int8_t xmin = 0, xmax = 0;
-    if (glyph_size_remap(size, text, scratch, scratch_cap)) {
-        int8_t ymin, ymax;
-        kdisp_gfx_text_bbox(g_all_fonts, g_all_font_count, scratch, &xmin, &xmax, &ymin, &ymax);
-        // Keep the language's own horizontal origin — centring instead would eat the
-        // space the shift preview lives in — but clamp both edges into the window,
-        // since a big glyph runs up to 43 px wide.
-        int8_t x = small_x;
-        if (x + xmax > BUFFER_X + SCREEN_WIDTH - 1) x = (int8_t)(BUFFER_X + SCREEN_WIDTH - 1 - xmax);
-        if (x + xmin < BUFFER_X)                    x = (int8_t)(BUFFER_X - xmin);
-        // The tier's nominal baseline, clamped so the ink stays on the panel. The
-        // nominal is what keeps ordinary letters on a shared baseline; the clamp is
-        // what stops a tall accent stack or a deep descender from clipping.
-        int8_t y = glyph_size_baseline[size];
-        if (y + ymin < 0)                 y = (int8_t)(-ymin);
-        if (y + ymax > SCREEN_HEIGHT - 1) y = (int8_t)(SCREEN_HEIGHT - 1 - ymax);
-        out->text = scratch;
-        out->x = x; out->y = y;
-        out->ink_min = (int8_t)(x + xmin);
-        out->ink_max = (int8_t)(x + xmax);
-        out->big = true;
-        return;
-    }
-    kdisp_gfx_text_bounds(g_all_fonts, g_all_font_count, text, &xmin, &xmax);
-    out->text = text;
-    out->x = small_x; out->y = small_y;
-    out->ink_min = (int8_t)(small_x + xmin);
-    out->ink_max = (int8_t)(small_x + xmax);
-    out->big = false;
+    legend_plan_main(&legend_plan_env, get_local_state()->glyph_size, text, small_x, small_y,
+                     scratch, scratch_cap, out);
 }
 
 static inline void draw_main_legend(const main_legend_t* p) {

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -75,6 +75,7 @@
 #    include "polymod_ltr559.h"
 #    define LTR559_LOG_MS 600000   // sensor telemetry log cadence: 10 min
 #endif
+#include "ltr559_policy.h"        // the POLICY on the module (POLYKYBD_LTR559_DRIVE)
 
 #include "state.h"
 #include "poly_macro.h"
@@ -716,76 +717,9 @@ void poly_prepare_for_flash(void) {
     sync_and_refresh_displays();
 }
 
-#ifdef POLYKYBD_LTR559_DRIVE
-// --- LTR-559 auto-brightness + idle-inhibit (opt-in; needs hardware tuning) -----
-//
-// The sensor is just another SOURCE feeding the existing auto-brightness path:
-// the 5 s-average lux is mapped to a contrast and pushed through
-// set_auto_brightness_value() — exactly the volatile/host-auto channel the PC
-// host uses — so the resulting contrast reaches the slave over the existing
-// poly_sync_t brightness transport.
-//
-// Brightness and idle are master-authoritative, so the decision runs on the
-// master. The sensor lives on the RIGHT half, so:
-//   * master IS the right half  -> read the sensor locally
-//   * master is the LEFT half   -> pull {avg lux, proximity} from the slave over
-//     the generic USER_SYNC_SLAVE_DATA channel (kind = SLAVE_DATA_SENSOR) — the
-//     split slot freed by the FW_UP transaction consolidation.
-// Either way driving works regardless of which half USB is plugged into.
-// All tunables below are first-cut guesses to be dialled in against the OLED.
-// Proximity (0..2047) that counts as "close" -> wake / inhibit idle. Measured on
-// hardware: hand at ~5 cm 400, ~1 cm 1000, hole fully covered ~2000 (saturated).
-// The resting (nothing near) baseline depends on the housing: ~129 on the open
-// bench, ~325 once mounted in the enclosure (its walls reflect IR back). 350 was
-// kept as the wake point (wakes as a hand comes within ~5-6 cm). NOTE: with the
-// housed ~325 baseline the margin is only ~25 counts — raise toward 400 if the
-// mounted sensor ever self-triggers; lower toward the baseline for an earlier wake.
-#    define LTR559_NEAR_THRESHOLD 350
-#    define LTR559_DRIVE_MS 500         // how often the master samples + applies
-#    define LTR559_LUX_FULL_REF 100     // avg lux mapped to FULL_BRIGHT (ceiling)
-                                        // Tuned on hardware: a ~28 lux office reads
-                                        // B≈26 (was B≈19 at 200), matching the level
-                                        // the user set by hand. Curve (sqrt): ~4 in a
-                                        // dark room, 26 @ 28 lux, 35 @ 50 lux, full @ 100+.
-#    define LTR559_MIN_CONTRAST 4       // auto-brightness floor — the sensor never
-                                        // drives below this. 4 = a dim but visible
-                                        // night level; still clear of the near-off
-                                        // B=1/DISP_OFF. (The power-on dark-screen was a
-                                        // separate boot transient, fixed by the
-                                        // don't-engage-until-first-reading guard below.)
-
-// USER_SYNC_SLAVE_DATA is a GENERIC op-dispatched slave->master pull channel (see
-// config.h): the master's request is a 1-byte `kind` selecting which slave-side
-// payload to return. Append a new kind + a case below to carry other data over
-// the same one split slot — no new transaction needed. Both halves run the same
-// firmware image, so the per-kind payload structs can change freely (no split
-// versioning); the handler just bounds every copy by out_len.
-enum slave_data_kind {
-    SLAVE_DATA_SENSOR = 0,  // ltr559_sync_t: {avg lux, proximity}
-    // SLAVE_DATA_xxx = 1, ...  // future slave-side data reuses this slot
-};
-
-typedef struct {
-    uint16_t lux;   // 5 s-average lux
-    uint16_t prox;  // latest raw proximity (0..2047)
-} ltr559_sync_t;
-
-// Slave side: answer the master's pull for the requested `kind`. Registered on
-// both halves; only ever runs on the slave (the master initiates the exec).
-static void user_sync_slave_data_handler(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data) {
-    uint8_t kind = (in_len >= 1) ? ((const uint8_t*)in_data)[0] : SLAVE_DATA_SENSOR;
-    switch (kind) {
-        case SLAVE_DATA_SENSOR: {
-            ltr559_sync_t s = { ltr559_avg_lux(), ltr559_prox() };
-            if (out_len >= sizeof(s)) {
-                memcpy(out_data, &s, sizeof(s));
-            }
-            break;
-        }
-        default:
-            break;  // unknown kind: leave the reply buffer as-is
-    }
-}
+// The LTR-559 auto-brightness + idle-inhibit POLICY (the slave-data pull channel,
+// lux -> contrast mapping and the proximity wake) lives in ltr559_policy.c —
+// see poly_ltr559_register_split_handler() / poly_ltr559_drive().
 
 #ifdef POLY_DUMMY_TXN_TEST
 // Root-cause experiment: a no-op split-transaction handler. Registering three of these
@@ -796,137 +730,6 @@ static void user_sync_dummy_handler(uint8_t in_len, const void* in_data, uint8_t
     (void)in_len; (void)in_data; (void)out_len; (void)out_data;
 }
 #endif
-
-// Master-side: mirror the HID cmd-15 stop-idle path to force the displays awake.
-// Logged because this is the ONLY wake with no user-visible trigger — a proximity
-// wake used to restart the whole idle countdown silently, so the console showed a
-// second "Transition to idle" with nothing explaining the first one ending.
-static void poly_force_wake(void) {
-    poly_sync_t* local_state = access_local_state();
-    // The DOOM attract screensaver (IDLE_STYLE_IDDQD) runs with STATUS_DISP_ON SET
-    // and DISP_IDLE CLEARED — it owns the keycaps at active brightness via
-    // doom_tick(), not through the DISP_IDLE pulse path. So it matches NEITHER
-    // branch below, and proximity would be a silent no-op over it while pulse /
-    // jitter / eden (all DISP_IDLE) and full suspend wake normally — the reported
-    // "doom idle doesn't react to the proximity sensor, the other idle modes do".
-    // Tear it down exactly like a keypress does (doom_exit restores the legends and
-    // stamps a fresh last_update); only the screensaver, never an active game.
-    if (doom_mode_screensaver()) {
-        uprint("Wake by proximity (from doom screensaver)\n");
-        doom_screensaver_stop();
-        update_performed();
-        return;
-    }
-    if ((local_state->flags & (STATUS_DISP_ON | DISP_IDLE)) == 0) {
-        uprint("Wake by proximity (from suspend)\n");
-        suspend_wakeup_init_kb();   // fully suspended -> full wake
-    } else if (local_state->flags & DISP_IDLE) {
-        uprint("Wake by proximity (from idle)\n");
-        local_state->contrast = get_active_brightness();
-        local_state->flags &= ~((uint8_t)DISP_IDLE);
-        local_state->flags |= STATUS_DISP_ON;
-        reset_idle_jitter();
-        request_disp_refresh();
-        update_performed();
-    }
-}
-
-static uint32_t isqrt32(uint32_t x) {
-    uint32_t r = 0, b = 1UL << 30;
-    while (b > x) b >>= 2;
-    while (b) {
-        if (x >= r + b) { x -= r + b; r = (r >> 1) + b; }
-        else            { r >>= 1; }
-        b >>= 2;
-    }
-    return r;
-}
-
-static uint8_t lux_to_contrast(uint16_t lux) {
-    // Perceptual (sqrt) curve: brightness rises quickly out of the dark and eases
-    // toward the ceiling, so ordinary indoor light already gives a usable level
-    // instead of the near-off B=2 a linear map produced. LTR559_LUX_FULL_REF is
-    // the lux that reaches FULL_BRIGHT. (×100 before the sqrt for resolution.)
-    uint32_t sref = isqrt32((uint32_t)LTR559_LUX_FULL_REF * 100u);
-    uint32_t slux = isqrt32((uint32_t)lux * 100u);
-    if (slux >= sref) {
-        return FULL_BRIGHT;
-    }
-    uint32_t c = MIN_BRIGHT + ((uint32_t)(FULL_BRIGHT - MIN_BRIGHT) * slux) / sref;
-    if (c < LTR559_MIN_CONTRAST) c = LTR559_MIN_CONTRAST;  // never near-off
-    if (c > FULL_BRIGHT) c = FULL_BRIGHT;
-    return (uint8_t)c;
-}
-
-static void poly_ltr559_drive(void) {
-    static uint32_t last        = 0;
-    static bool     engaged     = false;
-    static uint8_t  last_logged = 0xFF;   // last brightness announced to the console
-    if (!is_usb_host_side()) {
-        return;   // decisions are master-only (the slave just serves reads)
-    }
-    if (timer_elapsed32(last) < LTR559_DRIVE_MS) {
-        return;
-    }
-    last = timer_read32();
-
-    // Brightness/idle decisions are master-only; the sensor is auto-detected on
-    // whichever half it's soldered to.
-    uint16_t lux, prox;
-    if (ltr559_available()) {
-        // The master itself has the sensor — read locally.
-        lux  = ltr559_avg_lux();
-        prox = ltr559_prox();
-    } else {
-        // Sensor is on the slave (right) half — pull its latest values up over the
-        // generic slave->master channel (kind = SLAVE_DATA_SENSOR), so driving
-        // works in either USB orientation.
-        uint8_t       kind = SLAVE_DATA_SENSOR;
-        ltr559_sync_t s;
-        if (!transaction_rpc_exec(USER_SYNC_SLAVE_DATA, sizeof(kind), &kind, sizeof(s), &s)) {
-            return;   // slave busy this round; try again next tick
-        }
-        lux  = s.lux;
-        prox = s.prox;
-    }
-
-    // Auto-brightness from the 5 s average lux, via the same volatile/host-auto
-    // path the host uses (keeps the manual brightness untouched).
-    //
-    // Don't engage until the sensor has produced a real reading: for the first
-    // ~1 s after boot the 5 s average is still 0 (no samples), and engaging then
-    // would yank the displays down to the floor. Hold at the manual/restored
-    // brightness until the first non-zero average, then engage. Once engaged we
-    // keep applying — a genuine dark-room 0 is floored by lux_to_contrast (never
-    // off), so a momentary 0 can't blank the keys.
-    if (!engaged) {
-        if (lux == 0) {
-            return;
-        }
-        set_brightness_auto_mode(true);
-        engaged = true;
-        uprintf("LTR-559: auto-brightness engaged (avg lux %u)\n", lux);
-    }
-
-    // Announce every brightness the sensor drives — but only when it actually
-    // changes: this runs every LTR559_DRIVE_MS (500 ms), so an unconditional print
-    // would drown the console. Without it a sensor-driven brightness move is
-    // indistinguishable from a key/host change (or from a bug) in the log.
-    const uint8_t target = lux_to_contrast(lux);
-    if (target != last_logged) {
-        last_logged = target;
-        uprintf("LTR-559: auto brightness -> %u (avg lux %u)%s\n", target, lux,
-                get_brightness_auto_mode() ? "" : " [auto off, not applied]");
-    }
-    set_auto_brightness_value(target);
-
-    // Proximity: something is close -> defer idle (and wake if already idle).
-    if (prox > LTR559_NEAR_THRESHOLD) {
-        poly_force_wake();
-        update_performed();
-    }
-}
-#endif  // POLYKYBD_LTR559_DRIVE
 
 // Eden idle screensaver runs DIM (anti-burn-in + it's a sleeping-keyboard ambience,
 // not a legend you need to read). This is the OLED contrast register value, not a
@@ -4754,7 +4557,7 @@ void keyboard_post_init_user(void) {
     transaction_register_rpc(USER_SYNC_FLASH_STAGE,         user_sync_flash_stage_handler);
     transaction_register_rpc(USER_SYNC_RESET,               user_sync_reset_handler);
 #ifdef POLYKYBD_LTR559_DRIVE
-    transaction_register_rpc(USER_SYNC_SLAVE_DATA,          user_sync_slave_data_handler);
+    poly_ltr559_register_split_handler();
 #endif
 #ifdef POLY_DUMMY_TXN_TEST
     // Root-cause experiment: register 3 no-op transactions so NUM_TOTAL_TRANSACTIONS

--- a/keyboards/polykybd/rules.mk
+++ b/keyboards/polykybd/rules.mk
@@ -75,7 +75,7 @@ OS_DETECTION_ENABLE = yes
 # drift the shared keymap exists to prevent. It also gets the strict PolyKybd warning
 # flags applied below, which the per-variant base sources do not. The same argument
 # covers emoji/emoji_layer.c and hints/os_hints.c.
-POLY_SRC := poly_keymap.c layer_names.c boot_diag.c side.c state.c split_sync.c split_fw_up.c multicore_exec.c hid_com.c hid_fw_up.c hid_fontpack.c fill_overlay.c poly_util.c matrix_helper.c bridge_helper.c oled_helper.c keycode_helper.c mru.c lang_layer.c os_actions.c anim/startup_anim.c emoji/emoji_layer.c hints/os_hints.c base/fw_up_verdict.c poly_macro.c base/macro_decode.c ltr559_policy.c
+POLY_SRC := poly_keymap.c layer_names.c boot_diag.c side.c state.c split_sync.c split_fw_up.c multicore_exec.c hid_com.c hid_fw_up.c hid_fontpack.c fill_overlay.c poly_util.c matrix_helper.c bridge_helper.c oled_helper.c keycode_helper.c mru.c lang_layer.c os_actions.c anim/startup_anim.c emoji/emoji_layer.c hints/os_hints.c base/fw_up_verdict.c poly_macro.c base/macro_decode.c ltr559_policy.c base/legend_plan.c
 SRC += $(POLY_SRC)
 
 # emoji/emoji_layer.c is listed here, not in a keymap's rules.mk: the keyboard-level

--- a/keyboards/polykybd/rules.mk
+++ b/keyboards/polykybd/rules.mk
@@ -75,7 +75,7 @@ OS_DETECTION_ENABLE = yes
 # drift the shared keymap exists to prevent. It also gets the strict PolyKybd warning
 # flags applied below, which the per-variant base sources do not. The same argument
 # covers emoji/emoji_layer.c and hints/os_hints.c.
-POLY_SRC := poly_keymap.c layer_names.c boot_diag.c side.c state.c split_sync.c split_fw_up.c multicore_exec.c hid_com.c hid_fw_up.c hid_fontpack.c fill_overlay.c poly_util.c matrix_helper.c bridge_helper.c oled_helper.c keycode_helper.c mru.c lang_layer.c os_actions.c anim/startup_anim.c emoji/emoji_layer.c hints/os_hints.c base/fw_up_verdict.c poly_macro.c base/macro_decode.c
+POLY_SRC := poly_keymap.c layer_names.c boot_diag.c side.c state.c split_sync.c split_fw_up.c multicore_exec.c hid_com.c hid_fw_up.c hid_fontpack.c fill_overlay.c poly_util.c matrix_helper.c bridge_helper.c oled_helper.c keycode_helper.c mru.c lang_layer.c os_actions.c anim/startup_anim.c emoji/emoji_layer.c hints/os_hints.c base/fw_up_verdict.c poly_macro.c base/macro_decode.c ltr559_policy.c
 SRC += $(POLY_SRC)
 
 # emoji/emoji_layer.c is listed here, not in a keymap's rules.mk: the keyboard-level


### PR DESCRIPTION
## Summary

Deferred item **1** from #236: the first two gradual extractions from the 5,124-line `poly_keymap.c`, exactly the two candidates that review named. Behaviour-identical and RAM-neutral; two commits, one extraction each.

1. **LTR-559 drive policy → `ltr559_policy.c/.h`** (~210 lines). The auto-brightness + idle-inhibit POLICY — the `USER_SYNC_SLAVE_DATA` pull channel, the lux → contrast sqrt curve, and the proximity wake — moves verbatim, still gated on `POLYKYBD_LTR559_DRIVE` (the DRIVER stays the `polymod_ltr559` community module). The split handler stays private to the new file; `poly_keymap.c` registers it via `poly_ltr559_register_split_handler()` and housekeeping keeps calling `poly_ltr559_drive()` under the same gates. The sensor telemetry heartbeat stays in housekeeping (it is a log line, not policy). One latent nesting straightened: the `POLY_DUMMY_TXN_TEST` no-op handler sat *inside* the LTR block while its registration had an independent `#ifdef` — the dummy-test-without-drive config could never have linked; it now sits under its own `#ifdef` only (no shipping config changes).
2. **Legend-size planner → pure `base/legend_plan.c/.h`**. `glyph_size_remap()` + `plan_main_legend()` become a pure planner behind two callbacks (has-glyph, bbox); `poly_keymap.c` keeps wrappers with the old signatures bound to `g_all_fonts` / `kdisp_gfx_text_bbox` and the variant's visible window, so the render path and all call sites are unchanged. `_Static_assert`s pin the planner's size indices to `poly_glyph_size`. The small-face path now measures through `kdisp_gfx_text_bbox` instead of `kdisp_gfx_text_bounds` — the latter is documented as a wrapper over the former, so the measurement is identical.

**New suite: `make test:polykybd_legend_plan` (12 tests)** — pins the tier bases (0xF0000/0xF3000), the all-or-nothing fallback, the dropped-vs-bailing cursor-op sets (the shape of the AZERTY number-row regression, which the rig cannot see), the length cap, the nominal baselines, and all four origin clamps. **Mutation-checked** with 5 deliberate breaks (dropped 0x0C nudge, wrong L base, partial-hit relocation, baseline off-by-one, removed right x-clamp) — each caught by the intended test. CI picks the suite up automatically (derived `TEST_LIST`).

**Cog verified unbroken**: `poly_keymap.c` carries the language cog blocks, so after the extraction the whole `run_cog.sh` set (`lang_lut.c/.h`, `named_glyphs.h`, `poly_keymap.c`, `keycode_helper.h`, `uni.h`, `hid_com.c`) was regenerated and the tree is byte-identical (baseline reproducibility confirmed on the clean tree first).

**RAM**: monolith (`POLYKYBD_DOOM=yes`, the tight flavour) is byte-identical to base — `.data` 15,144 / `.bss` 27,508 / `.heap` free 3,484 B.

## Version bump label

*(none — patch: internal refactor, no behaviour change, no protocol change)*

## Testing
- [x] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`) — plus the `POLYKYBD_DOOM=yes` monolith and split42
- [ ] Flashed and tested on hardware — HIL rig covers this; `hil-extended` requested since the split-transaction registration and the idle-inhibit path were touched (moved, not changed)
- [x] If protocol changed: n/a

All 10 unit suites green (129 tests: 117 existing + 12 new), local lint job (`qmk lint --strict` both keyboards + `ci-validate-*` + tracked-ignored + format checks) clean, cog regeneration byte-identical, cppcheck clean on the new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8pW42ifgtNjFFVdrWPZ2m

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8pW42ifgtNjFFVdrWPZ2m)_

## Summary by Sourcery

Extract the LTR-559 policy and legend-size planning logic from poly_keymap.c into focused modules while preserving firmware behavior and adding unit coverage for the planner.

Enhancements:
- Extract the LTR-559 auto-brightness, split-sensor synchronization, and proximity wake policy into a dedicated module without changing behavior.
- Extract the keycap legend-size relocation and placement logic into a pure, callback-based planner while preserving the existing rendering path.
- Add compile-time checks and build integration to keep planner size definitions aligned with the keyboard state model.

Build:
- Add the extracted LTR-559 policy and legend planner sources to the PolyKybd build.

Tests:
- Add a dedicated 12-test legend-planner suite covering glyph-tier relocation, fallback behavior, display-list controls, length limits, baselines, and origin clamping.

Chores:
- Correct the conditional placement of the dummy transaction handler so it can be built independently of the LTR-559 drive policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved PolyKybd key legend sizing, placement, and fallback behavior across display sizes.
  * Added optional ambient-light brightness adjustment and proximity-based display wake support for compatible hardware.

* **Bug Fixes**
  * Improved legend positioning by keeping glyphs within visible display boundaries.
  * Safely handles unsupported glyphs, operations, empty legends, and capacity limits.

* **Tests**
  * Added comprehensive automated coverage for legend remapping, sizing, positioning, fallback, and boundary handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->