### PR TITLE
ci: stop a workflow-only change occupying the HIL rig

### DIFF
--- a/.github/workflows/qmk-test.yml
+++ b/.github/workflows/qmk-test.yml
@@ -8,28 +8,50 @@ on:
     # push delays every real build queued behind it).
     #
     # Beyond Markdown: `scripts/` holds only publish_release.py (the release
-    # publisher — nothing the build reads), and `.claude/` holds skills and
-    # settings. A change confined to either cannot reach a firmware image.
-    # ⚠️ Verify that stays true before adding a path here: the test is whether
-    # the build or the rig ever READS it, not whether it looks unrelated.
+    # publisher — nothing the build reads), `.claude/` holds skills and settings,
+    # and the other workflows are not build inputs (see the note on that line).
+    # A change confined to any of them cannot reach a firmware image.
+    # ⚠️ Verify that stays true before adding an exclusion here: the test is
+    # whether the build or the rig ever READS it, not whether it looks unrelated.
     #
-    # ⚠️ `paths-ignore` skips the workflow only when EVERY changed file matches,
-    # so a mixed docs+code PR still runs the gate in full — this can never hide
-    # a code change behind a README edit.
+    # ⚠️ The workflow runs when AT LEAST ONE changed file is included, so a mixed
+    # docs+code (or workflow+code) PR still runs the gate in full — this can
+    # never hide a code change behind a README or a CI edit.
     #
-    # ⚠️ `**.md` does NOT match this workflow file, so a change to the CI wiring
-    # itself still triggers a run and gets verified. `workflow_dispatch` has no
-    # paths filter at all, so a manual run is unaffected either way.
+    # ⚠️ This is `paths`, NOT `paths-ignore`, and it has to be: the `!` negation
+    # prefix works ONLY in `paths`, and the two filters cannot both be used for
+    # one event. Excluding the other workflows while still verifying THIS one is
+    # not expressible with `paths-ignore` at all.
+    #
+    # ⚠️ ORDER IS LOAD-BEARING. The last pattern that matches a path decides it:
+    # a negative after a positive excludes, a positive after a negative
+    # re-includes. So the leading `**` is what makes an ordinary source file
+    # match, and the qmk-test.yml line MUST stay last or this workflow stops
+    # verifying changes to itself.
+    #
+    # ⚠️ `workflow_dispatch` has no paths filter at all, so a manual run is
+    # unaffected either way.
     #
     # ⚠️ If `Build firmware` / `HIL test (split72)` are ever made REQUIRED status
     # checks in branch protection, remove this: a workflow that never runs never
     # reports, and the merge button would deadlock on a docs-only PR (a *skipped
     # job* satisfies a required check; a never-started workflow does not). The
     # fix in that case is a paths-filter job feeding `if:` conditions instead.
-    paths-ignore:
-      - '**.md'
-      - 'scripts/**'
-      - '.claude/**'
+    paths:
+      - '**'
+      - '!**.md'
+      - '!scripts/**'
+      - '!.claude/**'
+      # No `uses: ./...` anywhere in this file — every action it runs is external
+      # (docker://qmkfm/qmk_cli, actions/*) — so no workflow is a build input and
+      # a workflow-only change cannot alter a firmware image. Deliberately scoped
+      # to `workflows/` rather than all of `.github/`: if a composite action is
+      # ever added under `.github/actions/` and used here, it stays outside this
+      # exclusion and keeps triggering a run, which is the safe direction.
+      - '!.github/workflows/**'
+      # …except this file. It IS the gate, so a change to it must still be built
+      # and run on the rig. Positive-after-negative re-includes; keep it LAST.
+      - '.github/workflows/qmk-test.yml'
   pull_request:
     # `labeled` is NOT in GitHub's default set (opened/synchronize/reopened), and
     # without it adding the `perf` label to an open PR fires no run at all — the
@@ -38,11 +60,15 @@ on:
     # 'labeled'`) so the repo's auto-labeler can't re-run the whole expensive
     # pipeline every time it tags a PR by path.
     types: [opened, synchronize, reopened, labeled]
