### PR TITLE
publish_release: tag the version's own commit, not the branch head

### DIFF
--- a/scripts/publish_release.py
+++ b/scripts/publish_release.py
@@ -13,7 +13,10 @@ What it does (no bash-isms, no extra pip installs — Python 3.7+ stdlib only):
      whatever branch you have checked out.
   2. Reads the prepared release notes for that tag from the unprotected
      `release-notes` branch (`<TAG>.md`, first line `# <title>`, rest = body).
-  3. Creates + publishes the GitHub Release (or updates it if it already exists).
+  3. Creates + publishes the GitHub Release (or updates it if it already exists),
+     tagging the commit that DECLARES the prepared version rather than the
+     branch head — so a merge landing between preparing the notes and
+     publishing them cannot ship a binary whose version differs from its label.
      Firmware and wincompose: publishing fires the `release: published`
      workflow, which builds and attaches the assets (.bin/.uf2 / the installer
      + portable zip + SHA256SUMS) — you do NOT attach anything by hand.
@@ -21,10 +24,10 @@ What it does (no bash-isms, no extra pip installs — Python 3.7+ stdlib only):
 Auth: uses `GH_TOKEN` / `GITHUB_TOKEN` if set, else `gh auth token`. No token and
 no `gh` -> it tells you how to fix it. `gh` is optional; a token alone is enough.
 
