### PR TITLE
Remove lang_lut.c's sideways include of hid_com.h

### DIFF
--- a/keyboards/polykybd/hid_com.h
+++ b/keyboards/polykybd/hid_com.h
@@ -5,8 +5,9 @@
 
 #define HID_CMD_IDX 1
 #define HID_DATA_IDX 2
-#define LANG_TO_UI32(a,b,c,d) (((uint32_t)(a))<<24 | ((uint32_t)(b))<<16 | ((uint32_t)(c))<<8 | (d))
-#define LANG_TO_UI32_ARR(arr) (((uint32_t)(arr[0]))<<24 | ((uint32_t)(arr[1]))<<16 | ((uint32_t)(arr[2]))<<8 | (arr[3]))
+// LANG_TO_UI32 / LANG_TO_UI32_ARR moved to lang/lang_lut.h — they are the
+// lang-code encoding, and keeping them here made the generated lang_lut.c
+// include the HID layer for one macro.
 
 enum legacy_command_id {
     id_get_protocol_version                 = 0x01, // always 0x01

--- a/keyboards/polykybd/lang/lang_lut.c
+++ b/keyboards/polykybd/lang/lang_lut.c
@@ -14,7 +14,6 @@
 #include "quantum.h"
 
 #include "../state.h"
-#include "../hid_com.h"
 
 static const uint32_t* lang_plane [ALPHA + NUM + ADDITIONAL][NUM_LANG * 4] = {
     /*[[[cog

--- a/keyboards/polykybd/lang/lang_lut.h
+++ b/keyboards/polykybd/lang/lang_lut.h
@@ -9,6 +9,15 @@
 #include <stdbool.h>
 #include "named_glyphs.h"
 
+// Pack a 4-char language code ("enUS") into one big-endian uint32 — the form
+// decode_lang() answers with and the HID change-language command compares
+// against. These live HERE because they are the lang-code encoding, not a HID
+// concern: they used to sit in hid_com.h, which forced this cog-generated
+// module to reach sideways into the HID layer for one macro (the include graph's
+// only upward edge out of lang/).
+#define LANG_TO_UI32(a,b,c,d) (((uint32_t)(a))<<24 | ((uint32_t)(b))<<16 | ((uint32_t)(c))<<8 | (d))
+#define LANG_TO_UI32_ARR(arr) (((uint32_t)(arr[0]))<<24 | ((uint32_t)(arr[1]))<<16 | ((uint32_t)(arr[2]))<<8 | (arr[3]))
+
 enum {ALPHA = 26, NUM = 10, ADDITIONAL = 18};
 enum variation_index{VAR_SMALL = 0, VAR_SHIFT, VAR_CAPS, VAR_ALTGR};
 enum lang_layer {


### PR DESCRIPTION
## Summary

Item 3 of the four deferred follow-ups from the architecture review (#236). `lang/lang_lut.c` — the cog-generated 160-layout language table — included `../hid_com.h` for exactly one thing: the `LANG_TO_UI32` macro its `LANGSTR_TO_UI32` table builder wraps. That was the include graph's only upward edge out of `lang/`, making the generated language tables look dependent on the HID command dispatcher.

The two macros (`LANG_TO_UI32` / `LANG_TO_UI32_ARR`) are the **lang-code encoding** — the form `decode_lang()` answers with and the change-language command (cmd 9) compares against — so they move to `lang/lang_lut.h`, where the rest of the lang-code contract lives. `hid_com.c` already includes `lang/lang_lut.h`, so its one `LANG_TO_UI32_ARR` use site needs no change; `hid_com.h` keeps a pointer comment. `lang_lut.c` drops the sideways include.

Because the touched `.c` is generated, this was verified harder than a normal include cleanup:

- **cog does not break**: `cog -r` on all 7 `run_cog.sh` files re-emits byte-identical content — the edit sits in the hand-written preamble, outside every cog block, so regeneration can never resurrect the old include.
- **The image is functionally byte-identical**: `SKIP_VERSION=yes` builds before/after have identical `text`/`data`/`bss` byte counts; the only binary diff is the linker's long-branch veneer block emitted in a permuted order (same thunk set, same set of target-address literal words, `bl` sites re-encoded to match). No function body and no data changed — the same "922 of 954 differing lines are `.word` literals" class as the `RPC_M2S_BUFFER_SIZE` measurement, and the build was confirmed deterministic first (two builds of the same tree are md5-identical).

## Version bump label

None — include-graph cleanup, patch bump.

## Testing
- [x] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`) — plus split42 and the monolithic `POLYKYBD_DOOM=yes` flavour
- [ ] Flashed and tested on hardware — image proven functionally byte-identical (see above), so there is nothing hardware could distinguish
- [ ] If protocol changed: host updated and tested together — no protocol change

All 9 unit suites green (117 tests), local lint job clean (`qmk lint --strict` both keyboards, tracked-ignored empty, both `ci-validate-*`, line endings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8pW42ifgtNjFFVdrWPZ2m

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8pW42ifgtNjFFVdrWPZ2m)_

## Summary by Sourcery

Enhancements:
- Move language-code encoding macros into the language lookup header so the generated language module no longer depends on the HID command header.