### PR TITLE
Idle jitter moves composite legend art; settings-More telemetry; Eden as the split72 idle default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1706,7 +1706,47 @@ the looping "Eden" comet-field screensaver). The first two are described in deta
 below; IDDQD/EDEN are full-screen animations that own the keycaps via their own
 tick (`doom_tick()` / `startup_anim_tick()`), so `update_displays()` early-returns
 while they run (see "Eden startup animation & idle screensaver" below for EDEN):
-- **`IDLE_STYLE_PULSE` (0, default, legacy):** `kdisp_idle()` only modulates each
+
+⚠️ **The DEFAULT is board-dependent since 2026-08-31: `POLY_DEFAULT_IDLE_STYLE`
+(`state.h`) is EDEN on split72 and PULSE everywhere else.** Three things about that
+change generalise well beyond this setting:
+- ⚠️ **EDEN on split42 would have been an anti-burn-in setting that does NOTHING —
+  and the enum's own comment claimed it "behaves like PULSE".** It does not.
+  `anim/startup_anim.c` is `#if defined(KEYBOARD_polykybd_split72)` with no-op
+  stubs, *and* every other idle painter stands down for EDEN by design:
+  `kdisp_idle()` returns immediately, the engage branch holds contrast at
+  `EDEN_IDLE_BRIGHTNESS` instead of computing a pulse, and `update_displays()`
+  early-returns while `DISP_IDLE`. So the legends **freeze**, dim and unmoving,
+  until the TURN_OFF suspend — the one outcome this whole feature exists to
+  prevent. The default macro is gated on the **same** board macro the animation
+  compiles itself on, so a default whose renderer is not in the image is not
+  expressible. **Before defaulting anything to a feature with stubs, check what the
+  stub path actually leaves running** — "degrades gracefully" was written down and
+  was wrong.
+- ⚠️ **An explicit PULSE on a pre-2026-08-31 board is NOT RECOVERABLE, because the
+  old format never recorded it.** `IDLE_STYLE_PULSE` is 0 and QMK's wear levelling
+  hands back a cleared byte as **zero** (the trap that made `latin_assign` read as
+  "every key hosts 'a'"), so "chose pulse" and "never chose" are the *same byte*. No
+  migration scheme can separate them, which is what makes the one-time move of the
+  whole pre-sentinel population to the board default the honest reading rather than
+  a compromise. Say so plainly in release notes: **existing keyboards that never
+  picked JITTER/IDDQD/EDEN will come up in the new default once.**
+- **The fix for next time is the `idle_style_fmt` sentinel** (`0x3C`, tail byte,
+  same shape as `latin_ext_fmt` / `keymap_layers_fmt`). `load_user_eeconf()`
+  substitutes the board default while it is unstamped; `save_user_settings()` stamps
+  it **after** the block it guards, so an interrupted write cannot claim a choice
+  that was not stored. From the first save onwards the byte is taken verbatim — so a
+  *future* default change can no longer overwrite a real choice, which is exactly
+  the property this one lacked. `eeconfig_init_user()` writes both, so a fresh
+  EEPROM is born stamped and never migrates. Cost: `EECONFIG_USER_DATA_SIZE`
+  156 → 157, well inside the 256-byte reservation, so **no keymap relocation and no
+  user reset**.
+- **Verify the gate in the compiled object, not the preprocessor.** `g_idle_style`
+  lands in `.data` on split72 (`objdump -s -j .data.g_idle_style` → `03`) and in
+  `.bss` on split42 (zero = PULSE) — one command per board, against the image that
+  actually ships.
+
+- **`IDLE_STYLE_PULSE` (0, legacy; the default on boards without Eden):** `kdisp_idle()` only modulates each
   keycap's SSD1306 contrast register (a per-key out-of-phase "breathing"). The
   buffer is never re-rendered, so the lit pixels never move — the burn-in risk.
 - **`IDLE_STYLE_JITTER` (1):** keeps the pulse, but **each key independently**
@@ -1768,7 +1808,11 @@ while they run (see "Eden startup animation & idle screensaver" below for EDEN):
     synced offset.)
   A "Matrix-style" idle animation was considered but shelved — it defeats the
   "glance at the dimmed legend and resume typing" hint the pulse preserves; jitter
-  was chosen as the default-preserving, legibility-preserving fix.
+  was chosen as the default-preserving, legibility-preserving fix. ⚠️ **That
+  reasoning no longer describes the shipped default on split72**, which is EDEN (see
+  the board-default note at the top of this section) — a deliberate trade of the
+  glance affordance for a screensaver that actually repaints the panel. It still
+  describes why JITTER, not an animation, was the fix *within* the pulse family.
 
 ### Eden startup animation & idle screensaver (`anim/startup_anim.*`, `poly_keymap.c`)
 A **fully procedural** (no framebuffer) per-keycap comet-field animation that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1314,6 +1314,36 @@ new ISO codes append at the next free slot; private pseudo-codes with no ISO
     size; a 90° turn swaps the axes), because the first version asked the helper what
     to expect and therefore agreed with it by construction — a "don't halve the width"
     mutation sailed straight through. Same trap as the macro-icon preview note below.
+  - ⚠️ **The offset was not the only per-primitive property the composite ops
+    bypassed — `s_gfx_erase` and `s_gfx_scanline` were the SAME shape, and the
+    scanline one was live.** Both are static plotter modes that only the two char
+    writers honoured, so under `IDLE_STYLE_EDEN` — which draws the resting legend
+    `kdisp_set_gfx_scanline(true)` as a dim half-density ghost — the text came out
+    half-density while the composited art stayed fully lit. Measured over the shipped
+    legends, three carry composite art AND are reachable as a resting legend (i.e. at
+    idle), all three on the split72 default keymap: `ICON_SCRLOCK_ON/OFF` (`KC_SCRL`,
+    a 19×19 `HINT_BADGE`), `ICON_MEDIA_STOP` (`KC_MSTP`, **badge only** — so the whole
+    keycap ignored the dimming) and `ICON_CONTEXT_MENU` (`KC_APP`, the ROT'd pointer).
+    The other three composite legends (`ICON_GFX_RESTART`/`_RELOAD`, and the
+    `HINT_FRAME` hints) are held-modifier hints, never drawn at idle.
+    - **Same remedy, one level down: `kdisp_plot_ink()`.** Every ink primitive —
+      HALF / THIN / ROT / BADGE / FRAME / `_double_at`, and both char writers — plots
+      through it, so it is now the single definition of "ink" and a sixth op inherits
+      both modes by construction.
+    - ⚠️ **Deliberately NOT pushed down into `SET_PIXEL_CLIPPED`.** Ground fills and
+      bitmap blits (`kdisp_fill_rect`, `kdisp_draw_bitmap`, the tab/MRU chrome,
+      `clear_line`) must stay unconditional, or an overlay image drawn while the flag
+      is up would silently scanline-dim. The split is what the primitive **is**, not a
+      list of call sites to keep in sync.
+    - **It made the image SMALLER**: `.text` 285320 → 284320 (**−1000 B**), `.data`
+      and `.bss` byte-identical (monolith `.heap` free 2772 either way) — fourteen
+      duplicated per-pixel plot sequences collapsed into one out-of-line call. Verified
+      in the compiled image rather than the source: `kdisp_plot_ink` is emitted
+      out-of-line and `objdump` shows every composite primitive `bl`-ing it.
+    - ⚠️ **`disp_array.c` has NO unit suite** (it owns the scratch buffer), so this
+      class is only ever caught by reading the code or by looking at hardware —
+      `oled_preview.py` refuses these ops, so the usual "render it" rule does not
+      reach them either. That is why the same mistake was made twice in one file.
 - **`kdisp_send_window()` vs `kdisp_send_buffer()`**: `kdisp_send_buffer()` pushes
   the full 1024-byte scratch; `kdisp_send_window()` pushes only the **visible 360
   bytes** (pages 0–4 at column `BUFFER_X`) — the same region the keycap actually
@@ -2410,9 +2440,12 @@ drew an icon, and one pair of keys was replaced by a single state-reflecting key
   - ⚠️ **`HINT_ERASE` restores the PREVIOUS `s_gfx_erase`, not `false`.** It is a
     static plotter mode, so leaving it on blanks every keycap drawn after this one in
     the same pass — and a caller may already be mid-erase (the inverted-keycap
-    pattern), which a hardcoded `false` would clobber. It also covers only the text
-    paths; `\x0F`/`\x11` composite through `kdisp_draw_glyph_*_at`, which plot
-    unconditionally.
+    pattern), which a hardcoded `false` would clobber. ⚠️ It used to cover **only the
+    text paths** — `\x0F`/`\x11`/`\x15`/`\x13`/`\x12` composite through their own
+    primitives, which plotted unconditionally — so `HINT_ERASE` before a HALF or a
+    BADGE silently drew it lit. Fixed by the same choke-point move as the jitter
+    offset: every ink primitive now plots through **`kdisp_plot_ink()`**. See the
+    plotter-mode note below.
   - The arrow **alone** was rendered first and is too sparse to identify, and the
     Caps/Num badge glyphs could not be borrowed because they carry a literal `A` / `1`.
 - **Pause spells the word out**, at half the **L legend tier** (`0xF3000`) — 14 px

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1280,6 +1280,40 @@ new ISO codes append at the next free slot; private pseudo-codes with no ISO
     27px `Qwty` lost 10px too. The tighter 19px spacing only made a long-standing
     defect impossible to miss. **The check is a pixel count against the same legend
     drawn with `cy_radius` 0**, not a visual read; all 15 legends now match it exactly.
+- ⚠️ **The anti-burn-in jitter offset is applied ONCE at the display-list cursor
+  (`gfx_text_run`), NOT inside the drawing primitives — it used to be the other way
+  round and that moved only the text.** `s_draw_ox/oy` were added in
+  `kdisp_write_gfx_char` and `kdisp_write_gfx_char_half`, which between them cover
+  ordinary glyphs and `HINT_SMALL` and nothing else: every **composite op** plots
+  through a primitive of its own (`\x0F` HALF, `\x11` THIN, `\x15` ROT →
+  `kdisp_draw_glyph_*_at`; `\x13` BADGE, `\x12` FRAME → the rect drawers), none of
+  which ever saw the offset. So an idle relocation slid the letters and left the
+  composited art pinned to the buffer — reported from hardware as *"the cursor on the
+  context menu icon is not moving in the idle modes, but the hamburger menu icon
+  does"* (2026-08-31). It is a CLASS bug, not one icon: `ICON_CONTEXT_MENU`'s pointer,
+  and the `ICON_SCRLOCK_ON/OFF` + `ICON_MEDIA_STOP` badges, which are composite art
+  **only** and so never moved at all.
+  - **The fix is the choke point, not five more `+= s_draw_ox` lines.** Offsetting the
+    cursor once means a sixth composite op inherits it by construction; adding it per
+    primitive is the enumerating-guard shape this repo keeps getting caught by
+    (`sync_is_link_fault()`, the log-source registry, the `find_matching_entry` gate).
+    ⚠️ A MOVE must **re-apply** it (`x_cursor = sat8(text[1] + s_draw_ox)`) — an
+    absolute position is exactly what the cursor's own offset does not reach, and
+    assigning the raw coordinate is what pinned the art in the first place.
+  - ⚠️ **Fixing the DRAW alone would have made it worse, and that is the half worth
+    remembering.** `roll_idle_offset()` measured the slack with the RELATIVE bbox,
+    which for `ICON_CONTEXT_MENU` is the hamburger alone — so once the whole cell
+    moved as a unit, that slack would have carried the pointer off the panel; and for
+    `ICON_MEDIA_STOP`, whose legend is a MOVE plus a BADGE and nothing else, the
+    relative box is **empty** (`0,0,0,0`), i.e. "you may move it anywhere". Hence
+    `kdisp_gfx_text_bbox_abs()` above, and hence the pair had to land together.
+  - **The ROT geometry moved to `font_lookup.c` (`kdisp_gfx_rot_half_extent`) so the
+    drawer and the measurement cannot disagree** about which pixels a rotated glyph
+    touches — a box that disagrees with the pixels is a legend that clips. ⚠️ Its
+    tests derive the expectation from **arithmetic** (a 0° turn is exactly the halved
+    size; a 90° turn swaps the axes), because the first version asked the helper what
+    to expect and therefore agreed with it by construction — a "don't halve the width"
+    mutation sailed straight through. Same trap as the macro-icon preview note below.
 - **`kdisp_send_window()` vs `kdisp_send_buffer()`**: `kdisp_send_buffer()` pushes
   the full 1024-byte scratch; `kdisp_send_window()` pushes only the **visible 360
   bytes** (pages 0–4 at column `BUFFER_X`) — the same region the keycap actually
@@ -1435,6 +1469,34 @@ flushed, **then** `DISPLAY_ON` — boot shows black → splash.
 landed; revisit only if a full swap still looks slow on hardware): raise
 `OLED_UPDATE_PROCESS_LIMIT`, or bump I2C to Fast-Mode+ 1 MHz (`I2C1_CLOCK_SPEED`,
 above SSD1306 spec — A/B on real hardware).
