### PR TITLE
Split state.c into policy (state.c) and persistence (state_store.c)

### DIFF
--- a/keyboards/polykybd/rules.mk
+++ b/keyboards/polykybd/rules.mk
@@ -75,7 +75,7 @@ OS_DETECTION_ENABLE = yes
 # drift the shared keymap exists to prevent. It also gets the strict PolyKybd warning
 # flags applied below, which the per-variant base sources do not. The same argument
 # covers emoji/emoji_layer.c and hints/os_hints.c.
-POLY_SRC := poly_keymap.c layer_names.c boot_diag.c side.c state.c split_sync.c split_fw_up.c multicore_exec.c hid_com.c hid_fw_up.c hid_fontpack.c fill_overlay.c poly_util.c matrix_helper.c bridge_helper.c oled_helper.c keycode_helper.c mru.c lang_layer.c os_actions.c anim/startup_anim.c emoji/emoji_layer.c hints/os_hints.c base/fw_up_verdict.c poly_macro.c base/macro_decode.c
+POLY_SRC := poly_keymap.c layer_names.c boot_diag.c side.c state.c state_store.c split_sync.c split_fw_up.c multicore_exec.c hid_com.c hid_fw_up.c hid_fontpack.c fill_overlay.c poly_util.c matrix_helper.c bridge_helper.c oled_helper.c keycode_helper.c mru.c lang_layer.c os_actions.c anim/startup_anim.c emoji/emoji_layer.c hints/os_hints.c base/fw_up_verdict.c poly_macro.c base/macro_decode.c
 SRC += $(POLY_SRC)
 
 # emoji/emoji_layer.c is listed here, not in a keymap's rules.mk: the keyboard-level

--- a/keyboards/polykybd/state.c
+++ b/keyboards/polykybd/state.c
@@ -190,116 +190,10 @@ void copy_global_latin_table(const latin_sync_t* value) {
 }
 
 
