### PR TITLE
Make the legend bbox resolve glyphs the way the draw does

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2564,7 +2564,42 @@ op-argument table, the SMALL/MID semantics and the baseline-shift rule.
     by origin), so its 34 existing tests still pin it. **Use the absolute one whenever
     you need to know where ALL of a legend lands** — which is exactly what the idle
     jitter needs, and what it did not have (below).
-
+- ✅ **TWO bbox-vs-draw asymmetries were FIXED 2026-08-29 — both made the measured
+  box describe glyphs the draw would not produce.** Worth knowing they existed,
+  because the shape recurs: this function and the draw resolved glyphs by two
+  different routes, so they could disagree without either looking wrong.
+  1. **The `'!'` substitution had no `small` guard.** The measure path did
+     `if (!f) { f = pool[0]; …; ch = U'!'; }` unconditionally, while the SMALL draw
+     (`kdisp_write_gfx_char_half`) does `if (glyph == NULL …) return 0;` — no ink and
+     **no advance**. So a `HINT_SMALL` run containing an uncovered codepoint measured a
+     half-`'!'` *and* spent an advance the draw never spends, putting every following
+     glyph at the wrong x.
+  2. **The scan did not skip 0x0 GAP records.** It was a bare
+     `if (ch >= first && ch <= last) { f = pool[i]; break; }`, where every draw path
+     goes through `kdisp_gfx_glyph_font`, which skips a `{0,0,0,0,0,0}` padding record
+     so a later font wins. A codepoint inside a padded span — Pashto letters under
+     `_PerArab_`'s wider range — measured the empty gap while the draw resolved a real
+     glyph from the next font.
+  **The fix is one line of intent: resolve through `kdisp_gfx_glyph_font`, the same
+  lookup the draw uses**, and skip the codepoint instead of substituting when a SMALL
+  run finds nothing. Don't reintroduce a private range scan here — that is what made
+  (2) possible, and a second resolver can always drift from the first.
+  - **It mattered because `plan_main_legend()` positions the main legend from this box
+    and clamps it to the panel**, and `roll_idle_offset()` derives a glyph's idle travel
+    from it — so a wrong box is a mis-placed or clipped legend, not just a wrong number.
+    Reachability was narrow (a legend needs a missing glyph *and* a size op, or a gapped
+    codepoint), which is why nothing had reported it.
+  - ⚠️ **The old C suite passed over BOTH.** `GapRecordFallsThroughToTheNextFont` covers
+    the *resolver*, not the bbox, and there was no missing-glyph-in-a-SMALL-run case at
+    all — 34 tests, neither asymmetry visible. The two added with the fix
+    (`SmallSkipsAMissingGlyphInsteadOfSubstitutingBang`, `FontBboxGapTest`) were
+    confirmed to FAIL against the pre-fix file and pass after, with the other 34
+    unmoved. **A suite that measures a resolver is not measuring its callers.**
+  - ⚠️ **The host's Python mirror moves with this.** `PolyKybdHost`'s
+    `oled_preview.Renderer` reproduces this function; it already skipped gaps (so (2)
+    was never wrong there) but deliberately pinned the `'!'` substitution as C parity.
+    That pin is now backwards — it needs inverting in the host repo, or the two
+    diverge again in the opposite direction.
 **The legend-size key is now ONE key that states its own tier.** `KC_GLYPH_SIZE_UP` on
 `_UL` draws `ICON_FONT_BIGGER` plus the current tier as a digit in the top-right;
 holding **Shift** swaps the icon to `ICON_FONT_SMALLER` and reverses the step, so the

