### PR TITLE
ci: pass PR label names to the shell via env, not by interpolation

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -27,8 +27,16 @@ jobs:
 
       - name: Determine bump type from PR labels
         id: bump_type
+        # Label names reach the script through the ENVIRONMENT, never by being
+        # interpolated into its text. A GitHub label may contain a single
+        # quote, which in the old `LABELS='${{ ... }}'` form closed the shell
+        # string and let the rest of the name run as commands. Applying a label
+        # needs write access, which already allows more than this would buy, so
+        # this is defence in depth rather than a closed hole -- but the safe
+        # form costs nothing.
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |
-          LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
           if echo "$LABELS" | grep -q '"bump:major"'; then
             echo "type=major" >> "$GITHUB_OUTPUT"
           elif echo "$LABELS" | grep -q '"bump:minor"'; then
@@ -40,8 +48,16 @@ jobs:
           fi
 
       - name: Bump version in config.h
+        # Same rule as above: the bump type is read from the environment rather
+        # than pasted into the Python source. It can only be one of four
+        # literals this workflow itself wrote, so nothing is exploitable here --
+        # but with this there is no `${{ }}` left inside any `run:` body, which
+        # makes the file safe by inspection instead of by tracing each value.
+        env:
+          BUMP_TYPE: ${{ steps.bump_type.outputs.type }}
         run: |
           python3 - <<'PYEOF'
+          import os
           import re
 
           path = "keyboards/polykybd/config.h"
@@ -54,7 +70,7 @@ jobs:
           m_proto = re.search(r'#define PROTOCOL_VERSION (\d+)', content)
           proto = int(m_proto.group(1)) if m_proto else 1
 
-          bump = "${{ steps.bump_type.outputs.type }}"
+          bump = os.environ["BUMP_TYPE"]
           if bump == "major":
               major += 1; minor = 0; patch = 0
           elif bump == "minor":


### PR DESCRIPTION
## Summary

`bump-version.yml` built its label test by pasting the label names into the script text:

```yaml
run: |
  LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
```

A GitHub label name may contain a single quote, which closes that string and lets the rest of the name run as commands. The value now reaches the script through `env:` instead.

⚠️ **Defence in depth, not a closed hole.** Applying a label needs write or triage access, and anyone holding that can already push workflow changes — so the injection buys an attacker nothing they don't already have. Worth fixing because the safe form costs nothing, not because it was reachable. Flagging that plainly so nobody reads this as an incident.

### Demonstrated, not assumed

With a label named `x'; touch /tmp/PWNED; :'`:

| Form | Result | Step output |
|---|---|---|
| old (interpolated) | **`/tmp/PWNED` created** | still `type=minor` |
| new (via `env:`) | not created | `type=minor` |

Note the second column: the injection left the step's *result* correct, so nothing downstream would have looked wrong. Both forms resolve the legitimate `bump:minor` label identically, so behaviour is unchanged.

### Also moved: the Python heredoc's `${{ }}`

`bump = "${{ steps.bump_type.outputs.type }}"` now reads `os.environ["BUMP_TYPE"]`. That value provably cannot be hostile — it's one of four literals this workflow itself writes one step earlier. The reason to move it is that **there is now no `${{ }}` inside any `run:` body in this file**, so it's safe by inspection rather than by tracing where each value came from.

### Siblings checked before stopping

Across the five fork-local workflows, `github.event.*` appeared in exactly **one** `run:` body — the one fixed here:

| Workflow | Expressions in `run:` | Externally sourced |
|---|---|---|
| `bump-version.yml` | 0 (was 2) | — |
| `qmk-test.yml` | 11 | none — `steps.*.outputs`, `needs.*.outputs` |
| `release.yml` | 7 | none — `env.KB`/`env.KM`, `github.repository` |
| `cppcheck.yml` | 0 | — |
| `polykybd-unit-test.yml` | 0 | — |

Stock upstream workflows are deliberately untouched — editing them conflicts on every catch-up merge, and `ci_build_major_branch_keymap.yml` (flagged by the same audit) is inert in this fork anyway: its only caller gates on `if: github.repository == 'qmk/qmk_firmware'`.

## Version bump label

None — patch bump is right.

## Testing
- [ ] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`)
- [ ] Flashed and tested on hardware
- [ ] If protocol changed: host updated and tested together

None apply — CI wiring only, no firmware source touched, and `qmk-test.yml` carries `paths-ignore: ['**.md']` but this is a workflow file so the build and rig do run. Validated instead that:

- the YAML parses, and both `env:` values are **single-line** — a folded multi-line expression silently stops being a valid GitHub expression;
- the heredoc'd Python still compiles (`ast.parse`) and reads `BUMP_TYPE` from the environment;
- no `${{ }}` remains in any `run:` body;
- the injection reproduces on the old form and does not on the new one (table above).

🔎 **Self-testing on merge:** this PR changes the very workflow that bumps the version when it merges, so the modified `bump-version.yml` runs against this PR. A green run producing a patch bump is the end-to-end confirmation; a failure would be visible in that run rather than silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqGGmtbLW5CDwm24rPL5Go

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqGGmtbLW5CDwm24rPL5Go)_

## Summary by Sourcery

Harden version-bump workflow inputs by passing dynamic values through the environment rather than embedding them in shell or Python scripts.

Bug Fixes:
- Prevent shell command injection by passing pull-request label data to the version-bump workflow through the environment instead of interpolating it into the script.

Enhancements:
- Remove GitHub expression interpolation from the workflow's run bodies by reading the bump type from the environment.

CI:
- Harden the version-bump workflow's handling of externally sourced label data and step output values.