-// Writes only lang+brightness+idle_style+unused (4 bytes) to EEPROM.
-void save_user_settings(void) {
-    const poly_eeconf_t ee = { .lang = l_state.lang, .brightness = (uint8_t)(~g_user_brightness),
-                               .idle_style = g_idle_style, .auto_brightness = pack_auto_brightness() };
-    eeconfig_update_user_datablock(&ee, 0, offsetof(poly_eeconf_t, latin_ex));
-}
-
-// Writes only the packed latin variation picks to EEPROM.
-// ⚠️ These go to latin_ex_wide, NOT the legacy latin_ex: g_latin.ex is 6-bit
-// fields, so writing it at the old 26-byte offset would run straight into
-// mru_emoji. The sentinel is stamped in the same breath, so a half-written
-// migration cannot leave the wide block claiming to be converted.
-//
-// ⚠️ The RAM table is one flat array over all LATIN_TARGETS, but EEPROM keeps the
-// letters and the punctuation in SEPARATE blocks — the letter block must keep the
-// size and offset it shipped with, or the format byte behind it moves and can no
-// longer be found (see state.h). So each write is explicitly bounded rather than
-// sizeof(g_latin.ex): the letters go to the original block, the rest to the tail.
-void save_user_latin(void) {
-    eeconfig_update_user_datablock(g_latin.ex, offsetof(poly_eeconf_t, latin_ex_wide),
-                                   LATIN_PICK_BASE_BYTES);
-    eeconfig_update_user_datablock(g_latin.assign, offsetof(poly_eeconf_t, latin_assign),
-                                   LATIN_ASSIGN_BASE_BYTES);
-    // Picks split on a byte boundary (39 = 52 fields x 6 bits), so the tail is a
-    // plain slice of the same array. Assignments do NOT (26 x 6 = 156 bits), so the
-    // punctuation ones are re-packed into their own array indexed from zero.
-    eeconfig_update_user_datablock(g_latin.ex + LATIN_PICK_BASE_BYTES,
-                                   offsetof(poly_eeconf_t, latin_ex_ext),
-                                   LATIN_PICK_EXT_BYTES);
-    uint8_t assign_ext[LATIN_ASSIGN_EXT_BYTES] = {0};
-    for(uint8_t i = 0; i < LATIN_PUNCT_TARGETS; i++) {
-        latin_bits_set(assign_ext, LATIN_ASSIGN_EXT_BYTES, i,
-                       latin_bits_get(g_latin.assign, LATIN_ASSIGN_BYTES,
-                                      (uint8_t)(LATIN_LETTER_TARGETS + i)));
-    }
-    eeconfig_update_user_datablock(assign_ext, offsetof(poly_eeconf_t, latin_assign_ext),
-                                   sizeof(assign_ext));
-    // Stamp the format versions LAST, so an interrupted write can never leave a
-    // block claiming a layout it does not have.
-    const uint8_t marker = LATIN_PICK_ASSIGN_OK;
-    eeconfig_update_user_datablock(&marker, offsetof(poly_eeconf_t, latin_pick_migrated),
-                                   sizeof(marker));
-    const uint8_t ext_marker = LATIN_EXT_OK;
-    eeconfig_update_user_datablock(&ext_marker, offsetof(poly_eeconf_t, latin_ext_fmt),
-                                   sizeof(ext_marker));
-}
-
-// Record that the stored dynamic keymap now matches this build's layer enum. Written
-// straight through rather than via the dirty-flag/suspend path: the keymap has already
-// been reset by the time this is called, so losing the stamp to a power cut would cost
-// the user a SECOND reset on the next boot.
-void stamp_keymap_layers_fmt(void) {
-    const uint8_t marker = KEYMAP_STORAGE_CURRENT;
-    eeconfig_update_user_datablock(&marker, offsetof(poly_eeconf_t, keymap_layers_fmt),
-                                   sizeof(marker));
-}
-
-// Saves both settings and latin table. Use save_user_settings() or save_user_latin() when only one part changed.
-void save_user_eeconf(void) {
-    save_user_settings();
-    save_user_latin();
-}
-
-// Writes the MRU blob (emoji + lang recents) to EEPROM, but only when it changed
-// since the last load/save. Keeps the write off the hot path so flash wear and
-// the ~50 ms consolidation erase only ever happen on a real suspend.
-void save_user_mru_if_dirty(void) {
-    if (!mru_dirty()) {
-        return;
-    }
-    uint8_t packed[MRU_EMOJI_PACKED];
-    mru_emoji_pack(packed);
-    eeconfig_update_user_datablock(packed, offsetof(poly_eeconf_t, mru_emoji), MRU_EMOJI_PACKED);
-    uint8_t lang_packed[MRU_CAP];
-    mru_lang_pack(lang_packed);
-    eeconfig_update_user_datablock(lang_packed, offsetof(poly_eeconf_t, mru_lang),
-                                   MRU_CAP * sizeof(uint8_t));
-    mru_clear_dirty();
-}
-
-// Loads the persisted MRU lists from EEPROM into the RAM lists.
-void load_user_mru(void) {
-    poly_eeconf_t ee;
-    eeconfig_read_user_datablock(&ee, 0, sizeof(ee));
-    mru_load(ee.mru_emoji, ee.mru_lang);
-}
-
-// Loads user keyboard configuration from EEPROM with brightness validation against maximum.
-// Global variables: (none - returns result)
-poly_eeconf_t load_user_eeconf(void) {
-    poly_eeconf_t ee;
-    eeconfig_read_user_datablock(&ee, 0, sizeof(ee));
-    ee.brightness = ~ee.brightness;
-    if(ee.brightness>FULL_BRIGHT) {
-        ee.brightness = FULL_BRIGHT;
-    }
-    if(ee.idle_style >= IDLE_STYLE_COUNT) {
-        ee.idle_style = IDLE_STYLE_PULSE;   // unwritten/garbage EEPROM -> safe default
-    }
-    if(ee.glyph_script == 0xFF) {
-        ee.glyph_script = GLYPH_STD;        // erased/uninitialised EEPROM byte -> normal legends
-    }
-    // Any other value is kept verbatim (a glyph-script INDEX). An index this
-    // firmware doesn't know renders the normal legend; keeping it means the choice
-    // survives a firmware/font-pack update that later adds that script.
-    if(ee.glyph_size >= GLYPH_SIZE_COUNT) {
-        ee.glyph_size = GLYPH_SIZE_S;       // unwritten/garbage EEPROM -> the original face
-    }
-    return ee;
-}
+// The EEPROM block I/O — everything that knows the poly_eeconf_t offsets and
+// calls eeconfig_* — lives in state_store.c (the persistence half of this
+// module); this file owns the RAM state, the policy and the dirty flags, and
+// the store reads the values it persists through the public getters.
 
 // Increments brightness by BRIGHT_STEP with clamping to FULL_BRIGHT.
 // EEPROM write is deferred to the next flush (suspend / store key) via the dirty flag.