+
+**Settings → "More" shows TELEMETRY instead of the status screen** (`oled_helper.c`
+`oled_telemetry_screen()`, dispatched from `oled_task_user` on the synced
+`poly_sync_t.settings_more`). Four lines on the 64 px panel, two on the 32 px one:
+`FW <version>` · `P<protocol> HW <device_ver>` · `<USB|LNK> up <h:mm:ss>` ·
+`Lnk <err>% <frames>`. Shared across both variants and landscape on split42 too,
+matching the flash / confirm / apply screens there.
+
+- **The identity fields are the ones `GET_ID` reports** (`FW_VERSION`,
+  `PROTOCOL_VERSION`, `DEVICE_VER` — the same macros `hid_com.c` builds its string
+  from), so the panel and the host's view of the board cannot disagree.
+- ⚠️ **The link line reads `Lnk n/a` on the non-USB half, NOT `0.0%`.** The counters
+  live in `bridge_helper.c` and only the master calls `send_to_bridge()`, so the
+  slave's are zero because it never initiates — rendering that as a perfect link
+  would be a flattering lie on exactly the panel someone reads to judge the wire.
+  `poly_get_link_stats()` / `poly_link_err_permille()` expose them; the percentage is
+  computed by the same expression as the periodic console line, so the two can never
+  diverge. This puts the split-link health somewhere you can actually see it — until
+  now it existed only in a line emitted every 200 frames on a console nobody has open.
+- ⚠️ **Both link fields are COMPACTED, and the default fixture is what hides why.**
+  `ls_attempts` climbs for as long as the board is up (millions within hours), so
+  spelled out in full the line measures **135 px against a 127 px budget** — while the
+  `1234tx` of a fresh boot fits comfortably. The count is abbreviated `k`/`M` and the
+  rate drops its decimal at/above 10 %, which puts the widest reachable form at
+  122 px. Checked with `tools/status_oled_preview.py --telemetry --diag` at the worst
+  case (`--link 1000,4294967295 --uptime "999d 23h"`), not at the default.
+- `tools/status_oled_preview.py --telemetry` renders it (both halves, `--diag` for the
+  clipping check) — the same mirror-the-C treatment `build_fw_confirm_panel` gets.
 
 **split42: PORTRAIT status OLED (2026-07).** The split42 panel is 128×32 physical
 but **mounted rotated 90°**, so the user reads it as **32 wide × 128 tall**. The poly
@@ -2372,12 +2434,20 @@ op-argument table, the SMALL/MID semantics and the baseline-shift rule.
   below always did) closes the class for the existing ops **and any op added later**.
   ⚠️ **So check a new op byte against those macros' argument bytes** — or rather,
   don't have to, now that MOVE consumes its own.
-- ⚠️ **The MOVE itself is still ignored** — bbox works relative to the
-  draw origin and MOVE names an ABSOLUTE buffer position, which is not knowable at
-  measure time, so a MOVE'd
-  legend's box still only covers the part laid out relatively. **Prefer the ordinary
-  cursor advance over a MOVE in a main legend** — that is why `ICON_MUTE` places its X
-  with `\f\f` and the glyph's own `xAdvance` rather than a MOVE.
+- ⚠️ **`kdisp_gfx_text_bbox()` still ignores the MOVE itself** — it works relative to
+  the draw origin and MOVE names an ABSOLUTE buffer position, which is not knowable
+  without one, so a MOVE'd legend's box only covers the part laid out relatively (and
+  the composite ops contribute no extent at all — measuring them at an unresolvable
+  cursor would be worse than skipping them). **Prefer the ordinary cursor advance over
+  a MOVE in a main legend** — that is why `ICON_MUTE` places its X with `\f\f` and the
+  glyph's own `xAdvance` rather than a MOVE.
+  - ✅ **There IS now a form that resolves it: `kdisp_gfx_text_bbox_abs()`**, which
+    takes the draw origin and returns the ABSOLUTE buffer box — MOVE resolved, and
+    `\x0F`/`\x11`/`\x15`/`\x13`/`\x12` measured at their real extents. The relative
+    form is unchanged to the byte (both are one walk in `bbox_walk()`, parameterised
+    by origin), so its 34 existing tests still pin it. **Use the absolute one whenever
+    you need to know where ALL of a legend lands** — which is exactly what the idle
+    jitter needs, and what it did not have (below).
 
 **The legend-size key is now ONE key that states its own tier.** `KC_GLYPH_SIZE_UP` on
 `_UL` draws `ICON_FONT_BIGGER` plus the current tier as a digit in the top-right;

--- a/keyboards/polykybd/base/disp_array.c
+++ b/keyboards/polykybd/base/disp_array.c
@@ -96,6 +96,13 @@ uint8_t scratch_buffer[BUFFER_BYTE_WIDTH * BUFFER_BYTE_HEIGHT];
 static int8_t s_draw_ox = 0;
 static int8_t s_draw_oy = 0;
 
+// Saturating narrow to int8_t. Buffer coordinates and the jitter offset are both
+// int8_t, and their sum can leave the range on a legend near the right edge — where
+// a silent wrap would draw the art at a WRONG place rather than clipping it away.
+static inline int8_t sat8(int16_t v) {
+    return (int8_t)((v < -128) ? -128 : ((v > 127) ? 127 : v));
+}
+
 void kdisp_set_draw_offset(int8_t ox, int8_t oy) {
     s_draw_ox = ox;
     s_draw_oy = oy;
@@ -219,15 +226,6 @@ void kdisp_draw_glyph_thin_at(const GFXfont *const *fonts, uint8_t num_fonts, in
     }
 }
 
-// sin(k * 15 deg) in 8.8 fixed point, k = 0..23. cos(k) is sin(k + 6), so one
-// table covers both. 24 steps is the whole resolution the op offers: at these glyph
-// sizes a finer angle changes no pixels, and the table stays 48 bytes.
-static const int16_t s_sin15[24] = {
-       0,   66,  128,  181,  222,  247,  256,  247,
-     222,  181,  128,   66,    0,  -66, -128, -181,
-    -222, -247, -256, -247, -222, -181, -128,  -66,
-};
-
 // Rotate a glyph COUNTER-CLOCKWISE by step*15 degrees, then halve it, and plot the
 // result at the literal (x, y) — same "composite one icon into a hint" contract as
 // kdisp_draw_glyph_half_at (no baseline align, no xOffset, no cursor advance).
