### PR TITLE
docs: how to triage a security-scanner finding in a fork

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,15 +109,36 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
   reachable?** This is a fork of a 30k-commit project, so almost everything a
   path-based scanner walks was written by someone else and most of it is
   unreachable here. The checks, in order:
-  1. **Is it stock?** Fetch the same path from upstream at the merge base and
-     `diff`. Byte-identical means the finding is upstream's to fix (or not) and
-     ours only if we can reach it:
+  1. **Is it stock?** `diff` the same path against upstream. Byte-identical means
+     the finding is upstream's to fix (or not) and ours only if we can reach it:
      ```bash
      curl -sSL "https://raw.githubusercontent.com/qmk/qmk_firmware/master/<path>" \
        | diff - "<path>" && echo "IDENTICAL TO UPSTREAM"
      ```
+     ⚠️ **That compares against upstream's CURRENT master, which moves — so read
+     the two outcomes asymmetrically.** Identical is conclusive: we did not write
+     it. A **difference is not proof we own it** — upstream may simply have
+     changed the file since our last catch-up merge. Check
+     `keyboards/polykybd/UPSTREAM_PATCHES.md` (the maintained list of upstream
+     files we patch) and `git log --oneline -- <path>` before concluding we wrote
+     it; getting this backwards means "fixing" an inherited file and buying a
+     conflict at the next merge. When the distinction actually decides a finding,
+     compare at the **merge base** instead:
+     ```bash
+     git remote add upstream https://github.com/qmk/qmk_firmware   # usually absent here
+     git fetch -q upstream master
+     git show "$(git merge-base HEAD upstream/master):<path>" | diff - "<path>"
+     ```
+     ⚠️ **Run the `--is-shallow-repository` check first** — the container clone is
+     shallow, `git merge-base` then returns an **empty string** rather than
+     failing, and the command above silently degrades to `git show :<path>`. That
+     trap is written up under "Building & flashing"; it is why `master` is the
+     default recipe here and the merge base the deliberate escalation.
      ⚠️ **For workflows, don't guess which are ours — ask upstream.** A 404 means
-     the file does not exist there, i.e. we wrote it. Measured 2026-08-29:
+     the file does not exist there, i.e. we wrote it. (This one asks about
+     *existence*, not content, so the moving-master caveat above does not apply —
+     upstream deleting a workflow we still carry is the only way it misleads.)
+     Measured 2026-08-29:
      **only 5 of 23 are ours** — `bump-version.yml`, `cppcheck.yml`,
      `polykybd-unit-test.yml`, `qmk-test.yml`, `release.yml`. Re-derive rather
      than trusting that list:
@@ -186,8 +207,11 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
       is not evidence either way. ⚠️ **And its `Greptile Review` check run is not
       the answer** — measured, a green `success` one accompanied a PR it did not
       review, the same trap recorded above for Sourcery. Check `pull_request_read`
-      `get_reviews` on the PR in front of you, `commit_id` against the head sha,
-      rather than inferring from a check run or from this paragraph.
+      `get_reviews` on the PR in front of you and require **both** that a review's
+      `commit_id` equals the head sha **and** that its body is not a refusal
+      notice — a Sourcery refusal is itself a review object carrying the head sha,
+      so the sha alone reads as reviewed. Never infer from a check run or from
+      this paragraph.
   - **cppcheck has no quota, no star threshold and no file-count limit** — and
     is not an LLM, so it doesn't share the others' blind spots. That is why it
     was added, and it matters more now that it is the only automated reviewer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,10 +182,12 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
     - ⚠️ **A fourth bot, Greptile, now exists — see the Greptile entry in
       `PolyKybdHost/CLAUDE.md` before repeating "no LLM reviewer" as a fact.**
       Whether it reviews a catch-up merge is **untested**; what is measured is
-      that it reviews only some PRs and says *nothing at all* when it doesn't, so
-      its silence is not evidence either way. Check `pull_request_read`
-      `get_reviews` on the PR in front of you rather than inferring from this
-      paragraph.
+      that it reviews only some PRs and announces a skip nowhere, so its silence
+      is not evidence either way. ⚠️ **And its `Greptile Review` check run is not
+      the answer** — measured, a green `success` one accompanied a PR it did not
+      review, the same trap recorded above for Sourcery. Check `pull_request_read`
+      `get_reviews` on the PR in front of you, `commit_id` against the head sha,
+      rather than inferring from a check run or from this paragraph.
   - **cppcheck has no quota, no star threshold and no file-count limit** — and
     is not an LLM, so it doesn't share the others' blind spots. That is why it
     was added, and it matters more now that it is the only automated reviewer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,64 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
   in `raw_hid_receive()`, worth seconds of blocked main loop) that was adopted.
   Reply to the false ones with the evidence so they are not re-raised.
 