-    # Same reasoning as the push trigger above.
-    paths-ignore:
-      - '**.md'
-      - 'scripts/**'
-      - '.claude/**'
+    # Same reasoning, same ordering constraint, as the push trigger above — keep
+    # the two lists identical, and keep the qmk-test.yml re-include last.
+    paths:
+      - '**'
+      - '!**.md'
+      - '!scripts/**'
+      - '!.claude/**'
+      - '!.github/workflows/**'
+      - '.github/workflows/qmk-test.yml'
   # Manual trigger for the opt-in performance measurement below (the normal
   # build + HIL test always run; perf does not). No inputs: the baseline is moved
   # by committing the run's JSON to polykybd-ctnd, not by a workflow switch — the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -466,17 +466,36 @@ inherited-upstream noise:
     would analyse the whole upstream QMK tree — the same trap as the
     lint-on-upstream-keyboards problem below. The host repo runs CodeQL instead,
     where Python needs no build and the tree is entirely ours.
-- **A Markdown-only change does NOT run the build or the rig — `qmk-test.yml` has
-  `paths-ignore: ['**.md']`** on both its `push` and `pull_request` triggers (added
-  2026-08-21). The rig executes one job at a time, so before this a comment-only PR
-  occupied it for a full flash-and-test cycle per push and delayed every real build
-  queued behind it (#224 burned three rig runs and three review slots that way).
-  Four things follow, and the last is the one that would bite:
-  - **A mixed docs+code PR still runs the gate in full.** `paths-ignore` skips the
-    workflow only when EVERY changed file matches, so nothing can be smuggled in
-    behind a README edit.
-  - **`**.md` does not match `.github/workflows/qmk-test.yml`**, so a change to the
-    CI wiring itself still triggers a run and gets verified.
+- **A change that cannot alter the firmware does NOT run the build or the rig —
+  `qmk-test.yml` path-filters both its `push` and `pull_request` triggers.** Markdown
+  since 2026-08-21, then `scripts/` and `.claude/`, then the sibling workflow files
+  (#253, 2026-08-29). The rig executes one job at a time, so before this a
+  comment-only PR occupied it for a full flash-and-test cycle per push and delayed
+  every real build queued behind it (#224 burned three rig runs and three review
+  slots that way; #251 later did the same as a workflow-only PR). What follows —
+  the last one is still the one that would bite:
+  - ⚠️ **It is a `paths` list with `!` negations, NOT `paths-ignore`, and it cannot
+    be either one.** The `!` prefix works ONLY in `paths`, and the two filters may
+    not both be used for one event — so "exclude the sibling workflows but still
+    verify this one" is inexpressible with `paths-ignore`. The list is `**`,
+    `!**.md`, `!scripts/**`, `!.claude/**`, `!.github/workflows/**`,
+    `.github/workflows/qmk-test.yml`, identical on both triggers.
+  - ⚠️ **ORDER IS LOAD-BEARING — the LAST matching pattern decides.** The leading
+    `**` is what makes an ordinary source file match at all, and the trailing
+    `.github/workflows/qmk-test.yml` is what keeps the gate verifying its own edits.
+    Move that line above `!.github/workflows/**`, or drop it, and a change to this
+    workflow silently stops being built and rig-tested; drop the `**` and ordinary
+    firmware sources stop triggering anything. Both were confirmed by mutating the
+    list and re-running a simulation of GitHub's matcher, which is the only way to
+    check this without merging and waiting.
+  - **A mixed docs+code — or workflow+code — PR still runs the gate in full**, since
+    the workflow runs when AT LEAST ONE changed file is included. Nothing can be
+    smuggled in behind a README or a CI edit.
+  - **The exclusion is scoped to `.github/workflows/**`, not all of `.github/`.**
+    Nothing under `.github/` is a build input today — there is no `uses: ./...`
+    anywhere in `qmk-test.yml`, every action is external — but the narrower scope
+    leaves a composite action added later under `.github/actions/` still triggering
+    a run, which is the safe direction.
   - **`workflow_dispatch` has no paths filter**, so a manual run — including the
     both-tiers route above — works on any commit regardless.
   - ⚠️ **A path-filtered `pull_request` trigger applies to `labeled` too**, so


### PR DESCRIPTION
## Summary

`paths-ignore` spared Markdown, `scripts/` and `.claude/`, but not the other workflow files — so a PR touching only `.github/workflows/bump-version.yml` still ran a full firmware build **and a flash-and-test cycle on the rig**. #251 did exactly that: ~4 min of build and ~3 min of hardware for a diff that cannot alter a firmware image. The rig runs one job at a time, so it delays every real build behind it — the same reasoning the `**.md` exclusion was added for.

### Why this switches `paths-ignore` → `paths`

Forced, not a preference. Per GitHub's workflow syntax:

> "If you want to both include and exclude path patterns for a single event, use the `paths` filter prefixed with the `!` character"
> "You cannot use both the `paths` and `paths-ignore` filters for the same event in a workflow."

So *"exclude the other workflows but still verify this one"* is **not expressible with `paths-ignore` at all**.

```yaml
paths:
  - '**'
  - '!**.md'
  - '!scripts/**'
  - '!.claude/**'
  - '!.github/workflows/**'
  - '.github/workflows/qmk-test.yml'   # ← must stay LAST
```

⚠️ **A change to `qmk-test.yml` itself must keep triggering a run**, or the gate stops verifying its own edits. The trailing line re-includes it, and because the **last matching pattern decides**, that line has to stay last. Both facts are called out in the comments.

### Scope choice

Deliberately `.github/workflows/**`, not all of `.github/`. There is no `uses: ./...` anywhere in this file — every action is external (`docker://qmkfm/qmk_cli`, `actions/*`) — so no workflow is a build input. But if a composite action is ever added under `.github/actions/` and used here, the narrower scope leaves it triggering a run, which is the safe direction.

## Verification

Simulated GitHub's matcher over the filter list — 14 scenarios, all as intended:

| Changed files | Result |
|---|---|
| firmware source / `quantum/` | **runs** |
| docs / `scripts/` / `.claude/` only | skipped |
| **other workflow only** | **skipped** ← the point of this PR |
| **`qmk-test.yml` only** | **runs** ← self-test preserved |
| docs + firmware, workflow + firmware | **runs** (nothing hides behind a CI edit) |
| upstream catch-up merge | **runs** |
| `.github/actions/foo/action.yml` | **runs** (safe direction) |

Then mutation-checked the ordering claim rather than just asserting it:

| Mutation | Caught by |
|---|---|
| re-include moved **before** the negation | `qmk-test.yml`-only stops running |
| re-include deleted | same |
| leading `**` dropped | ordinary source stops running |
| broadened to `.github/**` | passes the three primary checks, but `.github/actions/` stops triggering — which is why the scope is narrow |

## Version bump label

None — patch bump is right.

## Testing
- [ ] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`)
- [ ] Flashed and tested on hardware
- [ ] If protocol changed: host updated and tested together

None apply — CI wiring only, no firmware source touched. Validated instead that the YAML parses, the push and `pull_request` lists are identical, the re-include is last, no `paths-ignore` key survives, and the scenario + mutation results above.

🔎 **What this PR's own run does and does not prove.** *(Corrected — an earlier version of this paragraph claimed the stronger thing.)* It changes `qmk-test.yml`, so the build and the rig must still trigger, and they did. But this run **cannot distinguish the old filter from the new one**: `paths-ignore` never mentioned workflows, so a `qmk-test.yml` edit ran under it too, and the new list re-includes that same file. A green board here therefore confirms triggering is not broken — **not** that the re-include is what did it.

The exclusion half gets its first real test on the next PR that touches a *different* workflow: it should show no `Build firmware` / `HIL test (split72)` at all. Until then, the evidence for both halves is the simulation and mutation results above.

## Known caveat (unchanged, already in the file)

If `Build firmware` / `HIL test (split72)` are ever made **required** status checks in branch protection, this has to go — a workflow that never runs never reports, so a docs-only PR would deadlock the merge button. The fix then is a paths-filter job feeding `if:` conditions, since a *skipped job* satisfies a required check while a never-started workflow does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqGGmtbLW5CDwm24rPL5Go

## Summary by Sourcery

Restrict the firmware test workflow to changes that can affect firmware while preserving self-validation and mixed-change coverage.

Bug Fixes:
- Prevent workflow-only changes from unnecessarily starting firmware builds and hardware-in-the-loop tests.
- Continue triggering the gate when qmk-test.yml itself changes.

Enhancements:
- Replace path exclusions with ordered include/exclude filters for both push and pull_request triggers, while preserving runs for mixed code and workflow changes.
- Document the workflow path-filter behavior, ordering constraints, scope, and validation guidance.

CI:
- Avoid occupying the single hardware rig for changes to unrelated workflow files.

Documentation:
- Update project guidance to describe the expanded CI path filtering and its implications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated testing triggers to run for relevant code changes while excluding documentation, scripts, configuration, and unrelated workflow updates.
  - Ensured changes to the testing workflow itself continue to trigger validation.
  - Preserved the option to run checks manually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->