@@ -580,6 +474,11 @@ void mark_boot_intro_done(void) {
     g_boot_dirty = true;
 }
 
+// The raw boot_flags byte, for the persistence half (save_user_boot_flags).
+uint8_t get_boot_flags(void) {
+    return g_boot_flags;
+}
+
 // ---- Active host-OS (enum poly_os) ----
 
 // The OS in effect: the manual pin while pinned, else the last resolved OS in auto
@@ -658,36 +557,6 @@ void load_os_state(uint8_t packed) {
     if (val == POLY_OS_IOS) { val = POLY_OS_MACOS; }
     if (g_os_auto) g_resolved_os = g_os_known ? val : (uint8_t)POLY_OS_UNKNOWN;
     else           g_user_os     = g_os_known ? val : (uint8_t)POLY_OS_UNKNOWN;
-}
-
-// Writes the single os_state byte to EEPROM. Separate from save_user_settings()
-// because os_state sits at the end of poly_eeconf_t (the former alignment byte),
-// not in the contiguous lang/brightness/idle/auto settings block.
-static void save_user_os(void) {
-    uint8_t packed = pack_os_state();
-    eeconfig_update_user_datablock(&packed, offsetof(poly_eeconf_t, os_state), sizeof(packed));
-}
-
-// Writes the single glyph_script byte to EEPROM. Separate from save_user_settings()
-// because glyph_script sits at the tail of poly_eeconf_t, not in the contiguous
-// lang/brightness/idle/auto settings block.
-static void save_user_glyph_script(void) {
-    eeconfig_update_user_datablock(&g_glyph_script, offsetof(poly_eeconf_t, glyph_script),
-                                   sizeof(g_glyph_script));
-}
-
-// Writes just the boot-intro marker tail byte (like glyph_script, it sits at the
-// tail of poly_eeconf_t, not in the contiguous settings block).
-// Writes the single glyph_size byte to EEPROM — same reasoning as
-// save_user_glyph_script(): it is a tail byte, not part of the settings block.
-static void save_user_glyph_size(void) {
-    eeconfig_update_user_datablock(&g_glyph_size, offsetof(poly_eeconf_t, glyph_size),
-                                   sizeof(g_glyph_size));
-}
-
-static void save_user_boot_flags(void) {
-    eeconfig_update_user_datablock(&g_boot_flags, offsetof(poly_eeconf_t, boot_flags),
-                                   sizeof(g_boot_flags));
 }
 
 // Defers a default-layer EEPROM write — safe to call from split sync handlers.

--- a/keyboards/polykybd/state.h
+++ b/keyboards/polykybd/state.h
@@ -526,6 +526,14 @@ void save_user_eeconf(void);
 // Loads user keyboard configuration from EEPROM with brightness validation against maximum.
 poly_eeconf_t load_user_eeconf(void);
 
+// The single-tail-byte writers (implemented in state_store.c with the rest of
+// the EEPROM block I/O). Each is dirty-gated by save_all_dirty(); nothing else
+// should call them, since a direct call bypasses the dirty bookkeeping.
+void save_user_os(void);
+void save_user_glyph_script(void);
+void save_user_glyph_size(void);
+void save_user_boot_flags(void);
+
 // Increments brightness by BRIGHT_STEP with clamping to FULL_BRIGHT (deferred EEPROM write).
 void inc_brightness(void);
 
@@ -635,6 +643,9 @@ void note_boot_flags(uint8_t flags);
 bool boot_intro_pending(void);
 // Persist BOOT_INTRO_DONE (one-time tail-byte write) so the intro won't replay.
 void mark_boot_intro_done(void);