+- ⚠️ **A security-scanner finding on a file under `.github/` or `lib/` is
+  probably UPSTREAM's, and two checks settle it in minutes: is it stock, and is it
+  reachable?** This is a fork of a 30k-commit project, so almost everything a
+  path-based scanner walks was written by someone else and most of it is
+  unreachable here. The checks, in order:
+  1. **Is it stock?** Fetch the same path from upstream at the merge base and
+     `diff`. Byte-identical means the finding is upstream's to fix (or not) and
+     ours only if we can reach it:
+     ```bash
+     curl -sSL "https://raw.githubusercontent.com/qmk/qmk_firmware/master/<path>" \
+       | diff - "<path>" && echo "IDENTICAL TO UPSTREAM"
+     ```
+     ⚠️ **For workflows, don't guess which are ours — ask upstream.** A 404 means
+     the file does not exist there, i.e. we wrote it. Measured 2026-08-29:
+     **only 5 of 23 are ours** — `bump-version.yml`, `cppcheck.yml`,
+     `polykybd-unit-test.yml`, `qmk-test.yml`, `release.yml`. Re-derive rather
+     than trusting that list:
+     ```bash
+     for f in .github/workflows/*.yml; do b=$(basename "$f")
+       c=$(curl -sSL -o /dev/null -w '%{http_code}' \
+           "https://raw.githubusercontent.com/qmk/qmk_firmware/master/.github/workflows/$b")
+       [ "$c" = 404 ] && echo "OURS: $b"; done
+     ```
+  2. **Is it reachable?** For a workflow, read its triggers and its callers — a
+     `workflow_call`-only file is dead unless something calls it, and upstream
+     gates several on `if: github.repository == 'qmk/qmk_firmware'`, which is
+     **permanently false** in a fork. For C, grep the `SRC`/`OBJ` lists: a file no
+     build includes cannot have a vulnerability in the shipped image.
+  Worked example (2026-08-29): an external audit reported a **critical** template
+  injection in `.github/workflows/ci_build_major_branch_keymap.yml`
+  (`qmk find -km ${{ inputs.keymap }}`). It is byte-identical to upstream, is
+  `workflow_call`-only, and its sole caller is repo-gated — so the chain cannot
+  execute here at all. Two commands, no change, finding closed.
+  - ⚠️ **The inverse is the part that makes this worth doing: the scanner looked
+    at the inherited file and NOT at ours.** The one genuine injection in the same
+    sweep was in `bump-version.yml` — a file we wrote — interpolating
+    `github.event.pull_request.labels.*.name` straight into a `run:` body, where a
+    PR label is attacker-controllable text. Nothing flagged it. **So when a report
+    names an upstream path, treat it as a prompt to audit the sibling files we own,
+    not just to dismiss the one it named.** The fix pattern is to pass every
+    `${{ }}` through `env:` and read it as `"$VAR"` / `os.environ[...]`, which is
+    what `bump-version.yml` now does.
+    - ⚠️ **That property holds for `bump-version.yml` ALONE — do not read it as
+      repo-wide.** A sweep the same day found **31 interpolations inside `run:`
+      bodies across 8 workflows**, `qmk-test.yml` and `release.yml` among them.
+      None is known to be exploitable — they carry build outputs, `env:` constants
+      and `matrix.*` values the workflow itself wrote, not user text — but that is
+      a judgement per site, not an audited fact, and the two files have not been
+      gone through line by line. `polykybd-ctnd/.claude/skills/verify-security-finding/`
+      carries the checker and the triage procedure.
+  - **Record the disposition even when nothing changes** — dismissed findings that
+    leave no artifact get re-raised in full by the next scan. The tracker is
+    `polykybd-ctnd/docs/SECURITY_AUDIT.md` § *"Checked and NOT vulnerable — don't
+    re-litigate"*. For a vendored tree the note belongs beside the code instead:
+    `keyboards/polykybd/doom/engine/PROVENANCE.md` carries the disposition of the
+    `textscreen/` findings, because that tree is a **verbatim upstream snapshot**
+    and must not be patched in place.
+
 - ⚠️ **An on-demand Claude reviewer (`@claude review`) was tried and REMOVED
   (2026-08-20) — don't rebuild it.** `.github/workflows/claude-review.yml` +
   `claude-mention.yml` existed in all three PolyKybd repos to cover exactly the
@@ -115,9 +173,19 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
   security"* and uploads no artifact. Workflows and the `CLAUDE_CODE_OAUTH_TOKEN`
   secret are gone from all three repos.
   - **So on an upstream-merge PR there is genuinely no LLM reviewer.** CodeRabbit
-    skips it outright at >100 files, and nothing replaces that. Treat the
+    skips it outright at >100 files, and **Sourcery has its own ceiling that lands
+    on the same PRs** — it refuses any diff over **20,000 lines** outright (*"the
+    GitHub API does not allow us to fetch diffs exceeding 20000 lines"*, a hard
+    limit, not a quota, so waiting does nothing). Treat the
     **build + HIL checks and hardware testing as the only verification**, say so
     on the PR, and don't read the green board as review cover.
