### PR TITLE
Extract font lookup + bbox interpreter into base/font_lookup, with a 34-test suite

### DIFF
--- a/keyboards/polykybd/base/disp_array.c
+++ b/keyboards/polykybd/base/disp_array.c
@@ -145,8 +145,11 @@ void kdisp_set_gfx_scanline2(bool scanline) {
 // so kdisp_write_gfx_char blits whole vertical bytes straight from flash. The old
 // runtime column-transpose cache (kdisp_set_base_colcache_font / s_colcache) is
 // gone — the data is already in the buffer's layout on disk.
-GFXglyph *pgm_read_glyph_ptr(const GFXfont *font, uint32_t c);  // defined below
-uint8_t  *pgm_read_bitmap_ptr(const GFXfont *font);             // defined below
+// pgm_read_glyph_ptr / pgm_read_bitmap_ptr, the glyph lookup
+// (kdisp_gfx_glyph_font / kdisp_gfx_glyph) and the display-list-aware bounding
+// box moved to base/font_lookup.h/.c (unit-tested on the host, see
+// base/tests/font_bbox_tests.cpp); this file keeps the draw paths and the
+// kdisp_gfx_text_bbox wrapper binding s_mid_font.
 
 uint8_t* get_scratch_buffer(void) {
     return scratch_buffer;
@@ -154,65 +157,6 @@ uint8_t* get_scratch_buffer(void) {
 
 int16_t get_scratch_buffer_size(void) {
     return BUFFER_BYTE_WIDTH * BUFFER_BYTE_HEIGHT;
-}
-
-inline GFXglyph *pgm_read_glyph_ptr(const GFXfont *font, uint32_t c) {
-#ifdef __AVR__
-    return &(((GFXglyph *)pgm_read_pointer(&font->glyph))[c]);
-#else
-    // expression in __AVR__ section may generate "dereferencing type-punned
-    // pointer will break strict-aliasing rules" warning In fact, on other
-    // platforms (such as STM32) there is no need to do this pointer magic as
-    // program memory may be read in a usual way So expression may be simplified
-    return font->glyph + c;
-#endif  //__AVR__
-}
-
-inline uint8_t *pgm_read_bitmap_ptr(const GFXfont *font) {
-#ifdef __AVR__
-    return (uint8_t *)pgm_read_pointer(&font->bitmap);
-#else
-    // expression in __AVR__ section generates "dereferencing type-punned pointer
-    // will break strict-aliasing rules" warning In fact, on other platforms (such
-    // as STM32) there is no need to do this pointer magic as program memory may
-    // be read in a usual way So expression may be simplified
-    return font->bitmap;
-#endif  //__AVR__
-}
-
-// Locate the glyph for codepoint `ch` in a font set, scanning front-to-back and
-// skipping empty (0x0) gap glyphs, exactly like the renderer's own lookup.
-// Returns NULL when no font actually covers `ch` (no '!' fallback) — callers use
-// this both to test coverage and to read glyph metrics. Used by the language
-// layer to draw a country flag only when the font pack supplying it is present.
-// As kdisp_gfx_glyph(), but also reports the font that owns the glyph (when
-// out_font != NULL). The language layer uses this to redraw the flag through a
-// single-font array { flag_font }: kdisp_write_gfx_char baseline-aligns every
-// glyph to fonts[0]->yAdvance, so drawing a pack font via the full g_all_fonts
-// (fonts[0] == IconsFont) shifts it by their yAdvance difference — passing the
-// owning font alone makes that adjustment zero.
-const GFXglyph *kdisp_gfx_glyph_font(const GFXfont *const *fonts, uint8_t num_fonts, uint32_t ch,
-                                     const GFXfont **out_font) {
-    for (uint8_t idx = 0; idx < num_fonts; ++idx) {
-        const GFXfont *f = fonts[idx];
-        uint32_t first = pgm_read_dword(&f->first);
-        uint32_t last  = pgm_read_dword(&f->last);
-        if (ch >= first && ch <= last) {
-            const GFXglyph *gg = pgm_read_glyph_ptr(f, ch - first);
-            if (pgm_read_byte(&gg->width) == 0 && pgm_read_byte(&gg->height) == 0 &&
-                pgm_read_byte(&gg->xAdvance) == 0) {
-                continue;  // non-contiguous-range padding; a later font may have it
-            }
-            if (out_font) *out_font = f;
-            return gg;
-        }
-    }
-    if (out_font) *out_font = NULL;
-    return NULL;
-}
-
-const GFXglyph *kdisp_gfx_glyph(const GFXfont *const *fonts, uint8_t num_fonts, uint32_t ch) {
-    return kdisp_gfx_glyph_font(fonts, num_fonts, ch, NULL);
 }
 
 // Blit a glyph at half resolution (2x2-OR downsample) with its top-left at buffer
@@ -684,14 +628,6 @@ int8_t kdisp_write_gfx_char(const GFXfont *const *fonts, uint8_t num_fonts, int8
     return pgm_read_byte(&glyph->xAdvance);
 }
 
-// Floor division by two. Glyph offsets are negative (above the baseline) and C
-// truncates toward zero, which would round those the wrong way and put a lowercase
-// glyph 1px off its run's baseline. Written out rather than `>> 1` because a right
-// shift of a negative value is only arithmetic by implementation guarantee.
-static inline int16_t half_floor(int16_t v) {
-    return (int16_t)((v >= 0) ? (v / 2) : -((int16_t)(((-v) + 1) / 2)));
-}
-
 // Half-scale sibling of kdisp_write_gfx_char, with the SAME baseline and advance
 // semantics — so a run of them lays out as text. This is what HINT_SMALL (\x10)
 // switches the text writer into, and it is the only way to get a smaller face onto
@@ -716,8 +652,8 @@ static int8_t kdisp_write_gfx_char_half(const GFXfont *const *fonts, uint8_t num
     const int16_t  xo = (int16_t)(int8_t)pgm_read_byte(&glyph->xOffset);
     const int16_t  yo = (int16_t)(int8_t)pgm_read_byte(&glyph->yOffset);
     const int16_t  yadj = (int16_t)pgm_read_byte(&font->yAdvance) - (int16_t)pgm_read_byte(&fonts[0]->yAdvance);
-    const int16_t  gx0 = (int16_t)(x + half_floor(xo));
-    const int16_t  gy0 = (int16_t)(y + half_floor((int16_t)(yadj + yo)));
+    const int16_t  gx0 = (int16_t)(x + glyph_half_floor(xo));
+    const int16_t  gy0 = (int16_t)(y + glyph_half_floor((int16_t)(yadj + yo)));
     const int16_t  hw = (int16_t)((w + 1) / 2), hh = (int16_t)((h + 1) / 2);
     const uint8_t  cb = glyph_col_bytes((uint8_t)h);
     for (int16_t dy = 0; dy < hh; ++dy) {
@@ -902,121 +838,11 @@ void kdisp_write_gfx_text_cy(const GFXfont *const *fonts, uint8_t num_fonts, int
 
 void kdisp_gfx_text_bbox(const GFXfont *const *fonts, uint8_t num_fonts, const uint32_t *text,
                          int8_t *out_xmin, int8_t *out_xmax, int8_t *out_ymin, int8_t *out_ymax) {
-    // Cursor relative to the draw origin: x from 0, y from the baseline (0). Mirrors
-    // every cursor rule of kdisp_write_gfx_text_cy, including the vertical controls,
-    // so the measured box matches what would actually be drawn — both axes.
-    int16_t x = 0, y = 0;
-    int16_t xmn = 127, xmx = -128, ymn = 127, ymx = -128;
-    const int16_t base_yadv = pgm_read_byte(&fonts[0]->yAdvance);
-    bool small = false;
-    // HINT_MID (\x16) swaps the font array for the rest of the run, exactly as the
-    // draw does — and, exactly as the draw does, PER GLYPH: the mid face is
-    // ASCII-only and anything outside it falls back to the caller's pool. The
-    // baseline reference has to follow that per-glyph choice, because the draw
-    // aligns by `font->yAdvance - fonts[0]->yAdvance` and fonts[0] is the mid face
-    // only for the glyphs the mid face supplied. Using one base for the whole run
-    // would report every fallback glyph shifted by the difference between the faces.
-    bool mid   = false;
-    while (*text != 0) {
-        switch (*text) {
-            case U'\x05':                     y += 2; break; // down 2px
-            case U'\f':                       y = y > 1 ? y - 2 : 0; break; // up 2px
-            case U'\v':                       y += ((y) / 15 + 1) * 15; break;
-            case U'\x18':                     x = 0; y = 0; break; // cancel -> origin
-            case U'\r':                       x = 0; break;
-            case U'\b':                       x = x > 1 ? x - 2 : 0; break;
-            case U'\x06':                     x += 2; break; // nudge right 2px
-            case U'\t':                       x += ((x) / 36 + 1) * 36; break;
-            case U'\n':                       y += base_yadv; x = 0; break;
-            // ---- the hint display-list ops, mirrored so their ARGUMENT codepoints are
-            //      not measured as glyphs. Without this each op byte and each argument
-            //      falls into `default:`, matches no font and is substituted with '!',
-            //      so a legend carrying one MOVE measured three bogus glyphs.
-            //      \x0E is an ABSOLUTE buffer position, which this relative-to-origin
-            //      measurement cannot resolve; skipping it is strictly better than
-            //      measuring '!', but a MOVE'd legend's box still only covers the part
-            //      of it that is laid out relatively.
-            case U'\x10':                    small = true; break;   // SMALL: rest of the run is half-scale
-            case U'\x16':                                            // MID: rest of the run is the 19px UI face
-                mid = true;                                          //   (per glyph — see the fallback below)
-                break;
-            case U'\x0F':                                           // HALF / THIN composite a glyph at the
-            case U'\x11': if (text[1]) text += 1; break;            //   cursor and do not advance
-            case U'\x15': if (text[1] && text[2]) text += 2; break;            // ROT (angle, glyph)
-            case U'\x0E':   // MOVE (x,y): the cursor lands on an ABSOLUTE buffer position, which
-                             //   this relative-to-origin measurement cannot resolve — so the move
-                             //   itself is ignored and a MOVE'd legend's box covers only the part
-                             //   laid out relatively. Its two ARGUMENTS are still skipped.
-                             //
-                             //   ⚠️ They MUST be, and this used to fall through to \x14 and skip
-                             //   nothing. A coordinate is an arbitrary byte, so it lands in this
-                             //   very switch on the next iteration: 13 of the 31 HINT_POS_* /
-                             //   HINT_SZ_* / MTB_* macros carry a byte that is also an op
-                             //   (HINT_SZ_STOPSQ is 15,15 = \x0F \x0F, i.e. HALF HALF). Before,
-                             //   that mis-measured a glyph; once \x15/\x16 existed it could
-                             //   silently latch a font for the rest of the run or eat two real
-                             //   codepoints. Skipping the arguments closes the whole class,
-                             //   including for any op added later.
-                if (text[1] && text[2]) text += 2;
-                break;
-            case U'\x14':                    /* ERASE: a mode, no extent */ break;
-            case U'\x13': if (text[1] && text[2] && text[3]) text += 3; break;  // BADGE (w,h,style)
-            case U'\x12': if (text[1] && text[2]) text += 2; break;             // FRAME (w,h)
-            default: {
-                // Locate the font whose [first,last] contains the codepoint (linear
-                // scan; this is a cold measuring path, no MRU cache needed).
-                uint32_t ch = *text, first = 0, last = 0;
-                // Mirror the draw's per-glyph fallback: MID applies only to codepoints
-                // the mid face actually has.
-                const bool            use_mid = mid && kdisp_gfx_glyph(s_mid_font, 1, *text) != NULL;
-                const GFXfont *const *pool = use_mid ? s_mid_font : fonts;
-                const uint8_t         cnt  = use_mid ? 1u : num_fonts;
-                const GFXfont *f = 0;
-                for (uint8_t i = 0; i < cnt; ++i) {
-                    first = pgm_read_dword(&pool[i]->first);
-                    last  = pgm_read_dword(&pool[i]->last);
-                    if (ch >= first && ch <= last) { f = pool[i]; break; }
-                }
-                if (!f) { f = pool[0]; first = pgm_read_dword(&f->first); ch = U'!'; }
-                const GFXglyph *g = pgm_read_glyph_ptr(f, ch - first);
-                int8_t w  = pgm_read_byte(&g->width);
-                int8_t h  = pgm_read_byte(&g->height);
-                int8_t xo = pgm_read_byte(&g->xOffset);
-                int8_t yo = pgm_read_byte(&g->yOffset);
-                if (w > 0 && h > 0) {
-                    // In a SMALL run mirror kdisp_write_gfx_char_half instead of
-                    // kdisp_write_gfx_char — halved extents and offsets with the same
-                    // floor rounding — so the measured box still matches the pixels.
-                    int16_t gx = small ? half_floor((int16_t)xo) : (int16_t)xo;
-                    int16_t gw = small ? (int16_t)((w + 1) / 2) : (int16_t)w;
-                    int16_t gh = small ? (int16_t)((h + 1) / 2) : (int16_t)h;
-                    int16_t l = x + gx, r = x + gx + gw - 1;
-                    if (l < xmn) xmn = l;
-                    if (r > xmx) xmx = r;
-                    // kdisp_write_gfx_char shifts each glyph by (font yAdvance - fonts[0]
-                    // yAdvance) before applying yOffset; mirror it so the vertical box
-                    // matches the rasterised pixels.
-                    int16_t yadj = (int16_t)pgm_read_byte(&f->yAdvance) -
-                                   (use_mid ? (int16_t)pgm_read_byte(&s_mid_font[0]->yAdvance) : base_yadv);
-                    int16_t gy = small ? half_floor((int16_t)(yadj + yo)) : (int16_t)(yadj + yo);
-                    int16_t t = y + gy, b = t + gh - 1;
-                    if (t < ymn) ymn = t;
-                    if (b > ymx) ymx = b;
-                }
-                {
-                    int16_t adv = (int16_t)pgm_read_byte(&g->xAdvance);
-                    x += small ? (int16_t)((adv + 1) / 2) : adv;
-                }
-                break;
-            }
-        }
-        text++;
-    }
-    if (xmx < xmn) { xmn = 0; xmx = 0; ymn = 0; ymx = 0; }   // empty / whitespace-only
-    *out_xmin = (int8_t)xmn;
-    *out_xmax = (int8_t)xmx;
-    *out_ymin = (int8_t)ymn;
-    *out_ymax = (int8_t)ymx;
+    // The interpreter itself is pure and lives in base/font_lookup.c
+    // (kdisp_gfx_text_bbox_in, unit-tested on the host); this wrapper binds the
+    // firmware's resident HINT_MID face — the same s_mid_font the draw uses — so
+    // the measurement and the draw cannot disagree about which face \x16 reaches.
+    kdisp_gfx_text_bbox_in(fonts, num_fonts, s_mid_font, 1, text, out_xmin, out_xmax, out_ymin, out_ymax);
 }
 
 void kdisp_gfx_text_bounds(const GFXfont *const *fonts, uint8_t num_fonts, const uint32_t *text, int8_t *out_min, int8_t *out_max) {

--- a/keyboards/polykybd/base/disp_array.h
+++ b/keyboards/polykybd/base/disp_array.h
@@ -4,6 +4,11 @@
 #pragma once
 
 #include "fonts/gfxfont.h"
+// The pure lookup + measurement half (kdisp_gfx_glyph / kdisp_gfx_glyph_font /
+// kdisp_gfx_text_bbox_in) lives in font_lookup.h so it links on the host without
+// the SPI/display plumbing; re-exported here so consumers are unchanged (the same
+// pattern as split_sync.h re-exporting base/sync_ack.h).
+#include "font_lookup.h"
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -38,15 +43,8 @@ void kdisp_set_gfx_scanline(bool scanline);
 // the fine scanline looks like flicker. Restore to false after the draw.
 void kdisp_set_gfx_scanline2(bool scanline);
 
-// Glyph for codepoint `c` in a font set, or NULL if no font covers it (skips
-// empty gap glyphs, no '!' fallback). For coverage tests + metric reads.
-const GFXglyph *kdisp_gfx_glyph(const GFXfont *const *fonts, uint8_t num_fonts, uint32_t c);
-
-// As above, but also writes the owning font to *out_font (or NULL when not
-// found / out_font is NULL) — lets a caller redraw a glyph through a single-font
-// array to avoid kdisp_write_gfx_char's baseline-align-to-fonts[0] shift.
-const GFXglyph *kdisp_gfx_glyph_font(const GFXfont *const *fonts, uint8_t num_fonts, uint32_t c,
-                                     const GFXfont **out_font);
+// kdisp_gfx_glyph / kdisp_gfx_glyph_font (glyph lookup, NULL when uncovered, gap
+// glyphs skipped) are declared in font_lookup.h, included above.
 
 // Composite a glyph downsampled 2x (2x2-OR) with its top-left at buffer coords
 // (x,y) — no baseline align, (x,y) is the literal top-left. OR-combining each 2x2
@@ -98,6 +96,8 @@ void kdisp_gfx_text_bounds(const GFXfont *const *fonts, uint8_t num_fonts, const
 // x, y from the baseline), mirroring every cursor rule — and the per-glyph vertical
 // shift — of kdisp_write_gfx_text_cy. Lets a caller clamp a draw offset so the
 // glyph stays fully on-screen (idle anti-burn-in jitter). All four are 0 for blank text.
+// A wrapper over font_lookup.h's kdisp_gfx_text_bbox_in binding the firmware's
+// resident HINT_MID face (the same s_mid_font the draw uses).
 void kdisp_gfx_text_bbox(const GFXfont *const *fonts, uint8_t num_fonts, const uint32_t *text,
                          int8_t *out_xmin, int8_t *out_xmax, int8_t *out_ymin, int8_t *out_ymax);
 

--- a/keyboards/polykybd/base/font_lookup.c
+++ b/keyboards/polykybd/base/font_lookup.c
@@ -1,0 +1,149 @@
+// Copyright 2025 thpoll83
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Pure font lookup + the display-list-aware bounding-box interpreter, moved
+// verbatim out of disp_array.c so they link on the host without the SPI/display
+// plumbing. See font_lookup.h for the contract; the tests live in
+// base/tests/font_bbox_tests.cpp (make test:polykybd_font_bbox).
+
+#include "font_lookup.h"
+
+const GFXglyph *kdisp_gfx_glyph_font(const GFXfont *const *fonts, uint8_t num_fonts, uint32_t ch,
+                                     const GFXfont **out_font) {
+    for (uint8_t idx = 0; idx < num_fonts; ++idx) {
+        const GFXfont *f = fonts[idx];
+        uint32_t first = pgm_read_dword(&f->first);
+        uint32_t last  = pgm_read_dword(&f->last);
+        if (ch >= first && ch <= last) {
+            const GFXglyph *gg = pgm_read_glyph_ptr(f, ch - first);
+            if (pgm_read_byte(&gg->width) == 0 && pgm_read_byte(&gg->height) == 0 &&
+                pgm_read_byte(&gg->xAdvance) == 0) {
+                continue;  // non-contiguous-range padding; a later font may have it
+            }
+            if (out_font) *out_font = f;
+            return gg;
+        }
+    }
+    if (out_font) *out_font = NULL;
+    return NULL;
+}
+
+void kdisp_gfx_text_bbox_in(const GFXfont *const *fonts, uint8_t num_fonts,
+                            const GFXfont *const *mid_font, uint8_t mid_count, const uint32_t *text,
+                            int8_t *out_xmin, int8_t *out_xmax, int8_t *out_ymin, int8_t *out_ymax) {
+    // Cursor relative to the draw origin: x from 0, y from the baseline (0). Mirrors
+    // every cursor rule of kdisp_write_gfx_text_cy, including the vertical controls,
+    // so the measured box matches what would actually be drawn — both axes.
+    int16_t x = 0, y = 0;
+    int16_t xmn = 127, xmx = -128, ymn = 127, ymx = -128;
+    const int16_t base_yadv = pgm_read_byte(&fonts[0]->yAdvance);
+    bool small = false;
+    // HINT_MID (\x16) swaps the font array for the rest of the run, exactly as the
+    // draw does — and, exactly as the draw does, PER GLYPH: the mid face is
+    // ASCII-only and anything outside it falls back to the caller's pool. The
+    // baseline reference has to follow that per-glyph choice, because the draw
+    // aligns by `font->yAdvance - fonts[0]->yAdvance` and fonts[0] is the mid face
+    // only for the glyphs the mid face supplied. Using one base for the whole run
+    // would report every fallback glyph shifted by the difference between the faces.
+    bool mid   = false;
+    while (*text != 0) {
+        switch (*text) {
+            case U'\x05':                     y += 2; break; // down 2px
+            case U'\f':                       y = y > 1 ? y - 2 : 0; break; // up 2px
+            case U'\v':                       y += ((y) / 15 + 1) * 15; break;
+            case U'\x18':                     x = 0; y = 0; break; // cancel -> origin
+            case U'\r':                       x = 0; break;
+            case U'\b':                       x = x > 1 ? x - 2 : 0; break;
+            case U'\x06':                     x += 2; break; // nudge right 2px
+            case U'\t':                       x += ((x) / 36 + 1) * 36; break;
+            case U'\n':                       y += base_yadv; x = 0; break;
+            // ---- the hint display-list ops, mirrored so their ARGUMENT codepoints are
+            //      not measured as glyphs. Without this each op byte and each argument
+            //      falls into `default:`, matches no font and is substituted with '!',
+            //      so a legend carrying one MOVE measured three bogus glyphs.
+            //      \x0E is an ABSOLUTE buffer position, which this relative-to-origin
+            //      measurement cannot resolve; skipping it is strictly better than
+            //      measuring '!', but a MOVE'd legend's box still only covers the part
+            //      of it that is laid out relatively.
+            case U'\x10':                    small = true; break;   // SMALL: rest of the run is half-scale
+            case U'\x16':                                            // MID: rest of the run is the 19px UI face
+                mid = true;                                          //   (per glyph — see the fallback below)
+                break;
+            case U'\x0F':                                           // HALF / THIN composite a glyph at the
+            case U'\x11': if (text[1]) text += 1; break;            //   cursor and do not advance
+            case U'\x15': if (text[1] && text[2]) text += 2; break;            // ROT (angle, glyph)
+            case U'\x0E':   // MOVE (x,y): the cursor lands on an ABSOLUTE buffer position, which
+                             //   this relative-to-origin measurement cannot resolve — so the move
+                             //   itself is ignored and a MOVE'd legend's box covers only the part
+                             //   laid out relatively. Its two ARGUMENTS are still skipped.
+                             //
+                             //   ⚠️ They MUST be, and this used to fall through to \x14 and skip
+                             //   nothing. A coordinate is an arbitrary byte, so it lands in this
+                             //   very switch on the next iteration: 13 of the 31 HINT_POS_* /
+                             //   HINT_SZ_* / MTB_* macros carry a byte that is also an op
+                             //   (HINT_SZ_STOPSQ is 15,15 = \x0F \x0F, i.e. HALF HALF). Before,
+                             //   that mis-measured a glyph; once \x15/\x16 existed it could
+                             //   silently latch a font for the rest of the run or eat two real
+                             //   codepoints. Skipping the arguments closes the whole class,
+                             //   including for any op added later.
+                if (text[1] && text[2]) text += 2;
+                break;
+            case U'\x14':                    /* ERASE: a mode, no extent */ break;
+            case U'\x13': if (text[1] && text[2] && text[3]) text += 3; break;  // BADGE (w,h,style)
+            case U'\x12': if (text[1] && text[2]) text += 2; break;             // FRAME (w,h)
+            default: {
+                // Locate the font whose [first,last] contains the codepoint (linear
+                // scan; this is a cold measuring path, no MRU cache needed).
+                uint32_t ch = *text, first = 0, last = 0;
+                // Mirror the draw's per-glyph fallback: MID applies only to codepoints
+                // the mid face actually has.
+                const bool            use_mid = mid && kdisp_gfx_glyph(mid_font, mid_count, *text) != NULL;
+                const GFXfont *const *pool = use_mid ? mid_font : fonts;
+                const uint8_t         cnt  = use_mid ? mid_count : num_fonts;
+                const GFXfont *f = 0;
+                for (uint8_t i = 0; i < cnt; ++i) {
+                    first = pgm_read_dword(&pool[i]->first);
+                    last  = pgm_read_dword(&pool[i]->last);
+                    if (ch >= first && ch <= last) { f = pool[i]; break; }
+                }
+                if (!f) { f = pool[0]; first = pgm_read_dword(&f->first); ch = U'!'; }
+                const GFXglyph *g = pgm_read_glyph_ptr(f, ch - first);
+                int8_t w  = pgm_read_byte(&g->width);
+                int8_t h  = pgm_read_byte(&g->height);
+                int8_t xo = pgm_read_byte(&g->xOffset);
+                int8_t yo = pgm_read_byte(&g->yOffset);
+                if (w > 0 && h > 0) {
+                    // In a SMALL run mirror kdisp_write_gfx_char_half instead of
+                    // kdisp_write_gfx_char — halved extents and offsets with the same
+                    // floor rounding — so the measured box still matches the pixels.
+                    int16_t gx = small ? glyph_half_floor((int16_t)xo) : (int16_t)xo;
+                    int16_t gw = small ? (int16_t)((w + 1) / 2) : (int16_t)w;
+                    int16_t gh = small ? (int16_t)((h + 1) / 2) : (int16_t)h;
+                    int16_t l = x + gx, r = x + gx + gw - 1;
+                    if (l < xmn) xmn = l;
+                    if (r > xmx) xmx = r;
+                    // kdisp_write_gfx_char shifts each glyph by (font yAdvance - fonts[0]
+                    // yAdvance) before applying yOffset; mirror it so the vertical box
+                    // matches the rasterised pixels.
+                    int16_t yadj = (int16_t)pgm_read_byte(&f->yAdvance) -
+                                   (use_mid ? (int16_t)pgm_read_byte(&mid_font[0]->yAdvance) : base_yadv);
+                    int16_t gy = small ? glyph_half_floor((int16_t)(yadj + yo)) : (int16_t)(yadj + yo);
+                    int16_t t = y + gy, b = t + gh - 1;
+                    if (t < ymn) ymn = t;
+                    if (b > ymx) ymx = b;
+                }
+                {
+                    int16_t adv = (int16_t)pgm_read_byte(&g->xAdvance);
+                    x += small ? (int16_t)((adv + 1) / 2) : adv;
+                }
+                break;
+            }
+        }
+        text++;
+    }
+    if (xmx < xmn) { xmn = 0; xmx = 0; ymn = 0; ymx = 0; }   // empty / whitespace-only
+    *out_xmin = (int8_t)xmn;
+    *out_xmax = (int8_t)xmx;
+    *out_ymin = (int8_t)ymn;
+    *out_ymax = (int8_t)ymx;
+}

--- a/keyboards/polykybd/base/font_lookup.h
+++ b/keyboards/polykybd/base/font_lookup.h
@@ -22,28 +22,16 @@
 #    include "progmem.h"
 #endif
 
+// The Adafruit-GFX originals carried an #ifdef __AVR__ pointer-punning branch
+// here; this firmware only ever targets the RP2040 (and the host test harness),
+// where program memory is addressed like any other, so the accessors are the
+// plain reads the non-AVR branch always compiled to.
 static inline GFXglyph *pgm_read_glyph_ptr(const GFXfont *font, uint32_t c) {
-#ifdef __AVR__
-    return &(((GFXglyph *)pgm_read_pointer(&font->glyph))[c]);
-#else
-    // expression in __AVR__ section may generate "dereferencing type-punned
-    // pointer will break strict-aliasing rules" warning In fact, on other
-    // platforms (such as STM32) there is no need to do this pointer magic as
-    // program memory may be read in a usual way So expression may be simplified
     return font->glyph + c;
-#endif  //__AVR__
 }
 
 static inline uint8_t *pgm_read_bitmap_ptr(const GFXfont *font) {
-#ifdef __AVR__
-    return (uint8_t *)pgm_read_pointer(&font->bitmap);
-#else
-    // expression in __AVR__ section generates "dereferencing type-punned pointer
-    // will break strict-aliasing rules" warning In fact, on other platforms (such
-    // as STM32) there is no need to do this pointer magic as program memory may
-    // be read in a usual way So expression may be simplified
     return font->bitmap;
-#endif  //__AVR__
 }
 
 // Floor division by two. Glyph offsets are negative (above the baseline) and C

--- a/keyboards/polykybd/base/font_lookup.h
+++ b/keyboards/polykybd/base/font_lookup.h
@@ -1,0 +1,82 @@
+// Pure font lookup + legend measurement — no display, no SPI, no quantum.h.
+//
+// Extracted from disp_array.c so the glyph resolver and the display-list-aware
+// bounding-box interpreter can be unit-tested on the host (the same seam as
+// fw_up_verdict / macro_decode / legend_plan: the arithmetic here is the part
+// with a bug history — the '!' substitution, the op-argument skipping, the
+// per-glyph MID fallback — and it was only reachable through the SPI driver).
+//
+// disp_array.h re-exports this header, so every existing consumer of
+// kdisp_gfx_glyph / kdisp_gfx_glyph_font / kdisp_gfx_text_bbox is unchanged.
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "fonts/gfxfont.h"
+
+// Host-built tests have no AVR/ARM progmem macros; QMK's progmem.h maps the
+// accessors to plain reads there. Firmware builds get them from quantum.h before
+// this header is reached (same pattern as glyph_meta.h).
+#ifndef pgm_read_byte
+#    include "progmem.h"
+#endif
+
+static inline GFXglyph *pgm_read_glyph_ptr(const GFXfont *font, uint32_t c) {
+#ifdef __AVR__
+    return &(((GFXglyph *)pgm_read_pointer(&font->glyph))[c]);
+#else
+    // expression in __AVR__ section may generate "dereferencing type-punned
+    // pointer will break strict-aliasing rules" warning In fact, on other
+    // platforms (such as STM32) there is no need to do this pointer magic as
+    // program memory may be read in a usual way So expression may be simplified
+    return font->glyph + c;
+#endif  //__AVR__
+}
+
+static inline uint8_t *pgm_read_bitmap_ptr(const GFXfont *font) {
+#ifdef __AVR__
+    return (uint8_t *)pgm_read_pointer(&font->bitmap);
+#else
+    // expression in __AVR__ section generates "dereferencing type-punned pointer
+    // will break strict-aliasing rules" warning In fact, on other platforms (such
+    // as STM32) there is no need to do this pointer magic as program memory may
+    // be read in a usual way So expression may be simplified
+    return font->bitmap;
+#endif  //__AVR__
+}
+
+// Floor division by two. Glyph offsets are negative (above the baseline) and C
+// truncates toward zero, which would round those the wrong way and put a lowercase
+// glyph 1px off its run's baseline. Written out rather than `>> 1` because a right
+// shift of a negative value is only arithmetic by implementation guarantee.
+static inline int16_t glyph_half_floor(int16_t v) {
+    return (int16_t)((v >= 0) ? (v / 2) : -((int16_t)(((-v) + 1) / 2)));
+}
+
+// Locate the glyph for codepoint `ch` in a font set, scanning front-to-back and
+// skipping empty (0x0) gap glyphs, exactly like the renderer's own lookup.
+// Returns NULL when no font actually covers `ch` (no '!' fallback) — callers use
+// this both to test coverage and to read glyph metrics. When out_font != NULL it
+// also reports the font that owns the glyph, in the same scan — that is what the
+// single-font baseline paths need (kdisp_write_gfx_char baseline-aligns every
+// glyph to fonts[0]->yAdvance, so drawing a pack glyph through its owning font
+// alone makes that adjustment zero; see the language-flag notes).
+const GFXglyph *kdisp_gfx_glyph_font(const GFXfont *const *fonts, uint8_t num_fonts, uint32_t ch, const GFXfont **out_font);
+
+static inline const GFXglyph *kdisp_gfx_glyph(const GFXfont *const *fonts, uint8_t num_fonts, uint32_t ch) {
+    return kdisp_gfx_glyph_font(fonts, num_fonts, ch, NULL);
+}
+
+// The display-list-aware bounding box with the HINT_MID face pool passed
+// explicitly. mid_font/mid_count name the single-font array \x16 switches the
+// measurement to (PER GLYPH, falling back to the caller's pool — the
+// word-over-icon case); pass NULL/0 to measure with no mid face available, in
+// which case every \x16 glyph falls back. disp_array.c's kdisp_gfx_text_bbox is
+// a thin wrapper binding the firmware's resident mid face.
+//
+// Mirrors the draw's cursor rules, op-argument consumption and per-glyph
+// yAdvance baseline shift; a MOVE (\x0E) names an ABSOLUTE buffer position
+// unknowable at measure time, so its arguments are consumed and the reposition
+// itself is ignored. Empty / whitespace-only input reports all-zero.
+void kdisp_gfx_text_bbox_in(const GFXfont *const *fonts, uint8_t num_fonts, const GFXfont *const *mid_font, uint8_t mid_count, const uint32_t *text, int8_t *out_xmin, int8_t *out_xmax, int8_t *out_ymin, int8_t *out_ymax);

--- a/keyboards/polykybd/base/tests/font_bbox_tests.cpp
+++ b/keyboards/polykybd/base/tests/font_bbox_tests.cpp
@@ -1,0 +1,372 @@
+// Copyright 2026 thpoll83
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Host-side tests for base/font_lookup.c — the glyph resolver and the
+// display-list-aware bounding-box interpreter (kdisp_gfx_text_bbox_in).
+//
+// The interpreter's whole bug history is measurement arithmetic that nothing
+// could reach through the SPI driver: the '!' substitution measuring op
+// ARGUMENTS as glyphs, MOVE (\x0E) skipping no arguments so a coordinate byte
+// that is also an op byte latched a font for the rest of the run
+// (HINT_SZ_STOPSQ is (15,15) = HALF HALF), the SMALL halving rounding a
+// negative offset toward zero instead of flooring, and the MID fallback using
+// one baseline reference for the whole run instead of per glyph. Every one of
+// those is pinned here against synthetic fonts whose metrics are written out
+// by hand.
+
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "font_lookup.h"
+}
+
+#include <vector>
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Synthetic fonts. Bitmap contents are irrelevant to the bbox (it reads only
+// metrics), so every font shares one dummy bitmap byte.
+
+uint8_t g_dummy_bitmap[1] = {0};
+
+struct TestFont {
+    std::vector<GFXglyph> glyphs;
+    GFXfont               font;
+
+    TestFont(uint32_t first, uint32_t last, int8_t yadv) {
+        glyphs.resize(last - first + 1, GFXglyph{0, 0, 0, 0, 0, 0});
+        font.bitmap   = g_dummy_bitmap;
+        font.glyph    = glyphs.data();
+        font.first    = first;
+        font.last     = last;
+        font.yAdvance = yadv;
+    }
+    void set(uint32_t cp, int8_t w, int8_t h, int8_t adv, int8_t xo, int8_t yo) {
+        glyphs[cp - font.first] = GFXglyph{0, w, h, adv, xo, yo};
+    }
+};
+
+// The caller's pool font (stands in for the resident keycap face, yAdvance 40).
+//   space: zero-extent, advance-only — what makes whitespace-only report zeros.
+//   '!':   deliberately DISTINCT metrics so the missing-glyph substitution is
+//          visible in the box, not just presumed.
+//   'a':   the ordinary glyph most expectations are computed from.
+//   'b':   ODD negative offsets — the floor-vs-truncate discriminator for SMALL.
+TestFont make_base() {
+    TestFont f(0x20, 0x7A, 40);
+    f.set(' ', 0, 0, 9, 0, 0);
+    f.set('!', 2, 12, 4, 0, -12);
+    for (uint32_t cp = 'a'; cp <= 'z'; ++cp) f.set(cp, 6, 10, 8, 1, -10);
+    f.set('b', 5, 9, 7, 3, -9);
+    // 'w'/'h'/'x'/'y' keep the ordinary 'a' metrics (set in the loop above);
+    // the truncated-op tests measure them as glyphs.
+    return f;
+}
+
+// A second, TALLER face in the pool (stands in for a pack font, yAdvance 54):
+// drawn through a multi-font array its glyphs shift by 54-40 = +14, through a
+// single-font array by 0 — the documented baseline-align rule.
+TestFont make_tall() {
+    TestFont f(0xE000, 0xE00F, 54);
+    for (uint32_t cp = 0xE000; cp <= 0xE00F; ++cp) f.set(cp, 20, 30, 22, 2, -28);
+    return f;
+}
+
+// The HINT_MID face (stands in for the 19px _Mid_ UI face, ASCII-only).
+TestFont make_mid() {
+    TestFont f(0x20, 0x7E, 26);
+    f.set(' ', 0, 0, 5, 0, 0);
+    for (uint32_t cp = '!'; cp <= 0x7E; ++cp) f.set(cp, 4, 7, 5, 0, -7);
+    return f;
+}
+
+// A font with a GAP record mid-range (the generated headers' padding for
+// non-contiguous ranges) plus a second font really covering the gapped cp.
+TestFont make_gappy() {
+    TestFont f(0x100, 0x10F, 40);
+    for (uint32_t cp = 0x100; cp <= 0x10F; ++cp) f.set(cp, 3, 5, 4, 0, -5);
+    f.set(0x105, 0, 0, 0, 0, 0);   // gap: w == h == xAdvance == 0
+    return f;
+}
+
+TestFont make_gap_filler() {
+    TestFont f(0x100, 0x10F, 44);
+    f.set(0x105, 7, 8, 9, 1, -8);
+    return f;
+}
+
+struct Box {
+    int8_t xmin, xmax, ymin, ymax;
+    bool   operator==(const Box &o) const {
+        return xmin == o.xmin && xmax == o.xmax && ymin == o.ymin && ymax == o.ymax;
+    }
+};
+
+std::ostream &operator<<(std::ostream &os, const Box &b) {
+    return os << "x[" << int(b.xmin) << ".." << int(b.xmax) << "] y[" << int(b.ymin) << ".." << int(b.ymax) << "]";
+}
+
+class FontBboxTest : public ::testing::Test {
+   protected:
+    TestFont base_ = make_base();
+    TestFont tall_ = make_tall();
+    TestFont mid_  = make_mid();
+
+    const GFXfont *pool_[2]  = {&base_.font, &tall_.font};
+    const GFXfont *midarr_[1] = {&mid_.font};
+
+    Box measure(std::initializer_list<uint32_t> cps, const GFXfont *const *mid = nullptr, uint8_t mid_count = 0) {
+        std::vector<uint32_t> text(cps);
+        text.push_back(0);
+        Box b{};
+        kdisp_gfx_text_bbox_in(pool_, 2, mid, mid_count, text.data(), &b.xmin, &b.xmax, &b.ymin, &b.ymax);
+        return b;
+    }
+    Box measure_mid(std::initializer_list<uint32_t> cps) {
+        return measure(cps, midarr_, 1);
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Plain glyph arithmetic
+
+TEST_F(FontBboxTest, SingleGlyphBoxMatchesItsMetrics) {
+    // 'a': xOffset 1 + width 6, yOffset -10 + height 10, own-font yadj 0.
+    EXPECT_EQ(measure({'a'}), (Box{1, 6, -10, -1}));
+}
+
+TEST_F(FontBboxTest, AdvanceAccumulatesAcrossGlyphs) {
+    // second 'a' starts at x = 8 (the advance), so its right edge is 8+1+6-1.
+    EXPECT_EQ(measure({'a', 'a'}), (Box{1, 14, -10, -1}));
+}
+
+TEST_F(FontBboxTest, EmptyAndWhitespaceOnlyReportAllZero) {
+    EXPECT_EQ(measure({}), (Box{0, 0, 0, 0}));
+    // space is advance-only (w == h == 0), so nothing sets the box.
+    EXPECT_EQ(measure({' ', ' '}), (Box{0, 0, 0, 0}));
+}
+
+TEST_F(FontBboxTest, LeadingSpaceAdvancesWithoutInk) {
+    EXPECT_EQ(measure({' ', 'a'}), (Box{10, 15, -10, -1}));
+}
+
+TEST_F(FontBboxTest, MissingGlyphIsMeasuredAsBang) {
+    // 0x4000 is in no pool font; the fallback substitutes '!' from fonts[0],
+    // whose metrics are deliberately distinct from every letter's.
+    EXPECT_EQ(measure({0x4000}), measure({'!'}));
+    EXPECT_EQ(measure({'!'}), (Box{0, 1, -12, -1}));
+}
+
+// ---------------------------------------------------------------------------
+// The per-glyph yAdvance baseline shift (the language-flag regression rule)
+
+TEST_F(FontBboxTest, TallerFontShiftsByYAdvanceDifferenceInAMultiFontPool) {
+    // tall glyph: yadj = 54-40 = +14, so top = 14-28 = -14, bottom = -14+30-1.
+    EXPECT_EQ(measure({0xE000}), (Box{2, 21, -14, 15}));
+}
+
+TEST_F(FontBboxTest, SingleFontArrayZeroesTheBaselineShift) {
+    const GFXfont *only_tall[1] = {&tall_.font};
+    const uint32_t text[]       = {0xE000, 0};
+    Box            b{};
+    kdisp_gfx_text_bbox_in(only_tall, 1, nullptr, 0, text, &b.xmin, &b.xmax, &b.ymin, &b.ymax);
+    // own font is fonts[0], adjustment 0: top = -28, bottom = 1.
+    EXPECT_EQ(b, (Box{2, 21, -28, 1}));
+}
+
+TEST_F(FontBboxTest, MixedRunUnionsBothFontsBoxes) {
+    // 'a' then the tall glyph at x = 8: x right = 8+2+20-1 = 29.
+    EXPECT_EQ(measure({'a', 0xE000}), (Box{1, 29, -14, 15}));
+}
+
+// ---------------------------------------------------------------------------
+// Cursor ops
+
+TEST_F(FontBboxTest, VerticalNudgesMoveTheBaseline) {
+    EXPECT_EQ(measure({0x05, 'a'}), (Box{1, 6, -8, 1}));            // down 2
+    EXPECT_EQ(measure({'\f', 'a'}), measure({'a'}));                // up 2 saturates at 0
+    EXPECT_EQ(measure({0x05, 0x05, '\f', 'a'}), (Box{1, 6, -8, 1})); // 4 down, 2 back up
+}
+
+TEST_F(FontBboxTest, HorizontalNudgesMoveTheCursor) {
+    EXPECT_EQ(measure({0x06, 'a'}), (Box{3, 8, -10, -1}));   // right 2
+    EXPECT_EQ(measure({'\b', 'a'}), measure({'a'}));         // back 2 saturates at 0
+    EXPECT_EQ(measure({'a', '\b', 'a'}), (Box{1, 12, -10, -1})); // second at x=6
+}
+
+TEST_F(FontBboxTest, CarriageReturnRestartsXOnly) {
+    EXPECT_EQ(measure({'a', 'a', '\r', 'a'}), (Box{1, 14, -10, -1}));
+}
+
+TEST_F(FontBboxTest, TabAddsA36pxStopSizedStep) {
+    // \t is x += (x/36 + 1) * 36 — an ADDITIVE step, not a snap-to-stop: after
+    // 'a' x = 8, the tab adds 36 and the next glyph starts at 44 (the draw's
+    // rule, mirrored).
+    EXPECT_EQ(measure({'a', '\t', 'a'}), (Box{1, 50, -10, -1}));
+}
+
+TEST_F(FontBboxTest, LineFeedStepsAFixed15AndKeepsX) {
+    // \v from y=0 lands on 15: box = 15-10 .. 15-1.
+    EXPECT_EQ(measure({'\v', 'a'}), (Box{1, 6, 5, 14}));
+}
+
+TEST_F(FontBboxTest, NewlineAdvancesByFontsZeroYAdvanceAndRestartsX) {
+    // \n: y += 40, x = 0 — second 'a' spans y 30..39 at x 1..6.
+    EXPECT_EQ(measure({'a', 'a', '\n', 'a'}), (Box{1, 14, -10, 39}));
+}
+
+TEST_F(FontBboxTest, ResetReturnsTheCursorToTheOrigin) {
+    EXPECT_EQ(measure({'a', 0x05, 0x06, 0x18, 'a'}), measure({'a'}));
+}
+
+// ---------------------------------------------------------------------------
+// Display-list op argument consumption. The rule: an op's argument codepoints
+// are DATA, never glyphs and never ops — 13 of the 31 HINT_POS_*/HINT_SZ_*/
+// MTB_* macros carry an argument byte that is also an op byte.
+
+TEST_F(FontBboxTest, HalfAndThinConsumeTheirGlyphArgument) {
+    // The composited glyph does not advance and is not measured.
+    EXPECT_EQ(measure({0x0F, 'a'}), (Box{0, 0, 0, 0}));
+    EXPECT_EQ(measure({0x11, 'a'}), (Box{0, 0, 0, 0}));
+    // ...and a following real glyph measures from the unmoved cursor.
+    EXPECT_EQ(measure({0x0F, 0xE000, 'a'}), measure({'a'}));
+}
+
+TEST_F(FontBboxTest, AnArgumentThatIsAnOpByteIsStillJustAnArgument) {
+    // HINT_SZ_STOPSQ's shape: \x0F consumes the following \x0F as its argument,
+    // so the 'a' after them is an ordinary glyph.
+    EXPECT_EQ(measure({0x0F, 0x0F, 'a'}), measure({'a'}));
+}
+
+TEST_F(FontBboxTest, MoveConsumesBothCoordinates) {
+    EXPECT_EQ(measure({0x0E, 'x', 'y', 'a'}), measure({'a'}));
+}
+
+TEST_F(FontBboxTest, MoveCoordinatesThatAreOpBytesDoNotLatchAFont) {
+    // The 2026-08-26 regression class: a MOVE whose coordinates are \x16 bytes.
+    // If the arguments leak into the switch, MID latches and 'a' measures in the
+    // mid face (box x[0..3] y[-7..-1]) instead of the base face.
+    EXPECT_EQ(measure_mid({0x0E, 0x16, 0x16, 'a'}), measure({'a'}));
+}
+
+TEST_F(FontBboxTest, RotFrameAndBadgeConsumeTheirArguments) {
+    EXPECT_EQ(measure({0x15, 'r', 0xE000, 'a'}), measure({'a'}));       // ROT (angle, glyph)
+    EXPECT_EQ(measure({0x12, 'w', 'h', 'a'}), measure({'a'}));          // FRAME (w, h)
+    EXPECT_EQ(measure({0x13, 'w', 'h', 's', 'a'}), measure({'a'}));     // BADGE (w, h, style)
+}
+
+TEST_F(FontBboxTest, EraseIsAModeWithNoExtentAndNoArguments) {
+    EXPECT_EQ(measure({0x14, 'a'}), measure({'a'}));
+}
+
+TEST_F(FontBboxTest, ATruncatedOpNeverSkipsPastTheTerminator) {
+    // MOVE with only one byte before the NUL: the guard refuses the skip, the
+    // stray byte measures as a glyph, and the walk stops at the terminator
+    // instead of running past it.
+    EXPECT_EQ(measure({0x0E, 'a'}), measure({'a'}));
+    // BADGE one argument short: 'w' and 'h' measure as ordinary glyphs.
+    EXPECT_EQ(measure({0x13, 'w', 'h'}), measure({'a', 'a'}));
+}
+
+// ---------------------------------------------------------------------------
+// HINT_SMALL (\x10): halved extents/offsets with FLOOR rounding, halved
+// (round-up) advance, unhalved baseline.
+
+TEST_F(FontBboxTest, SmallHalvesExtentsOffsetsAndAdvance) {
+    // 'a' small: gx = floor(1/2) = 0, gw = (6+1)/2 = 3, gy = floor(-10/2) = -5,
+    // gh = (10+1)/2 = 5.
+    EXPECT_EQ(measure({0x10, 'a'}), (Box{0, 2, -5, -1}));
+    // advance halves round-up: second 'a' at x = (8+1)/2 = 4.
+    EXPECT_EQ(measure({0x10, 'a', 'a'}), (Box{0, 6, -5, -1}));
+}
+
+TEST_F(FontBboxTest, SmallFloorsANegativeOffsetInsteadOfTruncating) {
+    // 'b' has yOffset -9 / xOffset 3: floor gives gy -5 and gx 1; C truncation
+    // would give -4 — the 1px-off-baseline bug the floor exists to prevent.
+    EXPECT_EQ(measure({0x10, 'b'}), (Box{1, 3, -5, -1}));
+}
+
+TEST_F(FontBboxTest, SmallLatchesForTheRestOfTheRun) {
+    // No back-to-full op exists, and \x18 resets only the cursor.
+    EXPECT_EQ(measure({0x10, 'a', 0x18, 'a'}), (Box{0, 2, -5, -1}));
+}
+
+// ---------------------------------------------------------------------------
+// HINT_MID (\x16): per-glyph face switch with per-glyph baseline reference.
+
+TEST_F(FontBboxTest, MidMeasuresFromTheMidFaceWithItsOwnBaseline) {
+    // mid 'a': w 4 h 7 xo 0 yo -7, and the baseline reference is the mid face
+    // itself (yadj 0) — NOT fonts[0], which would shift it by 26-40 = -14.
+    EXPECT_EQ(measure_mid({0x16, 'a'}), (Box{0, 3, -7, -1}));
+}
+
+TEST_F(FontBboxTest, MidFallsBackPerGlyphForCodepointsOutsideTheMidFace) {
+    // 0xE000 is not ASCII: it falls back to the caller's pool and measures
+    // exactly as it would without MID — including the fonts[0] baseline shift.
+    EXPECT_EQ(measure_mid({0x16, 0xE000}), measure({0xE000}));
+}
+
+TEST_F(FontBboxTest, MidMixedRunAdvancesWithEachGlyphsOwnFace) {
+    // mid 'a' advances 5, so the tall fallback glyph starts at x = 5.
+    EXPECT_EQ(measure_mid({0x16, 'a', 0xE000}), (Box{0, 26, -14, 15}));
+}
+
+TEST_F(FontBboxTest, MidMissingEverywhereSubstitutesBangFromThePool) {
+    // 0x4000 is neither in the mid face nor the pool: '!' from fonts[0].
+    EXPECT_EQ(measure_mid({0x16, 0x4000}), measure({'!'}));
+}
+
+TEST_F(FontBboxTest, ANullMidPoolMakesEveryMidGlyphFallBack) {
+    // The wrapper always passes the resident face, but the pure function
+    // tolerates measuring with none: \x16 then changes nothing.
+    EXPECT_EQ(measure({0x16, 'a'}, nullptr, 0), measure({'a'}));
+}
+
+// ---------------------------------------------------------------------------
+// kdisp_gfx_glyph_font: the front-to-back resolver with gap skipping.
+
+TEST(FontLookupTest, GapRecordFallsThroughToTheNextFont) {
+    TestFont gappy  = make_gappy();
+    TestFont filler = make_gap_filler();
+    const GFXfont *fonts[2] = {&gappy.font, &filler.font};
+
+    const GFXfont  *owner = nullptr;
+    const GFXglyph *g     = kdisp_gfx_glyph_font(fonts, 2, 0x105, &owner);
+    ASSERT_NE(g, nullptr);
+    EXPECT_EQ(owner, &filler.font);
+    EXPECT_EQ(g->width, 7);
+}
+
+TEST(FontLookupTest, FrontFontWinsWhenItReallyCoversTheCodepoint) {
+    TestFont gappy  = make_gappy();
+    TestFont filler = make_gap_filler();
+    const GFXfont *fonts[2] = {&gappy.font, &filler.font};
+
+    const GFXfont  *owner = nullptr;
+    const GFXglyph *g     = kdisp_gfx_glyph_font(fonts, 2, 0x104, &owner);
+    ASSERT_NE(g, nullptr);
+    EXPECT_EQ(owner, &gappy.font);
+    EXPECT_EQ(g->width, 3);
+}
+
+TEST(FontLookupTest, UncoveredCodepointReturnsNullAndNullFont) {
+    TestFont gappy = make_gappy();
+    const GFXfont *fonts[1] = {&gappy.font};
+
+    const GFXfont *owner = &gappy.font;   // must be overwritten to NULL
+    EXPECT_EQ(kdisp_gfx_glyph_font(fonts, 1, 0x1F0, &owner), nullptr);
+    EXPECT_EQ(owner, nullptr);
+    EXPECT_EQ(kdisp_gfx_glyph(fonts, 0, 0x104), nullptr);   // empty pool
+}
+
+TEST(FontLookupTest, HalfFloorFloorsNegativeValues) {
+    EXPECT_EQ(glyph_half_floor(8), 4);
+    EXPECT_EQ(glyph_half_floor(9), 4);
+    EXPECT_EQ(glyph_half_floor(-8), -4);
+    EXPECT_EQ(glyph_half_floor(-9), -5);   // truncation would give -4
+    EXPECT_EQ(glyph_half_floor(0), 0);
+    EXPECT_EQ(glyph_half_floor(-1), -1);
+}
+
+}  // namespace

--- a/keyboards/polykybd/base/tests/test_rules.mk
+++ b/keyboards/polykybd/base/tests/test_rules.mk
@@ -88,3 +88,15 @@ polykybd_layer_names_SRC := \
 polykybd_layer_names_INC := \
 	$(POLY_BASE_PATH) \
 	keyboards/polykybd
+
+# font_lookup.c is the pure lookup + bounding-box half of disp_array.c — no SPI,
+# no display, no quantum.h — so it links against synthetic in-memory fonts. The
+# progmem accessors resolve through platforms/progmem.h's host mapping, the same
+# route the glyph_meta suite takes.
+polykybd_font_bbox_SRC := \
+	$(POLY_BASE_PATH)/font_lookup.c \
+	$(POLY_BASE_PATH)/tests/font_bbox_tests.cpp
+
+polykybd_font_bbox_INC := \
+	$(POLY_BASE_PATH) \
+	keyboards/polykybd

--- a/keyboards/polykybd/base/tests/testlist.mk
+++ b/keyboards/polykybd/base/tests/testlist.mk
@@ -5,3 +5,4 @@ TEST_LIST += polykybd_map_codec
 TEST_LIST += polykybd_mode_byte
 TEST_LIST += polykybd_idle_update
 TEST_LIST += polykybd_layer_names
+TEST_LIST += polykybd_font_bbox

--- a/keyboards/polykybd/rules.mk
+++ b/keyboards/polykybd/rules.mk
@@ -75,7 +75,7 @@ OS_DETECTION_ENABLE = yes
 # drift the shared keymap exists to prevent. It also gets the strict PolyKybd warning
 # flags applied below, which the per-variant base sources do not. The same argument
 # covers emoji/emoji_layer.c and hints/os_hints.c.
-POLY_SRC := poly_keymap.c layer_names.c boot_diag.c side.c state.c split_sync.c split_fw_up.c multicore_exec.c hid_com.c hid_fw_up.c hid_fontpack.c fill_overlay.c poly_util.c matrix_helper.c bridge_helper.c oled_helper.c keycode_helper.c mru.c lang_layer.c os_actions.c anim/startup_anim.c emoji/emoji_layer.c hints/os_hints.c base/fw_up_verdict.c poly_macro.c base/macro_decode.c
+POLY_SRC := poly_keymap.c layer_names.c boot_diag.c side.c state.c split_sync.c split_fw_up.c multicore_exec.c hid_com.c hid_fw_up.c hid_fontpack.c fill_overlay.c poly_util.c matrix_helper.c bridge_helper.c oled_helper.c keycode_helper.c mru.c lang_layer.c os_actions.c anim/startup_anim.c emoji/emoji_layer.c hints/os_hints.c base/fw_up_verdict.c poly_macro.c base/macro_decode.c base/font_lookup.c
 SRC += $(POLY_SRC)
 
 # emoji/emoji_layer.c is listed here, not in a keymap's rules.mk: the keyboard-level


### PR DESCRIPTION
## Summary

Item 2 of the four deferred follow-ups from the architecture review (#236): extract and test `kdisp_gfx_text_bbox()` and the display-list op interpreter — the highest-value remaining test gap in the render path.

The pure half of `disp_array.c` moves **verbatim** into `base/font_lookup.c/.h`: the front-to-back glyph resolver (`kdisp_gfx_glyph_font` / `kdisp_gfx_glyph`, with gap-record skipping), the progmem glyph/bitmap accessors, the floor-halving helper, and the display-list-aware bounding-box interpreter. The interpreter takes the HINT_MID face pool as a parameter (`kdisp_gfx_text_bbox_in`); `disp_array.c` keeps `kdisp_gfx_text_bbox` as a wrapper binding the resident `s_mid_font`, so the measurement and the draw cannot disagree about which face `\x16` reaches. `disp_array.h` re-exports `font_lookup.h` (the `sync_ack.h` pattern), so every consumer — `poly_keymap.c`, both `status_oled.c`, `oled_helper.c`, `doom_blit.c` — is unchanged.

Why this seam: the bbox feeds `plan_main_legend()`'s shift-preview layout and the idle jitter travel, and its bug history is all measurement arithmetic — op ARGUMENT codepoints measured as `'!'` glyphs, MOVE (`\x0E`) skipping no arguments so a coordinate byte that is also an op byte could latch a font for the rest of the run (`HINT_SZ_STOPSQ` is (15,15) = HALF HALF — the 2026-08-26 regression), and the SMALL halving's floor-vs-truncate rounding. None of it was reachable without the SPI driver.

**New suite `make test:polykybd_font_bbox` — 34 tests** against synthetic in-memory fonts:
- box arithmetic, advance accumulation, empty/whitespace-only → zeros, `'!'` substitution with deliberately distinct metrics so it shows in the box
- the per-glyph yAdvance baseline shift: multi-font pool (+14 for a 54-vs-40 face) vs single-font array (0) — the language-flag regression rule, pinned
- every cursor op, including the **additive** `\t`/`\v` stop rule (`x += (x/36+1)*36` — a step, not a snap; the first draft of the tab test assumed a snap and the real behaviour corrected it)
- the full op-argument consumption table: HALF/THIN (1), MOVE/ROT/FRAME (2), BADGE (3), ERASE (0); arguments that are themselves op bytes; MOVE coordinates that are `\x16` bytes must not latch MID; truncated ops stop at the terminator
- SMALL semantics: floored negative offsets (a truncating implementation is off by 1px), round-up extents and advance, the latch surviving `\x18`
- MID semantics: per-glyph face switch with per-glyph baseline reference, per-glyph fallback to the caller's pool, NULL mid pool tolerated
- the resolver: gap records falling through to the next font, front-font wins, uncovered → NULL/NULL

**Mutation-tested against 7 deliberate breaks**, each caught by the intended test: MOVE arg skip reverted, truncating `half_floor`, run-wide MID baseline reference, gap skip dropped, `'!'` fallback changed, SMALL advance unhalved, HALF/THIN argument not consumed.

Behaviour-identical by construction and by measurement: the moved code is byte-for-byte the old code (only `s_mid_font` → parameter and `half_floor` → `glyph_half_floor`), and the monolithic `POLYKYBD_DOOM=yes` flavour's `.data`/`.bss`/`.heap` are **byte-identical** (3,484 B free heap, unchanged).

## Version bump label

None — internal refactor + tests, patch bump.

## Testing
- [x] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`) — plus split42 and the monolithic `POLYKYBD_DOOM=yes` flavour
- [ ] Flashed and tested on hardware — render-path extraction is behaviour-identical (RAM byte-identical, cog byte-identical); the HIL run's display tests cover the wired-through path
- [ ] If protocol changed: host updated and tested together — no protocol change

All 10 unit suites green (151 tests, `polykybd_font_bbox` included), cog regeneration byte-identical across the 7 `run_cog.sh` files, local lint job (`qmk lint --strict` both keyboards, tracked-ignored empty, both `ci-validate-*`) and CI's exact cppcheck invocation clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8pW42ifgtNjFFVdrWPZ2m

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8pW42ifgtNjFFVdrWPZ2m)_

## Summary by Sourcery

Extract the font lookup and text bounding-box logic into a reusable base module and comprehensively test its rendering semantics without changing consumer interfaces.

Enhancements:
- Extract font lookup and display-list-aware text bounding-box measurement into a standalone, host-testable base module while preserving existing display APIs.
- Add coverage for glyph resolution, cursor controls, display-list argument handling, SMALL/MID rendering semantics, baseline alignment, fallbacks, and gap records.

Build:
- Add the font lookup module to the PolyKybd firmware source set and define its standalone test target.

Tests:
- Add a 34-test synthetic-font suite for font lookup and bounding-box behavior, including mutation-focused regression coverage.