### PR TITLE
publish_release: fix four review findings; skip CI for scripts/ and .claude/

### DIFF
--- a/.github/workflows/qmk-test.yml
+++ b/.github/workflows/qmk-test.yml
@@ -3,9 +3,15 @@ name: Build and HIL Test
 on:
   push:
     branches: [PolyKybd, "PolyKybd/**"]
-    # A Markdown-only change cannot alter the firmware, so it should not occupy
-    # the HIL rig for a full flash-and-test cycle (the rig runs one job at a
-    # time, so a docs push delays every real build queued behind it).
+    # A change that cannot alter the firmware should not occupy the HIL rig for
+    # a full flash-and-test cycle (the rig runs one job at a time, so such a
+    # push delays every real build queued behind it).
+    #
+    # Beyond Markdown: `scripts/` holds only publish_release.py (the release
+    # publisher — nothing the build reads), and `.claude/` holds skills and
+    # settings. A change confined to either cannot reach a firmware image.
+    # ⚠️ Verify that stays true before adding a path here: the test is whether
+    # the build or the rig ever READS it, not whether it looks unrelated.
     #
     # ⚠️ `paths-ignore` skips the workflow only when EVERY changed file matches,
     # so a mixed docs+code PR still runs the gate in full — this can never hide
@@ -22,6 +28,8 @@ on:
     # fix in that case is a paths-filter job feeding `if:` conditions instead.
     paths-ignore:
       - '**.md'
+      - 'scripts/**'
+      - '.claude/**'
   pull_request:
     # `labeled` is NOT in GitHub's default set (opened/synchronize/reopened), and
     # without it adding the `perf` label to an open PR fires no run at all — the
@@ -33,6 +41,8 @@ on:
     # Same reasoning as the push trigger above.
     paths-ignore:
       - '**.md'
+      - 'scripts/**'
+      - '.claude/**'
   # Manual trigger for the opt-in performance measurement below (the normal
   # build + HIL test always run; perf does not). No inputs: the baseline is moved
   # by committing the run's JSON to polykybd-ctnd, not by a workflow switch — the

--- a/scripts/publish_release.py
+++ b/scripts/publish_release.py
@@ -167,10 +167,37 @@ def commit_for_version(kind, vpath, default_branch, version):
     before its own bump lands. Taking the newest match resolved v0.15.14 to a
     commit from PR #231, which actually shipped in 0.15.15; the oldest match is
     the bump commit, which is what every historical release was in fact tagged
