### PR TITLE
diag(fw-9): instrument the intermittent post-doom slave core1 wedge

### DIFF
--- a/keyboards/polykybd/base/fw_staging.c
+++ b/keyboards/polykybd/base/fw_staging.c
@@ -843,6 +843,10 @@ void fw_staging_get_status(fw_staging_status_t *out) {
     out->chunk_handler_errors      = s_chunk_handler_errors;
     out->process_deferred_calls    = s_process_deferred_calls;
     out->process_deferred_advances = s_process_deferred_advances;
+    uint16_t c1_calls = 0, c1_timeouts = 0;
+    multicore_launch_core1_bounded_stats(&c1_calls, &c1_timeouts);
+    out->core1_relaunch_calls    = (uint8_t)(c1_calls    > 255 ? 255 : c1_calls);
+    out->core1_relaunch_timeouts = (uint8_t)(c1_timeouts > 255 ? 255 : c1_timeouts);
     out->pad                       = 0;
 }
 

--- a/keyboards/polykybd/base/fw_staging.c
+++ b/keyboards/polykybd/base/fw_staging.c
@@ -59,10 +59,6 @@ _Static_assert(FW_RESOURCE_OFFSET + FW_DOOMPACK_SLOT_OFF + FW_DOOMPACK_SLOT_SIZE
 #ifdef USE_CORE1
 #include "polymod_core1.h"
 
-// PSM FRCE_OFF register + the PROC1 bit, as raw literals. Used ONLY by the
-// not-in-flash apply path (fw_staging_do_apply), which cannot call the
-// flash-resident multicore_hold_core1_off(); the ordinary halt/restart go through
-// that shared primitive instead.
 #define _PSM_FRCE_OFF  (*(volatile uint32_t *)0x40010004u)
 #define _PSM_PROC1_BIT (1u << 16)
 
@@ -70,18 +66,15 @@ _Static_assert(FW_RESOURCE_OFFSET + FW_DOOMPACK_SLOT_OFF + FW_DOOMPACK_SLOT_SIZE
 static bool s_core1_halted = false;
 
 static void fw_staging_halt_core1(void) {
-    // Force core1 into PSM reset and WAIT for the reset to latch before the caller
-    // touches flash. A bare force-off + DSB returns before core1 has actually
-    // stopped; once the doom engine has run on core1, the subsequent big erase then
-    // faults a still-running core1 and takes the whole (slave) half down — the
-    // intermittent post-doom slave wedge (FW-9). Consolidated with the Doom
-    // teardown's proven force-off→wait-for-latch sequence in polymod_core1.
-    multicore_hold_core1_off();
+    _PSM_FRCE_OFF |= _PSM_PROC1_BIT;
+    // FRCE_OFF takes effect within a few cycles; DSB ensures the write
+    // reaches the PSM peripheral before the caller touches flash.
+    __asm volatile ("dsb" ::: "memory");
     s_core1_halted = true;
 }
 
 static void fw_staging_restart_core1(void) {
-    multicore_release_core1_off();
+    _PSM_FRCE_OFF &= ~_PSM_PROC1_BIT;
     s_core1_halted = false;
     // BOUNDED relaunch, NOT the unbounded multicore_launch_core1(). core0 can
     // reach here with core1's FIFO launch handshake left desynced by a prior Doom
@@ -919,15 +912,12 @@ ram_word_copy(uint32_t *dst, const uint32_t *src, uint32_t nbytes) {
 // ---------------------------------------------------------------------------
 static void __no_inline_not_in_flash_func(fw_staging_do_apply)(uint32_t image_size) {
 #ifdef USE_CORE1
-    // Halt core1 via PSM reset, INLINED here: this function runs not-in-flash, so
-    // it cannot call the flash-resident multicore_hold_core1_off(). _PSM_FRCE_OFF /
-    // _PSM_PROC1_BIT are #defines (inlined register writes, no flash fetch). WAIT
-    // for the reset to latch before erasing below — a bare force-off returns before
-    // core1 has stopped, and a core1 still running from XIP faults on the erase
-    // (the same hazard fw_staging_halt_core1() waits out via the shared primitive).
+    // Halt core1 via PSM reset.  _PSM_FRCE_OFF / _PSM_PROC1_BIT are #defines
+    // (pure preprocessor text substitution → an inlined register write, no flash
+    // fetch), so this is byte-for-byte identical machine code to the raw literal
+    // it replaces — same as fw_staging_halt_core1(), inlined here for the
+    // not-in-flash apply path.
     _PSM_FRCE_OFF |= _PSM_PROC1_BIT;
-    while (!(_PSM_FRCE_OFF & _PSM_PROC1_BIT)) { /* wait for FRCE_OFF.PROC1 to latch */
-    }
     __asm volatile ("dsb" ::: "memory");
 #endif
     static uint8_t page_buf[FLASH_PAGE_SIZE];   // static (.bss): never on a moving stack

--- a/keyboards/polykybd/base/fw_staging.c
+++ b/keyboards/polykybd/base/fw_staging.c
@@ -63,6 +63,8 @@ static uint8_t  s_stage = FW_STAGE_IDLE;
 static uint8_t  s_doom_stop_result;    // 0 none, 1 relaunch ok, 2 timed out
 static uint8_t  s_doom_stop_attempts;
 static uint16_t s_doom_stop_ms;
+static uint8_t  s_doom_started;        // doom_engine_start launched the engine here
+static uint8_t  s_doom_stop_entered;   // doom_engine_stop reached (before its guard)
 
 #ifdef USE_CORE1
 #include "polymod_core1.h"
@@ -864,6 +866,8 @@ void fw_staging_get_status(fw_staging_status_t *out) {
     out->doom_stop_result    = s_doom_stop_result;
     out->doom_stop_attempts  = s_doom_stop_attempts;
     out->doom_stop_ms        = s_doom_stop_ms;
+    out->doom_started        = s_doom_started;
+    out->doom_stop_entered   = s_doom_stop_entered;
 }
 
 // FW-9 observability recorders. Pure — they only stamp the diagnostic snapshot
@@ -876,6 +880,14 @@ void fw_staging_note_doom_teardown(uint8_t result, uint8_t attempts, uint16_t ms
     s_doom_stop_result   = result;
     s_doom_stop_attempts = attempts;
     s_doom_stop_ms       = ms;
+}
+
+void fw_staging_note_doom_started(void) {
+    s_doom_started = 1;
+}
+
+void fw_staging_note_doom_stop_entered(void) {
+    s_doom_stop_entered = 1;
 }
 
 void fw_staging_note_begin_call(void) {

--- a/keyboards/polykybd/base/fw_staging.c
+++ b/keyboards/polykybd/base/fw_staging.c
@@ -56,6 +56,14 @@ _Static_assert(FW_RESOURCE_OFFSET + FW_DOOMPACK_SLOT_OFF + FW_DOOMPACK_SLOT_SIZE
 // so core1 never needs to be restarted.  On the failure path (CRC mismatch),
 // fw_staging_finalize() restarts core1 explicitly.
 // ---------------------------------------------------------------------------
+// FW-9 slave-teardown observability (see fw_staging.h). Declared up here because
+// fw_staging_restart_core1() below stamps `s_stage`. Last-write breadcrumb + the
+// doom core1 teardown outcome, both pulled by the master over the STATUS RPC.
+static uint8_t  s_stage = FW_STAGE_IDLE;
+static uint8_t  s_doom_stop_result;    // 0 none, 1 relaunch ok, 2 timed out
+static uint8_t  s_doom_stop_attempts;
+static uint16_t s_doom_stop_ms;
+
 #ifdef USE_CORE1
 #include "polymod_core1.h"
 
@@ -87,9 +95,11 @@ static void fw_staging_restart_core1(void) {
     // core1 leaves the RLE service down until the next reboot (the identical worst
     // case doom_engine_stop already accepts) but keeps THIS half's main loop alive,
     // so the erase's cleared s_erase_pending is actually observable to the master.
+    s_stage = FW_STAGE_RESTART;   // FW-9 breadcrumb: about to bounded-relaunch core1
     if (!multicore_launch_core1_bounded(100u * 1000u)) {
         uprintf("fw_staging: core1 relaunch timed out — RLE service down until reboot\n");
     }
+    s_stage = FW_STAGE_RESTART_DONE;
 }
 #endif
 
@@ -375,6 +385,7 @@ void fw_staging_begin_deferred_target(uint32_t image_size, uint32_t image_crc, u
     // on every restart; keeping it halted throughout eliminates that risk.
     // On the success path the chip hard-resets, so core1 is never restarted.
     // On the failure path fw_staging_finalize() restarts core1 explicitly.
+    s_stage = FW_STAGE_BEGIN_HALT;   // FW-9 breadcrumb: halting core1 for the erase
     fw_staging_halt_core1();
 #endif
 }
@@ -413,6 +424,7 @@ void fw_staging_process_deferred(void) {
         offset = target_data_offset() + s_erase_sector_next * FLASH_SECTOR_SIZE;
     }
     // core1 is already halted by fw_staging_begin_deferred(); no halt/restart here.
+    s_stage = FW_STAGE_ERASING;   // FW-9 breadcrumb: erase_sector_next carries the count
     uint32_t irq = save_and_disable_interrupts();
     flash_range_erase(offset, FLASH_SECTOR_SIZE);
     restore_interrupts(irq);
@@ -425,6 +437,7 @@ void fw_staging_process_deferred(void) {
     s_erase_sector_next++;
     if (s_erase_sector_next >= s_erase_sector_count) {
         s_erase_pending = false;
+        s_stage = FW_STAGE_ERASE_DONE;   // FW-9 breadcrumb: last sector erased
 #ifdef USE_CORE1
         // DIAGNOSTIC PROBE (2026-05-29): restart core1 the instant erase
         // completes, before the first chunk arrives.  Hypothesis: holding
@@ -847,7 +860,22 @@ void fw_staging_get_status(fw_staging_status_t *out) {
     multicore_launch_core1_bounded_stats(&c1_calls, &c1_timeouts);
     out->core1_relaunch_calls    = (uint8_t)(c1_calls    > 255 ? 255 : c1_calls);
     out->core1_relaunch_timeouts = (uint8_t)(c1_timeouts > 255 ? 255 : c1_timeouts);
-    out->pad                       = 0;
+    out->stage               = s_stage;
+    out->doom_stop_result    = s_doom_stop_result;
+    out->doom_stop_attempts  = s_doom_stop_attempts;
+    out->doom_stop_ms        = s_doom_stop_ms;
+}
+
+// FW-9 observability recorders. Pure — they only stamp the diagnostic snapshot
+// the master pulls over the STATUS RPC, never touching any control flow.
+void fw_staging_note_stage(uint8_t stage) {
+    s_stage = stage;
+}
+
+void fw_staging_note_doom_teardown(uint8_t result, uint8_t attempts, uint16_t ms) {
+    s_doom_stop_result   = result;
+    s_doom_stop_attempts = attempts;
+    s_doom_stop_ms       = ms;
 }
 
 void fw_staging_note_begin_call(void) {

--- a/keyboards/polykybd/base/fw_staging.c
+++ b/keyboards/polykybd/base/fw_staging.c
@@ -59,6 +59,10 @@ _Static_assert(FW_RESOURCE_OFFSET + FW_DOOMPACK_SLOT_OFF + FW_DOOMPACK_SLOT_SIZE
 #ifdef USE_CORE1
 #include "polymod_core1.h"
 
+// PSM FRCE_OFF register + the PROC1 bit, as raw literals. Used ONLY by the
+// not-in-flash apply path (fw_staging_do_apply), which cannot call the
+// flash-resident multicore_hold_core1_off(); the ordinary halt/restart go through
+// that shared primitive instead.
 #define _PSM_FRCE_OFF  (*(volatile uint32_t *)0x40010004u)
 #define _PSM_PROC1_BIT (1u << 16)
 
@@ -66,15 +70,18 @@ _Static_assert(FW_RESOURCE_OFFSET + FW_DOOMPACK_SLOT_OFF + FW_DOOMPACK_SLOT_SIZE
 static bool s_core1_halted = false;
 
 static void fw_staging_halt_core1(void) {
-    _PSM_FRCE_OFF |= _PSM_PROC1_BIT;
-    // FRCE_OFF takes effect within a few cycles; DSB ensures the write
-    // reaches the PSM peripheral before the caller touches flash.
-    __asm volatile ("dsb" ::: "memory");
+    // Force core1 into PSM reset and WAIT for the reset to latch before the caller
+    // touches flash. A bare force-off + DSB returns before core1 has actually
+    // stopped; once the doom engine has run on core1, the subsequent big erase then
+    // faults a still-running core1 and takes the whole (slave) half down — the
+    // intermittent post-doom slave wedge (FW-9). Consolidated with the Doom
+    // teardown's proven force-off→wait-for-latch sequence in polymod_core1.
+    multicore_hold_core1_off();
     s_core1_halted = true;
 }
 
 static void fw_staging_restart_core1(void) {
-    _PSM_FRCE_OFF &= ~_PSM_PROC1_BIT;
+    multicore_release_core1_off();
     s_core1_halted = false;
     // BOUNDED relaunch, NOT the unbounded multicore_launch_core1(). core0 can
     // reach here with core1's FIFO launch handshake left desynced by a prior Doom
@@ -912,12 +919,15 @@ ram_word_copy(uint32_t *dst, const uint32_t *src, uint32_t nbytes) {
 // ---------------------------------------------------------------------------
 static void __no_inline_not_in_flash_func(fw_staging_do_apply)(uint32_t image_size) {
 #ifdef USE_CORE1
-    // Halt core1 via PSM reset.  _PSM_FRCE_OFF / _PSM_PROC1_BIT are #defines
-    // (pure preprocessor text substitution → an inlined register write, no flash
-    // fetch), so this is byte-for-byte identical machine code to the raw literal
-    // it replaces — same as fw_staging_halt_core1(), inlined here for the
-    // not-in-flash apply path.
+    // Halt core1 via PSM reset, INLINED here: this function runs not-in-flash, so
+    // it cannot call the flash-resident multicore_hold_core1_off(). _PSM_FRCE_OFF /
+    // _PSM_PROC1_BIT are #defines (inlined register writes, no flash fetch). WAIT
+    // for the reset to latch before erasing below — a bare force-off returns before
+    // core1 has stopped, and a core1 still running from XIP faults on the erase
+    // (the same hazard fw_staging_halt_core1() waits out via the shared primitive).
     _PSM_FRCE_OFF |= _PSM_PROC1_BIT;
+    while (!(_PSM_FRCE_OFF & _PSM_PROC1_BIT)) { /* wait for FRCE_OFF.PROC1 to latch */
+    }
     __asm volatile ("dsb" ::: "memory");
 #endif
     static uint8_t page_buf[FLASH_PAGE_SIZE];   // static (.bss): never on a moving stack

--- a/keyboards/polykybd/base/fw_staging.h
+++ b/keyboards/polykybd/base/fw_staging.h
@@ -252,6 +252,31 @@ void fw_staging_arm_reboot(void);
 bool fw_staging_reboot_pending(void);
 
 // ---------------------------------------------------------------------------
+// FW-9 slave-teardown breadcrumb. The intermittent post-doom wedge is on the
+// SLAVE, and the rig reads only the MASTER console, so the slave must record
+// "where am I now" into a byte the master can pull over the STATUS RPC. Set at
+// each milestone of the two sequences that can hang a half after a doom session:
+//   doom_engine_stop() (doom's own core1 teardown) — DOOM_* below
+//   fw_staging_begin_deferred / process_deferred / restart_core1 (the erase that
+//   follows on the next flash) — BEGIN_HALT..RESTART_DONE.
+// It is a LAST-WRITE marker (not a max), so the value the master reads on its
+// final successful STATUS poll before the slave goes dark localizes the hang.
+// Observation only — setting it never changes control flow.
+// ---------------------------------------------------------------------------
+typedef enum {
+    FW_STAGE_IDLE = 0,          // nothing in flight / back in the normal main loop
+    FW_STAGE_DOOM_STOP_ENTER,   // doom_engine_stop() entered (slave doom teardown begins)
+    FW_STAGE_DOOM_CORE1_RESET,  // about to PSM-reset core1 in the teardown retry loop
+    FW_STAGE_DOOM_RELAUNCH,     // about to bounded-relaunch core1 in the teardown loop
+    FW_STAGE_DOOM_STOP_DONE,    // teardown relaunch loop returned
+    FW_STAGE_BEGIN_HALT,        // fw_staging_begin_deferred halting core1 for the erase
+    FW_STAGE_ERASING,           // process_deferred is erasing sectors (see erase_sector_next)
+    FW_STAGE_ERASE_DONE,        // last sector erased, about to restart core1
+    FW_STAGE_RESTART,           // about to bounded-relaunch core1 (any restart caller)
+    FW_STAGE_RESTART_DONE,      // core1 restart returned
+} fw_stage_t;
+
+// ---------------------------------------------------------------------------
 // Diagnostic snapshot — populated by the slave's handlers so the master can
 // query "what does the slave think happened" after a failed FW_UP_CHUNK.
 // ---------------------------------------------------------------------------
@@ -276,19 +301,24 @@ typedef struct _fw_staging_status_t {
     uint8_t  last_commit_ack;
     // Bounded core1 relaunch diagnostics (doom teardown + fw_staging FONTPACK/doom
     // restart both funnel through multicore_launch_core1_bounded). Clamped to 255.
-    // A DIAGNOSTIC add for the FW-9 wedge hunt: they grew the struct by two bytes
-    // (kept the trailing pad rather than reusing it), so the embedded status reply is
-    // now 36 B — still far under RPC_M2S_BUFFER_SIZE (96), and both split halves run
-    // the same image over this fontpack/doom path, so the reply length always
-    // matches. The rig read `core1_relaunch=0/255` (zero timeouts) across #914/#915/
-    // #916 — the master-side bounded relaunch never times out, which is what refuted
-    // the relaunch-timeout theory. NOTE the wedge is on the SLAVE (its own counter is
-    // never read here), and the run-916 fix attempt — waiting for the erase-time PSM
-    // latch — did NOT change the signature, so the disturbance is doom's own teardown
-    // on the slave, not the fw_staging erase halt. This pair is kept as a cross-check.
+    // A DIAGNOSTIC add for the FW-9 wedge hunt. The rig read `core1_relaunch=0/255`
+    // (zero timeouts) across #914/#915/#916 — the bounded relaunch never times out,
+    // which refuted the relaunch-timeout theory; and the run-916 fix attempt (waiting
+    // for the erase-time PSM latch) did NOT change the signature. That pointed the
+    // hunt at doom's own teardown on the slave rather than the fw_staging erase halt,
+    // which is what the stage / doom_stop_* fields below are here to observe.
     uint8_t  core1_relaunch_calls;
     uint8_t  core1_relaunch_timeouts;
-    uint8_t  pad;
+    // FW-9 slave-teardown observability (all set on the SLAVE, pulled by the
+    // master over the STATUS RPC — see the fw_stage_t comment above). `stage` is
+    // the last milestone reached; the doom_stop_* trio is the OUTCOME of the doom
+    // teardown that ran back in stop-idle (before the flash's BEGIN), which until
+    // now was printed only to the slave console the rig cannot see. Grows the
+    // reply to 40 B — still far under RPC_S2M_BUFFER_SIZE, asserted in split_fw_up.h.
+    uint8_t  stage;               // fw_stage_t — where the slave is NOW
+    uint8_t  doom_stop_result;    // 0 = teardown never ran, 1 = relaunch ok, 2 = timed out
+    uint8_t  doom_stop_attempts;  // bounded-relaunch attempts used (1..3), 0 if never ran
+    uint16_t doom_stop_ms;        // teardown relaunch elapsed (clamped to 65535)
 } fw_staging_status_t;
 
 // Fill `out` with the current internal state.  Safe to call from anywhere.
@@ -300,6 +330,14 @@ void fw_staging_note_chunk_call(uint32_t offset, uint8_t ack);
 // Record the ack the slave's COMMIT handler is about to return, so a later STATUS
 // probe can report the verdict even if that reply never reached the master.
 void fw_staging_note_commit_ack(uint8_t ack);
+
+// FW-9 observability. fw_staging_note_stage() records the last teardown/erase/
+// restart milestone reached (a fw_stage_t) so the master's STATUS poll can localize
+// a slave that goes dark; fw_staging_note_doom_teardown() records the outcome of the
+// doom core1 teardown so the rig sees it (it was previously slave-console only).
+// Both are pure recorders — they never touch control flow.
+void fw_staging_note_stage(uint8_t stage);
+void fw_staging_note_doom_teardown(uint8_t result, uint8_t attempts, uint16_t ms);
 
 // Diagnostic helper used while bisecting the fw_up slave-hang bug
 // (see FW_UP_DEBUG_NOTES.md): set the s_fw_up_active flag without

--- a/keyboards/polykybd/base/fw_staging.h
+++ b/keyboards/polykybd/base/fw_staging.h
@@ -276,6 +276,14 @@ typedef struct _fw_staging_status_t {
     // Consumes half the old pad, so the struct size — and therefore the RPC reply
     // size — is unchanged.
     uint8_t  last_commit_ack;
+    // Bounded core1 relaunch diagnostics (doom teardown + fw_staging FONTPACK/doom
+    // restart both funnel through multicore_launch_core1_bounded). A non-zero
+    // timeout count means a relaunch left core1 desynced — the suspected trigger of
+    // the intermittent slave wedge on a post-doom reflash (FW-9). Read early (at the
+    // first doom BEGIN) the count reflects the doom-teardown relaunch; a later
+    // increment is the fw_staging restart. Clamped to 255. Replaces the old pad.
+    uint8_t  core1_relaunch_calls;
+    uint8_t  core1_relaunch_timeouts;
     uint8_t  pad;
 } fw_staging_status_t;
 

--- a/keyboards/polykybd/base/fw_staging.h
+++ b/keyboards/polykybd/base/fw_staging.h
@@ -319,6 +319,13 @@ typedef struct _fw_staging_status_t {
     uint8_t  doom_stop_result;    // 0 = teardown never ran, 1 = relaunch ok, 2 = timed out
     uint8_t  doom_stop_attempts;  // bounded-relaunch attempts used (1..3), 0 if never ran
     uint16_t doom_stop_ms;        // teardown relaunch elapsed (clamped to 65535)
+    // Disambiguates a doom_stop_result==0 seen at begin-first: did the slave never
+    // run doom at all, or run it and never tear it down (core1 left on doom when the
+    // next flash halts it)? doom_started rises when doom_engine_start() launches core1;
+    // doom_stop_entered rises at the TOP of doom_engine_stop(), before its
+    // s_engine_running guard — so started=1 stop_entered=0 is "ran doom, never stopped".
+    uint8_t  doom_started;        // doom_engine_start() launched the engine on this half
+    uint8_t  doom_stop_entered;   // doom_engine_stop() was reached (before its guard)
 } fw_staging_status_t;
 
 // Fill `out` with the current internal state.  Safe to call from anywhere.
@@ -338,6 +345,10 @@ void fw_staging_note_commit_ack(uint8_t ack);
 // Both are pure recorders — they never touch control flow.
 void fw_staging_note_stage(uint8_t stage);
 void fw_staging_note_doom_teardown(uint8_t result, uint8_t attempts, uint16_t ms);
+// Disambiguators (see the struct fields): doom_engine_start() calls _started,
+// doom_engine_stop() calls _stop_entered at its very top.
+void fw_staging_note_doom_started(void);
+void fw_staging_note_doom_stop_entered(void);
 
 // Diagnostic helper used while bisecting the fw_up slave-hang bug
 // (see FW_UP_DEBUG_NOTES.md): set the s_fw_up_active flag without

--- a/keyboards/polykybd/base/fw_staging.h
+++ b/keyboards/polykybd/base/fw_staging.h
@@ -273,8 +273,6 @@ typedef struct _fw_staging_status_t {
     // This is what lets the master tell a REFUSAL from a lost acknowledgement when
     // the COMMIT reply itself goes missing: fw_up_active is cleared by finalize
     // either way, so it cannot distinguish them, but this records the verdict.
-    // Consumes half the old pad, so the struct size — and therefore the RPC reply
-    // size — is unchanged.
     uint8_t  last_commit_ack;
     // Bounded core1 relaunch diagnostics (doom teardown + fw_staging FONTPACK/doom
     // restart both funnel through multicore_launch_core1_bounded). Clamped to 255.

--- a/keyboards/polykybd/base/fw_staging.h
+++ b/keyboards/polykybd/base/fw_staging.h
@@ -276,12 +276,16 @@ typedef struct _fw_staging_status_t {
     uint8_t  last_commit_ack;
     // Bounded core1 relaunch diagnostics (doom teardown + fw_staging FONTPACK/doom
     // restart both funnel through multicore_launch_core1_bounded). Clamped to 255.
-    // These are a DIAGNOSTIC add for the FW-9 wedge hunt: they grew the struct by two
-    // bytes (kept the trailing pad rather than reusing it), so the embedded status
-    // reply is now 36 B — still far under RPC_M2S_BUFFER_SIZE (96), and both split
-    // halves run the same image over this fontpack/doom path, so the reply length
-    // always matches. The rig read `core1_relaunch=0/255` (zero timeouts): the
-    // relaunch never times out, so this pair is kept only as a cross-check.
+    // A DIAGNOSTIC add for the FW-9 wedge hunt: they grew the struct by two bytes
+    // (kept the trailing pad rather than reusing it), so the embedded status reply is
+    // now 36 B — still far under RPC_M2S_BUFFER_SIZE (96), and both split halves run
+    // the same image over this fontpack/doom path, so the reply length always
+    // matches. The rig read `core1_relaunch=0/255` (zero timeouts) across #914/#915/
+    // #916 — the master-side bounded relaunch never times out, which is what refuted
+    // the relaunch-timeout theory. NOTE the wedge is on the SLAVE (its own counter is
+    // never read here), and the run-916 fix attempt — waiting for the erase-time PSM
+    // latch — did NOT change the signature, so the disturbance is doom's own teardown
+    // on the slave, not the fw_staging erase halt. This pair is kept as a cross-check.
     uint8_t  core1_relaunch_calls;
     uint8_t  core1_relaunch_timeouts;
     uint8_t  pad;

--- a/keyboards/polykybd/base/fw_staging.h
+++ b/keyboards/polykybd/base/fw_staging.h
@@ -277,11 +277,13 @@ typedef struct _fw_staging_status_t {
     // size — is unchanged.
     uint8_t  last_commit_ack;
     // Bounded core1 relaunch diagnostics (doom teardown + fw_staging FONTPACK/doom
-    // restart both funnel through multicore_launch_core1_bounded). A non-zero
-    // timeout count means a relaunch left core1 desynced — the suspected trigger of
-    // the intermittent slave wedge on a post-doom reflash (FW-9). Read early (at the
-    // first doom BEGIN) the count reflects the doom-teardown relaunch; a later
-    // increment is the fw_staging restart. Clamped to 255. Replaces the old pad.
+    // restart both funnel through multicore_launch_core1_bounded). Clamped to 255.
+    // These are a DIAGNOSTIC add for the FW-9 wedge hunt: they grew the struct by two
+    // bytes (kept the trailing pad rather than reusing it), so the embedded status
+    // reply is now 36 B — still far under RPC_M2S_BUFFER_SIZE (96), and both split
+    // halves run the same image over this fontpack/doom path, so the reply length
+    // always matches. The rig read `core1_relaunch=0/255` (zero timeouts): the
+    // relaunch never times out, so this pair is kept only as a cross-check.
     uint8_t  core1_relaunch_calls;
     uint8_t  core1_relaunch_timeouts;
     uint8_t  pad;

--- a/keyboards/polykybd/doom/doom_mode.c
+++ b/keyboards/polykybd/doom/doom_mode.c
@@ -137,9 +137,13 @@ static void doom_engine_start(void) {
 #endif
     multicore_launch_core1_with_stack(doom_core1_entry, stack_bottom, DOOM_ARENA_STACK_BYTES);
     s_engine_running = true;
+    fw_staging_note_doom_started();   // FW-9: this half booted the doom engine on core1
 }
 
 static void doom_engine_stop(void) {
+    // FW-9: stamped BEFORE the s_engine_running guard so the master can tell "ran
+    // doom, never stopped it" (started=1 stop_entered=0) from "never ran doom".
+    fw_staging_note_doom_stop_entered();
     if (s_engine_running) {
         s_engine_running = false;
         // Kill the game mid-frame (it only touches pool memory) and hand core1

--- a/keyboards/polykybd/doom/doom_mode.c
+++ b/keyboards/polykybd/doom/doom_mode.c
@@ -85,14 +85,10 @@ static bool doom_whx_present(void) {
 // multicore_reset_core1 — not compiled here because the SDK's multicore.c
 // collides with the polymod_core1 launcher).
 static void doom_core1_reset(void) {
-    io_rw_32 *power_off     = (io_rw_32 *)(PSM_BASE + PSM_FRCE_OFF_OFFSET);
-    io_rw_32 *power_off_set = hw_set_alias(power_off);
-    io_rw_32 *power_off_clr = hw_clear_alias(power_off);
-    *power_off_set = PSM_FRCE_OFF_PROC1_BITS;
-    while (!(*power_off & PSM_FRCE_OFF_PROC1_BITS)) {
-        tight_loop_contents();
-    }
-    *power_off_clr = PSM_FRCE_OFF_PROC1_BITS;
+    // Force-off + wait-for-latch, then clear — the proven core1 reset now shared
+    // with fw_staging's flash halt/restart (see polymod_core1).
+    multicore_hold_core1_off();
+    multicore_release_core1_off();
 }
 
 static void doom_core1_entry(void) {

--- a/keyboards/polykybd/doom/doom_mode.c
+++ b/keyboards/polykybd/doom/doom_mode.c
@@ -85,10 +85,14 @@ static bool doom_whx_present(void) {
 // multicore_reset_core1 — not compiled here because the SDK's multicore.c
 // collides with the polymod_core1 launcher).
 static void doom_core1_reset(void) {
-    // Force-off + wait-for-latch, then clear — the proven core1 reset now shared
-    // with fw_staging's flash halt/restart (see polymod_core1).
-    multicore_hold_core1_off();
-    multicore_release_core1_off();
+    io_rw_32 *power_off     = (io_rw_32 *)(PSM_BASE + PSM_FRCE_OFF_OFFSET);
+    io_rw_32 *power_off_set = hw_set_alias(power_off);
+    io_rw_32 *power_off_clr = hw_clear_alias(power_off);
+    *power_off_set = PSM_FRCE_OFF_PROC1_BITS;
+    while (!(*power_off & PSM_FRCE_OFF_PROC1_BITS)) {
+        tight_loop_contents();
+    }
+    *power_off_clr = PSM_FRCE_OFF_PROC1_BITS;
 }
 
 static void doom_core1_entry(void) {

--- a/keyboards/polykybd/doom/doom_mode.c
+++ b/keyboards/polykybd/doom/doom_mode.c
@@ -150,11 +150,27 @@ static void doom_engine_stop(void) {
         // disconnect during the ~15 s post-exit silence). On a miss, PSM-reset
         // core1 and retry; worst case the RLE service stays down (overlay
         // decompression degrades until reboot) but the keyboard stays alive.
+        // FW-9 observability: this teardown runs on the SLAVE too (stop-idle
+        // bridges it), and the intermittent post-doom wedge is on the slave —
+        // whose console the rig cannot read. Stamp each step + the outcome into the
+        // fw_staging status snapshot the master pulls over the STATUS RPC, so the
+        // rig sees where a wedged slave stopped and how the relaunch went. Pure
+        // recording — it changes nothing about the teardown itself.
+        fw_staging_note_stage(FW_STAGE_DOOM_STOP_ENTER);
         const uint32_t t0 = timer_read32();
-        bool ok = false;
-        for (uint8_t attempt = 0; attempt < 3 && !ok; ++attempt) {
+        bool    ok       = false;
+        uint8_t attempt  = 0;
+        for (; attempt < 3 && !ok; ++attempt) {
+            fw_staging_note_stage(FW_STAGE_DOOM_CORE1_RESET);
             doom_core1_reset();
+            fw_staging_note_stage(FW_STAGE_DOOM_RELAUNCH);
             ok = multicore_launch_core1_bounded(100u * 1000u);
+        }
+        {
+            uint32_t ms = timer_elapsed32(t0);
+            fw_staging_note_doom_teardown(ok ? 1u : 2u, attempt,
+                                          (uint16_t)(ms > 65535u ? 65535u : ms));
+            fw_staging_note_stage(FW_STAGE_DOOM_STOP_DONE);
         }
         // The engine is GONE: every standalone vpatch decoder (ESC/label
         // STCFN, tall digits, menu tiles, the face) gates on this — with it

--- a/keyboards/polykybd/hid_fontpack.c
+++ b/keyboards/polykybd/hid_fontpack.c
@@ -131,6 +131,17 @@ bool hid_fontpack_receive(uint8_t *data, uint8_t length) {
                 send_to_bridge(USER_SYNC_FLASH_STAGE, &begin_msg, sizeof(begin_msg), 3);
                 uprintf("FONTPACK_BEGIN: bundle=%u size=%lu crc=0x%08lx (master+slave staging)\n",
                         bundle, (unsigned long)pack_size, (unsigned long)pack_crc);
+                // A2 instrumentation: read the slave EARLY — the BEGIN bridge above is
+                // synchronous, so by here the slave has just handled it (or gone dark).
+                // At this instant its core1_relaunch counters reflect the DOOM TEARDOWN
+                // relaunch (which ran back in stop-idle, before this BEGIN) — the
+                // fw_staging restart only runs ~14s later, after the slave's own erase.
+                // So a timeout here pins the wedge to the teardown; a slave already dark
+                // here means it died at/before the teardown. Doom-only, to keep normal
+                // font-pack flashes quiet.
+                if (is_doomwad || is_doompack) {
+                    fw_up_log_slave_status("begin-first");
+                }
             }
 
             uint8_t slave_ack = master_ok

--- a/keyboards/polykybd/hid_fontpack.c
+++ b/keyboards/polykybd/hid_fontpack.c
@@ -112,6 +112,9 @@ bool hid_fontpack_receive(uint8_t *data, uint8_t length) {
             // the image, not the bundle: tampered/unsigned share bundle 0x7e but
             // differ in pack_crc, so new_image re-arms between them.
             static uint8_t  s_last_begin_slave_ack = 0xFF;
+            // FW-9: last `stage` breadcrumb seen from the slave, so the not-ready
+            // re-log below can fire when it advances (not only when slave_ack does).
+            static uint8_t  s_last_begin_stage     = 0xFF;
             bool new_image = (pack_size != s_erased_size || pack_crc != s_erased_crc ||
                               bundle != s_erased_bundle);
 
@@ -120,6 +123,7 @@ bool hid_fontpack_receive(uint8_t *data, uint8_t length) {
                 s_erased_crc    = pack_crc;
                 s_erased_bundle = bundle;
                 s_last_begin_slave_ack = 0xFF;   // re-arm the not-ready diagnostic for this flash
+                s_last_begin_stage     = 0xFF;   // …and its stage-advance sibling
                 // Drop to the base layer + refresh before the flash holds the main
                 // loop, so the user can still type plain characters meanwhile.
                 poly_prepare_for_flash();
@@ -157,20 +161,37 @@ bool hid_fontpack_receive(uint8_t *data, uint8_t length) {
             // "slave not answering / wedged" (SYNC_GIVEUP / SYNC_CRC32_ERR). Change-
             // triggered so it never floods the ~1 Hz re-poll.
             if (master_ok && master_done && !slave_ok) {
-                if (slave_ack != s_last_begin_slave_ack) {
+                // A) slave visibility for the FW-9 doom re-flash wedge. The rig
+                // reads the master console only, so dump the slave's fw_staging
+                // counters over the read-only STATUS op (its own transaction, not
+                // a core1/erase change). It answers the exact question the
+                // slave_ack alone can't: is the slave DARK ("RPC FAILED — slave
+                // unresponsive") or ALIVE-BUT-STUCK — and if alive, whether it
+                // even saw the BEGIN (begin_handler_calls), started erasing
+                // (erase_sector_next/count), and is still ticking process_deferred.
+                //
+                // The slave_ack stays not-ready (SYNC_ACK_SIG/SYNC_BUSY) for the
+                // whole ~3.6 s erase, so triggering only on IT would give one
+                // snapshot and then "RPC FAILED" when the slave wedges — losing WHERE
+                // in the teardown/erase/restart it stopped. So on a DOOM flash, also
+                // re-log when the slave's `stage` breadcrumb advances: the last stage
+                // the master reads before the slave goes dark localizes the hang. One
+                // extra read-only STATUS RPC per ~1 Hz re-poll, doom-only, quiet on
+                // normal font-pack flashes.
+                bool    print = (slave_ack != s_last_begin_slave_ack);
+                uint8_t stage = 0xFF;
+                if (is_doomwad || is_doompack) {
+                    fw_staging_status_t s;
+                    if (fw_up_query_slave_status(&s)) {
+                        stage = s.stage;
+                        if (stage != s_last_begin_stage) print = true;
+                    }
+                }
+                if (print) {
                     s_last_begin_slave_ack = slave_ack;
+                    s_last_begin_stage     = stage;
                     uprintf("FONTPACK_BEGIN: master erased, slave not ready (bundle=%u slave_ack=0x%02x)\n",
                             bundle, slave_ack);
-                    // A) slave visibility for the FW-9 doom re-flash wedge. The rig
-                    // reads the master console only, so dump the slave's fw_staging
-                    // counters over the read-only STATUS op (its own transaction, not
-                    // a core1/erase change). It answers the exact question the
-                    // slave_ack alone can't: is the slave DARK ("RPC FAILED — slave
-                    // unresponsive") or ALIVE-BUT-STUCK — and if alive, whether it
-                    // even saw the BEGIN (begin_handler_calls), started erasing
-                    // (erase_sector_next/count), and is still ticking process_deferred.
-                    // Change-triggered like the line above, so one snapshot per state,
-                    // no re-poll flood. Read-only: adds a probe path, changes nothing.
                     fw_up_log_slave_status("begin-not-ready");
                 }
             }

--- a/keyboards/polykybd/split_fw_up.c
+++ b/keyboards/polykybd/split_fw_up.c
@@ -285,7 +285,8 @@ void fw_up_log_slave_status(const char *tag) {
     uprintf("slave status (%s): init=%u active=%u erase_pending=%u erase=%u/%u "
             "next_off=%lu begin_calls=%u chunk_calls=%u chunk_errs=%u "
             "last_chunk_off=%lu last_ack=0x%02x last_commit_ack=0x%02x "
-            "pd_calls=%u pd_advances=%u core1_relaunch=%u/%u%s\n",
+            "pd_calls=%u pd_advances=%u core1_relaunch=%u/%u "
+            "stage=%u doom_stop=%u/%u/%ums%s\n",
             tag,
             (unsigned)s.initialized, (unsigned)s.fw_up_active, (unsigned)s.erase_pending,
             (unsigned)s.erase_sector_next, (unsigned)s.erase_sector_count,
@@ -295,7 +296,10 @@ void fw_up_log_slave_status(const char *tag) {
             (unsigned long)s.last_chunk_offset, (unsigned)s.last_chunk_ack,
             (unsigned)s.last_commit_ack,
             (unsigned)s.process_deferred_calls, (unsigned)s.process_deferred_advances,
-            (unsigned)s.core1_relaunch_timeouts, (unsigned)s.core1_relaunch_calls, suspect);
+            (unsigned)s.core1_relaunch_timeouts, (unsigned)s.core1_relaunch_calls,
+            (unsigned)s.stage,
+            (unsigned)s.doom_stop_result, (unsigned)s.doom_stop_attempts,
+            (unsigned)s.doom_stop_ms, suspect);
 }
 
 // Classify a non-ACK COMMIT ack, asking the slave directly when the ack itself is

--- a/keyboards/polykybd/split_fw_up.c
+++ b/keyboards/polykybd/split_fw_up.c
@@ -285,7 +285,7 @@ void fw_up_log_slave_status(const char *tag) {
     uprintf("slave status (%s): init=%u active=%u erase_pending=%u erase=%u/%u "
             "next_off=%lu begin_calls=%u chunk_calls=%u chunk_errs=%u "
             "last_chunk_off=%lu last_ack=0x%02x last_commit_ack=0x%02x "
-            "pd_calls=%u pd_advances=%u%s\n",
+            "pd_calls=%u pd_advances=%u core1_relaunch=%u/%u%s\n",
             tag,
             (unsigned)s.initialized, (unsigned)s.fw_up_active, (unsigned)s.erase_pending,
             (unsigned)s.erase_sector_next, (unsigned)s.erase_sector_count,
@@ -294,7 +294,8 @@ void fw_up_log_slave_status(const char *tag) {
             (unsigned)s.chunk_handler_errors,
             (unsigned long)s.last_chunk_offset, (unsigned)s.last_chunk_ack,
             (unsigned)s.last_commit_ack,
-            (unsigned)s.process_deferred_calls, (unsigned)s.process_deferred_advances, suspect);
+            (unsigned)s.process_deferred_calls, (unsigned)s.process_deferred_advances,
+            (unsigned)s.core1_relaunch_timeouts, (unsigned)s.core1_relaunch_calls, suspect);
 }
 
 // Classify a non-ACK COMMIT ack, asking the slave directly when the ack itself is

--- a/keyboards/polykybd/split_fw_up.c
+++ b/keyboards/polykybd/split_fw_up.c
@@ -286,7 +286,7 @@ void fw_up_log_slave_status(const char *tag) {
             "next_off=%lu begin_calls=%u chunk_calls=%u chunk_errs=%u "
             "last_chunk_off=%lu last_ack=0x%02x last_commit_ack=0x%02x "
             "pd_calls=%u pd_advances=%u core1_relaunch=%u/%u "
-            "stage=%u doom_stop=%u/%u/%ums%s\n",
+            "stage=%u doom_stop=%u/%u/%ums started=%u stop_entered=%u%s\n",
             tag,
             (unsigned)s.initialized, (unsigned)s.fw_up_active, (unsigned)s.erase_pending,
             (unsigned)s.erase_sector_next, (unsigned)s.erase_sector_count,
@@ -299,7 +299,8 @@ void fw_up_log_slave_status(const char *tag) {
             (unsigned)s.core1_relaunch_timeouts, (unsigned)s.core1_relaunch_calls,
             (unsigned)s.stage,
             (unsigned)s.doom_stop_result, (unsigned)s.doom_stop_attempts,
-            (unsigned)s.doom_stop_ms, suspect);
+            (unsigned)s.doom_stop_ms,
+            (unsigned)s.doom_started, (unsigned)s.doom_stop_entered, suspect);
 }
 
 // Classify a non-ACK COMMIT ack, asking the slave directly when the ack itself is

--- a/modules/polykybd/polymod_core1/polymod_core1.c
+++ b/modules/polykybd/polymod_core1/polymod_core1.c
@@ -2,7 +2,8 @@
 #include "polymod_core1_irq.h"
 
 #include "hardware/structs/scb.h"
-#include "hardware/timer.h" // time_us_64 (bounded launch deadline)
+#include "hardware/structs/psm.h" // PSM FRCE_OFF (core1 hold/release)
+#include "hardware/timer.h"       // time_us_64 (bounded launch deadline)
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -23,6 +24,23 @@ static uint16_t s_bounded_launch_timeouts = 0;
 void multicore_launch_core1_bounded_stats(uint16_t *calls, uint16_t *timeouts) {
     if (calls) *calls = s_bounded_launch_calls;
     if (timeouts) *timeouts = s_bounded_launch_timeouts;
+}
+
+void multicore_hold_core1_off(void) {
+    io_rw_32 *power_off     = (io_rw_32 *)(PSM_BASE + PSM_FRCE_OFF_OFFSET);
+    io_rw_32 *power_off_set = hw_set_alias(power_off);
+    *power_off_set          = PSM_FRCE_OFF_PROC1_BITS;
+    // WAIT for the reset to latch: a bare write is not enough — the caller erases
+    // flash next, and a core1 still executing from XIP would fault (post-doom wedge).
+    while (!(*power_off & PSM_FRCE_OFF_PROC1_BITS)) {
+        tight_loop_contents();
+    }
+}
+
+void multicore_release_core1_off(void) {
+    io_rw_32 *power_off     = (io_rw_32 *)(PSM_BASE + PSM_FRCE_OFF_OFFSET);
+    io_rw_32 *power_off_clr = hw_clear_alias(power_off);
+    *power_off_clr          = PSM_FRCE_OFF_PROC1_BITS;
 }
 
 #ifdef CORE1_STACK_HWM

--- a/modules/polykybd/polymod_core1/polymod_core1.c
+++ b/modules/polykybd/polymod_core1/polymod_core1.c
@@ -2,15 +2,14 @@
 #include "polymod_core1_irq.h"
 
 #include "hardware/structs/scb.h"
-#include "hardware/timer.h"   // time_us_64 (bounded launch deadline)
+#include "hardware/timer.h" // time_us_64 (bounded launch deadline)
 
 #include <stdbool.h>
 #include <stdint.h>
 
 #define CORE1_STACK_SIZE 384
 
-static uint32_t core1_stack[CORE1_STACK_SIZE/4]
-    __attribute__((aligned(8)));
+static uint32_t core1_stack[CORE1_STACK_SIZE / 4] __attribute__((aligned(8)));
 
 // Diagnostic counters for the BOUNDED runtime relaunch (doom session teardown
 // and the fw_staging FONTPACK/doom-flash restart both funnel through
@@ -22,14 +21,14 @@ static uint16_t s_bounded_launch_calls    = 0;
 static uint16_t s_bounded_launch_timeouts = 0;
 
 void multicore_launch_core1_bounded_stats(uint16_t *calls, uint16_t *timeouts) {
-    if (calls)    *calls    = s_bounded_launch_calls;
+    if (calls) *calls = s_bounded_launch_calls;
     if (timeouts) *timeouts = s_bounded_launch_timeouts;
 }
 
 #ifdef CORE1_STACK_HWM
 // Stack high-water-mark instrumentation. Enable by adding CORE1_STACK_HWM to
 // rules.mk (OPT_DEFS += -DCORE1_STACK_HWM). See readme.md "For developers".
-#define CORE1_STACK_SENTINEL 0xDEADBEEFu
+#    define CORE1_STACK_SENTINEL 0xDEADBEEFu
 
 // Walks core1_stack from the low address upward and returns the number of bytes
 // that have been written (i.e. no longer hold the sentinel). The deepest the stack
@@ -37,8 +36,8 @@ void multicore_launch_core1_bounded_stats(uint16_t *calls, uint16_t *timeouts) {
 // reads are racy w.r.t. transient writes but the high-water mark is monotonic so
 // at worst we under-report by one frame.
 uint32_t core1_stack_high_water_mark(void) {
-    const size_t total = CORE1_STACK_SIZE / sizeof(uint32_t);
-    size_t untouched = 0;
+    const size_t total     = CORE1_STACK_SIZE / sizeof(uint32_t);
+    size_t       untouched = 0;
     while (untouched < total && core1_stack[untouched] == CORE1_STACK_SENTINEL) {
         untouched++;
     }
@@ -46,7 +45,7 @@ uint32_t core1_stack_high_water_mark(void) {
 }
 #endif
 
-static void __attribute__ ((naked)) core1_trampoline(void) {
+static void __attribute__((naked)) core1_trampoline(void) {
     // Mask IRQs on core1 as its VERY FIRST instruction, before core1_wrapper or
     // core1_entry run. core1_entry() also does `cpsid i`, but several instructions
     // (this trampoline + core1_wrapper's stack-guard install) execute on core1 with
@@ -61,7 +60,7 @@ static void __attribute__ ((naked)) core1_trampoline(void) {
     // for a core1 that is stuck in the NMI (field: "stuck on the PolyKybd splash after
     // flashing / reset"). Masking here closes the window: core1 has no IRQ-driven work
     // (it polls FIFO_ST), so keeping IRQs masked for its whole lifetime is safe.
-    __asm volatile ("cpsid i\n\tpop {r0, r1, pc}");
+    __asm volatile("cpsid i\n\tpop {r0, r1, pc}");
 }
 
 void multicore_launch_core1_raw(void (*entry)(void), uint32_t *sp, uint32_t vector_table) {
@@ -77,8 +76,7 @@ void multicore_launch_core1_raw(void (*entry)(void), uint32_t *sp, uint32_t vect
     // vector_table is value for VTOR register
     // sp is initial stack pointer (SP)
     // entry is the initial program counter (PC) (don't forget to set the thumb bit!)
-    const uint32_t cmd_sequence[] =
-            {0, 0, 1, (uintptr_t) vector_table, (uintptr_t) sp, (uintptr_t) entry};
+    const uint32_t cmd_sequence[] = {0, 0, 1, (uintptr_t)vector_table, (uintptr_t)sp, (uintptr_t)entry};
 
     uint seq = 0;
     do {
@@ -105,7 +103,7 @@ int core1_wrapper(int (*entry)(void), void *stack_base) {
 #else
     (void)stack_base;
 #endif
-    //runtime_run_per_core_initializers();
+    // runtime_run_per_core_initializers();
     return (*entry)();
 }
 
@@ -123,9 +121,9 @@ void multicore_launch_core1_with_stack(void (*entry)(void), uint32_t *stack_bott
 
     stack_ptr -= 3;
     uint32_t vector_table = scb_hw->vtor;
-    stack_ptr[0] = (uintptr_t) entry;
-    stack_ptr[1] = (uintptr_t) stack_bottom;
-    stack_ptr[2] = (uintptr_t) core1_wrapper;
+    stack_ptr[0]          = (uintptr_t)entry;
+    stack_ptr[1]          = (uintptr_t)stack_bottom;
+    stack_ptr[2]          = (uintptr_t)core1_wrapper;
 
     multicore_launch_core1_raw(core1_trampoline, stack_ptr, vector_table);
 }
@@ -143,21 +141,20 @@ bool multicore_launch_core1_bounded(uint32_t total_timeout_us) {
     uint32_t *stack_bottom = core1_stack;
     uint32_t *stack_ptr    = stack_bottom + CORE1_STACK_SIZE / sizeof(uint32_t);
     stack_ptr -= 3;
-    stack_ptr[0] = (uintptr_t) core1_entry;
-    stack_ptr[1] = (uintptr_t) stack_bottom;
-    stack_ptr[2] = (uintptr_t) core1_wrapper;
+    stack_ptr[0] = (uintptr_t)core1_entry;
+    stack_ptr[1] = (uintptr_t)stack_bottom;
+    stack_ptr[2] = (uintptr_t)core1_wrapper;
 
     uint irq_num = SIO_FIFO_IRQ_NUM(0);
     bool enabled = irq_is_enabled(irq_num);
     irq_set_enabled(irq_num, false);
 
-    const uint32_t cmd_sequence[] =
-            {0, 0, 1, (uintptr_t) scb_hw->vtor, (uintptr_t) stack_ptr, (uintptr_t) core1_trampoline};
+    const uint32_t cmd_sequence[] = {0, 0, 1, (uintptr_t)scb_hw->vtor, (uintptr_t)stack_ptr, (uintptr_t)core1_trampoline};
 
     if (s_bounded_launch_calls != UINT16_MAX) s_bounded_launch_calls++;
     const uint64_t deadline = time_us_64() + total_timeout_us;
-    bool ok  = true;
-    uint seq = 0;
+    bool           ok       = true;
+    uint           seq      = 0;
     do {
         uint cmd = cmd_sequence[seq];
         if (!cmd) {
@@ -165,19 +162,25 @@ bool multicore_launch_core1_bounded(uint32_t total_timeout_us) {
             SEV();
         }
         while (!multicore_fifo_wready()) {
-            if (time_us_64() > deadline) { ok = false; break; }
+            if (time_us_64() > deadline) {
+                ok = false;
+                break;
+            }
             tight_loop_contents();
         }
         if (!ok) break;
         sio_hw->fifo_wr = cmd;
         SEV();
         while (!multicore_fifo_rvalid()) {
-            if (time_us_64() > deadline) { ok = false; break; }
+            if (time_us_64() > deadline) {
+                ok = false;
+                break;
+            }
             tight_loop_contents();
         }
         if (!ok) break;
         uint32_t response = sio_hw->fifo_rd;
-        seq = cmd == response ? seq + 1 : 0;
+        seq               = cmd == response ? seq + 1 : 0;
     } while (seq < count_of(cmd_sequence));
 
     irq_set_enabled(irq_num, enabled);

--- a/modules/polykybd/polymod_core1/polymod_core1.c
+++ b/modules/polykybd/polymod_core1/polymod_core1.c
@@ -5,11 +5,26 @@
 #include "hardware/timer.h"   // time_us_64 (bounded launch deadline)
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #define CORE1_STACK_SIZE 384
 
 static uint32_t core1_stack[CORE1_STACK_SIZE/4]
     __attribute__((aligned(8)));
+
+// Diagnostic counters for the BOUNDED runtime relaunch (doom session teardown
+// and the fw_staging FONTPACK/doom-flash restart both funnel through
+// multicore_launch_core1_bounded). A non-zero timeout count means a relaunch
+// left core1 desynced — the suspected trigger of the intermittent slave wedge on
+// a post-doom reflash (FW-9). Surfaced to the master via fw_staging's status RPC
+// so the rig (master console only) can read them; see fw_up_log_slave_status.
+static uint16_t s_bounded_launch_calls    = 0;
+static uint16_t s_bounded_launch_timeouts = 0;
+
+void multicore_launch_core1_bounded_stats(uint16_t *calls, uint16_t *timeouts) {
+    if (calls)    *calls    = s_bounded_launch_calls;
+    if (timeouts) *timeouts = s_bounded_launch_timeouts;
+}
 
 #ifdef CORE1_STACK_HWM
 // Stack high-water-mark instrumentation. Enable by adding CORE1_STACK_HWM to
@@ -139,6 +154,7 @@ bool multicore_launch_core1_bounded(uint32_t total_timeout_us) {
     const uint32_t cmd_sequence[] =
             {0, 0, 1, (uintptr_t) scb_hw->vtor, (uintptr_t) stack_ptr, (uintptr_t) core1_trampoline};
 
+    if (s_bounded_launch_calls != UINT16_MAX) s_bounded_launch_calls++;
     const uint64_t deadline = time_us_64() + total_timeout_us;
     bool ok  = true;
     uint seq = 0;
@@ -165,5 +181,6 @@ bool multicore_launch_core1_bounded(uint32_t total_timeout_us) {
     } while (seq < count_of(cmd_sequence));
 
     irq_set_enabled(irq_num, enabled);
+    if (!ok && s_bounded_launch_timeouts != UINT16_MAX) s_bounded_launch_timeouts++;
     return ok;
 }

--- a/modules/polykybd/polymod_core1/polymod_core1.c
+++ b/modules/polykybd/polymod_core1/polymod_core1.c
@@ -2,8 +2,7 @@
 #include "polymod_core1_irq.h"
 
 #include "hardware/structs/scb.h"
-#include "hardware/structs/psm.h" // PSM FRCE_OFF (core1 hold/release)
-#include "hardware/timer.h"       // time_us_64 (bounded launch deadline)
+#include "hardware/timer.h" // time_us_64 (bounded launch deadline)
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -24,23 +23,6 @@ static uint16_t s_bounded_launch_timeouts = 0;
 void multicore_launch_core1_bounded_stats(uint16_t *calls, uint16_t *timeouts) {
     if (calls) *calls = s_bounded_launch_calls;
     if (timeouts) *timeouts = s_bounded_launch_timeouts;
-}
-
-void multicore_hold_core1_off(void) {
-    io_rw_32 *power_off     = (io_rw_32 *)(PSM_BASE + PSM_FRCE_OFF_OFFSET);
-    io_rw_32 *power_off_set = hw_set_alias(power_off);
-    *power_off_set          = PSM_FRCE_OFF_PROC1_BITS;
-    // WAIT for the reset to latch: a bare write is not enough — the caller erases
-    // flash next, and a core1 still executing from XIP would fault (post-doom wedge).
-    while (!(*power_off & PSM_FRCE_OFF_PROC1_BITS)) {
-        tight_loop_contents();
-    }
-}
-
-void multicore_release_core1_off(void) {
-    io_rw_32 *power_off     = (io_rw_32 *)(PSM_BASE + PSM_FRCE_OFF_OFFSET);
-    io_rw_32 *power_off_clr = hw_clear_alias(power_off);
-    *power_off_clr          = PSM_FRCE_OFF_PROC1_BITS;
 }
 
 #ifdef CORE1_STACK_HWM

--- a/modules/polykybd/polymod_core1/polymod_core1.h
+++ b/modules/polykybd/polymod_core1/polymod_core1.h
@@ -23,19 +23,6 @@ bool multicore_launch_core1_bounded(uint32_t total_timeout_us);
 // wedge correlates with a relaunch timeout. Either pointer may be NULL.
 void multicore_launch_core1_bounded_stats(uint16_t *calls, uint16_t *timeouts);
 
-// Hold core1 in PSM reset for a flash operation and WAIT for the reset to
-// actually latch before returning. A bare FRCE_OFF write returns before the core
-// has stopped, so a caller that then erases/programs flash (XIP disappears) can
-// fault a still-running core1 and take core0 down with it — the intermittent
-// post-doom slave wedge (FW-9): once the doom engine has run on core1, the next
-// big erase wedged the slave partway through. Spinning until the FRCE_OFF bit
-// reads back set is the proven guard the Doom engine teardown already used.
-void multicore_hold_core1_off(void);
-
-// Release the PSM reset taken by multicore_hold_core1_off(). Does NOT relaunch
-// core1 — pair with multicore_launch_core1_bounded() to restart the RLE service.
-void multicore_release_core1_off(void);
-
 // Launch core1 with a caller-provided entry + stack (the underlying primitive
 // of multicore_launch_core1; used by the Doom easter egg to hand core1 to the
 // game with a pool-backed stack).

--- a/modules/polykybd/polymod_core1/polymod_core1.h
+++ b/modules/polykybd/polymod_core1/polymod_core1.h
@@ -35,6 +35,5 @@ uint32_t core1_stack_high_water_mark(void);
 #endif
 
 static inline void dmb(void) {
-    __asm volatile ("dmb" ::: "memory");
+    __asm volatile("dmb" ::: "memory");
 }
-

--- a/modules/polykybd/polymod_core1/polymod_core1.h
+++ b/modules/polykybd/polymod_core1/polymod_core1.h
@@ -23,6 +23,19 @@ bool multicore_launch_core1_bounded(uint32_t total_timeout_us);
 // wedge correlates with a relaunch timeout. Either pointer may be NULL.
 void multicore_launch_core1_bounded_stats(uint16_t *calls, uint16_t *timeouts);
 
+// Hold core1 in PSM reset for a flash operation and WAIT for the reset to
+// actually latch before returning. A bare FRCE_OFF write returns before the core
+// has stopped, so a caller that then erases/programs flash (XIP disappears) can
+// fault a still-running core1 and take core0 down with it — the intermittent
+// post-doom slave wedge (FW-9): once the doom engine has run on core1, the next
+// big erase wedged the slave partway through. Spinning until the FRCE_OFF bit
+// reads back set is the proven guard the Doom engine teardown already used.
+void multicore_hold_core1_off(void);
+
+// Release the PSM reset taken by multicore_hold_core1_off(). Does NOT relaunch
+// core1 — pair with multicore_launch_core1_bounded() to restart the RLE service.
+void multicore_release_core1_off(void);
+
 // Launch core1 with a caller-provided entry + stack (the underlying primitive
 // of multicore_launch_core1; used by the Doom easter egg to hand core1 to the
 // game with a pool-backed stack).

--- a/modules/polykybd/polymod_core1/polymod_core1.h
+++ b/modules/polykybd/polymod_core1/polymod_core1.h
@@ -17,6 +17,12 @@ void multicore_launch_core1(void);
 // teardown), where a wedged handshake means a dead keyboard.
 bool multicore_launch_core1_bounded(uint32_t total_timeout_us);
 
+// Diagnostic counters for the bounded relaunch: how many were attempted and how
+// many timed out (left core1 desynced). Read by fw_staging's status RPC so the
+// master console (the rig's only window) can see whether a post-doom reflash
+// wedge correlates with a relaunch timeout. Either pointer may be NULL.
+void multicore_launch_core1_bounded_stats(uint16_t *calls, uint16_t *timeouts);
+
 // Launch core1 with a caller-provided entry + stack (the underlying primitive
 // of multicore_launch_core1; used by the Doom easter egg to hand core1 to the
 // game with a pool-backed stack).


### PR DESCRIPTION
## Summary

⚠️ **Diagnostic / investigation PR — NOT for merge as-is.** Its only purpose is to run the `hil-doom` set on the rig and read the new instrumentation, so we can localise the *intermittent* slave wedge left open after #249 before choosing a fix.

**Background.** #249 proved FW-9's signature gate on hardware (accept/tampered/unsigned all green). But the doom set is a **coin-flip**: sometimes, on a doom-slot reflash *after* the engine has run, the **slave goes dark** (`SYNC_GIVEUP` / `RPC FAILED`) and the reflash can't reach it. The merged `begin-not-ready` probe confirmed "dark", but not *where* the slave dies.

**Ruled out so far** (runs #914–#917): the master-side bounded relaunch never times out (`core1_relaunch=0/255`), and waiting for the erase-time PSM latch (the reverted fix (b)) did **not** change the signature. Both point away from the fw_staging erase halt and at **doom's own core1 teardown on the slave** — but nothing yet tells us *where* in that teardown the slave stops, because the rig reads only the **master** console and the slave's teardown logs to its own.

**What this commit adds (read-only, no behaviour change).** The slave now records *where it is* into a byte the master pulls over the existing STATUS RPC:

- **`fw_staging_status_t.stage`** — a `fw_stage_t` **last-write breadcrumb** stamped at each milestone of the two sequences that can hang a half after a doom session: doom's own core1 teardown (`DOOM_STOP_ENTER → DOOM_CORE1_RESET → DOOM_RELAUNCH → DOOM_STOP_DONE`) and the fw_staging halt/erase/restart of the next flash (`BEGIN_HALT → ERASING → ERASE_DONE → RESTART → RESTART_DONE`). The **last stage the master reads before the slave goes dark localizes the hang.**
- **`doom_stop_result` / `doom_stop_attempts` / `doom_stop_ms`** — the outcome of the doom teardown that ran back in stop-idle (before the flash's BEGIN), which until now was printed only to the slave console the rig cannot see.
- **`fw_up_log_slave_status()`** now prints `stage=… doom_stop=result/attempts/ms`.
- **`hid_fontpack` `CMD_FONTPACK_BEGIN`** — on a doom flash the not-ready re-poll re-logs whenever the slave's `stage` **advances**, not only when `slave_ack` changes. The slave_ack stays not-ready for the whole ~3.6 s erase, so triggering only on it gave one snapshot and then "RPC FAILED"; the stage tracker captures the progression.

**How to read the next round** (in the master console, on a wedged run):
- `stage` frozen at `DOOM_*` at `begin-first`, then RPC FAILED ⇒ it died in/right after the **doom teardown** (`doom_stop=2/3/…ms` = the teardown relaunch timed out its 3 attempts).
- `stage` advancing through `ERASING` then freezing at `ERASE_DONE`/`RESTART`, then RPC FAILED ⇒ the **fw_staging restart** is where it wedges.
- `doom_stop=1/1/0ms` (teardown reported clean) but a later stage freeze ⇒ the teardown left core1 degraded and the disturbance surfaces on the *next* halt/restart.

Because it's a coin-flip, re-run the doom tier a few times to get 2–3 captures before drawing a conclusion. The fix will land in a **separate, clean PR** once the mechanism is confirmed.

## Version bump label

*(none)* — diagnostic-only, and not intended to merge in this form.

## Testing
- [x] Compiled successfully — `split72 POLYKYBD_DOOM_PACK=yes` (links) + `split42 default` (links)
- [x] `make test:fw_up_verdict` green (27 tests; the STATUS struct grew, CRC covers `sizeof`)
- [ ] Hardware: needs the **`hil-doom`** label to run the FW-9 doom set on the rig and read the new `stage=… doom_stop=…` lines
- [x] No protocol change (read-only diagnostics; every added write is a pure recorder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8pW42ifgtNjFFVdrWPZ2m

## Summary by Sourcery

Instrument the intermittent post-Doom slave core1 wedge without changing firmware behavior.

Enhancements:
- Add slave-side FW-9 diagnostics that expose teardown, erase, restart, and bounded core1 relaunch progress through the existing status reporting path.
- Capture and report Doom teardown outcomes, timing, attempts, and lifecycle markers so intermittent post-Doom slave wedges can be localized from the master console.
- Log diagnostic status whenever the Doom flash stage advances, improving visibility during slave-not-ready polling.