+    - ⚠️ **A fourth bot, Greptile, now exists — see the Greptile entry in
+      `PolyKybdHost/CLAUDE.md` before repeating "no LLM reviewer" as a fact.**
+      Whether it reviews a catch-up merge is **untested**; what is measured is
+      that it reviews only some PRs and says *nothing at all* when it doesn't, so
+      its silence is not evidence either way. Check `pull_request_read`
+      `get_reviews` on the PR in front of you rather than inferring from this
+      paragraph.
   - **cppcheck has no quota, no star threshold and no file-count limit** — and
     is not an LLM, so it doesn't share the others' blind spots. That is why it
     was added, and it matters more now that it is the only automated reviewer


### PR DESCRIPTION
## Summary

Adds a code-review-conventions entry for a case this repo will keep hitting: **a security scanner flags a file under `.github/` or `lib/`.** This is a fork of a 30k-commit project with a vendored game engine, so most of what a path-based scanner walks was written by someone else and much of it never enters a shipped artifact. Two checks settle it in minutes — *is it stock upstream*, and *is it reachable at all*.

Worked example from the 2026-08-29 scan, which reported a **critical** template injection in `.github/workflows/ci_build_major_branch_keymap.yml` (`qmk find -km ${{ inputs.keymap }}`): the file is byte-identical to upstream, is `workflow_call`-only, and its sole caller is gated `if: github.repository == 'qmk/qmk_firmware'` — permanently false here. Two commands, no change, finding closed.

**The inverse is what makes the exercise worth doing, and it is the part of the note I most want kept:** the scanner read the inherited file and *not* ours. The one genuine injection in the same sweep was in `bump-version.yml` — a file we wrote — interpolating `github.event.pull_request.labels.*.name` straight into a `run:` body, where a PR label is attacker-controllable text. Nothing flagged it. So a report naming an upstream path is a prompt to **audit the sibling files we own**, not just to dismiss the one it named.

Also recorded:

- **Only 5 of 23 workflows here are ours** — `bump-version.yml`, `cppcheck.yml`, `polykybd-unit-test.yml`, `qmk-test.yml`, `release.yml` — with the 404-against-upstream loop that derives it, so the next reader re-measures instead of trusting a list that will go stale.
- A pointer to the new `verify-security-finding` skill and to `doom/engine/PROVENANCE.md`, which is where a vendored tree's disposition belongs (that tree is a verbatim upstream snapshot and must not be patched in place).
- ⚠️ **A correction to my own first draft of this note.** It claimed "no workflow in this repo interpolates into a shell or Python body". That is false: a sweep found **31 interpolations across 8 workflows**, including our own `qmk-test.yml` and `release.yml`. The property holds for `bump-version.yml` alone. None of the other 31 is *known* to be exploitable — they carry build outputs, `env:` constants and `matrix.*` values the workflow itself wrote rather than user text — but that is a judgement per site, not an audited fact, and the note now says so rather than implying the repo is clean.

Alongside it, a caveat on the existing *"on an upstream-merge PR there is genuinely no LLM reviewer"* line: a fourth bot (Greptile) now exists. Whether it reviews a catch-up merge is **untested**, and it says nothing at all when it skips a PR, so its silence is not evidence either way — the note points at the measured entry in `PolyKybdHost/CLAUDE.md` and tells you to check `get_reviews` on the PR in front of you. Sourcery's own ceiling is added too: it refuses any diff over 20,000 lines, a hard limit that lands on the same catch-up-merge PRs CodeRabbit skips at >100 files.

## Version bump label

*(none)* — documentation only, patch bump. No firmware source, no `PROTOCOL_VERSION`, no host counterpart needed.

## Testing

- [ ] ~~Compiled successfully~~ — N/A, `CLAUDE.md` only.
- [ ] ~~Flashed and tested on hardware~~ — N/A.
- [ ] ~~If protocol changed: host updated and tested together~~ — N/A, no protocol change.

Every command quoted in the new note was run for real while writing it: the upstream `diff`, the caller/`if:` greps, and the 404 loop across all 23 workflows.

Worth watching on this PR: it touches **only `CLAUDE.md`**, so under the path filter landed in #253 it should start **neither `Build firmware` nor `HIL test (split72)`**. That exclusion has so far only been proven by simulation and mutation testing — this is the first PR to exercise it for real, and the rig getting left alone here is the confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqGGmtbLW5CDwm24rPL5Go

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqGGmtbLW5CDwm24rPL5Go)_

## Summary by Sourcery

Document how to validate the provenance and reachability of security findings while directing reviewers to audit locally owned files and verify actual review coverage.

Enhancements:
- Document a repeatable process for triaging security-scanner findings by checking upstream provenance and code reachability, recording dispositions, and auditing related files owned by the fork.
- Clarify workflow ownership and execution assumptions in the fork, including how to identify locally authored workflows and assess reviewer coverage on large or catch-up pull requests.

Documentation:
- Add guidance for handling inherited and vendored security findings, including provenance records and a worked example of a non-reachable workflow finding.