-    at. Versions increase monotonically, so a version occupies exactly one
-    contiguous run of commits and the oldest match is unambiguous.
+    at.
+
+    ⚠️ The whole history is walked, with NO early exit. An earlier version broke
+    out on the first non-match after a match, on the theory that a version
+    occupies one contiguous run. That is true in time but FALSE in a path-limited
+    `git log`, where a PR's own commits and its merge commit interleave with the
+    mainline: the break stopped at the end of the first run and returned a commit
+    from a later release. Measured on this repo, 9 of 154 versions mis-resolved --
+    0.15.17 to a PR #234 feature commit that shipped in 0.16.0, and 0.15.18 to
+    that PR's merge commit. A full walk is ~1.1 s, so the break bought nothing.
+
+    ⚠️ `--first-parent` is load-bearing, for the same reason as the missing
+    break. `git log` orders by commit DATE, so commits merged in from a branch
+    interleave with the mainline and "last in the newest-first list" is not
+    topologically oldest -- measured, 6 of 151 versions then resolved to a
+    commit that is not even an ancestor of their bump. Restricting to the
+    mainline removes the interleaving at its source: 150 of 151 land exactly on
+    the `chore: bump ...` commit. The one exception (0.9.2) had its bump made on
+    a side branch, so first-parent resolves it to the merge that brought it onto
+    the mainline -- which still declares 0.9.2, so the label-matches-binary
+    invariant holds, which is the property that actually matters here.
+
+    ⚠️ The pathspec is `:(top)`-prefixed because a plain `-- <path>` is
+    CWD-RELATIVE. Run from a subdirectory -- which this script explicitly
+    supports -- it matches nothing and `git log` exits 0 with an EMPTY list, so
+    the returncode guard never fires and the caller silently falls back to the
+    branch head. (`show()` is unaffected: `<rev>:<path>` is always root-relative,
+    so nothing else looks wrong.)
     """
-    r = run(["git", "log", "--format=%H", f"origin/{default_branch}", "--", vpath])
+    r = run(["git", "log", "--format=%H", "--first-parent",
+             f"origin/{default_branch}", "--", f":(top){vpath}"])
     if r.returncode:
         return None
     found = None
@@ -181,8 +208,6 @@ def commit_for_version(kind, vpath, default_branch, version):
         try:
             if parse_version(kind, text) == version:
                 found = sha  # keep walking back; the last match is the oldest
-            elif found:
-                break        # walked past the start of this version's run
         except SystemExit:
             # An older revision the current parser can't read: skip it rather
             # than abort the publish.
@@ -228,24 +253,35 @@ def main():
     # publish* — NOT the tree version, which drifts forward on every PR merge
     # (each merge auto-bumps the version, so the tree is usually ahead of the
     # prepared release by the time you publish). Pick the newest prepared tag.
+    prepared = prepared_tags(tag_prefix)
     if args.tag:
         tag = args.tag
-        notes = show(f"origin/release-notes:{tag}.md")
-        if not notes or not notes.strip():
-            die(f"no prepared notes for {tag} on the release-notes branch "
-                f"(expected release-notes:{tag}.md).")
     else:
-        prepared = prepared_tags(tag_prefix)
         if not prepared:
             die("no prepared release notes on the release-notes branch "
                 f"(no {tag_prefix}<X.Y.Z>.md files).\n"
                 "  Draft + stage them first with the polykybd-github-release skill.")
         tag = prepared[-1][1]
-        notes = show(f"origin/release-notes:{tag}.md")
         if len(prepared) > 1:
             others = ", ".join(t for _, t in prepared[:-1])
             print(f"note: newest prepared tag is {tag}. Others on the branch: {others}")
             print(f"      (use --tag to publish a specific one.)")
+
+    # One guard for both paths. prepared_tags() matches on FILENAME only, so an
+    # empty or unreadable <TAG>.md reaches here on the auto-select path too --
+    # where it used to raise IndexError on lines[0] (or AttributeError on a None
+    # from show()) instead of saying what was wrong.
+    notes = show(f"origin/release-notes:{tag}.md")
+    if not notes or not notes.strip():
+        die(f"no prepared notes for {tag} on the release-notes branch "
+            f"(expected release-notes:{tag}.md, non-empty).")
+
+    # Only the newest prepared tag becomes "Latest release". The notes branch is
+    # an append-only archive and --tag exists to publish an older one, so an
+    # unconditional make_latest would re-point /releases/latest -- and the tray
+    # updater that reads it -- at older firmware.
+    newest_tag = prepared[-1][1] if prepared else tag
+    is_latest = (tag == newest_tag)
 
     # Tag the commit that DECLARES this version, not the branch head -- see
     # commit_for_version(). Falls back to the head so a publish never becomes
@@ -292,6 +328,8 @@ def main():
     print(f"repo    : {owner}/{repo}  ({kind})")
     print(f"tag     : {tag}   target: {target_desc}")
     print(f"title   : {title}")
+    if not is_latest:
+        print(f"latest  : NO — {newest_tag} is newer and keeps the Latest badge")
     print(f"body    : {len(body)} chars, {body.count(chr(10)) + 1} lines")
     print("-" * 60)
     print(body)
@@ -308,7 +346,7 @@ def main():
     status, rel = api(token, "GET", f"/repos/{owner}/{repo}/releases/tags/{tag}")
     if status == 200:
         st, res = api(token, "PATCH", f"/repos/{owner}/{repo}/releases/{rel['id']}",
-                      {"name": title, "body": body, "make_latest": "true", "draft": False})
+                      {"name": title, "body": body, "make_latest": str(is_latest).lower(), "draft": False})
         if st >= 300:
             die(f"updating existing release failed ({st}): {res.get('message')}")
         print(f"updated existing release {tag}")
@@ -322,7 +360,7 @@ def main():
         "target_commitish": target,
         "name": title,
         "body": body,
-        "make_latest": "true",
+        "make_latest": str(is_latest).lower(),
         "draft": False,
         "prerelease": False,
     })


### PR DESCRIPTION
## Summary

A code review of #247 (already merged) found **four real defects**, one of them
serious. I reproduced all four against this repo's real history before acting. Plus
the CI-filter change #247's own description raised.

### The serious one: the early `break` returned a commit from a LATER release

#247 removed an early exit… and then added a different one. It broke out on the first
non-match after a match, on the theory that *"a version occupies exactly one contiguous
run of commits"*. That is true in **time** and false in a **path-limited `git log`**,
where a PR's own commits and its merge commit interleave with the mainline.

Measured on this branch:

| version | resolved to | what that commit is | correct |
|---|---|---|---|
| `0.15.17` | `c1197289aa` | *"macro: let a macro keycap choose how it draws itself"* — a PR #234 commit that **shipped in 0.16.0** | `31b5f5a5f4` |
| `0.15.18` | `bd976d0bbe` | PR #234's **merge commit** | `6094378d07` |

**9 of 154 versions mis-resolved.** This is the same class of error #247's commit
message claims to have caught for v0.15.14 — just one run further along. Sampling four
releases found it there and missed it here; checking *every* bump commit is what caught
it now.

### Same root cause, one level deeper: `--first-parent`

Removing the break alone still left **6 of 151** versions resolving to a commit that is
not even an ancestor of their bump — `git log` orders by commit **date**, so merged
branches interleave and "last in the newest-first list" is not topologically oldest.
Restricting to the mainline removes it at source: **150 of 151** now land exactly on the
`chore: bump …` commit. The one exception (`0.9.2`) had its bump made on a side branch,
so first-parent resolves it to the merge that brought it onto the mainline — which still
declares `0.9.2`, so the label-matches-binary invariant holds.

### The silent one: a cwd-relative pathspec

`-- <path>` is **relative to the working directory**, which the docstring explicitly says
is anywhere in the checkout. Run from a subdirectory it matched nothing and `git log`
exited **0 with an empty list**, so the returncode guard never fired and it fell straight
back to the branch head — the exact behaviour #247 removed. `show()` was unaffected
(`<rev>:<path>` is root-relative), so nothing else looked wrong. `:(top)` fixes it;
verified from `keyboards/`.

### Two smaller ones

- The **auto-select path had no emptiness guard**. `prepared_tags()` matches on filename
  only, so an empty staged `<TAG>.md` reached `lines[0]` and raised `IndexError` instead
  of the intended `die()`. One guard now covers both paths.
- **`make_latest` was unconditional.** The notes branch is an append-only archive and
  `--tag` exists to publish an older one, so publishing an older tag re-pointed
  `/releases/latest` — and the host tray updater that reads it — at older firmware. Now
  only the newest prepared tag claims the badge, and `--dry-run` says when it won't.

## The CI change

`paths-ignore` covered `'**.md'` only, so **any** other change that cannot reach a
firmware image still started the full pipeline including a rig flash-and-test cycle.
#247 did exactly that — a release-tooling edit occupied the rig, which is the waste this
filter was added for. `scripts/` holds only `publish_release.py` (nothing the build
reads) and `.claude/` holds skills and settings.

Neither pattern matches `.github/workflows/`, so a change to the CI wiring itself still
triggers a run and gets verified, and `workflow_dispatch` has no paths filter at all. The
existing caveat is unchanged and already in the comment block: only safe while
`Build firmware` / `HIL test` are not **required** status checks.

## Testing

- [x] Compiled successfully — not applicable; no firmware source is touched (and by this
      PR's own change, the build no longer runs for it)
- [ ] Flashed and tested on hardware — not applicable
- [ ] If protocol changed — no protocol change

- **Every bump commit in the branch's history cross-checked**, not four samples: 150/151
  land on their own bump commit, the one exception explained above.
- The nine versions the review flagged all resolve correctly now.
- Subdirectory resolution verified from `keyboards/`.
- YAML verified with PyYAML after editing, including the `d[True]` `on:`-block quirk and
  the folded-scalar guards on `HIL_EXTENDED` and the `build` / `build-perf` `if:` blocks —
  all still newline-free.

## Note on the sibling repo

`scripts/publish_release.py` stays byte-identical across both repos; the same fix is in
thpoll83/PolyKybdHost#199, where `v0.14.1` / `v0.14.0` / `v0.13.16` each resolve to their
own bump commit. `cmp` clean.

## Version bump label

*(none)* — tooling and CI only, patch bump is correct.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LeoBsy75UBvecXehCiAoWg)_

## Summary by Sourcery

Fix release publication targeting and latest-release selection, and avoid unnecessary CI runs for non-firmware tooling and configuration changes.

Bug Fixes:
- Correct release commit resolution by walking the complete mainline history and using root-relative path matching, preventing releases from being associated with later or unrelated commits.
- Handle empty or unreadable release notes consistently instead of failing during tag selection.
- Prevent publishing an older tag from being marked as the latest release.

Enhancements:
- Improve publish output to indicate when a newer prepared tag retains the Latest badge.

CI:
- Skip firmware build and hardware-in-the-loop workflows for changes confined to scripts/ or .claude/, while continuing to run for mixed or workflow changes.