@@ -240,9 +238,9 @@ static const int16_t s_sin15[24] = {
 // full-resolution positions straight back into the source, so the cost is bounded
 // by the OUTPUT size and the stack is untouched.
 //
-// Screen y runs DOWN, so a visually counter-clockwise turn is a negative angle in
-// this arithmetic — hence the (24 - step) index. The op's argument is stated in the
-// direction a reader means by "counter-clockwise", not in the sign the maths uses.
+// The rotated frame itself (angle, centre, origin, plotted size) is computed by
+// kdisp_gfx_rot_half_extent() in font_lookup.c — see there for why it lives beside
+// the bounding-box interpreter rather than here.
 void kdisp_draw_glyph_rot_half_at(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, uint32_t ch, uint8_t step) {
     const GFXfont  *font  = NULL;
     const GFXglyph *glyph = kdisp_gfx_glyph_font(fonts, num_fonts, ch, &font);
@@ -254,28 +252,15 @@ void kdisp_draw_glyph_rot_half_at(const GFXfont *const *fonts, uint8_t num_fonts
     if (w <= 0 || h <= 0) return;
     const uint8_t cb = glyph_col_bytes((uint8_t)h);
 
-    const uint8_t idx = (uint8_t)((24u - (step % 24u)) % 24u);
-    const int32_t ct  = s_sin15[(idx + 6u) % 24u];
-    const int32_t st  = s_sin15[idx];
-
-    // Centre of the source box, and the output extent, both in 8.8. The extent comes
-    // from forward-rotating the four corners: a rotated box is wider than the original.
-    const int32_t cx = ((int32_t)(w - 1) << 8) / 2;
-    const int32_t cy = ((int32_t)(h - 1) << 8) / 2;
-    int32_t x0 = INT32_MAX, x1 = INT32_MIN, y0 = INT32_MAX, y1 = INT32_MIN;
-    for (uint8_t c = 0; c < 4; ++c) {
-        const int32_t sx = (c & 1u) ? cx : -cx;
-        const int32_t sy = (c & 2u) ? cy : -cy;
-        const int32_t dx = (sx * ct - sy * st) >> 8;
-        const int32_t dy = (sx * st + sy * ct) >> 8;
-        if (dx < x0) x0 = dx;
-        if (dx > x1) x1 = dx;
-        if (dy < y0) y0 = dy;
-        if (dy > y1) y1 = dy;
-    }
-    const int16_t ow = (int16_t)(((x1 - x0) >> 8) + 1);
-    const int16_t oh = (int16_t)(((y1 - y0) >> 8) + 1);
-    const int16_t hw = (ow + 1) / 2, hh = (oh + 1) / 2;
+    // Geometry (angle, source centre, rotated-frame origin, plotted size) comes from
+    // font_lookup.c so the bounding-box interpreter measures EXACTLY what is plotted
+    // here — see kdisp_gfx_rot_half_extent().
+    kdisp_rot_half_t rot;
+    kdisp_gfx_rot_half_extent(w, h, step, &rot);
+    const int32_t ct = rot.ct, st = rot.st;
+    const int32_t cx = rot.cx, cy = rot.cy;
+    const int32_t x0 = rot.x0, y0 = rot.y0;
+    const int16_t hw = rot.w, hh = rot.h;
 
     for (int16_t dy = 0; dy < hh; ++dy) {
         for (int16_t dx = 0; dx < hw; ++dx) {
@@ -450,8 +435,6 @@ void kdisp_draw_badge_rect(int8_t x, int8_t y, int8_t width, int8_t height, int8
 // Draw a single character at bottom-left (x,y); ch is a 32-bit Unicode codepoint
 // (SMP codepoints > 0xFFFF allowed).
 int8_t kdisp_write_gfx_char(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, uint32_t ch, int8_t cy_radius) {
-    x += s_draw_ox;   // anti-burn-in jitter offset (0 except during an idle relocation redraw)
-    y += s_draw_oy;
     const GFXfont * currentFont = 0;
     uint32_t first = 0;
     uint32_t last = 0;
@@ -643,8 +626,6 @@ static int8_t kdisp_write_gfx_char_half(const GFXfont *const *fonts, uint8_t num
     const GFXfont  *font  = NULL;
     const GFXglyph *glyph = kdisp_gfx_glyph_font(fonts, num_fonts, ch, &font);
     if (glyph == NULL || font == NULL) return 0;
-    x += s_draw_ox;   // anti-burn-in jitter offset, as the full-size writer applies
-    y += s_draw_oy;
     const uint8_t *bitmap = pgm_read_bitmap_ptr(font);
     const uint16_t bo = glyph_bitmap_offset(glyph);
     const int16_t  w  = glyph_width(glyph);
@@ -684,6 +665,22 @@ void kdisp_write_gfx_text(const GFXfont *const *fonts, uint8_t num_fonts, int8_t
 // One walk of the display list. Called twice by kdisp_write_gfx_text_cy when a
 // courtyard is requested — see there for why.
 static void gfx_text_run(const GFXfont *const *fonts, uint8_t num_fonts, int8_t x, int8_t y, const uint32_t *text, int8_t cy_radius) {
+    // ⚠️ The anti-burn-in jitter offset is applied ONCE, HERE, so that everything the
+    // display list draws moves as one unit. It used to be applied inside the two char
+    // writers instead — which covered the text and NOTHING ELSE, because every
+    // composite op (\x0F HALF, \x11 THIN, \x15 ROT, \x13 BADGE, \x12 FRAME) plots
+    // through a primitive of its own. So an idle relocation slid the letters and left
+    // the composited art pinned to the buffer: the context-menu keycap's ☰ moved while
+    // its pointer stayed put, and the scroll-lock / media-stop badges never moved at
+    // all (field, 2026-08-31 — "the cursor is not moving but the hamburger does").
+    //
+    // Putting it on the CURSOR rather than in each primitive is what keeps that fixed:
+    // a sixth composite op inherits the offset by construction instead of having to
+    // remember to add it, which is the enumerating-guard shape this repo keeps getting
+    // caught by. It is 0 outside an idle relocation redraw, so every other draw is
+    // unaffected.
+    x = sat8((int16_t)x + s_draw_ox);
+    y = sat8((int16_t)y + s_draw_oy);
     int8_t x_cursor = x;
     int8_t y_cursor = y;
     // HINT_SMALL (\x10) latches this for the REST of the string — there is no
@@ -734,7 +731,15 @@ static void gfx_text_run(const GFXfont *const *fonts, uint8_t num_fonts, int8_t 
             //      chosen buffer position, so update_displays() needs no per-keycode
             //      special-case. \x0E/\x12 take the next two codepoints as arguments. ----
             case U'\x0E':   // MOVE cursor to buffer coords (next two codepoints = x, y)
-                if (text[1] && text[2]) { x_cursor = (int8_t)text[1]; y_cursor = (int8_t)text[2]; text += 2; }
+                             //   ⚠️ An ABSOLUTE position, so it has to re-apply the jitter
+                             //   offset the cursor was seeded with — assigning the raw
+                             //   coordinate is what pinned MOVE'd art in place while the
+                             //   rest of the legend moved.
+                if (text[1] && text[2]) {
+                    x_cursor = sat8((int16_t)(int8_t)text[1] + s_draw_ox);
+                    y_cursor = sat8((int16_t)(int8_t)text[2] + s_draw_oy);
+                    text += 2;
+                }
                 break;
             case U'\x10':   // SMALL: draw every FOLLOWING glyph half-scale, advancing half
                 small = true;
@@ -843,6 +848,15 @@ void kdisp_gfx_text_bbox(const GFXfont *const *fonts, uint8_t num_fonts, const u
     // firmware's resident HINT_MID face — the same s_mid_font the draw uses — so
     // the measurement and the draw cannot disagree about which face \x16 reaches.
     kdisp_gfx_text_bbox_in(fonts, num_fonts, s_mid_font, 1, text, out_xmin, out_xmax, out_ymin, out_ymax);
+}
+
+void kdisp_gfx_text_bbox_abs(const GFXfont *const *fonts, uint8_t num_fonts, int8_t origin_x, int8_t origin_y,
+                             const uint32_t *text,
+                             int8_t *out_xmin, int8_t *out_xmax, int8_t *out_ymin, int8_t *out_ymax) {
+    // Same wrapper duty as kdisp_gfx_text_bbox — bind the resident HINT_MID face —
+    // for the absolute-frame measurement. See font_lookup.h for what it adds.
+    kdisp_gfx_text_bbox_abs_in(fonts, num_fonts, s_mid_font, 1, text, origin_x, origin_y,
+                               out_xmin, out_xmax, out_ymin, out_ymax);
 }
 
 void kdisp_gfx_text_bounds(const GFXfont *const *fonts, uint8_t num_fonts, const uint32_t *text, int8_t *out_min, int8_t *out_max) {

--- a/keyboards/polykybd/base/disp_array.c
+++ b/keyboards/polykybd/base/disp_array.c
@@ -146,6 +146,29 @@ void kdisp_set_gfx_scanline2(bool scanline) {
     s_gfx_scanline = scanline ? 2 : 0;
 }
 
+// Plot one INK pixel, honouring the two static plotter modes.
+//
+// ⚠️ The modes used to live inside the two char writers only — exactly the shape
+// that left the jitter offset covering the text and nothing else (see gfx_text_run).
+// Every composite display-list op (\x0F HALF, \x11 THIN, \x15 ROT, \x13 BADGE,
+// \x12 FRAME) plots through a primitive of its own, so under EDEN's scanline the
+// letters came out half-density while the composited art stayed fully lit: the
+// context-menu pointer, and the scroll-lock / media-stop badges, which are composite
+// art ONLY and so ignored the dimming entirely. Routing every ink primitive through
+// one plot point means a sixth op inherits both modes by construction.
+//
+// ⚠️ Deliberately NOT pushed down into SET_PIXEL_CLIPPED itself: ground fills and
+// bitmap blits (kdisp_fill_rect, kdisp_draw_bitmap, the tab/MRU chrome, clear_line)
+// must stay unconditional. The split is what the primitive IS — glyph and badge ink
+// follows the modes, a background does not — not a list of call sites to keep in sync.
+static inline void kdisp_plot_ink(int x, int y) {
+    if (s_gfx_erase) {
+        CLEAR_PIXEL_CLIPPED(x, y);
+    } else if (!scanline_skip_row(y)) {
+        SET_PIXEL_CLIPPED(x, y);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Glyph accessors. The glyph array + bitmap live in the font struct (flash), and
 // every glyph bitmap is stored COLUMN-NATIVE (OLED page-format — see gfxfont.h),
@@ -197,7 +220,7 @@ void kdisp_draw_glyph_half_at(const GFXfont *const *fonts, uint8_t num_fonts, in
                     if (byte & (1u << (sy & 7))) { lit = true; break; }
                 }
             }
-            if (lit) { SET_PIXEL_CLIPPED(x + dx, y + dy); }
+            if (lit) { kdisp_plot_ink(x + dx, y + dy); }
         }
     }
 }
@@ -221,7 +244,7 @@ void kdisp_draw_glyph_thin_at(const GFXfont *const *fonts, uint8_t num_fonts, in
         for (int16_t dx = 0; dx < hw; ++dx) {
             const int16_t sx = dx * 2;
             uint8_t byte = pgm_read_byte(&bitmap[bo + (uint16_t)sx * cb + (sy >> 3)]);
-            if (byte & (1u << (sy & 7))) { SET_PIXEL_CLIPPED(x + dx, y + dy); }
+            if (byte & (1u << (sy & 7))) { kdisp_plot_ink(x + dx, y + dy); }
         }
     }
 }
@@ -280,7 +303,7 @@ void kdisp_draw_glyph_rot_half_at(const GFXfont *const *fonts, uint8_t num_fonts
                 const uint8_t byte = pgm_read_byte(&bitmap[bo + (uint16_t)ix * cb + (iy >> 3)]);
                 if (byte & (1u << (iy & 7))) lit = true;
             }
-            if (lit) { SET_PIXEL_CLIPPED(x + dx, y + dy); }
+            if (lit) { kdisp_plot_ink(x + dx, y + dy); }
         }
     }
 }
@@ -298,10 +321,10 @@ void kdisp_draw_glyph_double_at(const GFXfont *const *fonts, uint8_t num_fonts, 
         for (int16_t sy = 0; sy < h; ++sy) {
             uint8_t byte = pgm_read_byte(&bitmap[bo + (uint16_t)sx * cb + (sy >> 3)]);
             if (!(byte & (1u << (sy & 7)))) continue;
-            SET_PIXEL_CLIPPED(x + sx * 2,     y + sy * 2);
-            SET_PIXEL_CLIPPED(x + sx * 2 + 1, y + sy * 2);
-            SET_PIXEL_CLIPPED(x + sx * 2,     y + sy * 2 + 1);
-            SET_PIXEL_CLIPPED(x + sx * 2 + 1, y + sy * 2 + 1);
+            kdisp_plot_ink(x + sx * 2,     y + sy * 2);
+            kdisp_plot_ink(x + sx * 2 + 1, y + sy * 2);
+            kdisp_plot_ink(x + sx * 2,     y + sy * 2 + 1);
+            kdisp_plot_ink(x + sx * 2 + 1, y + sy * 2 + 1);
         }
     }
 }
@@ -366,18 +389,18 @@ void kdisp_draw_round_rect(int8_t x, int8_t y, int8_t width, int8_t height, int8
     if (r > (width - 1) / 2)  r = (width - 1) / 2;
     if (r > (height - 1) / 2) r = (height - 1) / 2;
     // straight edges
-    for (int i = x0 + r; i <= x1 - r; ++i) { SET_PIXEL_CLIPPED(i, y0); SET_PIXEL_CLIPPED(i, y1); }
-    for (int j = y0 + r; j <= y1 - r; ++j) { SET_PIXEL_CLIPPED(x0, j); SET_PIXEL_CLIPPED(x1, j); }
+    for (int i = x0 + r; i <= x1 - r; ++i) { kdisp_plot_ink(i, y0); kdisp_plot_ink(i, y1); }
+    for (int j = y0 + r; j <= y1 - r; ++j) { kdisp_plot_ink(x0, j); kdisp_plot_ink(x1, j); }
     // corner arcs (centres at the four inset corner points)
     int cxl = x0 + r, cxr = x1 - r, cyt = y0 + r, cyb = y1 - r;
     int f = 1 - r, ddF_x = 1, ddF_y = -2 * r, px = 0, py = r;
     while (px < py) {
         if (f >= 0) { py--; ddF_y += 2; f += ddF_y; }
         px++; ddF_x += 2; f += ddF_x;
-        SET_PIXEL_CLIPPED(cxr + px, cyt - py); SET_PIXEL_CLIPPED(cxr + py, cyt - px); // top-right
-        SET_PIXEL_CLIPPED(cxl - px, cyt - py); SET_PIXEL_CLIPPED(cxl - py, cyt - px); // top-left
-        SET_PIXEL_CLIPPED(cxr + px, cyb + py); SET_PIXEL_CLIPPED(cxr + py, cyb + px); // bottom-right
-        SET_PIXEL_CLIPPED(cxl - px, cyb + py); SET_PIXEL_CLIPPED(cxl - py, cyb + px); // bottom-left
+        kdisp_plot_ink(cxr + px, cyt - py); kdisp_plot_ink(cxr + py, cyt - px); // top-right
+        kdisp_plot_ink(cxl - px, cyt - py); kdisp_plot_ink(cxl - py, cyt - px); // top-left
+        kdisp_plot_ink(cxr + px, cyb + py); kdisp_plot_ink(cxr + py, cyb + px); // bottom-right
+        kdisp_plot_ink(cxl - px, cyb + py); kdisp_plot_ink(cxl - py, cyb + px); // bottom-left
     }
 }
 
@@ -424,11 +447,11 @@ void kdisp_draw_badge_rect(int8_t x, int8_t y, int8_t width, int8_t height, int8
             const int hins = rr_row_inset(j, hy0, hy1, hr);
             const int ha = hx0 + hins, hb = hx1 - hins;
             for (int i = a; i <= b; ++i) {
-                if (i < ha || i > hb) SET_PIXEL_CLIPPED(i, j);
+                if (i < ha || i > hb) kdisp_plot_ink(i, j);
             }
             continue;
         }
-        for (int i = a; i <= b; ++i) SET_PIXEL_CLIPPED(i, j);
+        for (int i = a; i <= b; ++i) kdisp_plot_ink(i, j);
     }
 }
 
@@ -598,11 +621,7 @@ int8_t kdisp_write_gfx_char(const GFXfont *const *fonts, uint8_t num_fonts, int8
             const uint8_t  vmsk = (uint8_t)(1u << (yy & 7));
             for (xx = 0; xx < w; xx++) {
                 if (pgm_read_byte(&bitmap[base + (uint16_t)xx * cb]) & vmsk) {
-                    if (s_gfx_erase) {
-                        CLEAR_PIXEL_CLIPPED(x + xo + xx, y + yo + yy);
-                    } else if (!scanline_skip_row(y + yo + yy)) {
-                        SET_PIXEL_CLIPPED(x + xo + xx, y + yo + yy);
-                    }
+                    kdisp_plot_ink(x + xo + xx, y + yo + yy);
                 }
             }
         }
@@ -648,11 +667,7 @@ static int8_t kdisp_write_gfx_char_half(const GFXfont *const *fonts, uint8_t num
                 }
             }
             if (!lit) continue;
-            if (s_gfx_erase) {
-                CLEAR_PIXEL_CLIPPED(gx0 + dx, gy0 + dy);
-            } else if (!scanline_skip_row(gy0 + dy)) {
-                SET_PIXEL_CLIPPED(gx0 + dx, gy0 + dy);
-            }
+            kdisp_plot_ink(gx0 + dx, gy0 + dy);
         }
     }
     return (int8_t)((pgm_read_byte(&glyph->xAdvance) + 1) / 2);
@@ -778,10 +793,11 @@ static void gfx_text_run(const GFXfont *const *fonts, uint8_t num_fonts, int8_t 
                     text += 3;
                 }
                 break;
-            case U'\x14':   // ERASE: draw every FOLLOWING TEXT glyph as a hole, not as ink.
-                            //   ⚠️ Covers the ordinary and \x10 (SMALL) paths, which both
-                            //   honour s_gfx_erase — NOT the \x0F/\x11 composite ops, whose
-                            //   kdisp_draw_glyph_*_at plot unconditionally.
+            case U'\x14':   // ERASE: draw everything FOLLOWING as a hole, not as ink —
+                            //   the composite ops (\x0F/\x11/\x15/\x13/\x12) included, since
+                            //   they now plot through kdisp_plot_ink() like the text does.
+                            //   (It used to cover the text paths ONLY, so a HINT_ERASE before
+                            //   a HALF/BADGE silently drew it lit.)
                 erase_latched = true;
                 s_gfx_erase   = true;
                 break;