+
+// The raw boot_flags byte, for the persistence half (save_user_boot_flags).
+uint8_t get_boot_flags(void);
 
 // ---- Active host-OS (enum poly_os) — see the poly_os comment in this header. ----
 

--- a/keyboards/polykybd/state_store.c
+++ b/keyboards/polykybd/state_store.c
@@ -1,0 +1,162 @@
+// Copyright 2025 thpoll83
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// The PERSISTENCE half of the state module: every function that knows the
+// poly_eeconf_t EEPROM layout and calls eeconfig_* lives here, split out of
+// state.c so the flash I/O and the RAM-state policy stop sharing one file.
+// The policy half (state.c) owns the values and the dirty flags and reads
+// nothing back from this file; this file reads the values to persist through
+// state.h's public getters, so the two halves meet only at that seam.
+//
+// Behaviour-identical to the pre-split state.c: same write contents, same
+// order, same offsets. The declarations stay in state.h, so consumers are
+// unchanged.
+
+#include "state.h"
+
+#include <stddef.h>
+#include "eeconfig.h"
+
+// Writes only lang+brightness+idle_style+unused (4 bytes) to EEPROM.
+void save_user_settings(void) {
+    const poly_eeconf_t ee = { .lang = get_local_state()->lang, .brightness = (uint8_t)(~get_user_brightness()),
+                               .idle_style = get_idle_style(), .auto_brightness = pack_auto_brightness() };
+    eeconfig_update_user_datablock(&ee, 0, offsetof(poly_eeconf_t, latin_ex));
+}
+
+// Writes only the packed latin variation picks to EEPROM.
+// ⚠️ These go to latin_ex_wide, NOT the legacy latin_ex: the pick table is 6-bit
+// fields, so writing it at the old 26-byte offset would run straight into
+// mru_emoji. The sentinel is stamped in the same breath, so a half-written
+// migration cannot leave the wide block claiming to be converted.
+//
+// ⚠️ The RAM table is one flat array over all LATIN_TARGETS, but EEPROM keeps the
+// letters and the punctuation in SEPARATE blocks — the letter block must keep the
+// size and offset it shipped with, or the format byte behind it moves and can no
+// longer be found (see state.h). So each write is explicitly bounded rather than
+// sizeof(->ex): the letters go to the original block, the rest to the tail.
+void save_user_latin(void) {
+    const latin_sync_t* latin = get_global_latin_table();
+    eeconfig_update_user_datablock(latin->ex, offsetof(poly_eeconf_t, latin_ex_wide),
+                                   LATIN_PICK_BASE_BYTES);
+    eeconfig_update_user_datablock(latin->assign, offsetof(poly_eeconf_t, latin_assign),
+                                   LATIN_ASSIGN_BASE_BYTES);
+    // Picks split on a byte boundary (39 = 52 fields x 6 bits), so the tail is a
+    // plain slice of the same array. Assignments do NOT (26 x 6 = 156 bits), so the
+    // punctuation ones are re-packed into their own array indexed from zero.
+    eeconfig_update_user_datablock(latin->ex + LATIN_PICK_BASE_BYTES,
+                                   offsetof(poly_eeconf_t, latin_ex_ext),
+                                   LATIN_PICK_EXT_BYTES);
+    uint8_t assign_ext[LATIN_ASSIGN_EXT_BYTES] = {0};
+    for(uint8_t i = 0; i < LATIN_PUNCT_TARGETS; i++) {
+        latin_bits_set(assign_ext, LATIN_ASSIGN_EXT_BYTES, i,
+                       latin_bits_get(latin->assign, LATIN_ASSIGN_BYTES,
+                                      (uint8_t)(LATIN_LETTER_TARGETS + i)));
+    }
+    eeconfig_update_user_datablock(assign_ext, offsetof(poly_eeconf_t, latin_assign_ext),
+                                   sizeof(assign_ext));
+    // Stamp the format versions LAST, so an interrupted write can never leave a
+    // block claiming a layout it does not have.
+    const uint8_t marker = LATIN_PICK_ASSIGN_OK;
+    eeconfig_update_user_datablock(&marker, offsetof(poly_eeconf_t, latin_pick_migrated),
+                                   sizeof(marker));
+    const uint8_t ext_marker = LATIN_EXT_OK;
+    eeconfig_update_user_datablock(&ext_marker, offsetof(poly_eeconf_t, latin_ext_fmt),
+                                   sizeof(ext_marker));
+}
+
+// Record that the stored dynamic keymap now matches this build's layer enum. Written
+// straight through rather than via the dirty-flag/suspend path: the keymap has already
+// been reset by the time this is called, so losing the stamp to a power cut would cost
+// the user a SECOND reset on the next boot.
+void stamp_keymap_layers_fmt(void) {
+    const uint8_t marker = KEYMAP_STORAGE_CURRENT;
+    eeconfig_update_user_datablock(&marker, offsetof(poly_eeconf_t, keymap_layers_fmt),
+                                   sizeof(marker));
+}
+
+// Saves both settings and latin table. Use save_user_settings() or save_user_latin() when only one part changed.
+void save_user_eeconf(void) {
+    save_user_settings();
+    save_user_latin();
+}
+
+// Writes the MRU blob (emoji + lang recents) to EEPROM, but only when it changed
+// since the last load/save. Keeps the write off the hot path so flash wear and
+// the ~50 ms consolidation erase only ever happen on a real suspend.
+void save_user_mru_if_dirty(void) {
+    if (!mru_dirty()) {
+        return;
+    }
+    uint8_t packed[MRU_EMOJI_PACKED];
+    mru_emoji_pack(packed);
+    eeconfig_update_user_datablock(packed, offsetof(poly_eeconf_t, mru_emoji), MRU_EMOJI_PACKED);
+    uint8_t lang_packed[MRU_CAP];
+    mru_lang_pack(lang_packed);
+    eeconfig_update_user_datablock(lang_packed, offsetof(poly_eeconf_t, mru_lang),
+                                   MRU_CAP * sizeof(uint8_t));
+    mru_clear_dirty();
+}
+
+// Loads the persisted MRU lists from EEPROM into the RAM lists.
+void load_user_mru(void) {
+    poly_eeconf_t ee;
+    eeconfig_read_user_datablock(&ee, 0, sizeof(ee));
+    mru_load(ee.mru_emoji, ee.mru_lang);
+}
+
+// Loads user keyboard configuration from EEPROM with brightness validation against maximum.
+poly_eeconf_t load_user_eeconf(void) {
+    poly_eeconf_t ee;
+    eeconfig_read_user_datablock(&ee, 0, sizeof(ee));
+    ee.brightness = ~ee.brightness;
+    if(ee.brightness>FULL_BRIGHT) {
+        ee.brightness = FULL_BRIGHT;
+    }
+    if(ee.idle_style >= IDLE_STYLE_COUNT) {
+        ee.idle_style = IDLE_STYLE_PULSE;   // unwritten/garbage EEPROM -> safe default
+    }
+    if(ee.glyph_script == 0xFF) {
+        ee.glyph_script = GLYPH_STD;        // erased/uninitialised EEPROM byte -> normal legends
+    }
+    // Any other value is kept verbatim (a glyph-script INDEX). An index this
+    // firmware doesn't know renders the normal legend; keeping it means the choice
+    // survives a firmware/font-pack update that later adds that script.
+    if(ee.glyph_size >= GLYPH_SIZE_COUNT) {
+        ee.glyph_size = GLYPH_SIZE_S;       // unwritten/garbage EEPROM -> the original face
+    }
+    return ee;
+}
+
+// Writes the single os_state byte to EEPROM. Separate from save_user_settings()
+// because os_state sits at the end of poly_eeconf_t (the former alignment byte),
+// not in the contiguous lang/brightness/idle/auto settings block.
+void save_user_os(void) {
+    uint8_t packed = pack_os_state();
+    eeconfig_update_user_datablock(&packed, offsetof(poly_eeconf_t, os_state), sizeof(packed));
+}
+
+// Writes the single glyph_script byte to EEPROM. Separate from save_user_settings()
+// because glyph_script sits at the tail of poly_eeconf_t, not in the contiguous
+// lang/brightness/idle/auto settings block.
+void save_user_glyph_script(void) {
+    const uint8_t script = get_glyph_script();
+    eeconfig_update_user_datablock(&script, offsetof(poly_eeconf_t, glyph_script),
+                                   sizeof(script));
+}
+
+// Writes the single glyph_size byte to EEPROM — same reasoning as
+// save_user_glyph_script(): it is a tail byte, not part of the settings block.
+void save_user_glyph_size(void) {
+    const uint8_t size = get_glyph_size();
+    eeconfig_update_user_datablock(&size, offsetof(poly_eeconf_t, glyph_size),
+                                   sizeof(size));
+}
+
+// Writes just the boot-intro marker tail byte (like glyph_script, it sits at the
+// tail of poly_eeconf_t, not in the contiguous settings block).
+void save_user_boot_flags(void) {
+    const uint8_t flags = get_boot_flags();
+    eeconfig_update_user_datablock(&flags, offsetof(poly_eeconf_t, boot_flags),
+                                   sizeof(flags));
+}


