### PR TITLE
fix(FW-9): host &quot;stop idle&quot; tears down the DOOM attract screensaver

### DIFF
--- a/keyboards/polykybd/base/fw_staging.c
+++ b/keyboards/polykybd/base/fw_staging.c
@@ -76,7 +76,20 @@ static void fw_staging_halt_core1(void) {
 static void fw_staging_restart_core1(void) {
     _PSM_FRCE_OFF &= ~_PSM_PROC1_BIT;
     s_core1_halted = false;
-    multicore_launch_core1();
+    // BOUNDED relaunch, NOT the unbounded multicore_launch_core1(). core0 can
+    // reach here with core1's FIFO launch handshake left desynced by a prior Doom
+    // engine launch/stop cycle (doom_engine_stop uses the bounded launcher for the
+    // same reason). The unbounded handshake then blocks FOREVER, freezing this
+    // half — on the SLAVE that means it never answers the master's FONTPACK BEGIN
+    // re-poll, so the master polls '~' forever and the flash hangs. Seen on the
+    // 3rd consecutive doom-slot flash of the FW-9 rig set (accept/tampered/unsigned),
+    // once two doom load+teardown cycles had degraded core1. Bounded: a still-wedged
+    // core1 leaves the RLE service down until the next reboot (the identical worst
+    // case doom_engine_stop already accepts) but keeps THIS half's main loop alive,
+    // so the erase's cleared s_erase_pending is actually observable to the master.
+    if (!multicore_launch_core1_bounded(100u * 1000u)) {
+        uprintf("fw_staging: core1 relaunch timed out — RLE service down until reboot\n");
+    }
 }
 #endif
 

--- a/keyboards/polykybd/hid_com.c
+++ b/keyboards/polykybd/hid_com.c
@@ -615,6 +615,17 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                 break;
             case 15: //start/stop idle
                 if(data[HID_DATA_IDX]==0) {
+                    // A host "stop idle" is a wake, so it must tear down the DOOM
+                    // attract screensaver (IDLE_STYLE_IDDQD) too — exactly as a
+                    // keypress wake does via poly_force_wake()/poly_prepare_for_flash().
+                    // The attract demo runs with STATUS_DISP_ON SET and DISP_IDLE
+                    // CLEARED, so the flag handling below never reaches it; without
+                    // this the host cannot stop the screensaver over HID, and while
+                    // doom holds the overlay pool a subsequent font/doom re-flash is
+                    // refused (hid_fontpack.c FONTPACK_BEGIN gates on !doom_mode_active()).
+                    // Self-guards: only an active attract demo is affected; a no-op
+                    // inline stub on a non-doom build.
+                    doom_screensaver_stop();
                     if((local_state->flags & (STATUS_DISP_ON|DISP_IDLE))==0) {
                         suspend_wakeup_init_kb();
                     } else {

--- a/keyboards/polykybd/hid_fontpack.c
+++ b/keyboards/polykybd/hid_fontpack.c
@@ -104,6 +104,14 @@ bool hid_fontpack_receive(uint8_t *data, uint8_t length) {
             static uint32_t s_erased_size   = 0;
             static uint32_t s_erased_crc    = 0;
             static uint8_t  s_erased_bundle = 0xFF;
+            // One-shot dedup for the "slave not ready" diagnostic below. Hoisted
+            // here (not local to the telemetry block) so a fresh flash re-arms it:
+            // otherwise a second flash whose slave_ack equals the first's is
+            // suppressed — which is exactly why the FW-9 unsigned test logged no
+            // snapshot last round (same 0xe4 as the tampered test). It is keyed on
+            // the image, not the bundle: tampered/unsigned share bundle 0x7e but
+            // differ in pack_crc, so new_image re-arms between them.
+            static uint8_t  s_last_begin_slave_ack = 0xFF;
             bool new_image = (pack_size != s_erased_size || pack_crc != s_erased_crc ||
                               bundle != s_erased_bundle);
 
@@ -111,6 +119,7 @@ bool hid_fontpack_receive(uint8_t *data, uint8_t length) {
                 s_erased_size   = pack_size;
                 s_erased_crc    = pack_crc;
                 s_erased_bundle = bundle;
+                s_last_begin_slave_ack = 0xFF;   // re-arm the not-ready diagnostic for this flash
                 // Drop to the base layer + refresh before the flash holds the main
                 // loop, so the user can still type plain characters meanwhile.
                 poly_prepare_for_flash();
@@ -137,7 +146,6 @@ bool hid_fontpack_receive(uint8_t *data, uint8_t length) {
             // "slave not answering / wedged" (SYNC_GIVEUP / SYNC_CRC32_ERR). Change-
             // triggered so it never floods the ~1 Hz re-poll.
             if (master_ok && master_done && !slave_ok) {
-                static uint8_t s_last_begin_slave_ack = 0xFF;
                 if (slave_ack != s_last_begin_slave_ack) {
                     s_last_begin_slave_ack = slave_ack;
                     uprintf("FONTPACK_BEGIN: master erased, slave not ready (bundle=%u slave_ack=0x%02x)\n",

--- a/keyboards/polykybd/hid_fontpack.c
+++ b/keyboards/polykybd/hid_fontpack.c
@@ -130,6 +130,21 @@ bool hid_fontpack_receive(uint8_t *data, uint8_t length) {
             bool slave_ok    = (slave_ack == SYNC_ACK);
             bool master_done = !fw_staging_erase_pending();
 
+            // Telemetry for the FW-9 3rd-doom-flash hang: when OUR erase is done but
+            // the slave still isn't ready, surface WHAT the slave answered. The rig
+            // reads the master console only, so this is the one place that can tell
+            // "slave alive, still erasing" (SYNC_ACK_SIG / SYNC_BUSY) apart from
+            // "slave not answering / wedged" (SYNC_GIVEUP / SYNC_CRC32_ERR). Change-
+            // triggered so it never floods the ~1 Hz re-poll.
+            if (master_ok && master_done && !slave_ok) {
+                static uint8_t s_last_begin_slave_ack = 0xFF;
+                if (slave_ack != s_last_begin_slave_ack) {
+                    s_last_begin_slave_ack = slave_ack;
+                    uprintf("FONTPACK_BEGIN: master erased, slave not ready (bundle=%u slave_ack=0x%02x)\n",
+                            bundle, slave_ack);
+                }
+            }
+
             memset(data, 0, length);
             if (!master_ok) {
                 memcpy(data, "P\x50!", 3);   // invalid size

--- a/keyboards/polykybd/hid_fontpack.c
+++ b/keyboards/polykybd/hid_fontpack.c
@@ -142,6 +142,17 @@ bool hid_fontpack_receive(uint8_t *data, uint8_t length) {
                     s_last_begin_slave_ack = slave_ack;
                     uprintf("FONTPACK_BEGIN: master erased, slave not ready (bundle=%u slave_ack=0x%02x)\n",
                             bundle, slave_ack);
+                    // A) slave visibility for the FW-9 doom re-flash wedge. The rig
+                    // reads the master console only, so dump the slave's fw_staging
+                    // counters over the read-only STATUS op (its own transaction, not
+                    // a core1/erase change). It answers the exact question the
+                    // slave_ack alone can't: is the slave DARK ("RPC FAILED — slave
+                    // unresponsive") or ALIVE-BUT-STUCK — and if alive, whether it
+                    // even saw the BEGIN (begin_handler_calls), started erasing
+                    // (erase_sector_next/count), and is still ticking process_deferred.
+                    // Change-triggered like the line above, so one snapshot per state,
+                    // no re-poll flood. Read-only: adds a probe path, changes nothing.
+                    fw_up_log_slave_status("begin-not-ready");
                 }
             }
 


### PR DESCRIPTION
## Summary

The first hardware run of the FW-9 doom signature set (rig dispatch #898) confirmed the **Ed25519 accept path works** — a correctly-signed `.plyx` loads and the engine runs. But the two negative tests (`tampered`/`unsigned` refused) couldn't run: both died at setup with `BEGIN NACK for pseudo bundle 0x7e`.

Root cause is a firmware capability gap, not a signing break. `FONTPACK_BEGIN` gates on `!doom_mode_active()` (the stager halts core1 / holds the overlay pool). The accept test loads the engine via IDDQD idle, leaving doom active, then sends cmd 15 "stop idle" to end it — but **stop-idle only cleared `DISP_IDLE` and never tore down the attract demo**, which runs with `STATUS_DISP_ON` set / `DISP_IDLE` clear, so the flag handling never reached it. The host had no way to stop the screensaver over HID (only a physical keypress did, via `poly_force_wake()`), and the rig can't press keys — so the following tests could never re-flash their packs.

It's a chicken-and-egg: `poly_prepare_for_flash()` *would* stop doom, but it's only reached once `master_ok` is true, which requires doom already inactive. While the demo holds the pool, every BEGIN NACKs and nothing can tear it down.

**Fix:** cmd 15 stop-idle now calls `doom_screensaver_stop()` at the top of the branch, mirroring `poly_force_wake()`/`poly_prepare_for_flash()`. It self-guards (only an active attract demo is affected; no-op inline stub on a non-doom build) and runs inline, so the master tears down and `doom_ctl=0` is synced to the slave before the ACK. A host "stop idle" now stops any idle animation including the doom attract demo — the same thing a keypress wake already did.

No wire-format change (cmd 15 payload identical), so **no `PROTOCOL_VERSION` bump**.

## Version bump label

*(none)* — bug fix, patch bump.

## Testing
- [x] Compiled successfully — built `split72 POLYKYBD_DOOM_PACK=yes` (links)
- [ ] Hardware: needs the **`hil-doom`** label to re-run the FW-9 signature set on the rig and confirm the tampered/unsigned refusal tests now reach the Ed25519 gate and go green
- [x] No protocol change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8pW42ifgtNjFFVdrWPZ2m

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8pW42ifgtNjFFVdrWPZ2m)_

## Summary by Sourcery

Restore reliable repeated DOOM pack flashing by making host wake commands stop the attract screensaver and hardening staging recovery and diagnostics.

Bug Fixes:
- Allow host-issued stop-idle commands to terminate the DOOM attract screensaver so subsequent font and DOOM pack flashes can proceed.
- Prevent firmware staging relaunches from blocking indefinitely after degraded DOOM engine cycles.

Enhancements:
- Improve font-pack flash diagnostics by reporting slave readiness and staging status when the master has completed erasing but the slave is not ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stopping idle mode from the host now properly exits the active DOOM screensaver.
  * Host wake requests no longer leave the attract-mode demo running unexpectedly.
  * Firmware recovery no longer waits indefinitely when restarting a background service, allowing normal operation to continue.

* **Diagnostics**
  * Added additional status reporting when font-pack updates encounter delayed device readiness, improving troubleshooting of update issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->