--- a/keyboards/polykybd/base/disp_array.h
+++ b/keyboards/polykybd/base/disp_array.h
@@ -101,6 +101,13 @@ void kdisp_gfx_text_bounds(const GFXfont *const *fonts, uint8_t num_fonts, const
 void kdisp_gfx_text_bbox(const GFXfont *const *fonts, uint8_t num_fonts, const uint32_t *text,
                          int8_t *out_xmin, int8_t *out_xmax, int8_t *out_ymin, int8_t *out_ymax);
 
+// The ABSOLUTE-buffer sibling, binding the same mid face: the box this display list
+// would ink if drawn at (origin_x, origin_y). Resolves MOVE and measures the
+// composite ops, which the relative form cannot — see font_lookup.h.
+void kdisp_gfx_text_bbox_abs(const GFXfont *const *fonts, uint8_t num_fonts, int8_t origin_x, int8_t origin_y,
+                             const uint32_t *text,
+                             int8_t *out_xmin, int8_t *out_xmax, int8_t *out_ymin, int8_t *out_ymax);
+
 // Vertical (rotated -90°, bottom-to-top) single-font text, centred in the visible
 // height with its baseline along x = col_x.  `selected` draws it as dark text on
 // a filled bar (else lit text on the dark background).  Used by the lang layer.

--- a/keyboards/polykybd/base/font_lookup.c
+++ b/keyboards/polykybd/base/font_lookup.c
@@ -28,14 +28,69 @@ const GFXglyph *kdisp_gfx_glyph_font(const GFXfont *const *fonts, uint8_t num_fo
     return NULL;
 }
 
-void kdisp_gfx_text_bbox_in(const GFXfont *const *fonts, uint8_t num_fonts,
-                            const GFXfont *const *mid_font, uint8_t mid_count, const uint32_t *text,
-                            int8_t *out_xmin, int8_t *out_xmax, int8_t *out_ymin, int8_t *out_ymax) {
-    // Cursor relative to the draw origin: x from 0, y from the baseline (0). Mirrors
-    // every cursor rule of kdisp_write_gfx_text_cy, including the vertical controls,
-    // so the measured box matches what would actually be drawn — both axes.
-    int16_t x = 0, y = 0;
-    int16_t xmn = 127, xmx = -128, ymn = 127, ymx = -128;
+// sin(k * 15 deg) in 8.8 fixed point, k = 0..23. cos(k) is sin(k + 6), so one
+// table covers both. 24 steps is the whole resolution the ROT op offers: at these
+// glyph sizes a finer angle changes no pixels, and the table stays 48 bytes.
+static const int16_t s_sin15[24] = {
+       0,   66,  128,  181,  222,  247,  256,  247,
+     222,  181,  128,   66,    0,  -66, -128, -181,
+    -222, -247, -256, -247, -222, -181, -128,  -66,
+};
+
+void kdisp_gfx_rot_half_extent(int16_t w, int16_t h, uint8_t step, kdisp_rot_half_t *out) {
+    // Screen y runs DOWN, so a visually counter-clockwise turn is a negative angle
+    // in this arithmetic — hence the (24 - step) index. The op's argument is stated
+    // in the direction a reader means by "counter-clockwise", not the sign the
+    // maths uses.
+    const uint8_t idx = (uint8_t)((24u - (step % 24u)) % 24u);
+    out->ct = s_sin15[(idx + 6u) % 24u];
+    out->st = s_sin15[idx];
+
+    // Centre of the source box, and the output extent, both in 8.8. The extent
+    // comes from forward-rotating the four corners: a rotated box is wider than
+    // the original.
+    out->cx = ((int32_t)(w - 1) << 8) / 2;
+    out->cy = ((int32_t)(h - 1) << 8) / 2;
+    int32_t x0 = INT32_MAX, x1 = INT32_MIN, y0 = INT32_MAX, y1 = INT32_MIN;
+    for (uint8_t c = 0; c < 4; ++c) {
+        const int32_t sx = (c & 1u) ? out->cx : -out->cx;
+        const int32_t sy = (c & 2u) ? out->cy : -out->cy;
+        const int32_t dx = (sx * out->ct - sy * out->st) >> 8;
+        const int32_t dy = (sx * out->st + sy * out->ct) >> 8;
+        if (dx < x0) x0 = dx;
+        if (dx > x1) x1 = dx;
+        if (dy < y0) y0 = dy;
+        if (dy > y1) y1 = dy;
+    }
+    out->x0 = x0;
+    out->y0 = y0;
+    // The rotation runs at full resolution and is halved afterwards (halving first
+    // throws away the pixels the rotation needs to rebuild an edge), so the plotted
+    // size is the rotated extent halved — rounded UP, exactly as the drawer loops.
+    out->w = (int16_t)((((int16_t)(((x1 - x0) >> 8) + 1)) + 1) / 2);
+    out->h = (int16_t)((((int16_t)(((y1 - y0) >> 8) + 1)) + 1) / 2);
+}
+
+// One walk of the display list, shared by both bounding-box entry points below.
+//
+// (ox, oy) is the draw origin: x from there, y being the baseline. In the RELATIVE
+// form it is (0, 0), which reduces every cursor rule here to the expression it had
+// when this measured only in origin-relative space — so that form is unchanged, to
+// the byte, and its 34 tests still pin it.
+//
+// `resolve` says whether the cursor can be trusted to name a real buffer position.
+// It can only when the caller supplied the origin, and it is what gates the two
+// things that need one: resolving a MOVE, and measuring the composite ops (which
+// plot AT the cursor through primitives of their own, rather than advancing it).
+static void bbox_walk(const GFXfont *const *fonts, uint8_t num_fonts,
+                      const GFXfont *const *mid_font, uint8_t mid_count, const uint32_t *text,
+                      int16_t ox, int16_t oy, bool resolve,
+                      int8_t *out_xmin, int8_t *out_xmax, int8_t *out_ymin, int8_t *out_ymax) {
+    // Cursor. Mirrors every cursor rule of kdisp_write_gfx_text_cy, including the
+    // vertical controls, so the measured box matches what would actually be drawn —
+    // both axes.
+    int16_t x = ox, y = oy;
+    int16_t xmn = 32767, xmx = -32768, ymn = 32767, ymx = -32768;
     const int16_t base_yadv = pgm_read_byte(&fonts[0]->yAdvance);
     bool small = false;
     // HINT_MID (\x16) swaps the font array for the rest of the run, exactly as the
@@ -50,32 +105,68 @@ void kdisp_gfx_text_bbox_in(const GFXfont *const *fonts, uint8_t num_fonts,
         switch (*text) {
             case U'\x05':                     y += 2; break; // down 2px
             case U'\f':                       y = y > 1 ? y - 2 : 0; break; // up 2px
-            case U'\v':                       y += ((y) / 15 + 1) * 15; break;
-            case U'\x18':                     x = 0; y = 0; break; // cancel -> origin
-            case U'\r':                       x = 0; break;
+            case U'\v':                       y += ((y - oy) / 15 + 1) * 15; break;
+            case U'\x18':                     x = ox; y = oy; break; // cancel -> origin
+            case U'\r':                       x = ox; break;
             case U'\b':                       x = x > 1 ? x - 2 : 0; break;
             case U'\x06':                     x += 2; break; // nudge right 2px
-            case U'\t':                       x += ((x) / 36 + 1) * 36; break;
-            case U'\n':                       y += base_yadv; x = 0; break;
+            case U'\t':                       x += ((x - ox) / 36 + 1) * 36; break;
+            case U'\n':                       y += base_yadv; x = ox; break;
             // ---- the hint display-list ops, mirrored so their ARGUMENT codepoints are
             //      not measured as glyphs. Without this each op byte and each argument
             //      falls into `default:`, matches no font and is substituted with '!',
             //      so a legend carrying one MOVE measured three bogus glyphs.
-            //      \x0E is an ABSOLUTE buffer position, which this relative-to-origin
-            //      measurement cannot resolve; skipping it is strictly better than
-            //      measuring '!', but a MOVE'd legend's box still only covers the part
-            //      of it that is laid out relatively.
             case U'\x10':                    small = true; break;   // SMALL: rest of the run is half-scale
             case U'\x16':                                            // MID: rest of the run is the 19px UI face
                 mid = true;                                          //   (per glyph — see the fallback below)
                 break;
-            case U'\x0F':                                           // HALF / THIN composite a glyph at the
-            case U'\x11': if (text[1]) text += 1; break;            //   cursor and do not advance
-            case U'\x15': if (text[1] && text[2]) text += 2; break;            // ROT (angle, glyph)
-            case U'\x0E':   // MOVE (x,y): the cursor lands on an ABSOLUTE buffer position, which
-                             //   this relative-to-origin measurement cannot resolve — so the move
-                             //   itself is ignored and a MOVE'd legend's box covers only the part
-                             //   laid out relatively. Its two ARGUMENTS are still skipped.
+            case U'\x0F':                                            // HALF / THIN composite a glyph at the
+            case U'\x11':                                            //   cursor and do not advance
+                if (text[1]) {
+                    if (resolve) {
+                        // Both plot the literal TOP-LEFT at the cursor, at ceil(w/2)
+                        // x ceil(h/2) — no baseline align, no xOffset, no advance.
+                        const GFXglyph *g = kdisp_gfx_glyph(fonts, num_fonts, text[1]);
+                        if (g != NULL) {
+                            const int16_t gw = (int16_t)((pgm_read_byte(&g->width)  + 1) / 2);
+                            const int16_t gh = (int16_t)((pgm_read_byte(&g->height) + 1) / 2);
+                            if (gw > 0 && gh > 0) {
+                                if (x < xmn) xmn = x;
+                                if (x + gw - 1 > xmx) xmx = (int16_t)(x + gw - 1);
+                                if (y < ymn) ymn = y;
+                                if (y + gh - 1 > ymx) ymx = (int16_t)(y + gh - 1);
+                            }
+                        }
+                    }
+                    text += 1;
+                }
+                break;
+            case U'\x15':                                            // ROT (angle, glyph)
+                if (text[1] && text[2]) {
+                    if (resolve) {
+                        const GFXglyph *g = kdisp_gfx_glyph(fonts, num_fonts, text[2]);
+                        if (g != NULL) {
+                            kdisp_rot_half_t rot;
+                            kdisp_gfx_rot_half_extent((int16_t)pgm_read_byte(&g->width),
+                                                      (int16_t)pgm_read_byte(&g->height),
+                                                      (uint8_t)text[1], &rot);
+                            const int16_t gw = rot.w, gh = rot.h;
+                            if (gw > 0 && gh > 0) {
+                                if (x < xmn) xmn = x;
+                                if (x + gw - 1 > xmx) xmx = (int16_t)(x + gw - 1);
+                                if (y < ymn) ymn = y;
+                                if (y + gh - 1 > ymx) ymx = (int16_t)(y + gh - 1);
+                            }
+                        }
+                    }
+                    text += 2;
+                }
+                break;
+            case U'\x0E':   // MOVE (x,y): the cursor lands on an ABSOLUTE buffer position.
+                             //   Resolvable only when the caller named the origin; otherwise
+                             //   the move itself is ignored and a MOVE'd legend's box covers
+                             //   only the part laid out relatively. Its two ARGUMENTS are
+                             //   skipped either way.
                              //
                              //   ⚠️ They MUST be, and this used to fall through to \x14 and skip
                              //   nothing. A coordinate is an arbitrary byte, so it lands in this
@@ -86,11 +177,43 @@ void kdisp_gfx_text_bbox_in(const GFXfont *const *fonts, uint8_t num_fonts,
                              //   silently latch a font for the rest of the run or eat two real
                              //   codepoints. Skipping the arguments closes the whole class,
                              //   including for any op added later.
-                if (text[1] && text[2]) text += 2;
+                if (text[1] && text[2]) {
+                    if (resolve) { x = (int16_t)(int8_t)text[1]; y = (int16_t)(int8_t)text[2]; }
+                    text += 2;
+                }
                 break;
             case U'\x14':                    /* ERASE: a mode, no extent */ break;
-            case U'\x13': if (text[1] && text[2] && text[3]) text += 3; break;  // BADGE (w,h,style)
-            case U'\x12': if (text[1] && text[2]) text += 2; break;             // FRAME (w,h)
+            case U'\x13':                                                       // BADGE (w,h,style)
+                if (text[1] && text[2] && text[3]) {
+                    if (resolve) {
+                        const int16_t bw = (int16_t)(int8_t)text[1], bh = (int16_t)(int8_t)text[2];
+                        if (bw > 0 && bh > 0) {
+                            if (x < xmn) xmn = x;
+                            if (x + bw - 1 > xmx) xmx = (int16_t)(x + bw - 1);
+                            if (y < ymn) ymn = y;
+                            if (y + bh - 1 > ymx) ymx = (int16_t)(y + bh - 1);
+                        }
+                    }
+                    text += 3;
+                }
+                break;
+            case U'\x12':                                                       // FRAME (w,h)
+                if (text[1] && text[2]) {
+                    if (resolve) {
+                        // The rounded rect inks inside its own w x h box (and draws
+                        // nothing at all below 2x2 — measuring the box regardless is
+                        // the generous direction, which for a clamp is the safe one).
+                        const int16_t fw = (int16_t)(int8_t)text[1], fh = (int16_t)(int8_t)text[2];
+                        if (fw > 0 && fh > 0) {
+                            if (x < xmn) xmn = x;
+                            if (x + fw - 1 > xmx) xmx = (int16_t)(x + fw - 1);
+                            if (y < ymn) ymn = y;
+                            if (y + fh - 1 > ymx) ymx = (int16_t)(y + fh - 1);
+                        }
+                    }
+                    text += 2;
+                }
+                break;
             default: {
                 // Locate the font whose [first,last] contains the codepoint (linear
                 // scan; this is a cold measuring path, no MRU cache needed).
@@ -141,9 +264,26 @@ void kdisp_gfx_text_bbox_in(const GFXfont *const *fonts, uint8_t num_fonts,
         }
         text++;
     }
-    if (xmx < xmn) { xmn = 0; xmx = 0; ymn = 0; ymx = 0; }   // empty / whitespace-only
+    // Empty / whitespace-only input degenerates to a point AT THE ORIGIN — which in
+    // the relative form (ox = oy = 0) is the all-zero box it has always reported.
+    if (xmx < xmn) { xmn = xmx = ox; ymn = ymx = oy; }
     *out_xmin = (int8_t)xmn;
     *out_xmax = (int8_t)xmx;
     *out_ymin = (int8_t)ymn;
     *out_ymax = (int8_t)ymx;
+}
+
+void kdisp_gfx_text_bbox_in(const GFXfont *const *fonts, uint8_t num_fonts,
+                            const GFXfont *const *mid_font, uint8_t mid_count, const uint32_t *text,
+                            int8_t *out_xmin, int8_t *out_xmax, int8_t *out_ymin, int8_t *out_ymax) {
+    bbox_walk(fonts, num_fonts, mid_font, mid_count, text, 0, 0, false,
+              out_xmin, out_xmax, out_ymin, out_ymax);
+}
+
+void kdisp_gfx_text_bbox_abs_in(const GFXfont *const *fonts, uint8_t num_fonts,
+                                const GFXfont *const *mid_font, uint8_t mid_count, const uint32_t *text,
+                                int8_t origin_x, int8_t origin_y,
+                                int8_t *out_xmin, int8_t *out_xmax, int8_t *out_ymin, int8_t *out_ymax) {
+    bbox_walk(fonts, num_fonts, mid_font, mid_count, text, origin_x, origin_y, true,
+              out_xmin, out_xmax, out_ymin, out_ymax);
 }

--- a/keyboards/polykybd/base/font_lookup.h
+++ b/keyboards/polykybd/base/font_lookup.h
@@ -68,3 +68,39 @@ static inline const GFXglyph *kdisp_gfx_glyph(const GFXfont *const *fonts, uint8
 // unknowable at measure time, so its arguments are consumed and the reposition
 // itself is ignored. Empty / whitespace-only input reports all-zero.
 void kdisp_gfx_text_bbox_in(const GFXfont *const *fonts, uint8_t num_fonts, const GFXfont *const *mid_font, uint8_t mid_count, const uint32_t *text, int8_t *out_xmin, int8_t *out_xmax, int8_t *out_ymin, int8_t *out_ymax);
+
+// The geometry of kdisp_draw_glyph_rot_half_at(): a glyph of `w` x `h` rotated
+// counter-clockwise by `step` * 15 degrees and then halved. `w`/`h` are the
+// PLOTTED size (the rotation runs at full resolution and is halved after); the
+// rest is the rotated frame the drawer inverse-maps each output pixel through,
+// in 8.8 fixed point.
+//
+// ⚠️ It lives HERE, next to the bounding-box interpreter, rather than inside the
+// drawer, because BOTH need it and a second copy would drift: the measurement
+// decides how far the idle jitter may move a legend, so a box that disagrees with
+// the pixels is a legend that clips.
+typedef struct {
+    int32_t ct, st;   // cos / sin of the applied angle
+    int32_t cx, cy;   // centre of the source box
+    int32_t x0, y0;   // origin of the rotated frame
+    int16_t w, h;     // plotted (halved) output size, in pixels
+} kdisp_rot_half_t;
+
+void kdisp_gfx_rot_half_extent(int16_t w, int16_t h, uint8_t step, kdisp_rot_half_t *out);
+
+// The ABSOLUTE-buffer sibling of kdisp_gfx_text_bbox_in: the box the SAME display
+// list would ink if drawn at origin (origin_x, origin_y), in buffer coordinates.
+//
+// Two things it can do that the relative form cannot, both because it knows the
+// origin: a MOVE (\x0E) is RESOLVED rather than ignored, and the composite ops
+// (\x0F HALF, \x11 THIN, \x15 ROT, \x13 BADGE, \x12 FRAME) contribute their real
+// extents — they plot at the cursor through primitives of their own, so without a
+// resolvable cursor their position is unknowable and measuring them would be worse
+// than skipping them, which is exactly what the relative form does.
+//
+// That is what the idle anti-burn-in jitter measures with: it moves the whole
+// legend as one unit, so it has to know where ALL of it lands, composited art
+// included. Measuring the relative box instead reports only the part laid out by
+// the cursor — for a legend whose art hangs off a MOVE that can be most of it —
+// and the jitter then happily shifts the rest off the panel.
+void kdisp_gfx_text_bbox_abs_in(const GFXfont *const *fonts, uint8_t num_fonts, const GFXfont *const *mid_font, uint8_t mid_count, const uint32_t *text, int8_t origin_x, int8_t origin_y, int8_t *out_xmin, int8_t *out_xmax, int8_t *out_ymin, int8_t *out_ymax);

--- a/keyboards/polykybd/base/tests/font_bbox_tests.cpp
+++ b/keyboards/polykybd/base/tests/font_bbox_tests.cpp
@@ -126,6 +126,15 @@ class FontBboxTest : public ::testing::Test {
     Box measure_mid(std::initializer_list<uint32_t> cps) {
         return measure(cps, midarr_, 1);
     }
+    // The ABSOLUTE-frame measurement, at a draw origin — what the idle jitter uses.
+    Box measure_abs(std::initializer_list<uint32_t> cps, int8_t ox, int8_t oy,
+                    const GFXfont *const *mid = nullptr, uint8_t mid_count = 0) {
+        std::vector<uint32_t> text(cps);
+        text.push_back(0);
+        Box b{};
+        kdisp_gfx_text_bbox_abs_in(pool_, 2, mid, mid_count, text.data(), ox, oy, &b.xmin, &b.xmax, &b.ymin, &b.ymax);
+        return b;
+    }
 };
 
 // ---------------------------------------------------------------------------
@@ -367,6 +376,126 @@ TEST(FontLookupTest, HalfFloorFloorsNegativeValues) {
     EXPECT_EQ(glyph_half_floor(-9), -5);   // truncation would give -4
     EXPECT_EQ(glyph_half_floor(0), 0);
     EXPECT_EQ(glyph_half_floor(-1), -1);
+}
+
+
+// ---------------------------------------------------------------------------
+// The ABSOLUTE-frame measurement (kdisp_gfx_text_bbox_abs_in).
+//
+// This is what the idle anti-burn-in jitter clamps against, and the reason it
+// exists is a real field bug: the jitter offset moves the WHOLE display list, but
+// the relative box only covers what the cursor laid out — so composited art was
+// left out of the slack calculation entirely. The relative form's own behaviour is
+// unchanged and still pinned by the tests above; these pin the difference.
+
+TEST_F(FontBboxTest, AbsoluteBoxIsTheRelativeBoxTranslatedToTheOrigin) {
+    const Box rel = measure({'a', 'a'});
+    const Box abs = measure_abs({'a', 'a'}, 28, 23);
+    EXPECT_EQ(abs.xmin, rel.xmin + 28);
+    EXPECT_EQ(abs.xmax, rel.xmax + 28);
+    EXPECT_EQ(abs.ymin, rel.ymin + 23);
+    EXPECT_EQ(abs.ymax, rel.ymax + 23);
+}
+
+TEST_F(FontBboxTest, AbsoluteAtOriginZeroMatchesTheRelativeBox) {
+    // The two forms are one walk; at origin (0,0) they must agree exactly, which is
+    // what makes the relative form's 34 existing expectations evidence for both.
+    EXPECT_EQ(measure_abs({'a', 'b', 'a'}, 0, 0), measure({'a', 'b', 'a'}));
+    EXPECT_EQ(measure_abs({0x10, 'a', 'b'}, 0, 0), measure({0x10, 'a', 'b'}));
+    EXPECT_EQ(measure_abs({'a', 0x16, 'b'}, 0, 0, midarr_, 1), measure_mid({'a', 0x16, 'b'}));
+}
+
+TEST_F(FontBboxTest, AbsoluteResolvesMoveWhereRelativeIgnoresIt) {
+    // MOVE names an absolute buffer position, so only the absolute form can place
+    // what follows it. Relative measures the 'a' at the pre-MOVE cursor; absolute
+    // measures it at (60,30) + the glyph's own offsets.
+    const Box rel = measure({0x0E, 60, 30, 'a'});
+    EXPECT_EQ(rel, measure({'a'}));                       // move ignored
+    const Box abs = measure_abs({0x0E, 60, 30, 'a'}, 28, 23);
+    EXPECT_EQ(abs.xmin, 61);                              // 60 + xOffset 1
+    EXPECT_EQ(abs.xmax, 66);                              // + width 6 - 1
+    EXPECT_EQ(abs.ymin, 20);                              // 30 + yOffset -10
+    EXPECT_EQ(abs.ymax, 29);                              // + height 10 - 1
+}
+
+TEST_F(FontBboxTest, AbsoluteMeasuresCompositeOpsThatRelativeSkips) {
+    // HALF/THIN plot the literal top-left at the cursor at ceil(w/2) x ceil(h/2).
+    // The tall face is 20x30 -> 10x15.
+    EXPECT_EQ(measure({0x0F, 0xE000}), (Box{0, 0, 0, 0}));   // relative: no extent
+    EXPECT_EQ(measure_abs({0x0F, 0xE000}, 28, 23), (Box{28, 37, 23, 37}));
+    EXPECT_EQ(measure_abs({0x11, 0xE000}, 28, 23), (Box{28, 37, 23, 37}));
+}
+
+TEST_F(FontBboxTest, AbsoluteMeasuresBadgeAndFrameRects) {
+    // BADGE (w,h,style) and FRAME (w,h) ink inside their own w x h box at the cursor.
+    EXPECT_EQ(measure({0x13, 15, 15, 2}), (Box{0, 0, 0, 0}));
+    EXPECT_EQ(measure_abs({0x13, 15, 15, 2}, 40, 10), (Box{40, 54, 10, 24}));
+    EXPECT_EQ(measure_abs({0x12, 20, 12}, 40, 10), (Box{40, 59, 10, 21}));
+}
+
+// ⚠️ Derive the rotated extent from ARITHMETIC, not from the helper — a test that
+// computes its expectation by calling the thing under test agrees by construction
+// and cannot catch a wrong result. Two angles have a knowable answer: a 0-degree
+// turn must give exactly the un-rotated HALF size, and a 90-degree turn the same
+// with the axes swapped. (Written after a "don't halve the width" mutation escaped
+// a test that had asked the helper what to expect.)
+TEST_F(FontBboxTest, RotHalfExtentIsTheHalvedSizeAtZeroDegrees) {
+    kdisp_rot_half_t rot;
+    kdisp_gfx_rot_half_extent(20, 30, 0, &rot);
+    EXPECT_EQ(rot.w, 10);   // ceil(20/2)
+    EXPECT_EQ(rot.h, 15);   // ceil(30/2)
+    kdisp_gfx_rot_half_extent(21, 31, 0, &rot);
+    EXPECT_EQ(rot.w, 11);   // odd sizes round UP, as the drawer's loop bound does
+    EXPECT_EQ(rot.h, 16);
+}
+
+TEST_F(FontBboxTest, RotHalfExtentSwapsTheAxesAtNinetyDegrees) {
+    kdisp_rot_half_t rot;
+    kdisp_gfx_rot_half_extent(20, 30, 6, &rot);   // 6 * 15 == 90 degrees
+    EXPECT_EQ(rot.w, 15);
+    EXPECT_EQ(rot.h, 10);
+}
+
+TEST_F(FontBboxTest, AbsoluteMeasuresARotatedCompositeGlyph) {
+    // ROT plots at the cursor too. The extent must be the ROTATED one — a rotated
+    // box is wider than the original — and it must come from the same helper the
+    // drawer uses, so the two cannot disagree about which pixels are touched.
+    kdisp_rot_half_t rot;
+    kdisp_gfx_rot_half_extent(20, 30, 8, &rot);   // the tall face's 20x30 at 120 deg
+    ASSERT_GT(rot.w, 0);
+    ASSERT_GT(rot.h, 0);
+    const Box abs = measure_abs({0x15, 8, 0xE000}, 50, 12);
+    EXPECT_EQ(abs, (Box{50, (int8_t)(50 + rot.w - 1), 12, (int8_t)(12 + rot.h - 1)}));
+    // A rotation genuinely widens the 20-wide source, so this is not measuring the
+    // un-rotated glyph by accident.
+    EXPECT_GT(rot.w, 10);
+}
+
+TEST_F(FontBboxTest, AbsoluteCoversMovedCompositeArtBesideCursorText) {
+    // The shipped ICON_CONTEXT_MENU shape: a cursor-laid-out glyph, then a MOVE, then
+    // composited art. The absolute box must span BOTH — this is exactly the case the
+    // relative box under-reports, which let the jitter carry the art off the panel.
+    const Box abs = measure_abs({0xE000, 0x0E, 90, 30, 0x0F, 0xE001}, 28, 23);
+    EXPECT_EQ(abs.xmin, 30);                 // the tall glyph at 28 + xOffset 2
+    EXPECT_EQ(abs.xmax, 99);                 // the half-scale art at 90, 10 wide
+    const Box rel_only = measure_abs({0xE000}, 28, 23);
+    EXPECT_LT(rel_only.xmax, abs.xmax);      // the art really extends the box
+}
+
+TEST_F(FontBboxTest, EmptyTextDegeneratesToThePointAtTheOrigin) {
+    // Whitespace-only reports a degenerate box AT the origin, so a caller's clamp
+    // sees a point where the legend is rather than a point at buffer (0,0).
+    EXPECT_EQ(measure_abs({' ', ' '}, 28, 23), (Box{28, 28, 23, 23}));
+    EXPECT_EQ(measure({' ', ' '}), (Box{0, 0, 0, 0}));   // relative form unchanged
+}
+
+TEST_F(FontBboxTest, AbsoluteStillSkipsOpArgumentsSoTheyAreNotMeasuredAsGlyphs) {
+    // The op-argument skipping is the interpreter's worst bug history, and resolving
+    // MOVE must not weaken it: (15,15) is HALF HALF and (19,19) is BADGE BADGE.
+    EXPECT_EQ(measure_abs({0x0E, 15, 15, 'a'}, 0, 0), measure_abs({0x0E, 15, 15, 'a'}, 0, 0));
+    const Box b = measure_abs({0x0E, 15, 15, 'a'}, 0, 0);
+    EXPECT_EQ(b.xmin, 16);   // 'a' at x=15 + xOffset 1 — one glyph, not three
+    EXPECT_EQ(b.xmax, 21);
 }
 
 }  // namespace

--- a/keyboards/polykybd/bridge_helper.c
+++ b/keyboards/polykybd/bridge_helper.c
@@ -44,6 +44,22 @@ static uint32_t ls_call_giveup    = 0;  // calls that exhausted every retry on a
                                         //  see the note where it is incremented)
 static uint32_t ls_last_log       = 0;  // ls_attempts at the last emitted summary
 
+void poly_get_link_stats(poly_link_stats_t* out) {
+    if (!out) return;
+    out->attempts       = ls_attempts;
+    out->crc_err        = ls_crc_err;
+    out->nack           = ls_nack;
+    out->transport_fail = ls_transport_fail;
+    out->giveup         = ls_call_giveup;
+}
+
+uint32_t poly_link_err_permille(void) {
+    // Same expression as the periodic console summary above — kept here rather than
+    // duplicated at the caller so the panel and the log can never diverge.
+    const uint32_t errs = ls_crc_err + ls_transport_fail;
+    return ls_attempts ? (uint32_t)(((uint64_t)errs * 1000U) / ls_attempts) : 0U;
+}
+
 void set_com_state(enum com_state state) {
     com = state;
 }

--- a/keyboards/polykybd/bridge_helper.h
+++ b/keyboards/polykybd/bridge_helper.h
@@ -17,3 +17,27 @@ const char* tid_to_str(int8_t tid);
 uint8_t send_to_bridge(int8_t tid, void* buffer_with4crc_bytes, const uint8_t num_bytes, const uint8_t max_retries);
 
 bool differ(const void* b1, const void* b2, uint8_t byte_count);
+
+/* Split-link health counters, cumulative since boot — the same numbers the periodic
+   "Split link: …" console line reports, so the status OLED and the log cannot
+   disagree about the state of the wire.
+
+   ⚠️ MASTER-ONLY BY CONSTRUCTION. Only the master calls send_to_bridge(), so on the
+   slave every field is 0 — that is "this half never initiates", not "the link is
+   perfect". A reader must say so rather than render a flattering 0.0%. */
+typedef struct {
+    uint32_t attempts;        /* frames sent */
+    uint32_t crc_err;         /* payload corrupted in flight */
+    uint32_t nack;            /* valid non-ACK answer (BUSY / REFUSED) — NOT a fault */
+    uint32_t transport_fail;  /* timeout / handshake / no reply */
+    uint32_t giveup;          /* calls that exhausted every retry on a LINK fault */
+} poly_link_stats_t;
+
+void poly_get_link_stats(poly_link_stats_t* out);
+
+/* Detected LINK-fault rate in per-mille of frames sent, 0 when nothing was sent.
+   ⚠️ Counts crc_err + transport_fail ONLY, exactly like the console line's err%:
+   `nack` is a valid answer over a working wire, and SYNC_BUSY arrives on every
+   erase re-poll of a flash, so including it would inflate the one number used to
+   judge cable / baud / drive changes. */
+uint32_t poly_link_err_permille(void);

--- a/keyboards/polykybd/oled_helper.c
+++ b/keyboards/polykybd/oled_helper.c
@@ -5,6 +5,7 @@
 
 #include "state.h"
 #include "side.h"
+#include "bridge_helper.h"   // is_usb_host_side() + the split-link health counters
 #include "base/com.h"
 #include "base/disp_array.h"
 #include "base/fw_staging.h"
@@ -287,6 +288,117 @@ void oled_fw_apply_screen(void) {
     oled_render_dirty(true);   // one synchronous full flush before the reboot
 }
 
+// ---------------------------------------------------------------------------
+// Settings -> "More" telemetry screen
+//
+// The advanced settings row is revealed by KC_SETTINGS_MORE, and while it is open
+// the status OLED has nothing to say that the keycaps do not — so it states what
+// the board IS instead: the versions a support round always asks for first, and
+// the split-link health, which until now existed only in the periodic console line
+// (every 200 frames, on a console nobody has open).
+//
+// Deliberately landscape on split42 too, matching the flash / confirm / apply
+// screens there — that panel's portrait rework is still deferred, so it renders
+// sideways on split42 rather than not at all.
+//
+// Driven by the SYNCED poly_sync_t.settings_more, so both halves show it together
+// and it clears itself when the settings layer is left (layer_state_set_user).
+
+// Uptime as h:mm:ss, or Nd Nh once hours reach three digits. Sourced from
+// timer_read32(), so it is THIS half's own uptime and it wraps with the 32-bit ms
+// timer at 49.7 days — long enough to be useful, short enough to say so.
+static void telemetry_uptime(char* out, size_t cap) {
+    const uint32_t secs = timer_read32() / 1000U;
+    const uint32_t h    = secs / 3600U;
+    if (h < 100U) {
+        snprintf(out, cap, "%lu:%02lu:%02lu", (unsigned long)h,
+                 (unsigned long)((secs / 60U) % 60U), (unsigned long)(secs % 60U));
+    } else {
+        snprintf(out, cap, "%lud %luh", (unsigned long)(h / 24U), (unsigned long)(h % 24U));
+    }
+}
+
+void oled_telemetry_screen(void) {
+    const GFXfont* small    = &NotoSans_Regular_Small_15px7b;
+    const GFXfont* fonts[]  = { small };
+    const bool     tall     = OLED_DISPLAY_HEIGHT >= 64;
+
+    char up[16];
+    telemetry_uptime(up, sizeof(up));
+
+    // The identity fields are exactly the ones GET_ID reports (hid_com.c), so the
+    // panel and the host's view of the board can never disagree.
+    char l_fw[24], l_ver[24], l_up[24], l_link[24];
+    snprintf(l_fw,  sizeof(l_fw),  "FW %s", FW_VERSION);
+    snprintf(l_ver, sizeof(l_ver), "P%d  HW %s", (int)PROTOCOL_VERSION, STR(DEVICE_VER));
+    snprintf(l_up,  sizeof(l_up),  "%s  up %s", is_usb_host_side() ? "USB" : "LNK", up);
+
+    poly_link_stats_t ls;
+    poly_get_link_stats(&ls);
+    if (!is_usb_host_side()) {
+        // ⚠️ Not "0.0%". Only the master initiates bridges, so this half's counters
+        // are zero because it never sends — rendering that as a perfect link would
+        // be a flattering lie on exactly the panel someone reads to judge the wire.
+        snprintf(l_link, sizeof(l_link), "Lnk n/a");
+    } else if (ls.attempts == 0U) {
+        snprintf(l_link, sizeof(l_link), "Lnk idle");
+    } else {
+        // ⚠️ Both fields are COMPACTED because the worst case, not the typical one,
+        // decides whether the line fits: the frame count climbs for as long as the
+        // board is up (millions within hours), and spelled out in full it runs off
+        // the 128 px panel — measured at 135 px against a 127 px budget, while the
+        // "1234tx" a fresh boot shows fits comfortably and hides it.
+        // One decimal below 10 % (where the precision is the whole point) and a
+        // whole percent above it keeps the widest form at 122 px.
+        char tx[8];
+        if (ls.attempts < 1000U) {
+            snprintf(tx, sizeof(tx), "%lu", (unsigned long)ls.attempts);
+        } else if (ls.attempts < 1000000U) {
+            snprintf(tx, sizeof(tx), "%luk", (unsigned long)(ls.attempts / 1000U));
+        } else {
+            snprintf(tx, sizeof(tx), "%luM", (unsigned long)(ls.attempts / 1000000U));
+        }
+        const uint32_t pm = poly_link_err_permille();
+        if (pm < 100U) {
+            snprintf(l_link, sizeof(l_link), "Lnk %lu.%lu%% %s",
+                     (unsigned long)(pm / 10U), (unsigned long)(pm % 10U), tx);
+        } else {
+            snprintf(l_link, sizeof(l_link), "Lnk %lu%% %s", (unsigned long)((pm + 5U) / 10U), tx);
+        }
+    }
+
+    // The 32 px panel holds two lines, so it keeps the two that cannot be read off
+    // anything else on the board; uptime and link health are split72-only.
+    const char* lines[4] = { l_fw, l_ver, l_up, l_link };
+    const uint8_t count  = tall ? 4u : 2u;
+
+    oled_on();
+    kdisp_set_buffer(0);   // clear the scratch to black
+
+    // Even vertical distribution, each line centred in its own band from its OWN
+    // bbox — the same layout the FW-2 confirm screen uses, so a line with a
+    // descender sits level instead of being pushed by the tallest line in the set.
+    const int8_t band = (int8_t)(OLED_DISPLAY_HEIGHT / count);
+    for (uint8_t i = 0; i < count; ++i) {
+        uint32_t txt[24];
+        ascii_to_u32_string((char*)txt, sizeof(txt), lines[i]);
+        int8_t x0 = 0, x1 = 0, y0 = 0, y1 = 0;
+        kdisp_gfx_text_bbox(fonts, 1, txt, &x0, &x1, &y0, &y1);
+        const int8_t w = (int8_t)(x1 - x0 + 1);
+        int16_t      x = (int16_t)((OLED_DISPLAY_WIDTH - w) / 2 - x0);
+        if (x < 0) x = 0;
+        const int8_t base = (int8_t)(band * i + band / 2 - (y0 + y1) / 2);
+        kdisp_write_gfx_text(fonts, 1, (int8_t)x, base, txt);
+    }
+
+    oled_write_raw((char*)get_scratch_buffer(), get_scratch_buffer_size());
+    // One synchronous pass: this is a full-screen swap the user asked for by pressing
+    // a key, so it must land complete rather than dribble in a block per main loop.
+    // A no-op once the screen is static (oled_render_dirty early-returns when clean),
+    // which matters because the uptime line changes only once a second.
+    oled_render_dirty(true);
+}
+
 // Typing-speed dial (11x6 speedometer). Shared by BOTH variants' status OLEDs, so it
 // is defined once here (oled_helper.c is in the shared POLY_SRC) and referenced via
 // extern from each status_oled.c -- defining it per variant drifts the two copies.
@@ -337,6 +449,12 @@ bool oled_task_user(void) {
 #endif
     } else if ((get_local_state()->flags & DISP_IDLE) != 0) {
         oled_render_logos();
+    } else if (get_local_state()->settings_more != 0) {
+        // Settings -> "More" is open: show what the board IS. Below the idle branch
+        // on purpose — an idled board has nothing to report and the logos are the
+        // lower-power screen; settings_more clears itself on leaving the layer.
+        oled_scroll_off();
+        oled_telemetry_screen();
     } else {
         oled_scroll_off();
         oled_status_screen();

--- a/keyboards/polykybd/oled_helper.h
+++ b/keyboards/polykybd/oled_helper.h
@@ -54,5 +54,9 @@ uint8_t fw_update_percent(void);   /* 0..100 progress of the in-flight flash */
 extern const uint8_t wpm_gauge_bitmap[];
 #define WPM_ICON_W 11
 #define WPM_ICON_H 6
+/* Settings -> "More": firmware / protocol / hardware version, this half's uptime and
+   the split-link health, in place of the ordinary status screen while the advanced
+   settings row is revealed. Driven by the synced poly_sync_t.settings_more. */
+void oled_telemetry_screen(void);
 void oled_render_logos(void);
 bool oled_task_user(void);

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -2774,10 +2774,18 @@ static uint16_t display_keycode_at(const poly_layer_t* lyr, uint8_t row, uint8_t
 // separate clamp step is needed.
 static void roll_idle_offset(const uint32_t* text, int8_t ox, int8_t oy, uint32_t seed,
                              int8_t* dx, int8_t* dy) {
+    // ⚠️ The ABSOLUTE box, not the relative one. The whole display list moves as a
+    // unit under the jitter offset, so the slack has to be measured over ALL of it —
+    // including art positioned by a MOVE and drawn by a composite op, which the
+    // relative box cannot see (font_lookup.h). Measuring the relative box instead
+    // reports only the cursor-laid-out part: for the context-menu keycap that is the
+    // hamburger alone, granting travel that would carry its pointer off the panel,
+    // and for a legend that is ONLY composite art (the media-stop badge) it reports
+    // an empty box and would allow the lot.
     int8_t xmin, xmax, ymin, ymax;
-    kdisp_gfx_text_bbox(g_all_fonts, g_all_font_count, text, &xmin, &xmax, &ymin, &ymax);
-    int16_t axmin = ox + xmin, axmax = ox + xmax;   // glyph extent at the un-jittered origin
-    int16_t aymin = oy + ymin, aymax = oy + ymax;
+    kdisp_gfx_text_bbox_abs(g_all_fonts, g_all_font_count, ox, oy, text, &xmin, &xmax, &ymin, &ymax);
+    int16_t axmin = xmin, axmax = xmax;   // glyph extent at the un-jittered origin
+    int16_t aymin = ymin, aymax = ymax;
     int16_t xlo = (int16_t)BUFFER_X - axmin;                      // keep left edge >= BUFFER_X
     int16_t xhi = (int16_t)(BUFFER_X + SCREEN_WIDTH - 1) - axmax; // keep right edge on-screen
     int16_t ylo = -aymin;                                         // keep top >= 0

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -4768,13 +4768,18 @@ void eeconfig_init_kb(void) {
 void eeconfig_init_user(void) {
     uprint("Init EE config\n");
     // Zero the WHOLE struct: the write below is a full-struct write, but not every
-    // field is assigned here (idle_style, os_state, glyph_script, boot_flags are
-    // not), so an uninitialised local would persist stack garbage into a fresh
-    // EEPROM for those.
+    // field is assigned here (os_state, glyph_script, boot_flags are not), so an
+    // uninitialised local would persist stack garbage into a fresh EEPROM for those.
     poly_eeconf_t ee = {0};
     ee.lang = g_lang_init;
     ee.brightness = ~FULL_BRIGHT;
     ee.auto_brightness = 0;   // host-auto off on a fresh EEPROM
+    // Born with the board default already recorded as a real choice, rather than
+    // leaning on load_user_eeconf()'s pre-sentinel substitution. Same reasoning as
+    // latin_ex_wide being born widened: a fresh EEPROM should never have to be
+    // migrated, and the zero that {0} leaves here means PULSE, not "unset".
+    ee.idle_style     = POLY_DEFAULT_IDLE_STYLE;
+    ee.idle_style_fmt = IDLE_STYLE_FMT_OK;
     memset(ee.latin_ex, 0, sizeof(ee.latin_ex));
     // A fresh EEPROM is born already widened: zeroed picks (every letter on its
     // first variation) plus the sentinel, so it never runs the legacy conversion.

--- a/keyboards/polykybd/split42/keymaps/default/config.h
+++ b/keyboards/polykybd/split42/keymaps/default/config.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 #define ENABLE_COMPILE_KEYCODE
 
-#define EECONFIG_USER_DATA_SIZE 156  // +39 latin_ex_wide +1 fmt +20 latin_assign, then +18/+9/+1 for the punctuation targets, +1 glyph_size +1 keymap_layers_fmt
+#define EECONFIG_USER_DATA_SIZE 157  // +39 latin_ex_wide +1 fmt +20 latin_assign, then +18/+9/+1 for the punctuation targets, +1 glyph_size +1 keymap_layers_fmt +1 idle_style_fmt
                                      // +20 latin_assign (6-bit base-letter per key).
                                      // POLY_EECONFIG_USER_RESERVED was raised 128->256 for
                                      // this: 126 still fits 128, but with 2 bytes left the

--- a/keyboards/polykybd/split72/keymaps/default/config.h
+++ b/keyboards/polykybd/split72/keymaps/default/config.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 #define ENABLE_COMPILE_KEYCODE
 
-#define EECONFIG_USER_DATA_SIZE 156  // +39 latin_ex_wide +1 fmt +20 latin_assign, then +18/+9/+1 for the punctuation targets, +1 glyph_size +1 keymap_layers_fmt
+#define EECONFIG_USER_DATA_SIZE 157  // +39 latin_ex_wide +1 fmt +20 latin_assign, then +18/+9/+1 for the punctuation targets, +1 glyph_size +1 keymap_layers_fmt +1 idle_style_fmt
                                      // +20 latin_assign (6-bit base-letter per key).
                                      // POLY_EECONFIG_USER_RESERVED was raised 128->256 for
                                      // this: 126 still fits 128, but with 2 bytes left the

--- a/keyboards/polykybd/split72/keymaps/revision2/config.h
+++ b/keyboards/polykybd/split72/keymaps/revision2/config.h
@@ -3,7 +3,7 @@
 
 #define ENABLE_COMPILE_KEYCODE
 
-#define EECONFIG_USER_DATA_SIZE 156  // +39 latin_ex_wide +1 fmt +20 latin_assign, then +18/+9/+1 for the punctuation targets, +1 glyph_size +1 keymap_layers_fmt
+#define EECONFIG_USER_DATA_SIZE 157  // +39 latin_ex_wide +1 fmt +20 latin_assign, then +18/+9/+1 for the punctuation targets, +1 glyph_size +1 keymap_layers_fmt +1 idle_style_fmt
                                      // +20 latin_assign (6-bit base-letter per key).
                                      // POLY_EECONFIG_USER_RESERVED was raised 128->256 for
                                      // this: 126 still fits 128, but with 2 bytes left the

--- a/keyboards/polykybd/state.c
+++ b/keyboards/polykybd/state.c
@@ -24,7 +24,7 @@ static bool g_brightness_dirty = false;   // lang + brightness need a flush
 static uint8_t g_user_brightness = FULL_BRIGHT;
 
 // Active idle (anti-burn-in) display style — persisted alongside lang+brightness.
-static uint8_t g_idle_style = IDLE_STYLE_PULSE;
+static uint8_t g_idle_style = POLY_DEFAULT_IDLE_STYLE;
 
 // Active glyph-script override (enum poly_glyph_script). Persisted at the tail of
 // poly_eeconf_t (its own byte, like os_state) and flushed via g_glyph_dirty.
@@ -369,7 +369,7 @@ void set_idle_style(uint8_t style) {
 
 // Records the idle style without marking settings dirty (boot-time EEPROM load).
 void note_idle_style(uint8_t style) {
-    g_idle_style = (style < IDLE_STYLE_COUNT) ? style : IDLE_STYLE_PULSE;
+    g_idle_style = (style < IDLE_STYLE_COUNT) ? style : POLY_DEFAULT_IDLE_STYLE;
 }
 
 // Console-log name for an idle style. Keep in sync with enum poly_idle_style.

--- a/keyboards/polykybd/state.h
+++ b/keyboards/polykybd/state.h
@@ -17,8 +17,16 @@
 // falls back to PULSE at runtime, so the value is always safe to accept/persist.
 // EDEN loops the "Eden" boot animation as a screensaver (split72 only): it reuses
 // the normal idle machinery (DISP_IDLE flag → wake on key + TURN_OFF suspend) but
-// renders looping Eden frames on both halves instead of the pulse; on split42 the
-// no-op anim stubs leave it behaving like PULSE.
+// renders looping Eden frames on both halves instead of the pulse.
+// ⚠️ On split42 EDEN does NOT degrade to the pulse — it degrades to NOTHING, which is
+// the one thing an anti-burn-in setting must never do. The animation is
+// split72-only (anim/startup_anim.c is #if'd on the board, with no-op stubs
+// otherwise), and every other idle painter stands down for EDEN by design:
+// kdisp_idle() returns immediately, the engage branch holds contrast steady at
+// EDEN_IDLE_BRIGHTNESS instead of computing a pulse, and update_displays()
+// early-returns while DISP_IDLE. So the legends simply FREEZE, dim and unmoving,
+// until the TURN_OFF suspend. That is why POLY_DEFAULT_IDLE_STYLE below is
+// board-gated — do not hand split42 an EDEN default.
 // Values are append-only (persisted + on the wire in poly_sync_t.idle_style).
 enum poly_idle_style {
     IDLE_STYLE_PULSE  = 0,
@@ -27,6 +35,18 @@ enum poly_idle_style {
     IDLE_STYLE_EDEN   = 3,   // looping "Eden" boot animation screensaver (host: IdleStyle.EDEN)
     IDLE_STYLE_COUNT
 };
+
+// The idle style a board comes up with when nothing has been chosen. EDEN wherever
+// the animation exists, because a screensaver that repaints the whole keycap is
+// strictly better anti-burn-in than a pulse that never moves a lit pixel; PULSE
+// elsewhere, per the ⚠️ above — the stubs would leave split42 with no anti-burn-in
+// at all. Gated on the SAME macro anim/startup_anim.c compiles itself on, so the
+// two cannot drift into a default whose renderer isn't in the image.
+#if defined(KEYBOARD_polykybd_split72)
+#    define POLY_DEFAULT_IDLE_STYLE IDLE_STYLE_EDEN
+#else
+#    define POLY_DEFAULT_IDLE_STYLE IDLE_STYLE_PULSE
+#endif
 
 // Glyph-script override (HID cmd 30, protocol v9+). Replaces the language-layer
 // letter/digit legends with an alternative script's glyphs while leaving overlays
@@ -420,9 +440,23 @@ typedef struct _poly_eeconf_t {
     // value: `poly_eeconf_t ee = {0}` in eeconfig_init_user() leaves it zero on a
     // fresh EEPROM too, and a fresh EEPROM wants the reset just as much.
     uint8_t  keymap_layers_fmt;
+    // Whether `idle_style` above was written by a build that knew about
+    // POLY_DEFAULT_IDLE_STYLE. It exists because idle_style is the one setting whose
+    // default MOVED, and on the old format an explicit PULSE and "never chosen" are
+    // the SAME BYTE: PULSE is 0 and QMK's wear levelling hands back cleared bytes as
+    // zero (the trap that made latin_assign read as "every key hosts 'a'"). So no
+    // scheme can rescue an old board's deliberate PULSE — it is not recorded anywhere
+    // — and the honest thing is to migrate every pre-sentinel board to the board
+    // default once, then never touch it again. Anything but IDLE_STYLE_FMT_OK means
+    // "predates the default change, or fresh"; load_user_eeconf() substitutes
+    // POLY_DEFAULT_IDLE_STYLE and save_user_settings() stamps the marker with the
+    // block it guards, so from the first save onwards the stored style is verbatim
+    // and a LATER default change cannot silently overwrite a real choice.
+    uint8_t  idle_style_fmt;
 } poly_eeconf_t;
 
 #define BOOT_INTRO_DONE     0x5A   // sentinel written after the startup animation has played
+#define IDLE_STYLE_FMT_OK   0x3C   // poly_eeconf_t.idle_style holds a real choice (see above)
 // Format versions for latin_ex_wide + latin_assign, oldest first. Anything
 // unrecognised means the legacy one-byte-per-letter nibble pairs in latin_ex[].
 #define LATIN_PICK_MIGRATED    0xA5 // 6-bit fields, case-BLOCKED; no assignment map

--- a/keyboards/polykybd/state_store.c
+++ b/keyboards/polykybd/state_store.c
@@ -22,6 +22,13 @@ void save_user_settings(void) {
     const poly_eeconf_t ee = { .lang = get_local_state()->lang, .brightness = (uint8_t)(~get_user_brightness()),
                                .idle_style = get_idle_style(), .auto_brightness = pack_auto_brightness() };
     eeconfig_update_user_datablock(&ee, 0, offsetof(poly_eeconf_t, latin_ex));
+    // Stamp the idle-style format marker AFTER the block it describes, same rule as
+    // the latin sentinels below: an interrupted write must never leave the byte
+    // claiming a choice that was not stored. From here on load_user_eeconf() takes
+    // idle_style verbatim, so a future default change cannot overwrite a real one.
+    const uint8_t idle_marker = IDLE_STYLE_FMT_OK;
+    eeconfig_update_user_datablock(&idle_marker, offsetof(poly_eeconf_t, idle_style_fmt),
+                                   sizeof(idle_marker));
 }
 
 // Writes only the packed latin variation picks to EEPROM.
@@ -113,8 +120,16 @@ poly_eeconf_t load_user_eeconf(void) {
     if(ee.brightness>FULL_BRIGHT) {
         ee.brightness = FULL_BRIGHT;
     }
-    if(ee.idle_style >= IDLE_STYLE_COUNT) {
-        ee.idle_style = IDLE_STYLE_PULSE;   // unwritten/garbage EEPROM -> safe default
+    // ⚠️ Gate the idle style on its format byte, NOT on the value. PULSE is 0 and an
+    // unwritten byte reads back as 0 (wear levelling), so on a pre-sentinel EEPROM
+    // "the user chose pulse" and "nobody ever chose" are indistinguishable — see the
+    // idle_style_fmt comment in state.h. Substituting the board default for the whole
+    // pre-sentinel population is therefore the only honest reading, and it is what
+    // moves an existing board onto the new default exactly once.
+    // Two ways to reach the board default, one remedy: the byte predates the
+    // sentinel, or it is out of range.
+    if(ee.idle_style_fmt != IDLE_STYLE_FMT_OK || ee.idle_style >= IDLE_STYLE_COUNT) {
+        ee.idle_style = POLY_DEFAULT_IDLE_STYLE;
     }
     if(ee.glyph_script == 0xFF) {
         ee.glyph_script = GLYPH_STD;        // erased/uninitialised EEPROM byte -> normal legends

--- a/keyboards/polykybd/tools/status_oled_preview.py
+++ b/keyboards/polykybd/tools/status_oled_preview.py
@@ -208,7 +208,10 @@ def build_telemetry_panel(usb_side, small, fw="0.16.18", proto=15, hw="0x0320",
     (err_permille, frames) for the master, or None for a link that has sent
     nothing yet."""
     pts = []
-    setp = lambda px, py: pts.append((px, py))
+
+    def setp(px, py):
+        pts.append((px, py))
+
     l_fw = "FW %s" % fw
     l_ver = "P%d  HW %s" % (proto, hw)
     l_up = "%s  up %s" % ("USB" if usb_side else "LNK", uptime)
@@ -564,15 +567,34 @@ def main():
     ap.add_argument('--telemetry', action='store_true',
                     help='preview the settings->More telemetry screen instead of the status screen')
     ap.add_argument('--uptime', default='1:23:45', help='uptime string shown by --telemetry')
-    ap.add_argument('--link', default='4,1234',
+    def link_arg(v):
+        # Validated here rather than at use: an unparsable value otherwise reached
+        # the "pm, frames = link" unpack and came out as a raw traceback, and a
+        # negative / >100% rate rendered a reading the firmware counters cannot
+        # produce. argparse reports it as an ordinary usage error instead.
+        if v == 'idle':
+            return None
+        parts = v.split(',')
+        if len(parts) != 2:
+            raise argparse.ArgumentTypeError('link must be "idle" or "<err_permille>,<frames>"')
+        try:
+            pm, frames = (int(p) for p in parts)
+        except ValueError:
+            raise argparse.ArgumentTypeError('link fields must be whole numbers')
+        if not 0 <= pm <= 1000:
+            raise argparse.ArgumentTypeError('err_permille must be 0..1000 (1000 = 100 percent)')
+        if frames < 0:
+            raise argparse.ArgumentTypeError('frames must not be negative')
+        return (pm, frames)
+
+    ap.add_argument('--link', type=link_arg, default=(4, 1234),
                     help='--telemetry link health as "<err_permille>,<frames>", or "idle"')
     args = ap.parse_args()
 
     disp, small, icons, tiny, globe = load_fonts()
     if args.telemetry:
-        link = None if args.link == 'idle' else tuple(int(v) for v in args.link.split(','))
-        L = build_telemetry_panel(True,  small, uptime=args.uptime, link=link)
-        R = build_telemetry_panel(False, small, uptime=args.uptime, link=link)
+        L = build_telemetry_panel(True,  small, uptime=args.uptime, link=args.link)
+        R = build_telemetry_panel(False, small, uptime=args.uptime, link=args.link)
     else:
         rgb = None if args.rgb_off else (128, 255, 100, 80, 5, 'Rainbow')
         L = build_panel('L', disp, small, icons, tiny, globe, args.brightness, rgb, args.lang,

--- a/keyboards/polykybd/tools/status_oled_preview.py
+++ b/keyboards/polykybd/tools/status_oled_preview.py
@@ -580,11 +580,13 @@ def main():
         try:
             pm, frames = (int(p) for p in parts)
         except ValueError:
-            raise argparse.ArgumentTypeError('link fields must be whole numbers')
+            raise argparse.ArgumentTypeError('link fields must be whole numbers') from None
         if not 0 <= pm <= 1000:
             raise argparse.ArgumentTypeError('err_permille must be 0..1000 (1000 = 100 percent)')
-        if frames < 0:
-            raise argparse.ArgumentTypeError('frames must not be negative')
+        # The firmware counter is a uint32_t, so anything outside that range is a
+        # reading the panel can never show -- same reasoning as the rate bound above.
+        if not 0 <= frames <= 0xFFFFFFFF:
+            raise argparse.ArgumentTypeError('frames must be 0..4294967295 (the uint32_t counter)')
         return (pm, frames)
 
     ap.add_argument('--link', type=link_arg, default=(4, 1234),

--- a/keyboards/polykybd/tools/status_oled_preview.py
+++ b/keyboards/polykybd/tools/status_oled_preview.py
@@ -195,6 +195,55 @@ def build_fw_confirm_panel(side, small):
     return pts
 
 
+def build_telemetry_panel(usb_side, small, fw="0.16.18", proto=15, hw="0x0320",
+                          uptime="1:23:45", link=None):
+    """Settings -> "More" telemetry screen — mirror of oled_helper.c's
+    oled_telemetry_screen(). Four lines on the 64px panel (two on a 32px one),
+    each centred in its own band from its own bbox, exactly as the FW-2 confirm
+    screen above and the C do.
+
+    `usb_side` picks the half: the USB (master) half is the only one that owns the
+    split-link counters, so the LINK line reads "n/a" on the other — the C refuses
+    to render the slave's all-zero counters as a perfect 0.0%. `link` is
+    (err_permille, frames) for the master, or None for a link that has sent
+    nothing yet."""
+    pts = []
+    setp = lambda px, py: pts.append((px, py))
+    l_fw = "FW %s" % fw
+    l_ver = "P%d  HW %s" % (proto, hw)
+    l_up = "%s  up %s" % ("USB" if usb_side else "LNK", uptime)
+    if not usb_side:
+        l_link = "Lnk n/a"
+    elif link is None:
+        l_link = "Lnk idle"
+    else:
+        pm, frames = link
+        # Same compaction as the C: the count climbs into the millions, so it is
+        # abbreviated, and the rate drops its decimal at/above 10% -- both so the
+        # WORST case fits the 128px panel rather than only the fresh-boot one.
+        if frames < 1000:
+            tx = "%d" % frames
+        elif frames < 1000000:
+            tx = "%dk" % (frames // 1000)
+        else:
+            tx = "%dM" % (frames // 1000000)
+        l_link = ("Lnk %d.%d%% %s" % (pm // 10, pm % 10, tx)) if pm < 100 \
+            else ("Lnk %d%% %s" % ((pm + 5) // 10, tx))
+
+    lines = [l_fw, l_ver, l_up, l_link][:(4 if P_H >= 64 else 2)]
+    band = P_H // len(lines)
+    for i, line in enumerate(lines):
+        txt = s2cp(line)
+        bx0, bx1, by0, by1 = text_bbox(small, txt)
+        w = bx1 - bx0 + 1
+        x = (P_W - w) // 2 - bx0
+        if x < 0:
+            x = 0
+        base = band * i + band // 2 - (by0 + by1) // 2
+        draw(setp, small, x, base, txt)
+    return pts
+
+
 def measure_width(font, text):
     """Rightmost lit pixel of `text`, mirroring kdisp_gfx_text_bounds' hi. Skips
     out-of-range codepoints exactly as draw() does, so a missing glyph can't raise."""
@@ -512,18 +561,30 @@ def main():
                          "(Qwerty, 'Qwerty Stag!', 'Colemak DH', Neo, Workman)")
     ap.add_argument('--rgb-off', action='store_true',
                     help='preview the RGB-off layout (both panels re-flow to three rows)')
+    ap.add_argument('--telemetry', action='store_true',
+                    help='preview the settings->More telemetry screen instead of the status screen')
+    ap.add_argument('--uptime', default='1:23:45', help='uptime string shown by --telemetry')
+    ap.add_argument('--link', default='4,1234',
+                    help='--telemetry link health as "<err_permille>,<frames>", or "idle"')
     args = ap.parse_args()
 
     disp, small, icons, tiny, globe = load_fonts()
-    rgb = None if args.rgb_off else (128, 255, 100, 80, 5, 'Rainbow')
-    L = build_panel('L', disp, small, icons, tiny, globe, args.brightness, rgb, args.lang,
-                    args.wpm, args.layout)
-    R = build_panel('R', disp, small, icons, tiny, globe, args.brightness, rgb, args.lang,
-                    args.wpm, args.layout)
+    if args.telemetry:
+        link = None if args.link == 'idle' else tuple(int(v) for v in args.link.split(','))
+        L = build_telemetry_panel(True,  small, uptime=args.uptime, link=link)
+        R = build_telemetry_panel(False, small, uptime=args.uptime, link=link)
+    else:
+        rgb = None if args.rgb_off else (128, 255, 100, 80, 5, 'Rainbow')
+        L = build_panel('L', disp, small, icons, tiny, globe, args.brightness, rgb, args.lang,
+                        args.wpm, args.layout)
+        R = build_panel('R', disp, small, icons, tiny, globe, args.brightness, rgb, args.lang,
+                        args.wpm, args.layout)
 
     if args.diag:
-        Li, lc = render_diag(L, 'LEFT (layout)  128x64  |  RED = clipped')
-        Ri, rc = render_diag(R, 'RIGHT (RGB)    128x64  |  RED = clipped')
+        ltitle = 'USB half   128x64  |  RED = clipped' if args.telemetry else 'LEFT (layout)  128x64  |  RED = clipped'
+        rtitle = 'LINK half  128x64  |  RED = clipped' if args.telemetry else 'RIGHT (RGB)    128x64  |  RED = clipped'
+        Li, lc = render_diag(L, ltitle)
+        Ri, rc = render_diag(R, rtitle)
         w = max(Li.width, Ri.width)
         c = Image.new('RGB', (w, Li.height + Ri.height + 12), (18, 18, 22))
         c.paste(Li, (0, 0)); c.paste(Ri, (0, Li.height + 12))


### PR DESCRIPTION
## Summary

Three changes, one per commit — all on the idle/status-display path.

### 1. `fix:` the context-menu cursor does not move at idle (and it is a class bug)

Reported as *"the cursor on the context menu icon is not moving in the idle modes, but the hamburger menu icon does — that means it is somehow drawn special"*. The icon is not special; **the jitter offset was**.

`s_draw_ox/oy` was applied inside `kdisp_write_gfx_char` and `kdisp_write_gfx_char_half`, which between them cover ordinary glyphs and `HINT_SMALL` and nothing else. Every **composite** display-list op plots through a primitive of its own — `\x0F` HALF, `\x11` THIN and `\x15` ROT via `kdisp_draw_glyph_*_at`, `\x13` BADGE and `\x12` FRAME via the rect drawers — and none of them ever saw it. So an idle relocation slid the letters and left the composited art pinned to the buffer.

It is a class bug rather than one icon: `ICON_CONTEXT_MENU`'s ROT'd pointer, plus `ICON_SCRLOCK_ON/OFF` and `ICON_MEDIA_STOP`, which are composite art **only** and so never moved at all.

The fix applies the offset **once, at the display-list cursor** in `gfx_text_run()`, so a sixth composite op inherits it by construction instead of each primitive having to remember — the enumerating-guard shape this repo keeps getting caught by. A MOVE re-applies it, since an absolute position is exactly what the cursor's own offset does not reach.

⚠️ **Fixing the draw alone would have made it worse.** `roll_idle_offset()` sized the slack from the *relative* bbox, which covers only the cursor-laid-out part — the hamburger alone for the context menu, and for `ICON_MEDIA_STOP` (a MOVE plus a BADGE and nothing else) an **empty** box, i.e. "move it anywhere". Once the cell moved as a unit that slack would have carried the art clean off the panel. So `kdisp_gfx_text_bbox_abs()` had to land with it: it takes the draw origin, resolves MOVE and measures the composite extents. The relative form is unchanged to the byte — both are one walk parameterised by origin — so its 34 existing tests still pin it.

The rotated-glyph geometry moves to `font_lookup.c` beside the interpreter, so the drawer and the measurement cannot disagree about which pixels a rotated glyph touches.

### 2. `feat:` settings → "More" shows telemetry on the status OLED

While the advanced settings row is revealed the panel has nothing to say that the keycaps do not, so it states what the board *is*. Four lines on the 64 px panel, two on the 32 px one — rendered from the real fonts by `tools/status_oled_preview.py --telemetry`:

```
   USB half (master)            LINK half (slave)
   FW 0.16.18                   FW 0.16.18
   P15  HW 0x0320               P15  HW 0x0320
   USB  up 1:23:45              LNK  up 1:23:45
   Lnk 0.4% 1M                  Lnk n/a
```

Identity comes from the same macros `hid_com.c` builds `GET_ID` from, so the panel and the host cannot disagree about the board.

The link line is the part that had nowhere to be read before — those counters only ever surfaced in a console line emitted every 200 frames. On the non-USB half it reads `Lnk n/a`, **not** `0.0%`: only the master calls `send_to_bridge()`, so its zeros mean "never initiates", and rendering that as a perfect link would be a flattering lie on the one panel someone reads to judge the wire.

Both link fields are compacted, because the **worst** case decides whether the line fits and the default fixture hides it: `ls_attempts` reaches millions within hours and spelled out in full the line measures **135 px against a 127 px budget**, while the `1234tx` of a fresh boot fits comfortably. Abbreviating the count and dropping the rate's decimal at/above 10 % puts the widest reachable form at 122 px.

### 3. `feat:` Eden becomes the idle default — on split72 only

`POLY_DEFAULT_IDLE_STYLE` (`state.h`) is `IDLE_STYLE_EDEN` on split72 and `IDLE_STYLE_PULSE` everywhere else, gated on the **same** board macro `anim/startup_anim.c` compiles itself on. A screensaver that repaints the whole keycap is strictly better anti-burn-in than a pulse that never moves a lit pixel.

⚠️ **The board gate is a correctness constraint, not tidiness — and the enum's own comment was wrong about why.** It claimed EDEN "behaves like PULSE" on split42. It does not: the animation is stubbed out there, *and* every other idle painter stands down for EDEN by design — `kdisp_idle()` returns immediately, the engage branch holds contrast at `EDEN_IDLE_BRIGHTNESS` instead of computing a pulse, and `update_displays()` early-returns while `DISP_IDLE`. The legends would simply **freeze**, dim and unmoving, until the TURN_OFF suspend: an anti-burn-in setting that does nothing. That comment is corrected here.

⚠️ **Existing split72 boards will move to Eden once, and an explicit PULSE choice cannot be preserved — because the old format never recorded it.** `IDLE_STYLE_PULSE` is 0 and QMK's wear levelling hands back a cleared byte as **zero** (the trap that made `latin_assign` read as "every key hosts 'a'"), so "chose pulse" and "never chose" are the *same byte*. No migration scheme can separate them, which makes moving the whole pre-sentinel population the honest reading rather than a compromise. **Worth a line in the release notes.** Anyone who had picked JITTER, IDDQD or EDEN keeps it.

Going forward the new `poly_eeconf_t.idle_style_fmt` sentinel (`0x3C`, tail byte, same shape as `latin_ext_fmt` / `keymap_layers_fmt`) closes that: `load_user_eeconf()` substitutes the default only while it is unstamped, `save_user_settings()` stamps it **after** the block it guards (an interrupted write cannot claim a choice that was not stored), and `eeconfig_init_user()` writes both so a fresh EEPROM is born stamped and never migrates. From the first save on, the stored style is taken verbatim — so a *future* default change can no longer overwrite a real choice, which is exactly the property this one lacked.

`EECONFIG_USER_DATA_SIZE` 156 → 157, well inside the 256-byte reservation: **no keymap relocation, no user reset**. No protocol change — the host still just reads whatever the keyboard reports over cmd 28.

## Version bump label

`bump:minor` — new features (the telemetry screen, the changed default), backwards compatible. No protocol change, so no matching PolyKybdHost PR is needed.

## Testing

- [x] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`), **plus** split42 and the monolithic `POLYKYBD_DOOM=yes` flavour that PR CI does not build
- [ ] Flashed and tested on hardware
- [x] If protocol changed: n/a — no protocol change

Verified here:

- **Unit tests**: `polykybd_font_bbox` 34 → 45 (count checked, not just green). All 14 polykybd suites pass.
- **Mutation-checked** the new tests against dropping the MOVE resolution, the composite extents, the origin and the rotation halving. ⚠️ The halving mutation **escaped** a first version whose expectation was computed by calling the helper under test — it agreed by construction. Rewritten to derive from arithmetic (a 0° turn is exactly the halved size; a 90° turn swaps the axes), it now fails as intended.
- **Layout**: `tools/status_oled_preview.py --telemetry --diag` at the worst case (`--link 1000,4294967295 --uptime "999d 23h"`) — **0 clipped pixels** on both halves.
- **The idle default is checked in the compiled objects, not the preprocessor**: `g_idle_style` lands in `.data` on split72 (`objdump -s -j .data.g_idle_style` → `03` = EDEN) and in `.bss` on split42 (`0` = PULSE). The `sizeof(poly_eeconf_t) == EECONFIG_USER_DATA_SIZE` static assert passing on both is the proof the 157 bump is right.
- **Size**: **0 bytes of RAM** for changes 1–2 (`.bss` byte-identical on the monolith, heap free unchanged at 3480 B), +1552 B `.text` / +128 B `.data`.
- `qmk lint --strict` on both keyboards, `ci-validate-keyboard-targets`, `ci-validate-aliases`, and cppcheck with the workflow's exact invocation — all clean.

**Not verified here:** `disp_array.c` is not host-linkable, so the draw half of the fix has no unit test — the pointer actually moving on an idled keycap needs the hardware round above. The bbox half, which is where the arithmetic bug history lives, is covered. The Eden default likewise wants a real idle cycle on a split72, and — because it touches persisted state and the idle path — the **`hil-extended`** label is worth applying so the rig runs the reboot power-cycle and idle/animation checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013sYxo4vyR5LhSzgGg5BAwM

## Summary by Sourcery

Fix composite legend idle rendering, add settings telemetry, and make the idle animation default board-aware with safe persistence migration.

New Features:
- Show firmware, hardware, uptime, and split-link telemetry in the settings “More” OLED screen.
- Use Eden as the default idle animation on split72 while retaining Pulse on other boards, with persisted idle-style format migration support.

Bug Fixes:
- Apply idle redraw offsets and scanline/erase modes consistently to complete display-list legends, including composite glyphs, badges, frames, and moved artwork.
- Calculate idle movement bounds from the full absolute legend geometry so composite and MOVE-positioned artwork remains on-screen.

Enhancements:
- Share rotated-glyph geometry between rendering and bounding-box measurement to keep displayed and measured extents consistent.

Build:
- Increase the persisted user configuration size by one byte for the idle-style format marker.

Documentation:
- Document composite display-list rendering behavior, telemetry layout, and board-dependent idle defaults and migration semantics.

Tests:
- Expand font bounding-box coverage for absolute positioning, composite operations, MOVE handling, and rotated extents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Settings → More screen showing firmware, hardware, protocol, uptime, and split-link health.
  * Added compact uptime and link-status formatting, including `n/a` where link data is unavailable.
  * Board-specific default idle styles are now applied reliably.

* **Bug Fixes**
  * Improved anti-burn-in movement so composite artwork and badges move with text.
  * Improved idle-position bounds for rotated and composite graphics.
  * Scanline and erase modes now apply consistently to composite artwork.
  * Fixed idle-style settings compatibility during startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->