### PR TITLE
fix(doom): bound the engine core1 launch so a soak+accept can't wedge core0

### DIFF
--- a/keyboards/polykybd/doom/doom_mode.c
+++ b/keyboards/polykybd/doom/doom_mode.c
@@ -150,8 +150,20 @@ static void doom_engine_start(void) {
     if (!ok) {
         // core1 would not come up for the game — do NOT leave core0 blocked.
         // Fall back to the fire demo, the same degradation as a missing WHX.
-        printf("doom: core1 launch FAILED after %lu ms — running the fire demo instead\n",
-               (unsigned long)timer_elapsed32(t0));
+        // Unlike the missing-WHX/no-pack fallbacks (which return before ever
+        // touching core1), we have already reset core1, so it is sitting idle
+        // in reset — and doom_engine_stop won't relaunch the RLE service on
+        // session exit because s_engine_running is false. Put core1 back to the
+        // overlay-RLE service ourselves so overlay decompression isn't degraded
+        // until reboot; if this relaunch also misses, core1 stays reset (no
+        // worse, and still no core0 hang).
+        bool rle_ok = false;
+        for (uint8_t attempt = 0; attempt < 3 && !rle_ok; ++attempt) {
+            doom_core1_reset();
+            rle_ok = multicore_launch_core1_bounded(100u * 1000u);
+        }
+        printf("doom: core1 launch FAILED after %lu ms — fire demo; RLE core relaunch %s\n",
+               (unsigned long)timer_elapsed32(t0), rle_ok ? "ok" : "FAILED");
         s_engine_running = false;
         return;
     }

--- a/keyboards/polykybd/doom/doom_mode.c
+++ b/keyboards/polykybd/doom/doom_mode.c
@@ -127,7 +127,6 @@ static void doom_engine_start(void) {
     // Take core1 from the overlay-RLE service (idle in game mode — the
     // pool-writing HID commands are frozen) and give it to the game, with its
     // stack at the tail of the pool.
-    doom_core1_reset();
 #ifdef POLYKYBD_DOOM_PACK
     uint32_t *stack_bottom = (uint32_t *)(s_fb + DOOM_POOL_BYTES - DOOM_ARENA_STACK_BYTES);
 #else
@@ -135,7 +134,27 @@ static void doom_engine_start(void) {
     // GCC's array-bounds check)
     uint32_t *stack_bottom = (uint32_t *)((uintptr_t)__doom_shared_end__ - DOOM_ARENA_STACK_BYTES);
 #endif
-    multicore_launch_core1_with_stack(doom_core1_entry, stack_bottom, DOOM_ARENA_STACK_BYTES);
+    // BOUNDED launch, mirroring doom_engine_stop's relaunch: the plain
+    // multicore_launch_core1_with_stack blocks core0 FOREVER if core1 is not
+    // cleanly back in the bootrom wait loop, and cumulative doom-slot flashes
+    // (the signed-accept path after a soak) can leave it exactly that way — the
+    // console then never drains and the session reads as a 30 s silence
+    // (verdict=none). PSM-reset + bounded handshake, retry, and on a total miss
+    // degrade to the fire demo (observable) rather than wedging the main loop.
+    const uint32_t t0 = timer_read32();
+    bool ok = false;
+    for (uint8_t attempt = 0; attempt < 3 && !ok; ++attempt) {
+        doom_core1_reset();
+        ok = multicore_launch_core1_with_stack_bounded(doom_core1_entry, stack_bottom, DOOM_ARENA_STACK_BYTES, 100u * 1000u);
+    }
+    if (!ok) {
+        // core1 would not come up for the game — do NOT leave core0 blocked.
+        // Fall back to the fire demo, the same degradation as a missing WHX.
+        printf("doom: core1 launch FAILED after %lu ms — running the fire demo instead\n",
+               (unsigned long)timer_elapsed32(t0));
+        s_engine_running = false;
+        return;
+    }
     s_engine_running = true;
 }
 

--- a/modules/polykybd/polymod_core1/polymod_core1.c
+++ b/modules/polykybd/polymod_core1/polymod_core1.c
@@ -119,16 +119,23 @@ void multicore_launch_core1(void) {
     multicore_launch_core1_with_stack(core1_entry, core1_stack, CORE1_STACK_SIZE);
 }
 
-// Bounded variant of the launch handshake (see core1.h). Identical protocol
-// to multicore_launch_core1_raw, but every FIFO wait checks an overall
-// deadline — if core1 is not in the bootrom wait loop (held in reset, or
-// mid power-up after a PSM force-off), the unbounded handshake blocks
-// forever (fw_staging.c carries the same lore for the post-apply reboot).
-bool multicore_launch_core1_bounded(uint32_t total_timeout_us) {
-    uint32_t *stack_bottom = core1_stack;
-    uint32_t *stack_ptr    = stack_bottom + CORE1_STACK_SIZE / sizeof(uint32_t);
+// Bounded variant of the launch handshake, with a caller-provided entry +
+// stack (the bounded sibling of multicore_launch_core1_with_stack — see
+// core1.h). Identical protocol to multicore_launch_core1_raw, but every FIFO
+// wait checks an overall deadline — if core1 is not in the bootrom wait loop
+// (held in reset, or mid power-up after a PSM force-off), the unbounded
+// handshake blocks forever (fw_staging.c carries the same lore for the
+// post-apply reboot). Returns false on a miss so the caller can PSM-reset
+// core1 and retry (or degrade gracefully) instead of wedging core0.
+bool multicore_launch_core1_with_stack_bounded(void (*entry)(void), uint32_t *stack_bottom, size_t stack_size_bytes, uint32_t total_timeout_us) {
+#ifdef CORE1_STACK_HWM
+    for (size_t i = 0; i < stack_size_bytes / sizeof(uint32_t); i++) {
+        stack_bottom[i] = CORE1_STACK_SENTINEL;
+    }
+#endif
+    uint32_t *stack_ptr = stack_bottom + stack_size_bytes / sizeof(uint32_t);
     stack_ptr -= 3;
-    stack_ptr[0] = (uintptr_t) core1_entry;
+    stack_ptr[0] = (uintptr_t) entry;
     stack_ptr[1] = (uintptr_t) stack_bottom;
     stack_ptr[2] = (uintptr_t) core1_wrapper;
 
@@ -166,4 +173,10 @@ bool multicore_launch_core1_bounded(uint32_t total_timeout_us) {
 
     irq_set_enabled(irq_num, enabled);
     return ok;
+}
+
+// Bounded relaunch into the built-in RLE service (core1_entry). Thin wrapper
+// over multicore_launch_core1_with_stack_bounded.
+bool multicore_launch_core1_bounded(uint32_t total_timeout_us) {
+    return multicore_launch_core1_with_stack_bounded(core1_entry, core1_stack, CORE1_STACK_SIZE, total_timeout_us);
 }

--- a/modules/polykybd/polymod_core1/polymod_core1.c
+++ b/modules/polykybd/polymod_core1/polymod_core1.c
@@ -2,19 +2,18 @@
 #include "polymod_core1_irq.h"
 
 #include "hardware/structs/scb.h"
-#include "hardware/timer.h"   // time_us_64 (bounded launch deadline)
+#include "hardware/timer.h" // time_us_64 (bounded launch deadline)
 
 #include <stdbool.h>
 
 #define CORE1_STACK_SIZE 384
 
-static uint32_t core1_stack[CORE1_STACK_SIZE/4]
-    __attribute__((aligned(8)));
+static uint32_t core1_stack[CORE1_STACK_SIZE / 4] __attribute__((aligned(8)));
 
 #ifdef CORE1_STACK_HWM
 // Stack high-water-mark instrumentation. Enable by adding CORE1_STACK_HWM to
 // rules.mk (OPT_DEFS += -DCORE1_STACK_HWM). See readme.md "For developers".
-#define CORE1_STACK_SENTINEL 0xDEADBEEFu
+#    define CORE1_STACK_SENTINEL 0xDEADBEEFu
 
 // Walks core1_stack from the low address upward and returns the number of bytes
 // that have been written (i.e. no longer hold the sentinel). The deepest the stack
@@ -22,8 +21,8 @@ static uint32_t core1_stack[CORE1_STACK_SIZE/4]
 // reads are racy w.r.t. transient writes but the high-water mark is monotonic so
 // at worst we under-report by one frame.
 uint32_t core1_stack_high_water_mark(void) {
-    const size_t total = CORE1_STACK_SIZE / sizeof(uint32_t);
-    size_t untouched = 0;
+    const size_t total     = CORE1_STACK_SIZE / sizeof(uint32_t);
+    size_t       untouched = 0;
     while (untouched < total && core1_stack[untouched] == CORE1_STACK_SENTINEL) {
         untouched++;
     }
@@ -31,7 +30,7 @@ uint32_t core1_stack_high_water_mark(void) {
 }
 #endif
 
-static void __attribute__ ((naked)) core1_trampoline(void) {
+static void __attribute__((naked)) core1_trampoline(void) {
     // Mask IRQs on core1 as its VERY FIRST instruction, before core1_wrapper or
     // core1_entry run. core1_entry() also does `cpsid i`, but several instructions
     // (this trampoline + core1_wrapper's stack-guard install) execute on core1 with
@@ -46,7 +45,7 @@ static void __attribute__ ((naked)) core1_trampoline(void) {
     // for a core1 that is stuck in the NMI (field: "stuck on the PolyKybd splash after
     // flashing / reset"). Masking here closes the window: core1 has no IRQ-driven work
     // (it polls FIFO_ST), so keeping IRQs masked for its whole lifetime is safe.
-    __asm volatile ("cpsid i\n\tpop {r0, r1, pc}");
+    __asm volatile("cpsid i\n\tpop {r0, r1, pc}");
 }
 
 void multicore_launch_core1_raw(void (*entry)(void), uint32_t *sp, uint32_t vector_table) {
@@ -62,8 +61,7 @@ void multicore_launch_core1_raw(void (*entry)(void), uint32_t *sp, uint32_t vect
     // vector_table is value for VTOR register
     // sp is initial stack pointer (SP)
     // entry is the initial program counter (PC) (don't forget to set the thumb bit!)
-    const uint32_t cmd_sequence[] =
-            {0, 0, 1, (uintptr_t) vector_table, (uintptr_t) sp, (uintptr_t) entry};
+    const uint32_t cmd_sequence[] = {0, 0, 1, (uintptr_t)vector_table, (uintptr_t)sp, (uintptr_t)entry};
 
     uint seq = 0;
     do {
@@ -90,7 +88,7 @@ int core1_wrapper(int (*entry)(void), void *stack_base) {
 #else
     (void)stack_base;
 #endif
-    //runtime_run_per_core_initializers();
+    // runtime_run_per_core_initializers();
     return (*entry)();
 }
 
@@ -108,9 +106,9 @@ void multicore_launch_core1_with_stack(void (*entry)(void), uint32_t *stack_bott
 
     stack_ptr -= 3;
     uint32_t vector_table = scb_hw->vtor;
-    stack_ptr[0] = (uintptr_t) entry;
-    stack_ptr[1] = (uintptr_t) stack_bottom;
-    stack_ptr[2] = (uintptr_t) core1_wrapper;
+    stack_ptr[0]          = (uintptr_t)entry;
+    stack_ptr[1]          = (uintptr_t)stack_bottom;
+    stack_ptr[2]          = (uintptr_t)core1_wrapper;
 
     multicore_launch_core1_raw(core1_trampoline, stack_ptr, vector_table);
 }
@@ -135,20 +133,19 @@ bool multicore_launch_core1_with_stack_bounded(void (*entry)(void), uint32_t *st
 #endif
     uint32_t *stack_ptr = stack_bottom + stack_size_bytes / sizeof(uint32_t);
     stack_ptr -= 3;
-    stack_ptr[0] = (uintptr_t) entry;
-    stack_ptr[1] = (uintptr_t) stack_bottom;
-    stack_ptr[2] = (uintptr_t) core1_wrapper;
+    stack_ptr[0] = (uintptr_t)entry;
+    stack_ptr[1] = (uintptr_t)stack_bottom;
+    stack_ptr[2] = (uintptr_t)core1_wrapper;
 
     uint irq_num = SIO_FIFO_IRQ_NUM(0);
     bool enabled = irq_is_enabled(irq_num);
     irq_set_enabled(irq_num, false);
 
-    const uint32_t cmd_sequence[] =
-            {0, 0, 1, (uintptr_t) scb_hw->vtor, (uintptr_t) stack_ptr, (uintptr_t) core1_trampoline};
+    const uint32_t cmd_sequence[] = {0, 0, 1, (uintptr_t)scb_hw->vtor, (uintptr_t)stack_ptr, (uintptr_t)core1_trampoline};
 
     const uint64_t deadline = time_us_64() + total_timeout_us;
-    bool ok  = true;
-    uint seq = 0;
+    bool           ok       = true;
+    uint           seq      = 0;
     do {
         uint cmd = cmd_sequence[seq];
         if (!cmd) {
@@ -156,19 +153,25 @@ bool multicore_launch_core1_with_stack_bounded(void (*entry)(void), uint32_t *st
             SEV();
         }
         while (!multicore_fifo_wready()) {
-            if (time_us_64() > deadline) { ok = false; break; }
+            if (time_us_64() > deadline) {
+                ok = false;
+                break;
+            }
             tight_loop_contents();
         }
         if (!ok) break;
         sio_hw->fifo_wr = cmd;
         SEV();
         while (!multicore_fifo_rvalid()) {
-            if (time_us_64() > deadline) { ok = false; break; }
+            if (time_us_64() > deadline) {
+                ok = false;
+                break;
+            }
             tight_loop_contents();
         }
         if (!ok) break;
         uint32_t response = sio_hw->fifo_rd;
-        seq = cmd == response ? seq + 1 : 0;
+        seq               = cmd == response ? seq + 1 : 0;
     } while (seq < count_of(cmd_sequence));
 
     irq_set_enabled(irq_num, enabled);

--- a/modules/polykybd/polymod_core1/polymod_core1.h
+++ b/modules/polykybd/polymod_core1/polymod_core1.h
@@ -38,6 +38,5 @@ uint32_t core1_stack_high_water_mark(void);
 #endif
 
 static inline void dmb(void) {
-    __asm volatile ("dmb" ::: "memory");
+    __asm volatile("dmb" ::: "memory");
 }
-

--- a/modules/polykybd/polymod_core1/polymod_core1.h
+++ b/modules/polykybd/polymod_core1/polymod_core1.h
@@ -22,6 +22,15 @@ bool multicore_launch_core1_bounded(uint32_t total_timeout_us);
 // game with a pool-backed stack).
 void multicore_launch_core1_with_stack(void (*entry)(void), uint32_t *stack_bottom, size_t stack_size_bytes);
 
+// Bounded sibling of multicore_launch_core1_with_stack: the FIFO handshake is
+// bounded by an overall deadline instead of blocking forever. False = core1
+// never answered (not in the bootrom wait loop) — the caller can PSM-reset it
+// and retry. This is what multicore_launch_core1_bounded is built on; the Doom
+// easter egg uses it directly to hand core1 the game with a pool-backed stack
+// WITHOUT risking a wedged core0 when core1 is not cleanly back in the bootrom
+// wait loop (e.g. after cumulative flashes have disturbed it).
+bool multicore_launch_core1_with_stack_bounded(void (*entry)(void), uint32_t *stack_bottom, size_t stack_size_bytes, uint32_t total_timeout_us);
+
 void core1_entry(void);
 
 #ifdef CORE1_STACK_HWM


### PR DESCRIPTION
## Problem

FW-9 follow-up. On the signed-accept doom load **after a soak** (cumulative doom-slot flashes), the doom engine goes silent — the `hil-doom` rig reads `verdict=none`, ~30 s of firmware silence, and the screensaver never engages — while the tampered/unsigned refusals still pass.

The accept path is the **only** doom test that branches into and runs the engine on core1. It did so via the **unbounded** `multicore_launch_core1_with_stack`, whose FIFO handshake blocks core0 **forever** when core1 is not cleanly back in the bootrom wait loop. After a soak, core1 can be left exactly that way, so the accept handshake hangs, the console is never drained, and the session times out as `verdict=none`. Tampered/unsigned refuse **before** launching (they never touch core1), which is why only accept — after a soak — fails.

`doom_engine_stop()` already solves this same hazard for the RLE-service relaunch with a **bounded** launcher plus a PSM-reset retry loop; `doom_engine_start()` had no equivalent.

## Change

- Add `multicore_launch_core1_with_stack_bounded()` to `polymod_core1` — the bounded sibling of `multicore_launch_core1_with_stack` (deadline-checked FIFO handshake, returns `false` on a miss). Refactor `multicore_launch_core1_bounded()` to call it.
- `doom_engine_start()` now PSM-resets + bounded-launches in a 3× retry loop, mirroring `doom_engine_stop()`. On a total miss it degrades to the **fire demo** (observable) instead of blocking the main loop — the same degradation path as a missing WHX / no usable pack.

Supersedes the abandoned `fw_staging` core1-reset approach on #256 (that change was hardening but did not reach the actual hang, which is in `doom_engine_start`'s launcher, not the staging restart). #256 will be closed.

## Verification

- Builds link: `split72 POLYKYBD_DOOM_PACK`, `split72 POLYKYBD_DOOM` (monolith), `split42 default`.
- `make test:fw_up_verdict` green (27 tests).
- No new statics — RAM unaffected.
- **Rig validation is the real gate**: this PR is labelled `hil-doom` to run the FW-9 doom set (soak → signed accept / tampered / unsigned). Success = soak passes AND the signed accept loads the pack instead of `verdict=none`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8pW42ifgtNjFFVdrWPZ2m

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8pW42ifgtNjFFVdrWPZ2m)_

## Summary by Sourcery

Bound Doom's core1 startup and degrade gracefully when the engine cannot be launched.

Bug Fixes:
- Prevent Doom engine startup from wedging core0 when core1 is not ready after cumulative flashes.
- Fall back to the fire demo and restore the RLE service when core1 cannot be launched.

Enhancements:
- Provide a reusable bounded core1 launch API for custom entries while retaining the existing bounded service relaunch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when starting the Doom experience.
  * Prevented the keyboard from becoming unresponsive if the game fails to initialize.
  * Added automatic recovery attempts when startup encounters an issue.
  * Added a safe fallback to the fire demo when Doom cannot start successfully.
  * Improved recovery of background services after an unsuccessful game launch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->