--- a/keyboards/polykybd/base/font_lookup.c
+++ b/keyboards/polykybd/base/font_lookup.c
@@ -215,22 +215,32 @@ static void bbox_walk(const GFXfont *const *fonts, uint8_t num_fonts,
                 }
                 break;
             default: {
-                // Locate the font whose [first,last] contains the codepoint (linear
-                // scan; this is a cold measuring path, no MRU cache needed).
-                uint32_t ch = *text, first = 0, last = 0;
                 // Mirror the draw's per-glyph fallback: MID applies only to codepoints
                 // the mid face actually has.
                 const bool            use_mid = mid && kdisp_gfx_glyph(mid_font, mid_count, *text) != NULL;
                 const GFXfont *const *pool = use_mid ? mid_font : fonts;
                 const uint8_t         cnt  = use_mid ? mid_count : num_fonts;
-                const GFXfont *f = 0;
-                for (uint8_t i = 0; i < cnt; ++i) {
-                    first = pgm_read_dword(&pool[i]->first);
-                    last  = pgm_read_dword(&pool[i]->last);
-                    if (ch >= first && ch <= last) { f = pool[i]; break; }
+                // ⚠️ Resolve through kdisp_gfx_glyph_font, the SAME lookup every draw
+                // path uses, rather than a hand-rolled range scan. The scan that used to
+                // be here did not skip a 0x0 GAP record (the generated headers' padding
+                // for a non-contiguous range), so a codepoint inside a padded span —
+                // Pashto letters under _PerArab_'s wider range is the documented case —
+                // measured the empty gap while the draw resolved a real glyph from the
+                // next font. Measuring a glyph the draw will not produce mis-places the
+                // legend, because plan_main_legend() positions from this box.
+                const GFXfont  *f = NULL;
+                const GFXglyph *g = kdisp_gfx_glyph_font(pool, cnt, *text, &f);
+                if (g == NULL) {
+                    // Nothing covers it. The full-size writer substitutes '!' from
+                    // fonts[0] and advances, so the box must too — but
+                    // kdisp_write_gfx_char_half returns 0: it draws NOTHING and does not
+                    // advance. Substituting here in a SMALL run therefore invented both
+                    // ink and an advance the draw never spends, shifting every following
+                    // glyph. Skip the codepoint instead, exactly as the half writer does.
+                    if (small) break;
+                    f = pool[0];
+                    g = pgm_read_glyph_ptr(f, U'!' - pgm_read_dword(&f->first));
                 }
-                if (!f) { f = pool[0]; first = pgm_read_dword(&f->first); ch = U'!'; }
-                const GFXglyph *g = pgm_read_glyph_ptr(f, ch - first);
                 int8_t w  = pgm_read_byte(&g->width);
                 int8_t h  = pgm_read_byte(&g->height);
                 int8_t xo = pgm_read_byte(&g->xOffset);

--- a/keyboards/polykybd/base/tests/font_bbox_tests.cpp
+++ b/keyboards/polykybd/base/tests/font_bbox_tests.cpp
@@ -296,6 +296,19 @@ TEST_F(FontBboxTest, SmallFloorsANegativeOffsetInsteadOfTruncating) {
     EXPECT_EQ(measure({0x10, 'b'}), (Box{1, 3, -5, -1}));
 }
 
+TEST_F(FontBboxTest, SmallSkipsAMissingGlyphInsteadOfSubstitutingBang) {
+    // ⚠️ The one place the measure and the draw used to disagree by construction.
+    // kdisp_write_gfx_char_half returns 0 for a glyph it cannot find — no ink, no
+    // advance — while this function substituted '!' unconditionally. So a SMALL run
+    // containing an uncovered codepoint measured a half-'!' AND spent its advance,
+    // putting every following glyph at the wrong x. 0x4000 is in no pool font.
+    EXPECT_EQ(measure({0x10, 0x4000}), (Box{0, 0, 0, 0}));
+    // ...and the phantom advance is gone too: the run measures as if it weren't there.
+    EXPECT_EQ(measure({0x10, 0x4000, 'a'}), measure({0x10, 'a'}));
+    // FULL size still substitutes, because kdisp_write_gfx_char does.
+    EXPECT_EQ(measure({0x4000}), measure({'!'}));
+}
+
 TEST_F(FontBboxTest, SmallLatchesForTheRestOfTheRun) {
     // No back-to-full op exists, and \x18 resets only the cursor.
     EXPECT_EQ(measure({0x10, 'a', 0x18, 'a'}), (Box{0, 2, -5, -1}));
@@ -330,6 +343,30 @@ TEST_F(FontBboxTest, ANullMidPoolMakesEveryMidGlyphFallBack) {
     // The wrapper always passes the resident face, but the pure function
     // tolerates measuring with none: \x16 then changes nothing.
     EXPECT_EQ(measure({0x16, 'a'}, nullptr, 0), measure({'a'}));
+}
+
+// ---------------------------------------------------------------------------
+// The bbox resolves through that same resolver — so a GAP record falls through
+// here too. It did not until 2026-08-29: this function ran its own range scan
+// with no gap check, so a codepoint inside a padded span measured the empty 0x0
+// record while the draw resolved the filler font's real glyph.
+
+TEST(FontBboxGapTest, AGapRecordIsSkippedSoTheFillerFontIsMeasured) {
+    TestFont gappy  = make_gappy();
+    TestFont filler = make_gap_filler();
+    const GFXfont *pool[2] = {&gappy.font, &filler.font};
+
+    auto measure = [&](uint32_t cp) {
+        const uint32_t text[] = {cp, 0};
+        Box            b{};
+        kdisp_gfx_text_bbox_in(pool, 2, nullptr, 0, text, &b.xmin, &b.xmax, &b.ymin, &b.ymax);
+        return b;
+    };
+    // 0x105 is a gap in `gappy` and real in `filler` (7x8, xo 1, yo -8, yAdv 44):
+    // yadj = 44-40 = +4, so top = 4-8 = -4, bottom = -4+8-1 = 3.
+    EXPECT_EQ(measure(0x105), (Box{1, 7, -4, 3}));
+    // An ordinary codepoint still measures from the FIRST font, gap or not.
+    EXPECT_EQ(measure(0x104), (Box{0, 2, -5, -1}));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`kdisp_gfx_text_bbox_in` and the draw resolved glyphs by **two different routes**, so they could disagree without either looking wrong. Two ways they did — both make the measured box describe glyphs the draw will not produce:

1. **The `'!'` substitution had no `small` guard.** The measure path did `if (!f) { f = pool[0]; …; ch = U'!'; }` unconditionally, while the SMALL draw (`kdisp_write_gfx_char_half`) does `if (glyph == NULL …) return 0;` — no ink and **no advance**. So a `HINT_SMALL` run containing an uncovered codepoint measured a half-`'!'` *and* spent an advance the draw never spends, putting every following glyph at the wrong x.

2. **The scan did not skip 0x0 GAP records.** It was a bare `if (ch >= first && ch <= last) { f = pool[i]; break; }`, where every draw path goes through `kdisp_gfx_glyph_font`, which skips a `{0,0,0,0,0,0}` padding record so a later font wins. A codepoint inside a padded span — Pashto letters under `_PerArab_`'s wider range is the documented case — measured the empty gap while the draw resolved a real glyph from the next font.

**The fix is one line of intent: resolve through `kdisp_gfx_glyph_font` itself**, and skip the codepoint rather than substituting when a SMALL run finds nothing. That removes the second resolver instead of patching it — a private range scan here is what made (2) possible, and a second resolver can always drift from the first.

### Why it matters

`plan_main_legend()` positions the main legend from this box **and clamps it to the panel**, and `roll_idle_offset()` derives a glyph's idle travel from it. A wrong box is a mis-placed or clipped legend, not just a wrong number. Reachability was narrow — a legend needs a missing glyph *and* a size op, or a gapped codepoint — which is why nothing had reported it.

### How it was found

Porting this interpreter to the host's keycap preview (PolyKybdHost#200). (1) was raised there by Greptile against the Python mirror and verified against this source; (2) turned up while checking whether the mirror was faithful.

## Version bump label

None — patch. No protocol or wire-format change.

## Testing

- [x] `make test:polykybd_font_bbox` — **36 passed** (34 existing + 2 new)
- [x] `qmk compile -kb polykybd/split72 -km default -e POLYKYBD_DOOM_PACK=yes` — links clean
- [x] `qmk lint --strict --keyboard polykybd/split72` — passed; no tracked-ignored files, no CRLF, trailing newlines present
- [ ] Tested on real hardware — not by me

⚠️ **The old suite passed over both defects.** `GapRecordFallsThroughToTheNextFont` covers the *resolver*, not the bbox, and there was no missing-glyph-in-a-SMALL-run case at all: 34 tests, neither asymmetry visible. So the two new cases were mutation-checked rather than assumed — reverted `font_lookup.c` to the pre-fix file (asserting the revert actually applied) and re-ran:

```
[  FAILED  ] FontBboxTest.SmallSkipsAMissingGlyphInsteadOfSubstitutingBang
[  FAILED  ] FontBboxGapTest.AGapRecordIsSkippedSoTheFillerFontIsMeasured
[  PASSED  ] 34 tests.
```

Exactly the two intended tests fail, the other 34 are unmoved, and both pass after. *A suite that measures a resolver is not measuring its callers.*

No new statics, so the monolithic RAM flavour is not at risk; the pack flavour links clean.

## Follow-up in another repo

`PolyKybdHost`'s `oled_preview.Renderer` mirrors this function. It already skipped gaps — so (2) was never wrong there — but it deliberately **pinned the `'!'` substitution as C parity**, with a test saying so. That pin is backwards once this merges and needs inverting, or the two diverge again in the opposite direction. Flagged in the CLAUDE.md note here and in PolyKybdHost#203; I'll do it once this lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LeoBsy75UBvecXehCiAoWg)_

## Summary by Sourcery

Make legend bounding-box measurement use the same glyph resolution behavior as rendering.

Bug Fixes:
- Align glyph bounding-box resolution with the draw path so missing glyphs in SMALL runs are omitted and gap records fall through to later fonts.
- Prevent incorrect legend positioning and clipping caused by bounding boxes measuring glyphs that rendering does not produce.

Documentation:
- Document the corrected bounding-box and draw-path behavior, including the required follow-up for the host-side renderer mirror.

Tests:
- Add coverage for missing glyphs in SMALL runs and glyph lookup across gap records, including regression checks for full-size fallback behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text measurement accuracy for small-size rendering when glyphs are missing.
  * Corrected measurement of characters located in padded font ranges so their actual glyphs are used.
  * Ensured text bounds match the results produced during drawing.

* **Tests**
  * Added coverage for missing glyph handling and padded font-range lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->