### PR DESCRIPTION
## Summary

Item 4 (the last) of the four deferred follow-ups from the architecture review (#236). `state.c` mixed two jobs in one 735-line file: the RAM state + policy (the synced struct accessors, the brightness auto/manual model, the OS pin/auto/host/detection ladder, idle style, glyph script/size, boot flags, and the dirty-flag bookkeeping) and the EEPROM persistence (everything that knows the `poly_eeconf_t` offsets and calls `eeconfig_*`).

The persistence half moves **verbatim** into `state_store.c`: `save_user_settings`, `save_user_latin`, `stamp_keymap_layers_fmt`, `save_user_eeconf`, `save_user_mru_if_dirty`, `load_user_mru`, `load_user_eeconf`, and the four tail-byte writers (`save_user_os` / `_glyph_script` / `_glyph_size` / `_boot_flags` — previously `static`, now declared in `state.h` with a "only `save_all_dirty` calls these" note, since a direct call would bypass the dirty bookkeeping).

The seam is deliberately one-directional: the store reads the values it persists through the **existing public getters** (`get_local_state`, `get_user_brightness`, `get_idle_style`, `pack_auto_brightness`, `get_global_latin_table`, `pack_os_state`, `get_glyph_script`, `get_glyph_size`) plus one new `get_boot_flags()`; nothing flows back. `state.c` keeps the dirty flags and the `save_all_dirty` orchestration — the flags stay with the values they guard, so a policy setter and its dirty mark can never drift into different files. Declarations stay in `state.h`, so every consumer is unchanged.

Behaviour-identical: same write contents, same write order, same offsets — the moved bodies differ from the originals only in reading through getters instead of file statics. The monolithic `POLYKYBD_DOOM=yes` flavour — the tightest RAM flavour, which PR CI does not build — was built locally: `.data` 15,144 / `.bss` 27,508 / `.heap` **3,484 B free, byte-identical to base** (the getter indirection costs a few cold `.text` bytes on the flush path only, which runs at suspend/shutdown/store).

This also sets up the next step recorded in the review: with the `eeconfig_*` calls isolated in one file, a host-built suite for the persistence layout (mock `eeconfig` backing store, the `wear_leveling/tests` pattern) becomes a contained follow-up rather than a refactor.

## Version bump label

None — internal refactor, patch bump.

## Testing
- [x] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`) — plus split42 and the monolithic `POLYKYBD_DOOM=yes` flavour (RAM byte-identical, see above)
- [ ] Flashed and tested on hardware — behaviour-identical move; the extended HIL tier's `reboot_persistence` check exercises the flush path this touches
- [ ] If protocol changed: host updated and tested together — no protocol change

All 9 unit suites green (117 tests), cog regeneration byte-identical across the 7 `run_cog.sh` files, local lint job clean, CI's exact cppcheck invocation clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8pW42ifgtNjFFVdrWPZ2m

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8pW42ifgtNjFFVdrWPZ2m)_

## Summary by Sourcery

Split PolyKybd state handling into policy and EEPROM persistence modules without changing persisted data, write ordering, or runtime behavior.

Enhancements:
- Separate RAM state and policy management from EEPROM persistence into dedicated modules while preserving existing behavior and consumer interfaces.

Build:
- Include the new state_store.c persistence module in the PolyKybd build sources.

Tests:
- Verify compilation across supported keyboard variants, including the monolithic low-RAM flavor, with unit suites, generated artifacts, lint, and static analysis remaining clean.