-Tags:
-  firmware    PolyKybd-fw-v<version>   (target branch: PolyKybd)
-  host        v<version>               (target branch: main)
-  wincompose  PK-<version>             (target branch: main)
+Tags (created at the commit declaring <version>, found on the branch named):
+  firmware    PolyKybd-fw-v<version>   (branch: PolyKybd)
+  host        v<version>               (branch: main)
+  wincompose  PK-<version>             (branch: main)
 """
 import argparse
 import json
@@ -142,6 +145,51 @@ def api(token, method, path, payload=None):
             return e.code, {"message": e.read().decode(errors="replace")}
 
 
+def commit_for_version(kind, vpath, default_branch, version):
+    """OLDEST commit on the default branch whose <vpath> declares `version`.
+
+    The release must be tagged at a commit that actually reports the version the
+    notes describe, not at whatever the branch head happens to be. Tagging the
+    head means any merge between preparing the notes and publishing them ships a
+    binary whose version differs from its label -- and since `bump-version.yml`
+    has no paths filter, *every* merge bumps, docs-only ones included. Left
+    unfixed that is not merely cosmetic: on 2026-08-29 nine merges landed inside
+    that window, one of them the FW-9 engine-pack signing fix, which would have
+    shipped under notes that never mentioned it.
+
+    Resolved by reading the version file at each commit rather than by matching a
+    `chore: bump ... version to X` message: it checks the property we actually
+    care about, and it works for wincompose, which has no bump commits at all.
+
+    ⚠️ OLDEST, not newest, and the difference is not academic. A version stays
+    declared from its bump commit until the next bump, so several commits report
+    it -- and the later ones are the NEXT release's work, sitting in the window
+    before its own bump lands. Taking the newest match resolved v0.15.14 to a
+    commit from PR #231, which actually shipped in 0.15.15; the oldest match is
+    the bump commit, which is what every historical release was in fact tagged
+    at. Versions increase monotonically, so a version occupies exactly one
+    contiguous run of commits and the oldest match is unambiguous.
+    """
+    r = run(["git", "log", "--format=%H", f"origin/{default_branch}", "--", vpath])
+    if r.returncode:
+        return None
+    found = None
+    for sha in r.stdout.split():  # git log is newest-first
+        text = show(f"{sha}:{vpath}")
+        if not text:
+            continue
+        try:
+            if parse_version(kind, text) == version:
+                found = sha  # keep walking back; the last match is the oldest
+            elif found:
+                break        # walked past the start of this version's run
+        except SystemExit:
+            # An older revision the current parser can't read: skip it rather
+            # than abort the publish.
+            continue
+    return found
+
+
 def prepared_tags(prefix):
     """All prepared <prefix><X.Y.Z>.md files on the release-notes branch,
     as (version_tuple, tag) sorted ascending."""
@@ -199,14 +247,38 @@ def main():
             print(f"note: newest prepared tag is {tag}. Others on the branch: {others}")
             print(f"      (use --tag to publish a specific one.)")
 
-    # Informational: warn if the tree has already bumped past this tag.
+    # Tag the commit that DECLARES this version, not the branch head -- see
+    # commit_for_version(). Falls back to the head so a publish never becomes
+    # impossible, but says so loudly, because the fallback is the old broken
+    # behaviour and must not pass unnoticed.
+    version = tag[len(tag_prefix):]
+    target = commit_for_version(kind, vpath, default_branch, version)
+    if target is None:
+        shallow = (run(["git", "rev-parse", "--is-shallow-repository"])
+                   .stdout.strip() == "true")
+        print(f"WARNING: no commit on {default_branch} declares version {version}; "
+              f"falling back to the branch head.")
+        if shallow:
+            print("         This clone is SHALLOW, so the search saw truncated "
+                  "history. Run `git fetch origin --unshallow` and retry.")
+        else:
+            print("         The published binary may then report a different "
+                  "version than this tag's label. Check before announcing it.")
+        target = default_branch
+        target_desc = default_branch
+    else:
+        target_desc = f"{target[:10]} (declares {version})"
+
+    # Informational: the tree drifting past the prepared tag is normal and, now
+    # that the tag is pinned above, harmless -- later merges ship in the NEXT
+    # release rather than silently joining this one.
     vtext = show(f"origin/{default_branch}:{vpath}")
     if vtext:
         try:
             tree_tag = tag_prefix + parse_version(kind, vtext)
             if tree_tag != tag:
-                print(f"note: default branch is at {tree_tag}; publishing prepared {tag} "
-                      f"(the difference is post-prep merges, typically release tooling).")
+                print(f"note: default branch has moved on to {tree_tag}; publishing "
+                      f"prepared {tag} at its own commit, so the drift is harmless.")
         except SystemExit:
             pass
     lines = notes.splitlines()
@@ -218,7 +290,7 @@ def main():
     owner, repo = owner_repo(root)
 
     print(f"repo    : {owner}/{repo}  ({kind})")
-    print(f"tag     : {tag}   target: {default_branch}")
+    print(f"tag     : {tag}   target: {target_desc}")
     print(f"title   : {title}")
     print(f"body    : {len(body)} chars, {body.count(chr(10)) + 1} lines")
     print("-" * 60)
@@ -247,7 +319,7 @@ def main():
 
     st, res = api(token, "POST", f"/repos/{owner}/{repo}/releases", {
         "tag_name": tag,
-        "target_commitish": default_branch,
+        "target_commitish": target,
         "name": title,
         "body": body,
         "make_latest": "true",


### PR DESCRIPTION
## Summary

`publish_release.py` sent `"target_commitish": default_branch`, so the release tag was
created wherever the branch happened to point when you ran it — not at the commit whose
version the prepared notes describe.

That matters because **`bump-version.yml` has no paths filter, so every merge bumps the
version**, docs-only ones included. Any merge between staging the notes and publishing
them therefore shipped a binary whose version differed from its label, and silently
pulled that merge's work into the release.

It is not hypothetical. On 2026-08-29 that window took **nine merges**, one of them the
FW-9 engine-pack signing fix — which would have shipped under notes that never mentioned
it. It also forced the prepared notes to be re-staged three times just to chase the tree,
and produced a duplicate release when a re-stage raced a publish.

`commit_for_version()` finds the commit whose version file *declares* the prepared
version and tags that. Later merges then land in the **next** release, where they belong,
and the prepared tag stops being perishable.

## Two design choices worth reviewing

**Reads the version file; does not grep the commit message.** A `chore: bump … version to
X` match would depend on wording that differs per repo, and **wincompose has no bump
commits at all** — its version is a hand-edited `AssemblyVersion`. Reading the file checks
the property we actually care about and works for all three repos.

**Takes the OLDEST match, not the newest — and my first cut had this wrong.** A version
stays declared from its bump commit until the next bump, so several commits report it, and
the later ones are the *next* release's work waiting for its own bump. Taking the newest
resolved `v0.15.14` to a commit from PR #231, which actually shipped in 0.15.15 — tagging
it would have pulled a later PR into an earlier release. Versions increase monotonically,
so a version occupies exactly one contiguous run and the oldest match is unambiguous.

I only caught it by checking a second known-good release instead of stopping at the first
that passed.

## Testing

- [x] Compiled successfully — CI builds this PR (see the CI note below); no firmware
      source is touched, so the build is unaffected by the diff
- [ ] Flashed and tested on hardware — not applicable
- [ ] If protocol changed: host updated and tested together — no protocol change

**Verified against four published releases**, each resolving to exactly the `head_sha` its
`release.yml` run actually used:

| tag | resolved | actual release head_sha |
|---|---|---|
| `PolyKybd-fw-v0.16.10` | `c7c3580cac` | `c7c3580cac` ✅ |
| `PolyKybd-fw-v0.15.14` | `3b2fb6890d` | `3b2fb6890d` ✅ |
| `PolyKybd-fw-v0.15.2` | `d2b5f30e5c` | `d2b5f30e5c` ✅ |
| `PolyKybd-fw-v0.11.0` | `00f919ecc3` | `00f919ecc3` ✅ |

So the change makes explicit what was previously true only by luck of timing. Also checked
`v0.14.1` and `v0.13.16` in the host copy, and the not-found path returns `None` for a
version no commit declares.

**The fallback is loud, never fatal.** A version that cannot be resolved falls back to the
branch head with a warning that names a shallow clone as the likely cause — the documented
trap in this container — so a publish can never become impossible, but the old behaviour
cannot pass unnoticed either. `--dry-run` prints `target: c7c3580cac (declares 0.16.10)`
so the check is visible before anything is created.

The drift note also stops misleading: it claimed the gap was "typically release tooling",
which was wrong every time it appeared, and now says the drift is harmless *because* the
tag is pinned.

## ⚠️ Correction: this PR does run the build and the rig

An earlier version of this description said `qmk-test.yml` does not cover `scripts/`, so
neither the build nor the rig would run. **That was wrong and I did not verify it before
writing it.** The trigger is `paths-ignore: ['**.md']` and nothing else, so *any*
non-Markdown change starts the full pipeline — including this one, which cannot affect a
firmware build.

It passes (no firmware source is touched), but it costs a rig flash-and-test cycle for a
release-tooling change, which is the same waste `paths-ignore` was added for in #225 after
a comment-only PR burned three rig runs. Whether `scripts/**` (and `.claude/**`) should
join that filter is worth deciding — deliberately **not** in this PR, since widening the
filter is its own change with its own caveat: it is only safe while neither check is a
required status check.

## Note on the sibling repo

`scripts/publish_release.py` is byte-identical across `qmk_firmware` and `PolyKybdHost`
by convention, so the same commit is in thpoll83/PolyKybdHost#198. `cmp` confirms they
still match. wincompose has no copy.

## Version bump label

*(none)* — tooling only, patch bump is correct.