### PR TITLE
fix(fw-9): reset core1 to a known-good state around the staging erase

### DIFF
--- a/keyboards/polykybd/base/fw_staging.c
+++ b/keyboards/polykybd/base/fw_staging.c
@@ -66,14 +66,37 @@ _Static_assert(FW_RESOURCE_OFFSET + FW_DOOMPACK_SLOT_OFF + FW_DOOMPACK_SLOT_SIZE
 static bool s_core1_halted = false;
 
 static void fw_staging_halt_core1(void) {
+    // Force core1 off AND wait for the force-off to LATCH before returning. The
+    // caller immediately does flash_range_* (which flushes the XIP cache core1
+    // executes from), so a core1 that is not yet actually held in reset would
+    // fault on its next instruction fetch. A bare write plus a DSB (the previous
+    // form) only ordered the store — it did not confirm the reset took. This is
+    // doom_core1_reset()'s set-then-wait; FRCE_OFF.PROC1 is a core0-owned control
+    // bit that reads back essentially immediately, so the spin is a few cycles
+    // (doom relies on the same, unbounded).
     _PSM_FRCE_OFF |= _PSM_PROC1_BIT;
-    // FRCE_OFF takes effect within a few cycles; DSB ensures the write
-    // reaches the PSM peripheral before the caller touches flash.
+    while (!(_PSM_FRCE_OFF & _PSM_PROC1_BIT)) {
+        __asm volatile("" ::: "memory");
+    }
     __asm volatile ("dsb" ::: "memory");
     s_core1_halted = true;
 }
 
 static void fw_staging_restart_core1(void) {
+    // Do a FULL power-on reset PULSE first — set FRCE_OFF.PROC1, wait for the
+    // latch, then clear — so core1 is guaranteed back in the bootrom FIFO-wait
+    // loop (a known-good launch state) before the handshake, rather than merely
+    // releasing it from a halt that may not have cleanly latched. This is
+    // exactly doom_core1_reset() + multicore_launch_core1_bounded(), the pair
+    // doom_engine_stop() uses, which is proven to survive repeated launch/stop
+    // cycles. A bare clear (the previous form) could release core1 from an
+    // indeterminate state: the bounded handshake then times out, the RLE service
+    // stays down, and — the FW-9 soak+accept signal — a wedged core1 also broke
+    // the NEXT doom-slot flash's engine launch.
+    _PSM_FRCE_OFF |= _PSM_PROC1_BIT;
+    while (!(_PSM_FRCE_OFF & _PSM_PROC1_BIT)) {
+        __asm volatile("" ::: "memory");
+    }
     _PSM_FRCE_OFF &= ~_PSM_PROC1_BIT;
     s_core1_halted = false;
     // BOUNDED relaunch, NOT the unbounded multicore_launch_core1(). core0 can


### PR DESCRIPTION
## Summary

Behavioral follow-up to FW-9 (the `.plyx` Ed25519 gate, #249). Closes the intermittent **post-doom core1 wedge** that the rig now reproduces deterministically.

**The seam.** `fw_staging`'s deferred-erase path halts core1 with a bare PSM force-off write + `dsb` (no wait for the reset to latch) and later restarts it with a bare bit-clear before the bounded relaunch. Neither matches `doom_core1_reset()`, which does a full **set → wait-for-latch → clear** pulse before every core1 launch and is proven to survive repeated launch/stop cycles (`doom_engine_stop()` pairs it with `multicore_launch_core1_bounded()`).

**The failure.** A halt that has not cleanly latched, released by a bare clear, can leave core1 in an indeterminate state: the bounded launch handshake times out, the overlay-RLE service stays down, and a wedged core1 goes on to break the *next* doom-slot flash's engine launch.

**The reproducible signal** (isolated on the rig over runs #923–#925):
- **no preceding erases** → signed-accept doom load succeeds (`pack v4 loaded`).
- **three back-to-back doom-slot flashes** (the new `test_doompack_flash_only_soak`, ctnd #83, now on `main`) → the flash-only soak passes 3/3, but the following signed-accept doom load goes **silent** (loader logs nothing, the screensaver never engages) — reproduced 2/2.

So repeated doom-slot erases alone don't wedge the split link; they break the *next* doom run on core1, and the accept path is the only doom test that actually branches into and executes the engine on core1.

**The fix** — make `fw_staging`'s core1 handoff deterministic and identical to the proven doom pattern, in `base/fw_staging.c` only:
- `fw_staging_halt_core1()` now waits for `FRCE_OFF.PROC1` to read back set before touching flash;
- `fw_staging_restart_core1()` does a full reset pulse (set, wait, clear) before the bounded relaunch, so core1 is guaranteed back in the bootrom FIFO-wait loop.

`FRCE_OFF.PROC1` is a core0-owned control bit that reads back immediately, so each spin is a few cycles (doom relies on the same, unbounded). No new statics — RAM-neutral.

The FIRMWARE-target apply path (`fw_staging_do_apply`) keeps its inlined bare write: it hard-resets the chip and is a delicate not-in-flash routine, and the FW-9 signal runs entirely through the fontpack/doom-slot restart path.

## Version bump label
*(none)* — bug fix, patch bump.

## Testing
- [x] Compiled successfully — both `-e POLYKYBD_DOOM_PACK=yes` and the monolith `-e POLYKYBD_DOOM=yes` split72 flavours link.
- [x] `make test:fw_up_verdict` — 27 tests pass (tree-health sanity; the change is orthogonal to this suite).
- [ ] **Rig validation via `hil-doom`**: the reproducible signal is soak PASS + signed-accept `pack v4 loaded`. Labeling this PR `hil-doom` runs `build-doom` + `doom-test` (TIER_DOOM), which drives the soak and the signed-accept together against real hardware. Green = wedge closed.
- [ ] Flashed and tested on hardware.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8pW42ifgtNjFFVdrWPZ2m)_

## Summary by Sourcery

Bug Fixes:
- Ensure core1 is fully latched in reset before staging flash operations and reset to a known-good state before relaunch, preventing intermittent post-erase wedges and subsequent doom engine launch failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved processor core shutdown reliability by confirming the power-off command is fully latched before proceeding.
  * Improved core restart reliability by performing a complete power-reset sequence before relaunching.
  * Reduced the risk of inconsistent core state during halt and restart operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->