### PR TITLE
docs: two macro learnings that only existed in PR comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2298,6 +2298,42 @@ knowing is the parts that are NOT what you would write from scratch:
   the host's layout editor, so a user who never opens it pays nothing — and `via.c` is
   the only core dispatcher for that range, which we do not compile, so the keycodes
   are ours outright.
+- ⚠️ **A PREVIEW THAT MIRRORS THE IMPLEMENTATION AGREES BY CONSTRUCTION — it cannot
+  catch a placement bug, and this is the limit of the repo's "verify by rendering"
+  rule.** `draw_macro_mark()` first drew a chosen icon at its native size or skipped
+  it. A pack emoji inks **26–39 px** while a captioned keycap leaves about **29 rows**
+  above the label, so measured over the icons the host picker offers, **four in five
+  drew nothing at all**. `macro_label_preview.py` models the same placement, so it
+  showed the same nothing — the field report was *"after selecting the icon I cannot
+  see it in the preview and also not on the keyboard"* (2026-08-27), and neither half
+  could contradict the other. Rendering only proves the C and the Python agree; the
+  check that would have caught this is **measuring the glyph against the space it has
+  to fit**, which is a different question and needs the real font metrics. The fix
+  halves an overflowing icon through `kdisp_draw_glyph_half_at` (2×2-OR, which keeps
+  the thin strokes plain decimation loses; half of even the tallest pack glyph is
+  ~20 px) and falls back to the index when it fits at no size — the same fallback a
+  missing glyph already took, so a keycap can never end up unmarked.
+- ⚠️ **A guard whose precondition NOBODY ESTABLISHES is not a guard, and the comment
+  claiming it holds is what hides that.** `poly_macro_start()` refuses to play a
+  buffer whose last byte is not NUL (`poly_macro_buffer_intact`), and the case-37
+  comment asserted this covered a half-streamed upload because "the host leaves the
+  last byte clear until the final chunk". It does not: `join_buffer()` zero-fills to
+  capacity, so the byte reads 0 **before** a write, **during** it and **after** it —
+  the guard could never fire. An interrupted upload therefore left a *playable*
+  splice, and the splice is made of the old macro:
+  ```
+  before: "password123\0"   write: "hi\0" (interrupted)
+  after:  "hi\0sword123\0"  -> macro 0 = "hi", macro 1 = "sword123"
+  ```
+  i.e. a fragment of a former macro becomes something a keypress types. Closed at
+  **both** ends and the two are not redundant: the host raises a non-zero marker in
+  the last byte *before* streaming and clears it with the final window
+  (`write_macro_buffer`), and `poly_macro_write()` invalidates that byte on any
+  window that does not carry it — the firmware must not depend on the host to arm its
+  own integrity guard, and the host half is the one a mocked test can exercise.
+  ⚠️ Consequence: a deliberate **prefix** write now leaves the buffer unplayable until
+  something writes the tail. That is correct, and it is why the rig's prefix-write
+  test restores the terminating NUL.
 - **Cost: 208 B of RAM** (the 192 B label cache + the playback state), 0 B of EEPROM
   beyond the reclaim above. ⚠️ Verified against the **monolithic `POLYKYBD_DOOM=yes`**
   flavour, which PR CI does not build and which is the first thing to fail on any RAM

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2321,7 +2321,7 @@ knowing is the parts that are NOT what you would write from scratch:
   capacity, so the byte reads 0 **before** a write, **during** it and **after** it —
   the guard could never fire. An interrupted upload therefore left a *playable*
   splice, and the splice is made of the old macro:
-  ```
+  ```text
   before: "password123\0"   write: "hi\0" (interrupted)
   after:  "hi\0sword123\0"  -> macro 0 = "hi", macro 1 = "sword123"
   ```


### PR DESCRIPTION
## Summary

Two things the macro work discovered that were written up only in PR comments on #234,
where nothing greps them. Both are in the `Dynamic macros` section of `CLAUDE.md`.

**A preview that mirrors the implementation agrees by construction.** `draw_macro_mark()`
drew a chosen icon at its native size or skipped it. A pack emoji inks **26–39 px** while
a captioned keycap leaves about **29 rows** above the label — so measured over the icons
the host picker offers, **four in five drew nothing at all**. `macro_label_preview.py`
models the same placement, so it showed the same nothing; the field report was *"after
selecting the icon I cannot see it in the preview and also not on the keyboard"* and
neither half could contradict the other.

This is the limit of the repo's own "verify by rendering" rule, which is why it is worth
recording: rendering proves the C and the Python agree, and says nothing about whether
the glyph fits the space it has. That is a different question and needs the real font
metrics.

**A guard whose precondition nobody establishes is not a guard.** `poly_macro_start()`
refuses a buffer whose last byte is not NUL, and the case-37 comment claimed that covered
a half-streamed upload because "the host leaves the last byte clear until the final
chunk". It does not — `join_buffer()` zero-fills to capacity, so the byte reads 0 before
a write, during it and after it, and the guard could never fire. An interrupted upload
left a *playable* splice made of the previous macro:

```
before: "password123\0"   write: "hi\0" (interrupted)
after:  "hi\0sword123\0"  -> macro 0 = "hi", macro 1 = "sword123"
```

The fix landed in #234 on both ends; only the reasoning was missing from the tree.

## Version bump label

*(none)* — documentation only, patch bump is correct.

## Testing

- [x] Compiled successfully — not applicable, no source file is touched
- [ ] Flashed and tested on hardware — not applicable
- [ ] If protocol changed: host updated and tested together — no protocol change

`qmk-test.yml` carries `paths-ignore: ['**.md']`, so this PR deliberately runs neither
the build nor the rig. That is the intended behaviour for a Markdown-only change and not
a missing check.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LeoBsy75UBvecXehCiAoWg)_

## Summary by Sourcery

Record the macro-development lessons about validating visual fit independently and establishing buffer-integrity guards.

Documentation:
- Document the limitations of implementation-mirroring previews and the need to validate glyph fit using real font metrics.
- Document the requirement to establish guard preconditions and the protections against interrupted macro-buffer uploads producing playable stale-data splices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for dynamic macro icon rendering, including fallback behavior when icons do not fit.
  - Documented safeguards that prevent interrupted macro uploads from leaving outdated macro content playable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->