### PR TITLE
fw: fix the HID firmware-update brick — the self-apply's page buffer was unaligned

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,9 +153,32 @@ jobs:
         run: |
           TARGET=$(echo "${{ env.KB }}" | tr '/' '_')_${{ env.KM }}
           PACK_VER=$(cat keyboards/polykybd/doom/pack/PACK_VERSION)
-          ASSETS=( "${TARGET}.uf2" "${TARGET}.bin" "doom_pack_v${PACK_VER}.plyx" )
+          # ⚠️ Stamp the VERSION into the asset filenames. Every release used to
+          # ship "polykybd_split72_default.{uf2,bin,bin.sig}", identical across all
+          # releases, so downloading two versions to compare them collides in the
+          # browser and you get "... (1).bin" / "... (2).bin" with nothing to say
+          # which is which. That is not cosmetic: it produced a mis-flash during a
+          # firmware-update bisect (#258) and sent the investigation to a wrong
+          # conclusion for several rounds. The board cannot help either -- every
+          # test build reports its own FW_VERSION only once it is already running.
+          #
+          # Safe for the host updater: polyhost/services/updater.py selects assets
+          # by SUFFIX (endswith ".bin" / ".uf2" / ".bin.sig"), never by exact name,
+          # so the version prefix is invisible to it. Keep the suffixes intact --
+          # and note ".bin.sig" must keep ending in ".bin.sig", since the updater
+          # tests it BEFORE ".bin".
+          VER="${TAG#PolyKybd-fw-v}"
+          NAMED="polykybd_split72_v${VER}"
+          cp "${TARGET}.uf2" "${NAMED}.uf2"
+          cp "${TARGET}.bin" "${NAMED}.bin"
+          ASSETS=( "${NAMED}.uf2" "${NAMED}.bin" "doom_pack_v${PACK_VER}.plyx" )
           # Include the detached signature when the Sign step produced one (FW-2).
-          [ -f "${TARGET}.bin.sig" ] && ASSETS+=("${TARGET}.bin.sig")
+          # It must travel as "<bin>.sig" of the RENAMED bin, or hid_fw_up.py will
+          # not find it (sig_path = bin_path + ".sig").
+          if [ -f "${TARGET}.bin.sig" ]; then
+            cp "${TARGET}.bin.sig" "${NAMED}.bin.sig"
+            ASSETS+=("${NAMED}.bin.sig")
+          fi
           if [ "$HAVE_NOTES" = "1" ]; then
             NOTES_ARGS=( --title "$TITLE" --notes-file _release_body.md )
           else

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1548,6 +1548,45 @@ field.** The 72 was sized for exactly these, all derived from `HID_REPORT_SIZE` 
 `HID_REPORT_SIZE` bump, and an app switch would hit the silent rejection above and
 present as missing keycap images. At 96 that path has 27 B of headroom.
 
+### ⚠️ The self-apply's page buffer must be `uint32_t` — a `uint8_t` one bricked the board
+
+`fw_staging_do_apply()` copies the staged image a page at a time through a static
+buffer, with `ram_word_copy()` — which takes `uint32_t *`, so the compiler emits
+word loads and stores. The buffer was declared `static uint8_t page_buf[256]`,
+whose alignment requirement is **1**, so the linker packed it at whatever byte
+offset the previous `.bss` symbol happened to leave. An unaligned `STMIA` is a
+**HardFault on Cortex-M0+**, taken with `PRIMASK` set inside a function that never
+returns — an instant lockup, no console line, no breadcrumb. The board comes back
+only via BOOTSEL+UF2.
+
+⚠️ **This is why the bisect and the disassembly disagreed, and the disassembly was
+the misleading one.** A HID update that reported success then bricked the keyboard
+bisected cleanly to the macro PR (#234) — which touches nothing in the applier. And
+`fw_staging_do_apply` really was **byte-identical** across the regression: same
+address, same size, same instructions. What #234 changed was `.bss`: its label cache
+shifted `page_buf` from a 4-aligned address to `…ce3`, and the first page of the
+first sector faulted the core. Ten rounds of probes were aimed at the applier's
+*code* on the strength of that byte-identical comparison. **When a bisect blames a
+commit that cannot have touched the failing code, check whether it moved the failing
+code's DATA** — `arm-none-eabi-nm -S <elf> | grep <buffer>` and look at `addr % 4`.
+
+**The fix is the type, not an `aligned(4)` attribute**: the buffer is declared
+`static uint32_t page_buf[FLASH_PAGE_SIZE / 4]` and the `(uint32_t *)` casts are
+gone, so no later edit can silently reintroduce the hazard. `flash_range_program`
+takes `(const uint8_t *)page_buf`.
+
+Two things that made this diagnosable, and are worth keeping:
+- **The in-flash progress log** (`FW_APPLY_LOG_OFFSET`, `FW_STAGING_OFFSET + 1 MB`):
+  erased at the start of every apply, one page written per completed sector, plus
+  bracket markers around the first sector. It lives past the image, so it survives
+  the BOOTSEL recovery that reading it requires — the watchdog scratch does not
+  (scratch survives a watchdog reset, **not** a power cycle).
+- ⚠️ **The log markers worked while the copy did not, and that asymmetry IS the
+  clue.** GCC knew `page_buf` was byte-aligned, so it compiled
+  `((uint32_t *)page_buf)[0] = marker` into four `strb`s — which are fine unaligned.
+  Only the `uint32_t *`-typed helper got word instructions. So "flash writes work
+  here but that one copy dies" was pointing at alignment the whole time.
+
 ### Firmware signing enforcement & the on-keycap confirmation (FW-2)
 
 `rules.mk` sets `-DFW_REQUIRE_SIGNATURE`, so `fw_staging_finalize()` only stamps the

--- a/keyboards/polykybd/base/fw_staging.c
+++ b/keyboards/polykybd/base/fw_staging.c
@@ -59,17 +59,86 @@ _Static_assert(FW_RESOURCE_OFFSET + FW_DOOMPACK_SLOT_OFF + FW_DOOMPACK_SLOT_SIZE
 #ifdef USE_CORE1
 #include "polymod_core1.h"
 
+#define _PSM_WDSEL     (*(volatile uint32_t *)(0x40010000u + 0x08u))
+#define _WD_CTRL       (*(volatile uint32_t *)(0x40058000u + 0x00u))
+// SCRATCH0..3 are free for us; the bootrom owns SCRATCH4..7. These survive a
+// watchdog reset (not a power cycle), which is what makes them the only channel a
+// self-flash has: the console is gone, interrupts are off, and the routine never
+// returns. A half that comes back can then say how far its copy got; a half that
+// does not come back is identified by its silence.
+#define _WD_SCRATCH0   (*(volatile uint32_t *)(0x40058000u + 0x0cu))
+#define _WD_SCRATCH1   (*(volatile uint32_t *)(0x40058000u + 0x10u))
+#define _WD_SCRATCH2   (*(volatile uint32_t *)(0x40058000u + 0x14u))
+#define _WD_SCRATCH4   (*(volatile uint32_t *)(0x40058000u + 0x1cu))
+#define FW_APPLY_CRUMB_SECTOR 0xB0070000u   // | sector currently being written
+#define FW_APPLY_CRUMB_DONE   0xB007D01Eu   // copy loop finished, about to reset
+#define FW_APPLY_DONE_MAGIC   0xD09EF1A5u   // same, recorded in flash so it outlives a power cycle
+#define FW_APPLY_LOG_MAGIC    0x5EC70000u   // | sector, one page per completed sector
+#define FW_APPLY_LOG_START    0x57A27EDDu   // written to the log's LAST page before sector 1 is touched
+// Bracket markers around the FIRST image sector only -- the copy dies there, and log
+// writes provably work at that moment, so these name the exact call that kills it.
+#define FW_APPLY_LOG_PRE_ERASE   0xB1000001u
+#define FW_APPLY_LOG_POST_ERASE  0xB1000002u
+#define FW_APPLY_LOG_POST_PROG   0xB1000003u
+#define FW_APPLY_LOG_PAGE_PRE    121u
+#define FW_APPLY_LOG_POST        122u
+#define FW_APPLY_LOG_PAGE_PROG   123u
+#define FW_APPLY_LOG_POST_READ   0xB1000004u
+#define FW_APPLY_LOG_PAGE_READ   124u
+// A per-sector progress log, far enough into staging (1 MB in) to be clear of the
+// image and of everything FW_UP_BEGIN erases. 8 sectors = 128 pages >= the 121 the
+// image needs, so the copy can record EXACTLY how far it got in a place that outlives
+// the power cycle a BOOTSEL recovery needs.
+#define FW_APPLY_LOG_OFFSET   (FW_STAGING_OFFSET + 0x100000u)
+#define FW_APPLY_LOG_SECTORS  8u
+#define FW_APPLY_LOG_PAGES    (FW_APPLY_LOG_SECTORS * (FLASH_SECTOR_SIZE / FLASH_PAGE_SIZE))
+
+// DMA is the LAST bus master that can touch XIP once core1 is in reset and interrupts
+// are off. A channel still in flight whose read address is in flash will stall the bus
+// the moment the QSPI leaves XIP mode for an erase -- and nothing on this path stops
+// DMA. Abort every channel and wait for them to actually go quiet. Raw register writes
+// (DMA_BASE + CHAN_ABORT) so this stays inlinable in the RAM routine with no call.
+#define _DMA_ABORT (*(volatile uint32_t *)(0x50000000u + 0x444u))
+static inline void __attribute__((always_inline)) dma_abort_all(void) {
+    _DMA_ABORT = 0xFFFFu;
+    __asm volatile ("dsb" ::: "memory");
+    uint32_t spins = 0;
+    while (_DMA_ABORT && spins < 1000000u) spins++;
+}
+
 #define _PSM_FRCE_OFF  (*(volatile uint32_t *)0x40010004u)
+#define _PSM_DONE      (*(volatile uint32_t *)0x4001000cu)
 #define _PSM_PROC1_BIT (1u << 16)
+
+// Spin until the PSM has actually driven core1 into reset, and report how long it
+// took. Writing FRCE_OFF and issuing a DSB only guarantees the STORE reached the
+// peripheral -- it says nothing about the reset having propagated, and core1 keeps
+// fetching instructions from XIP until it has. The moment core0 takes the QSPI out
+// of XIP mode for an erase, an in-flight core1 fetch can never complete: the bus
+// stalls, flash_range_erase() never returns, and the half is wedged mid-apply with
+// no reset and no way to say so.
+//
+// always_inline because callers include the RAM-resident apply routine, which must
+// not generate a call into flash (invariant 1 there).  Bounded so a PSM that never
+// reports DONE degrades to the old behaviour instead of replacing one hang with
+// another; the count is a breadcrumb, not a control flow input.
+static inline uint32_t __attribute__((always_inline)) psm_wait_proc1_off(void) {
+    uint32_t spins = 0;
+    while ((_PSM_DONE & _PSM_PROC1_BIT) && spins < 1000000u) {
+        spins++;
+    }
+    return spins;
+}
 
 // True while this module holds a PSM reset on core1.
 static bool s_core1_halted = false;
 
 static void fw_staging_halt_core1(void) {
     _PSM_FRCE_OFF |= _PSM_PROC1_BIT;
-    // FRCE_OFF takes effect within a few cycles; DSB ensures the write
-    // reaches the PSM peripheral before the caller touches flash.
     __asm volatile ("dsb" ::: "memory");
+    // ...and then WAIT for it. The DSB orders the store; only PSM->DONE says the
+    // reset has landed and core1 has stopped fetching from XIP. See psm_wait_proc1_off().
+    (void)psm_wait_proc1_off();
     s_core1_halted = true;
 }
 
@@ -248,7 +317,136 @@ static void write_staging_header(uint32_t size, uint32_t crc) {
 // Public API
 // ---------------------------------------------------------------------------
 
+// Captured once at boot from the watchdog scratch registers, then cleared so a later
+// boot cannot re-report a stale apply. Printed by the boot banner (boot_diag.c).
+static uint32_t s_crumb_sector = 0;
+static uint32_t s_crumb_done   = 0;
+static uint32_t s_crumb_spins  = 0;
+static uint32_t s_done_sectors = 0;   // from the in-flash record, 0 = none present
+static uint32_t s_done_size    = 0;
+static uint32_t s_done_spins   = 0;
+static uint32_t s_done_diff_at = 0xFFFFFFFFu;   // offset of the first byte the copy got wrong
+static uint32_t s_done_diff_got = 0;
+static uint32_t s_done_diff_want = 0;
+static uint32_t s_log_max   = 0;   // highest sector the copy logged as completed
+static uint32_t s_log_min   = 0;   // lowest ditto -- the copy runs top-down, so this is where it stopped
+static uint32_t s_log_count = 0;   // how many sectors it logged at all
+static bool     s_log_started = false;   // the copy reached its first sector
+static uint32_t s_mark_stage = 0;        // 0 none, 1 pre-erase, 2 post-erase, 3 post-program
+static uint32_t s_mark_addr  = 0;        // flash offset of the first image sector touched
+static uint32_t s_mark_read_erased = 0;  // its first word read back after the erase
+static uint32_t s_mark_read_progd  = 0;  // ...and after the first page was programmed
+static uint32_t s_mark_src_word    = 0;  // first word read back from the staging source
+
+bool fw_staging_apply_marks(uint32_t *stage, uint32_t *addr, uint32_t *erased, uint32_t *progd, uint32_t *srcw) {
+    if (s_mark_stage == 0) return false;
+    if (stage)  *stage  = s_mark_stage;
+    if (addr)   *addr   = s_mark_addr;
+    if (erased) *erased = s_mark_read_erased;
+    if (progd)  *progd  = s_mark_read_progd;
+    if (srcw)   *srcw   = s_mark_src_word;
+    return true;
+}
+
+bool fw_staging_apply_progress(uint32_t *lowest, uint32_t *highest, uint32_t *count) {
+    if (s_log_count == 0) return false;
+    if (lowest)  *lowest  = s_log_min;
+    if (highest) *highest = s_log_max;
+    if (count)   *count   = s_log_count;
+    return true;
+}
+
+bool fw_staging_apply_started(void) { return s_log_started; }
+
+bool fw_staging_last_apply_completed(uint32_t *sectors, uint32_t *size, uint32_t *psm_spins) {
+    if (s_done_sectors == 0) return false;
+    if (sectors)   *sectors   = s_done_sectors;
+    if (size)      *size      = s_done_size;
+    if (psm_spins) *psm_spins = s_done_spins;
+    return true;
+}
+
+bool fw_staging_last_apply_diff(uint32_t *offset, uint32_t *got, uint32_t *want) {
+    if (s_done_sectors == 0) return false;
+    if (offset) *offset = s_done_diff_at;
+    if (got)    *got    = s_done_diff_got;
+    if (want)   *want   = s_done_diff_want;
+    return true;
+}
+
+bool fw_staging_apply_breadcrumb(uint32_t *last_sector, bool *completed, uint32_t *psm_spins) {
+    if ((s_crumb_sector & 0xFFFF0000u) != FW_APPLY_CRUMB_SECTOR) return false;
+    if (last_sector) *last_sector = s_crumb_sector & 0xFFFFu;
+    if (completed)   *completed   = (s_crumb_done == FW_APPLY_CRUMB_DONE);
+    if (psm_spins)   *psm_spins   = s_crumb_spins;
+    return true;
+}
+
+// Public core1 lockout for a caller that is about to do its OWN flash work.
+//
+// The RP2040 hazard is not specific to this file: while core0 has the QSPI out of
+// XIP mode, core1 must not fetch an instruction from flash or the bus stalls and the
+// operation never completes. fw_staging halts core1 around every write it makes --
+// but QMK's wear-levelling backing store (platforms/chibios/drivers/wear_leveling/
+// wear_leveling_rp2040_flash.c) calls flash_range_erase() with core1 running and free
+// to be anywhere. Normally the window is small enough to get away with; on the apply
+// path save_all_dirty() can force a consolidation at the exact moment core1 has just
+// been relaunched after the staging erase, which is where it stops being survivable.
+//
+// Wrapping the whole flush is the fix, and it is a lockout rather than a fw_staging
+// internal because the caller (poly_keymap's apply block) owns the sequencing.
+void fw_staging_core1_lockout_begin(void) {
+#ifdef USE_CORE1
+    if (!s_core1_halted) fw_staging_halt_core1();
+#endif
+}
+
+void fw_staging_core1_lockout_end(void) {
+#ifdef USE_CORE1
+    if (s_core1_halted) fw_staging_restart_core1();
+#endif
+}
+
 void fw_staging_init(void) {
+    for (uint32_t i = 0; i < FW_APPLY_LOG_PAGES; i++) {
+        const uint32_t w = *(const uint32_t *)(XIP_BASE + FW_APPLY_LOG_OFFSET + i * FLASH_PAGE_SIZE);
+        const uint32_t w1 = *(const uint32_t *)(XIP_BASE + FW_APPLY_LOG_OFFSET + i * FLASH_PAGE_SIZE + 4);
+        if (w == FW_APPLY_LOG_START) {
+            s_log_started = true;
+        } else if (w == FW_APPLY_LOG_PRE_ERASE) {
+            s_mark_stage = 1; s_mark_addr = w1;
+        } else if (w == FW_APPLY_LOG_POST_ERASE) {
+            if (s_mark_stage < 2) s_mark_stage = 2;
+            s_mark_read_erased = w1;
+        } else if (w == FW_APPLY_LOG_POST_READ) {
+            if (s_mark_stage < 3) s_mark_stage = 3;
+            s_mark_src_word = w1;
+        } else if (w == FW_APPLY_LOG_POST_PROG) {
+            if (s_mark_stage < 4) s_mark_stage = 4;
+            s_mark_read_progd = w1;
+        } else if ((w & 0xFFFF0000u) == FW_APPLY_LOG_MAGIC) {
+            s_log_count++;
+            const uint32_t sec = w & 0xFFFFu;
+            if (sec > s_log_max || s_log_count == 1) s_log_max = sec;
+            if (sec < s_log_min || s_log_count == 1) s_log_min = sec;
+        }
+    }
+    const uint32_t *done = (const uint32_t *)(XIP_BASE + FW_STAGING_OFFSET + FLASH_PAGE_SIZE);
+    if (done[0] == FW_APPLY_DONE_MAGIC) {
+        s_done_sectors = done[1];
+        s_done_size    = done[2];
+        s_done_spins   = done[3];
+        s_done_diff_at   = done[4];
+        s_done_diff_got  = done[5];
+        s_done_diff_want = done[6];
+    }
+    s_crumb_sector = _WD_SCRATCH0;
+    s_crumb_done   = _WD_SCRATCH1;
+    s_crumb_spins  = _WD_SCRATCH2;
+    _WD_SCRATCH0 = 0;
+    _WD_SCRATCH1 = 0;
+    _WD_SCRATCH2 = 0;
+
     s_initialized          = true;
     s_commit_pending       = false;
     s_reboot_pending       = false;
@@ -915,8 +1113,26 @@ static void __no_inline_not_in_flash_func(fw_staging_do_apply)(uint32_t image_si
     // not-in-flash apply path.
     _PSM_FRCE_OFF |= _PSM_PROC1_BIT;
     __asm volatile ("dsb" ::: "memory");
+    // The DSB only orders the store. Wait for the reset to actually land before any
+    // flash operation, or core1 is still fetching from XIP when the QSPI leaves XIP
+    // mode and the bus stalls for good. This is the one unsynchronised step in the
+    // whole apply, and a few-cycle window is exactly why it presented as one half
+    // completing while the other wedged on identical code (field, 2026-08-31).
+    const uint32_t psm_spins = psm_wait_proc1_off();
+    _WD_SCRATCH2 = psm_spins;
 #endif
-    static uint8_t page_buf[FLASH_PAGE_SIZE];   // static (.bss): never on a moving stack
+    dma_abort_all();
+    // ⚠️ uint32_t, NOT uint8_t, and the type is the whole fix. ram_word_copy() below
+    // copies words, so the compiler emits ldmia/stmia -- and an unaligned STMIA is a
+    // HardFault on Cortex-M0+, taken with PRIMASK set inside a function that never
+    // returns, i.e. an instant lockup with no trace. A uint8_t[256] has alignment 1,
+    // so the linker packs it at whatever byte offset the previous .bss symbol leaves.
+    // That is what bricked the HID firmware update: adding the macro label cache to
+    // .bss shifted this buffer to ...ce3, and the first page of the first sector
+    // faulted the core. The applier's CODE was byte-identical across the regression;
+    // only its buffer moved, which is why a disassembly diff found nothing.
+    // Declaring it as words means no cast can silently reintroduce the hazard.
+    static uint32_t page_buf[FLASH_PAGE_SIZE / 4];   // static (.bss): never on a moving stack
     uint32_t num_sectors = (image_size + FLASH_SECTOR_SIZE - 1) / FLASH_SECTOR_SIZE;
     uint32_t pages = FLASH_SECTOR_SIZE / FLASH_PAGE_SIZE;
 
@@ -926,27 +1142,116 @@ static void __no_inline_not_in_flash_func(fw_staging_do_apply)(uint32_t image_si
     // Erase+program one sector from staging.  Reads source via XIP (re-enabled by
     // flash_range_erase on return) into the RAM page buffer BEFORE program() drops
     // XIP again.  Staging (≥1 MB) is never erased here, so it stays XIP-readable.
+    // One log page: word0 = marker, word1 = a witness value worth capturing.
+    #define LOG_MARK(page, marker, witness)                                               \
+        do {                                                                              \
+            page_buf[0] = (marker);                                 \
+            page_buf[1] = (witness);                                \
+            flash_range_program(FW_APPLY_LOG_OFFSET + (page) * FLASH_PAGE_SIZE,           \
+                                (const uint8_t *)page_buf, FLASH_PAGE_SIZE);                               \
+        } while (0)
+
     #define APPLY_ONE_SECTOR(sec)                                                         \
         do {                                                                              \
+            _WD_SCRATCH0 = FW_APPLY_CRUMB_SECTOR | ((sec) & 0xFFFFu);                     \
             uint32_t _dst = (sec) * FLASH_SECTOR_SIZE;                                    \
             uint32_t _src = XIP_BASE + FW_STAGING_DATA_OFFSET + (sec) * FLASH_SECTOR_SIZE;\
+            if (_first) LOG_MARK(FW_APPLY_LOG_PAGE_PRE, FW_APPLY_LOG_PRE_ERASE, _dst);    \
             flash_range_erase(_dst, FLASH_SECTOR_SIZE);                                   \
+            if (_first) LOG_MARK(FW_APPLY_LOG_POST, FW_APPLY_LOG_POST_ERASE,              \
+                                 *(const volatile uint32_t *)(XIP_BASE + _dst));          \
             for (uint32_t _pg = 0; _pg < pages; _pg++) {                                  \
-                ram_word_copy((uint32_t *)page_buf,                                       \
+                ram_word_copy(page_buf,                                                   \
                               (const uint32_t *)(_src + _pg * FLASH_PAGE_SIZE),            \
                               FLASH_PAGE_SIZE);                                           \
-                flash_range_program(_dst + _pg * FLASH_PAGE_SIZE, page_buf, FLASH_PAGE_SIZE); \
+                uint32_t _w0 = page_buf[0];                                               \
+                flash_range_program(_dst + _pg * FLASH_PAGE_SIZE,                          \
+                                    (const uint8_t *)page_buf, FLASH_PAGE_SIZE);           \
+                if (_first && _pg == 0) LOG_MARK(FW_APPLY_LOG_PAGE_READ,                  \
+                                                 FW_APPLY_LOG_POST_READ, _w0);            \
+                if (_first && _pg == 0) {                                                 \
+                    LOG_MARK(FW_APPLY_LOG_PAGE_PROG, FW_APPLY_LOG_POST_PROG,              \
+                             *(const volatile uint32_t *)(XIP_BASE + _dst));              \
+                    _first = false;                                                       \
+                }                                                                         \
             }                                                                             \
+            _first = false;                                                               \
         } while (0)
+
+    // Fresh progress log. Erasing staging is safe here -- it is not the running
+    // firmware, and this area is past everything the image occupies.
+    for (uint32_t i = 0; i < FW_APPLY_LOG_SECTORS; i++) {
+        flash_range_erase(FW_APPLY_LOG_OFFSET + i * FLASH_SECTOR_SIZE, FLASH_SECTOR_SIZE);
+    }
+    #define LOG_SECTOR_DONE(sec)                                                          \
+        do {                                                                              \
+            page_buf[0] = FW_APPLY_LOG_MAGIC | ((sec) & 0xFFFFu);   \
+            flash_range_program(FW_APPLY_LOG_OFFSET + (sec) * FLASH_PAGE_SIZE,            \
+                                (const uint8_t *)page_buf, FLASH_PAGE_SIZE);                               \
+        } while (0)
+
+    // The log is erased and its start marker written BEFORE any sector of the running
+    // image is touched, so an empty log on the next boot means the applier never got
+    // this far -- distinguishing "died erasing the first sector" from "died before the
+    // copy began at all", which are different bugs and were previously the same symptom.
+    bool _first = true;   // bracket only the first image sector
+    page_buf[0] = FW_APPLY_LOG_START;
+    flash_range_program(FW_APPLY_LOG_OFFSET + (FW_APPLY_LOG_PAGES - 1) * FLASH_PAGE_SIZE,
+                        (const uint8_t *)page_buf, FLASH_PAGE_SIZE);
 
     // App body first: sectors 1..N-1, leaving sector 0's vectors written last.
     for (uint32_t sec = 1; sec < num_sectors; sec++) {
         APPLY_ONE_SECTOR(sec);
+        LOG_SECTOR_DONE(sec);
     }
     if (num_sectors > 0) {
         APPLY_ONE_SECTOR(0);   // vectors LAST
+        LOG_SECTOR_DONE(0);
     }
+    #undef LOG_SECTOR_DONE
     #undef APPLY_ONE_SECTOR
+    _WD_SCRATCH1 = FW_APPLY_CRUMB_DONE;   // the copy finished; anything after this is the reset
+
+    // ...and the same fact in FLASH, because the scratch register is useless in the
+    // case that matters: a half that never reboots, or reboots into an image that
+    // cannot print, can never read it back -- so "hung mid-copy" and "copied fine,
+    // booted dead" look identical from the outside. This page is in the staging
+    // header sector, erased by every BEGIN and otherwise unused, so it survives a
+    // power cycle and a BOOTSEL recovery and the NEXT firmware can report it.
+    // ⚠️ Do NOT clear page_buf first. A `for` loop filling it is recognised by GCC and
+    // turned into a call to memset -- which lives in FLASH, inside the region this
+    // routine has just erased. That is invariant (1) above, and it is what bricked the
+    // part in run 2. Only the first four words are read back; the rest of the page is
+    // residue from the last copied page, which nothing ever looks at.
+    // Check our own work before resetting into it. The source has already been
+    // verified byte-correct in flash (APPLY 3/4), so comparing the region we just
+    // wrote against that same source answers the one remaining question -- did the
+    // copy put the right bytes down? -- and it answers it in a place that survives
+    // the BOOTSEL recovery, which is the only way back from a bad apply.
+    //
+    // volatile so GCC cannot turn this into a memcmp() call: that lives in flash,
+    // inside the region just erased and rewritten, and calling into it here is the
+    // invariant-(1) violation that bricked the part in run 2.
+    volatile const uint32_t *wrote = (volatile const uint32_t *)(XIP_BASE);
+    volatile const uint32_t *want  = (volatile const uint32_t *)(XIP_BASE + FW_STAGING_DATA_OFFSET);
+    uint32_t diff_at = 0xFFFFFFFFu, got_w = 0, want_w = 0;
+    for (uint32_t w = 0; w < image_size / 4u; w++) {
+        if (wrote[w] != want[w]) {
+            diff_at = w * 4u;
+            got_w   = wrote[w];
+            want_w  = want[w];
+            break;
+        }
+    }
+
+    page_buf[0] = FW_APPLY_DONE_MAGIC;
+    page_buf[1] = num_sectors;
+    page_buf[2] = image_size;
+    page_buf[3] = psm_spins;
+    page_buf[4] = diff_at;
+    page_buf[5] = got_w;
+    page_buf[6] = want_w;
+    flash_range_program(FW_STAGING_OFFSET + FLASH_PAGE_SIZE, (const uint8_t *)page_buf, FLASH_PAGE_SIZE);
 
     // Full-chip reset via the watchdog — NOT NVIC_SystemReset().  NVIC_SystemReset
     // only resets the M0+ core (AIRCR.SYSRESETREQ) and leaves USB/PLL/peripheral
@@ -958,9 +1263,6 @@ static void __no_inline_not_in_flash_func(fw_staging_do_apply)(uint32_t image_si
     //   WATCHDOG_SCRATCH4 = 0  → bootrom takes the normal flash boot path
     //   WATCHDOG_CTRL |= TRIGGER → immediate full reset
     // (RP2040 datasheet §4.7; mirrors pico-sdk watchdog_reboot(0,0,0).)
-    #define _PSM_WDSEL       (*(volatile uint32_t *)(0x40010000u + 0x08u))
-    #define _WD_CTRL         (*(volatile uint32_t *)(0x40058000u + 0x00u))
-    #define _WD_SCRATCH4     (*(volatile uint32_t *)(0x40058000u + 0x1cu))
 #ifdef USE_CORE1
     // Release core1 from the PSM force-off asserted at the top of this function,
     // so it is NOT left held in reset across the watchdog reboot.  The watchdog
@@ -980,9 +1282,69 @@ static void __no_inline_not_in_flash_func(fw_staging_do_apply)(uint32_t image_si
     while (1) { /* wait for the watchdog reset to take effect */ }
 }
 
+// Re-CRC the staged bytes AS THEY SIT IN FLASH.
+//
+// COMMIT does not do this and never has: s_staged_crc is accumulated in
+// fw_staging_write_chunk() over the bytes as they ARRIVE, in RAM. That proves the
+// host's image reached us intact; it proves nothing about what landed in flash. The
+// applier is about to erase the only working copy of the firmware on the strength of
+// it, so verify the actual source first and refuse if it does not match -- a refusal
+// leaves a working keyboard, writing an unverified image does not.
+//
+// Affordable here (~25 ms over ~490 KB) precisely because this runs from housekeeping.
+// The same scan inside COMMIT overflowed the split-transaction window on the slave,
+// which is why finalize keeps the O(1) running CRC -- do not move this there.
+bool fw_staging_verify_staged_flash(uint32_t *size, uint32_t *expect_crc, uint32_t *actual_crc) {
+    const uint32_t *hdr = (const uint32_t *)(XIP_BASE + FW_STAGING_OFFSET);
+    if (hdr[0] != FW_STAGING_MAGIC) return false;
+    // ⚠️ crc32_large(), NOT crc32_1byte(): that one takes a uint16_t length, so a
+    // ~490 KB image silently truncates to (size & 0xFFFF) and the CRC is computed over
+    // the first few percent of the file. It then never matches, so the verify below
+    // refuses EVERY image over 64 KB -- which is exactly what it did on its first
+    // outing (reported c48f3db3, the CRC of the leading 34164 bytes of a 492916-byte
+    // image). The helper exists for this and says so in its own comment.
+    const uint32_t crc = crc32_large((const uint8_t *)(XIP_BASE + FW_STAGING_DATA_OFFSET),
+                                     hdr[1]);
+    if (size)       *size       = hdr[1];
+    if (expect_crc) *expect_crc = hdr[2];
+    if (actual_crc) *actual_crc = crc;
+    return crc == hdr[2];
+}
+
+void fw_staging_cancel_apply(void) {
+    s_commit_pending = false;
+}
+
 void fw_staging_apply_and_reboot(void) {
     const uint32_t *hdr = (const uint32_t *)(XIP_BASE + FW_STAGING_OFFSET);
-    if (hdr[0] != FW_STAGING_MAGIC) return;   // no valid staged image
+    if (hdr[0] != FW_STAGING_MAGIC) {
+        // ⚠️ This used to be a bare `return`, which left s_commit_pending SET — so
+        // housekeeping re-entered the WHOLE apply block on every pass, forever:
+        // clear_keyboard() (board dead), poly_flash_rgb_now() (orange latched),
+        // oled_fw_apply_screen() ("Applying") and save_all_dirty(). From the outside
+        // that is indistinguishable from a half-written flash, and nothing anywhere
+        // said why. Report it and disarm so the board stays usable.
+        uprintf("FWAPPLY refused: no staged image (magic %08lx)\n", (unsigned long)hdr[0]);
+        s_commit_pending = false;
+        return;
+    }
+
+    // The size the applier trusts, printed BEFORE the blocking self-flash — this is
+    // the last thing the console can ever see from this build (the copy disables
+    // interrupts, never returns, and console_task() never runs again). The filler
+    // line that follows is not decoration: QMK's console only ships FULL 32-byte HID
+    // reports and the remainder waits for a main loop that is about to stop existing,
+    // so without it the tail of the real line is lost.
+    if (!fw_staging_verify_staged_flash(NULL, NULL, NULL)) {
+        uprintf("FWAPPLY refused: staged image FAILED its flash CRC - not overwriting\n");
+        s_commit_pending = false;
+        return;
+    }
+
+    const uint32_t sectors = (hdr[1] + FLASH_SECTOR_SIZE - 1) / FLASH_SECTOR_SIZE;
+    uprintf("FWAPPLY sectors=%lu size=%lu crc=%08lx\n",
+            (unsigned long)sectors, (unsigned long)hdr[1], (unsigned long)hdr[2]);
+    uprint("FWAPPLY ------------------------------------------------------------\n");
 
     s_commit_pending = false;
     fw_staging_do_apply(hdr[1]);   // never returns

--- a/keyboards/polykybd/base/fw_staging.c
+++ b/keyboards/polykybd/base/fw_staging.c
@@ -89,6 +89,15 @@ _Static_assert(FW_RESOURCE_OFFSET + FW_DOOMPACK_SLOT_OFF + FW_DOOMPACK_SLOT_SIZE
 // image and of everything FW_UP_BEGIN erases. 8 sectors = 128 pages >= the 121 the
 // image needs, so the copy can record EXACTLY how far it got in a place that outlives
 // the power cycle a BOOTSEL recovery needs.
+// ⚠️ The log lives INSIDE the staging region, so it can collide with the staged
+// image itself: staging accepts up to FW_UP_MAX_SIZE (~2 MB, the whole region),
+// and data starts at FW_STAGING_DATA_OFFSET, so any image over ~1 MB reaches
+// this offset. The erase below would then destroy 32 KB of the source AFTER the
+// pre-copy CRC verified it and BEFORE the copy reads it -- and the post-copy
+// compare would read the same corrupted source and report a match. So the log is
+// BEST-EFFORT: a log_fits test gates every write on the image not reaching it,
+// and a too-large image is copied with no log rather than with a broken source.
+// The watchdog breadcrumb still records the sector in that case.
 #define FW_APPLY_LOG_OFFSET   (FW_STAGING_OFFSET + 0x100000u)
 #define FW_APPLY_LOG_SECTORS  8u
 #define FW_APPLY_LOG_PAGES    (FW_APPLY_LOG_SECTORS * (FLASH_SECTOR_SIZE / FLASH_PAGE_SIZE))
@@ -1145,6 +1154,7 @@ static void __no_inline_not_in_flash_func(fw_staging_do_apply)(uint32_t image_si
     // One log page: word0 = marker, word1 = a witness value worth capturing.
     #define LOG_MARK(page, marker, witness)                                               \
         do {                                                                              \
+            if (!log_fits) break;                                                         \
             page_buf[0] = (marker);                                 \
             page_buf[1] = (witness);                                \
             flash_range_program(FW_APPLY_LOG_OFFSET + (page) * FLASH_PAGE_SIZE,           \
@@ -1178,13 +1188,22 @@ static void __no_inline_not_in_flash_func(fw_staging_do_apply)(uint32_t image_si
             _first = false;                                                               \
         } while (0)
 
-    // Fresh progress log. Erasing staging is safe here -- it is not the running
-    // firmware, and this area is past everything the image occupies.
-    for (uint32_t i = 0; i < FW_APPLY_LOG_SECTORS; i++) {
-        flash_range_erase(FW_APPLY_LOG_OFFSET + i * FLASH_SECTOR_SIZE, FLASH_SECTOR_SIZE);
+    // Fresh progress log. Erasing here is safe only while the staged image stops
+    // short of it -- see FW_APPLY_LOG_OFFSET. When it does not, the whole log is
+    // skipped: a missing diagnostic beats a corrupted source.
+    const bool log_fits = (FW_STAGING_DATA_OFFSET + image_size) <= FW_APPLY_LOG_OFFSET;
+    if (log_fits) {
+        for (uint32_t i = 0; i < FW_APPLY_LOG_SECTORS; i++) {
+            flash_range_erase(FW_APPLY_LOG_OFFSET + i * FLASH_SECTOR_SIZE, FLASH_SECTOR_SIZE);
+        }
     }
+    // ⚠️ Bounded by the log's own page count, not by the image's sector count: the
+    // page index IS the sector number, and a >512 KB image has more sectors than
+    // the log has pages, so an unbounded index would run straight off the end of
+    // the log and into whatever follows it.
     #define LOG_SECTOR_DONE(sec)                                                          \
         do {                                                                              \
+            if (!log_fits || (sec) >= FW_APPLY_LOG_PAGES) break;                          \
             page_buf[0] = FW_APPLY_LOG_MAGIC | ((sec) & 0xFFFFu);   \
             flash_range_program(FW_APPLY_LOG_OFFSET + (sec) * FLASH_PAGE_SIZE,            \
                                 (const uint8_t *)page_buf, FLASH_PAGE_SIZE);                               \
@@ -1195,9 +1214,11 @@ static void __no_inline_not_in_flash_func(fw_staging_do_apply)(uint32_t image_si
     // this far -- distinguishing "died erasing the first sector" from "died before the
     // copy began at all", which are different bugs and were previously the same symptom.
     bool _first = true;   // bracket only the first image sector
-    page_buf[0] = FW_APPLY_LOG_START;
-    flash_range_program(FW_APPLY_LOG_OFFSET + (FW_APPLY_LOG_PAGES - 1) * FLASH_PAGE_SIZE,
-                        (const uint8_t *)page_buf, FLASH_PAGE_SIZE);
+    if (log_fits) {
+        page_buf[0] = FW_APPLY_LOG_START;
+        flash_range_program(FW_APPLY_LOG_OFFSET + (FW_APPLY_LOG_PAGES - 1) * FLASH_PAGE_SIZE,
+                            (const uint8_t *)page_buf, FLASH_PAGE_SIZE);
+    }
 
     // App body first: sectors 1..N-1, leaving sector 0's vectors written last.
     for (uint32_t sec = 1; sec < num_sectors; sec++) {

--- a/keyboards/polykybd/base/fw_staging.c
+++ b/keyboards/polykybd/base/fw_staging.c
@@ -21,6 +21,15 @@ _Static_assert(FW_UP_MAX_SIZE <= FW_STAGING_OFFSET,
                "a staged image cannot be larger than the firmware partition");
 _Static_assert(FW_STAGING_DATA_OFFSET + FW_UP_MAX_SIZE <= FW_RESOURCE_OFFSET,
                "staging area overruns the resource region (FLASH_TARGET_OFFSET)");
+// ⚠️ THE wall between the staged image and the apply progress log, which lives at
+// the top of the same region. Raising FW_UP_MAX_SIZE without moving the log fails
+// the build here instead of silently erasing 32 KB of the source the applier is
+// about to copy -- after the pre-copy CRC has already verified it, and where the
+// post-copy compare would read that same corrupted source and report a match.
+_Static_assert(FW_STAGING_DATA_OFFSET + FW_UP_MAX_SIZE <= FW_APPLY_LOG_OFFSET,
+               "a staged image can reach the apply progress log");
+_Static_assert(FW_APPLY_LOG_OFFSET + FW_APPLY_LOG_BYTES <= FW_RESOURCE_OFFSET,
+               "the apply progress log runs into the resource region");
 
 // The wear-levelling EEPROM sits at the TOP of flash, inside what the map above
 // calls the resource region, so the last resource slot has to stop short of it.
@@ -89,17 +98,7 @@ _Static_assert(FW_RESOURCE_OFFSET + FW_DOOMPACK_SLOT_OFF + FW_DOOMPACK_SLOT_SIZE
 // image and of everything FW_UP_BEGIN erases. 8 sectors = 128 pages >= the 121 the
 // image needs, so the copy can record EXACTLY how far it got in a place that outlives
 // the power cycle a BOOTSEL recovery needs.
-// ⚠️ The log lives INSIDE the staging region, so it can collide with the staged
-// image itself: staging accepts up to FW_UP_MAX_SIZE (~2 MB, the whole region),
-// and data starts at FW_STAGING_DATA_OFFSET, so any image over ~1 MB reaches
-// this offset. The erase below would then destroy 32 KB of the source AFTER the
-// pre-copy CRC verified it and BEFORE the copy reads it -- and the post-copy
-// compare would read the same corrupted source and report a match. So the log is
-// BEST-EFFORT: a log_fits test gates every write on the image not reaching it,
-// and a too-large image is copied with no log rather than with a broken source.
-// The watchdog breadcrumb still records the sector in that case.
-#define FW_APPLY_LOG_OFFSET   (FW_STAGING_OFFSET + 0x100000u)
-#define FW_APPLY_LOG_SECTORS  8u
+// FW_APPLY_LOG_* live in the header, beside the FW_UP_MAX_SIZE they are asserted against.
 #define FW_APPLY_LOG_PAGES    (FW_APPLY_LOG_SECTORS * (FLASH_SECTOR_SIZE / FLASH_PAGE_SIZE))
 
 // DMA is the LAST bus master that can touch XIP once core1 is in reset and interrupts
@@ -1154,7 +1153,6 @@ static void __no_inline_not_in_flash_func(fw_staging_do_apply)(uint32_t image_si
     // One log page: word0 = marker, word1 = a witness value worth capturing.
     #define LOG_MARK(page, marker, witness)                                               \
         do {                                                                              \
-            if (!log_fits) break;                                                         \
             page_buf[0] = (marker);                                 \
             page_buf[1] = (witness);                                \
             flash_range_program(FW_APPLY_LOG_OFFSET + (page) * FLASH_PAGE_SIZE,           \
@@ -1188,14 +1186,10 @@ static void __no_inline_not_in_flash_func(fw_staging_do_apply)(uint32_t image_si
             _first = false;                                                               \
         } while (0)
 
-    // Fresh progress log. Erasing here is safe only while the staged image stops
-    // short of it -- see FW_APPLY_LOG_OFFSET. When it does not, the whole log is
-    // skipped: a missing diagnostic beats a corrupted source.
-    const bool log_fits = (FW_STAGING_DATA_OFFSET + image_size) <= FW_APPLY_LOG_OFFSET;
-    if (log_fits) {
-        for (uint32_t i = 0; i < FW_APPLY_LOG_SECTORS; i++) {
-            flash_range_erase(FW_APPLY_LOG_OFFSET + i * FLASH_SECTOR_SIZE, FLASH_SECTOR_SIZE);
-        }
+    // Fresh progress log. Safe to erase: it is not the running firmware, and the
+    // static assert above proves no accepted image can reach it.
+    for (uint32_t i = 0; i < FW_APPLY_LOG_SECTORS; i++) {
+        flash_range_erase(FW_APPLY_LOG_OFFSET + i * FLASH_SECTOR_SIZE, FLASH_SECTOR_SIZE);
     }
     // ⚠️ Bounded by the log's own page count, not by the image's sector count: the
     // page index IS the sector number, and a >512 KB image has more sectors than
@@ -1203,7 +1197,7 @@ static void __no_inline_not_in_flash_func(fw_staging_do_apply)(uint32_t image_si
     // the log and into whatever follows it.
     #define LOG_SECTOR_DONE(sec)                                                          \
         do {                                                                              \
-            if (!log_fits || (sec) >= FW_APPLY_LOG_PAGES) break;                          \
+            if ((sec) >= FW_APPLY_LOG_PAGES) break;                                       \
             page_buf[0] = FW_APPLY_LOG_MAGIC | ((sec) & 0xFFFFu);   \
             flash_range_program(FW_APPLY_LOG_OFFSET + (sec) * FLASH_PAGE_SIZE,            \
                                 (const uint8_t *)page_buf, FLASH_PAGE_SIZE);                               \
@@ -1214,11 +1208,9 @@ static void __no_inline_not_in_flash_func(fw_staging_do_apply)(uint32_t image_si
     // this far -- distinguishing "died erasing the first sector" from "died before the
     // copy began at all", which are different bugs and were previously the same symptom.
     bool _first = true;   // bracket only the first image sector
-    if (log_fits) {
-        page_buf[0] = FW_APPLY_LOG_START;
-        flash_range_program(FW_APPLY_LOG_OFFSET + (FW_APPLY_LOG_PAGES - 1) * FLASH_PAGE_SIZE,
-                            (const uint8_t *)page_buf, FLASH_PAGE_SIZE);
-    }
+    page_buf[0] = FW_APPLY_LOG_START;
+    flash_range_program(FW_APPLY_LOG_OFFSET + (FW_APPLY_LOG_PAGES - 1) * FLASH_PAGE_SIZE,
+                        (const uint8_t *)page_buf, FLASH_PAGE_SIZE);
 
     // App body first: sectors 1..N-1, leaving sector 0's vectors written last.
     for (uint32_t sec = 1; sec < num_sectors; sec++) {

--- a/keyboards/polykybd/base/fw_staging.h
+++ b/keyboards/polykybd/base/fw_staging.h
@@ -34,7 +34,18 @@
 #define FW_STAGING_HEADER_SIZE 0x001000UL      // first 4 KB of staging = header sector
 #define FW_STAGING_DATA_OFFSET (FW_STAGING_OFFSET + FW_STAGING_HEADER_SIZE)
 #define FW_RESOURCE_OFFSET     0x400000UL      // resource/overlay region (== FLASH_TARGET_OFFSET in keymap.c)
-#define FW_UP_MAX_SIZE         0x1FF000UL      // max staged image: 2 MB staging region minus the 4 KB header
+// The self-apply's progress log, at the TOP of the staging region. It has to live
+// somewhere the running firmware is not (it is written while that firmware is being
+// overwritten) and somewhere a BOOTSEL/UF2 recovery does not touch (reading it back
+// requires exactly that recovery) -- which leaves staging, and means it must be
+// walled off from the staged image itself. The static assert below is that wall:
+// without it, an image over ~1 MB would have 32 KB of its source erased AFTER the
+// pre-copy CRC verified it and BEFORE the copy read it, and the post-copy compare
+// would then read the same corrupted source and report a match.
+#define FW_APPLY_LOG_SECTORS   8UL
+#define FW_APPLY_LOG_BYTES     (FW_APPLY_LOG_SECTORS * 4096UL)
+#define FW_APPLY_LOG_OFFSET    (FW_RESOURCE_OFFSET - FW_APPLY_LOG_BYTES)
+#define FW_UP_MAX_SIZE         0x1F7000UL      // max staged image: staging region, minus the 4 KB header and the apply log
 #define FW_STAGING_MAGIC       0xD1F1A51BUL
 
 // Bytes per firmware-update chunk (HID and split-RPC payload).

--- a/keyboards/polykybd/base/fw_staging.h
+++ b/keyboards/polykybd/base/fw_staging.h
@@ -77,7 +77,56 @@ bool fw_staging_refused_unsigned(void);
 
 // Must be called once before any other fw_staging_* function.
 
+// Hold core1 out of flash for a caller doing its own flash work (EEPROM flush).
+// See the comment on the definition: QMK's wear-levelling backing store erases with
+// core1 running, which is only survivable while the window stays small.
+void fw_staging_core1_lockout_begin(void);
+void fw_staging_core1_lockout_end(void);
+
+// Re-CRC the staged image AS IT SITS IN FLASH. COMMIT only checks the bytes as they
+// arrived in RAM, so it says nothing about what actually landed -- and the applier is
+// about to erase the only working firmware on the strength of it.
+bool fw_staging_verify_staged_flash(uint32_t *size, uint32_t *expect_crc, uint32_t *actual_crc);
+
+// Disarm an armed apply without applying it.
+void fw_staging_cancel_apply(void);
+
+// Whether the LAST self-apply (this boot or any earlier one, until the next BEGIN
+// erases the record) finished its copy. Recorded in flash rather than the watchdog
+// scratch because the case that matters is a half that never came back: the scratch
+// dies with the power, this does not.
+bool fw_staging_last_apply_completed(uint32_t *sectors, uint32_t *size, uint32_t *psm_spins);
+
+// Where the last self-apply's copy first disagreed with its source, checked by the
+// applier itself before it reset. 0xFFFFFFFF = the written image matched the staged
+// one exactly, so the copy is not the problem.
+bool fw_staging_last_apply_diff(uint32_t *offset, uint32_t *got, uint32_t *want);
+
+// How far the last self-apply's copy actually got, from the per-sector log it writes
+// into staging. Survives the power cycle a BOOTSEL recovery needs, which the watchdog
+// scratch does not -- and a copy that stops partway leaves no other trace at all.
+// How far the last self-apply's sector copy got, read back from the in-flash progress
+// log. The copy runs top-down (N-1 .. 1, then 0), so *lowest is the sector it stopped
+// at; false means no sector completed at all.
+bool fw_staging_apply_progress(uint32_t *lowest, uint32_t *highest, uint32_t *count);
+
+// True when the last self-apply erased its log and marked it started, i.e. it reached
+// the copy. Separates "died before the first sector" from "died erasing it".
+bool fw_staging_apply_started(void);
+
+// Bracket markers around the first image sector the copy touched: how far into that
+// one sector it got (1 = about to erase, 2 = erase returned, 3 = first page written),
+// which flash offset, and the sector's first word read back at stages 2 and 3.
+bool fw_staging_apply_marks(uint32_t *stage, uint32_t *addr, uint32_t *erased, uint32_t *progd, uint32_t *srcw);
+
 void fw_staging_init(void);
+
+// What the LAST self-apply managed before this boot, read out of the watchdog scratch
+// registers (they survive a watchdog reset, not a power cycle) and cleared at init.
+// Returns false when no apply preceded this boot. The apply routine cannot log: the
+// console is gone, interrupts are off and it never returns -- so this is how a half
+// that came back reports how far its copy got.
+bool fw_staging_apply_breadcrumb(uint32_t *last_sector, bool *completed, uint32_t *psm_spins);
 
 // Staging target: which flash region a begin/chunk/finalize sequence writes to,
 // and how finalize completes. FIRMWARE stages to the 2 MB firmware-update region

--- a/keyboards/polykybd/boot_diag.c
+++ b/keyboards/polykybd/boot_diag.c
@@ -14,6 +14,7 @@
 #include "state.h"        // get_idle_style(), idle_style_name()
 #include "layers.h"       // _ADDLANG1 (Intl picker banner line)
 #include "quantum/keymap_introspection.h"   // keycode_at_keymap_location_raw()
+#include "base/fw_staging.h"   // fw_staging_apply_breadcrumb()
 #include "base/update.h"       // enum refresh_mode / ALL_AT_ONCE
 #include "base/disp_array.h"   // GFXfont type
 // Only the single splash font is needed. Don't pull in gfx_used_fonts.h — the
@@ -154,6 +155,86 @@ void emit_idle_config(void) {
             (unsigned int)TURN_OFF_TIME);
 }
 
+// The stored dynamic-keymap format version and whether this boot had to discard the
+// keymap because of it. Emitted on the banner tick for the same reason emit_idle_config()
+// is: it is only known after the EEPROM config load, which happens long after the
+// one-shot banner print, and the reset it reports is a once-per-upgrade event that
+// blocks post_init while it rewrites a few kB of wear-levelled EEPROM. A console that
+// cannot see it cannot tell "the board is still resetting its keymap" from "the board
+// is dead".
+static uint8_t  s_keymap_fmt_seen  = 0xFF;   // 0xFF = post_init has not run yet
+static bool     s_keymap_reset_ran = false;
+static uint32_t s_keymap_reset_ms  = 0;
+
+void note_keymap_storage(uint8_t stored_fmt, bool reset_ran, uint32_t elapsed_ms) {
+    s_keymap_fmt_seen  = stored_fmt;
+    s_keymap_reset_ran = reset_ran;
+    s_keymap_reset_ms  = elapsed_ms;
+}
+
+// What the previous self-apply achieved, if this boot followed one. Printed with the
+// banner because that is the only channel: fw_staging_do_apply() runs with interrupts
+// off and never returns, so it can leave a breadcrumb in the watchdog scratch and
+// nothing else.
+void emit_apply_breadcrumb_line(void) {
+    uint32_t last_sector = 0, spins = 0;
+    bool     completed   = false;
+    uint32_t p_low = 0, p_high = 0, p_count = 0;
+    if (fw_staging_apply_progress(&p_low, &p_high, &p_count)) {
+        uprintf("   apply: copy log - %lu sectors done, sectors %lu..%lu\n",
+                (unsigned long)p_count, (unsigned long)p_low, (unsigned long)p_high);
+    } else if (fw_staging_apply_started()) {
+        uprintf("   apply: copy log - STARTED but not one sector completed\n");
+    }
+    uint32_t m_stage = 0, m_addr = 0, m_erased = 0, m_progd = 0, m_srcw = 0;
+    if (fw_staging_apply_marks(&m_stage, &m_addr, &m_erased, &m_progd, &m_srcw)) {
+        static const char *const where[] = {"", "died IN the erase",
+                                            "died reading the staging source",
+                                            "died IN the program of the image",
+                                            "first page written OK"};
+        uprintf("   apply: first image sector 0x%lx - reached stage %lu (%s)\n",
+                (unsigned long)m_addr, (unsigned long)m_stage,
+                where[m_stage < 5 ? m_stage : 0]);
+        if (m_stage >= 2) uprintf("   apply: word after erase   = %08lx (ffffffff = erase took)\n",
+                                  (unsigned long)m_erased);
+        if (m_stage >= 3) uprintf("   apply: staging source word = %08lx (read OK)\n",
+                                  (unsigned long)m_srcw);
+        if (m_stage >= 4) uprintf("   apply: word after program  = %08lx\n", (unsigned long)m_progd);
+    }
+    uint32_t d_sectors = 0, d_size = 0, d_spins = 0;
+    if (fw_staging_last_apply_completed(&d_sectors, &d_size, &d_spins)) {
+        // From the in-flash record, so this survives the power cycle that a BOOTSEL
+        // recovery needs -- it describes the last apply that ran, not necessarily one
+        // that preceded THIS boot.
+        uprintf("   apply: last self-apply COMPLETED its copy (%lu sectors, %lu B, psm_spins=%lu)\n",
+                (unsigned long)d_sectors, (unsigned long)d_size, (unsigned long)d_spins);
+        uint32_t off = 0, got = 0, want = 0;
+        if (fw_staging_last_apply_diff(&off, &got, &want)) {
+            if (off == 0xFFFFFFFFu) {
+                uprintf("   apply: written image MATCHED the staged source exactly\n");
+            } else {
+                uprintf("   apply: written image DIFFERS at offset %lu (0x%lx): got %08lx want %08lx\n",
+                        (unsigned long)off, (unsigned long)off,
+                        (unsigned long)got, (unsigned long)want);
+            }
+        }
+    }
+    if (!fw_staging_apply_breadcrumb(&last_sector, &completed, &spins)) return;
+    uprintf("   apply: previous self-apply reached sector %lu, copy %s (psm_spins=%lu)\n",
+            (unsigned long)last_sector, completed ? "COMPLETE" : "INCOMPLETE",
+            (unsigned long)spins);
+}
+
+void emit_keymap_storage_line(void) {
+    uprintf("   keymap: stored_fmt=0x%02X current=0x%02X reset=%s%s\n",
+            (unsigned int)s_keymap_fmt_seen, (unsigned int)KEYMAP_STORAGE_CURRENT,
+            s_keymap_reset_ran ? "YES" : "no",
+            s_keymap_reset_ran ? "" : " (no discard needed)");
+    if (s_keymap_reset_ran) {
+        uprintf("   keymap: discard took %lums\n", (unsigned long)s_keymap_reset_ms);
+    }
+}
+
 void boot_banner_housekeeping_tick(void) {
     // Re-emit the boot identification banner a few times after power-on so a
     // `qmk console` attached shortly after boot still catches it (the one-shot
@@ -166,6 +247,8 @@ void boot_banner_housekeeping_tick(void) {
         } else if (timer_elapsed32(banner_timer) >= BOOT_BANNER_INTERVAL_MS) {
             emit_boot_banner();
             emit_idle_config();
+            emit_keymap_storage_line();
+            emit_apply_breadcrumb_line();
             banner_timer = timer_read32();
             banner_repeats++;
         }

--- a/keyboards/polykybd/boot_diag.h
+++ b/keyboards/polykybd/boot_diag.h
@@ -5,6 +5,7 @@
 // self-contained boot instrumentation; poly_keymap.c just calls into them.
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 
 // SPLASH_DONE draws the whole splash AND performs the final dwell + legend
@@ -21,6 +22,18 @@ void emit_boot_banner(void);
 // EEPROM config load; call it once from post_init after that load (the banner tick
 // re-emits it alongside the banner for a late console).
 void emit_idle_config(void);
+
+// Records what keyboard_post_init_user() found in poly_eeconf_t.keymap_layers_fmt and
+// whether that forced a dynamic-keymap discard (and how long the discard blocked).
+void note_keymap_storage(uint8_t stored_fmt, bool reset_ran, uint32_t elapsed_ms);
+
+// The stored dynamic-keymap format version + whether this boot discarded the keymap.
+// Re-emitted by the banner tick, like emit_idle_config().
+void emit_keymap_storage_line(void);
+
+// What the previous self-apply reached, if this boot followed one (watchdog-scratch
+// breadcrumb). Silent when no apply preceded this boot.
+void emit_apply_breadcrumb_line(void);
 
 // Throttled re-emit of the boot banner, called once per housekeeping pass. The
 // one-shot print in keyboard_post_init_user fires before a console is usually

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -818,7 +818,11 @@ void housekeeping_task_user(void) {
     // Drain at most one queued macro label to the slave. Master-only (the slave is the
     // receiver), and one per pass because each bridge can spend its retries -- sixteen
     // of them back to back would be a visible stall on a link that is already unhappy.
-    if (is_keyboard_master()) {
+    // Not while an apply is armed: the slave has already been told to reboot, so every
+    // bridge here spends its full retry budget on a link that is going dark -- hundreds
+    // of ms of blocked main loop immediately before the self-flash, for a label nobody
+    // will read.
+    if (is_keyboard_master() && !fw_staging_commit_pending()) {
         poly_macro_label_sync_tick();
     }
 
@@ -826,22 +830,85 @@ void housekeeping_task_user(void) {
     // Both must run regardless of fw_up_active so the slave's erase actually
     // progresses and the master's apply-and-reboot fires after a successful
     // commit.
+    // Split across housekeeping passes ON PURPOSE, one stage per pass.
+    //
+    // Two reasons, and the second is why it is worth the three extra passes. (1) The
+    // console only leaves this board from the main loop, so a marker printed
+    // immediately before a call that never returns is simply lost -- which is how a
+    // hang here has repeatedly been invisible. Returning between stages gives each
+    // marker a main loop to go out on, so the log names the stage that wedged.
+    // (2) EVERY stage below touches flash or the split link, and they must not be
+    // interleaved with the rest of housekeeping while core1 is locked out.
     if (fw_staging_commit_pending()) {
-        // Release anything still held. From here the main loop never scans the
-        // matrix again (the self-flash below does not return), so a key that is
-        // physically down when the apply is armed would never have its release
-        // reported — the host keeps it registered and auto-repeats until USB
-        // drops at the reboot (field: hundreds of repetitions).
-        clear_keyboard();
-        poly_flash_rgb_now();
-        // Paint the "⟳Applying / Firmware⟳" notice and flush it fully BEFORE the
-        // blocking self-flash + reset below (which never returns), so the status
-        // OLED is completely refreshed — not torn mid-transition — as the apply
-        // begins. Runs on both halves; each draws its own side's word. Its ~26 ms
-        // of I2C also gives the clear_keyboard() report time to leave over USB.
-        oled_fw_apply_screen();
-        save_all_dirty();   // persist MRU/settings before the firmware swap — this path resets via watchdog (never returns) and skips shutdown_quantum. Transfer is done by commit, so the blocking flash write is safe here.
-        fw_staging_apply_and_reboot();
+        static uint8_t apply_step = 0;
+        switch (apply_step) {
+            case 0:
+                // Release anything still held. From here the main loop never scans the
+                // matrix again (the self-flash below does not return), so a key that is
+                // physically down when the apply is armed would never have its release
+                // reported — the host keeps it registered and auto-repeats until USB
+                // drops at the reboot (field: hundreds of repetitions).
+                clear_keyboard();
+                poly_flash_rgb_now();
+                // Paint the "⟳Applying / Firmware⟳" notice and flush it fully BEFORE the
+                // blocking self-flash below (which never returns), so the status OLED is
+                // completely refreshed — not torn mid-transition — as the apply begins.
+                // Runs on both halves; each draws its own side's word. Its ~26 ms of I2C
+                // also gives the clear_keyboard() report time to leave over USB.
+                oled_fw_apply_screen();
+                uprintf("APPLY 1/4: keys cleared, RGB + OLED flushed\n");
+                apply_step = 1;
+                return;
+            case 1:
+                // Persist MRU/settings before the firmware swap — this path resets via
+                // watchdog (never returns) and skips shutdown_quantum. Transfer is done
+                // by commit, so the blocking flash write is safe here.
+                //
+                // ⚠️ Under the core1 lockout: this can force a wear-levelling
+                // CONSOLIDATION, i.e. a flash erase, and QMK's backing store does not
+                // lock core1 out itself. Core1 was relaunched moments ago by the staging
+                // erase, so it is free to be fetching from XIP exactly when the QSPI
+                // leaves XIP mode — the bus then stalls and the erase never returns.
+                fw_staging_core1_lockout_begin();
+                save_all_dirty();
+                uprintf("APPLY 2/4: EEPROM flushed with core1 held off\n");
+                apply_step = 2;
+                return;
+            case 2: {
+                // Verify the staged bytes IN FLASH and report them, then RETURN so the
+                // line actually goes out. Everything below this point is a call that
+                // does not come back, and the console only drains from the main loop --
+                // a marker printed immediately before it is simply lost, which is how
+                // "did it enter the copy?" stayed unanswerable for several rounds.
+                uint32_t size = 0, want = 0, got = 0;
+                const bool good = fw_staging_verify_staged_flash(&size, &want, &got);
+                uprintf("APPLY 3/4: staged %lu B (%lu sectors) crc want=%08lx got=%08lx -> %s\n",
+                        (unsigned long)size,
+                        (unsigned long)((size + 4095u) / 4096u),
+                        (unsigned long)want, (unsigned long)got, good ? "OK" : "MISMATCH");
+                if (!good) {
+                    // Refuse rather than erase a working firmware with an image we
+                    // cannot vouch for. The board stays usable and the host can retry.
+                    uprintf("APPLY: refusing to overwrite firmware from a bad staged image\n");
+                    fw_staging_cancel_apply();
+                    fw_staging_core1_lockout_end();
+                    apply_step = 0;
+                    return;
+                }
+                apply_step = 3;
+                return;
+            }
+            default:
+                // Nothing but the call: if the 3/4 line above is the last thing in the
+                // log, the copy was entered and did not come back.
+                apply_step = 0;
+                fw_staging_apply_and_reboot();
+                // Only reached when the apply was refused (no valid staged image); it
+                // disarms itself there, so hand core1 back rather than leaving the RLE
+                // service down on a board that is going to keep running.
+                fw_staging_core1_lockout_end();
+                break;
+        }
     }
     if (fw_staging_reboot_pending()) {
         clear_keyboard();   // same as above: no further matrix scan before the reset
@@ -4533,12 +4600,22 @@ void keyboard_post_init_user(void) {
     // user datablock and the keymap are separate blocks with separate lifetimes —
     // the keymap survives a user-data re-init, which is exactly the case that would
     // otherwise slip through.
-    if (ee.keymap_layers_fmt != KEYMAP_STORAGE_CURRENT) {
+    // Timed and reported on the banner tick (note_keymap_storage) as well as printed
+    // here: this discard rewrites the capped keymap, the encoder map and the whole
+    // macro region -- a few kB of wear-levelled EEPROM -- inside post_init, before USB
+    // is up. The one-shot uprintf below is usually emitted before a console can see
+    // it, so a board that spends a long time here (or never leaves) looks simply dead.
+    const uint8_t  stored_fmt = ee.keymap_layers_fmt;
+    const bool     need_reset = (stored_fmt != KEYMAP_STORAGE_CURRENT);
+    const uint32_t reset_t0   = timer_read32();
+    if (need_reset) {
         uprintf("Keymap layer enum changed (fmt %u) - resetting dynamic keymap\n",
-                (unsigned)ee.keymap_layers_fmt);
+                (unsigned)stored_fmt);
         dynamic_keymap_reset_poly();
         stamp_keymap_layers_fmt();
     }
+    note_keymap_storage(stored_fmt, need_reset,
+                        need_reset ? timer_elapsed32(reset_t0) : 0);
     // Restore the active-OS state (auto/manual + last known OS). Auto by default, so
     // a fresh EEPROM re-resolves per host via detection / host push; a manual pin
     // (e.g. Android) sticks. Seed local_state->active_os so the first render before

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -869,8 +869,18 @@ void housekeeping_task_user(void) {
                 // lock core1 out itself. Core1 was relaunched moments ago by the staging
                 // erase, so it is free to be fetching from XIP exactly when the QSPI
                 // leaves XIP mode — the bus then stalls and the erase never returns.
+                //
+                // ⚠️ The lockout is RELEASED before returning, not held across the
+                // remaining stages. Each stage hands control back to the main loop,
+                // which can service a raw-HID overlay -- and a compressed one is
+                // dispatched to core1 through a BLOCKING FIFO push plus a spin on
+                // core1's completion counter. With core1 in PSM reset nothing drains
+                // it, so core0 would hang before the apply could even start. The
+                // window is a pass or two; the failure is permanent. Holding it here
+                // bought nothing either: fw_staging_do_apply() halts core1 itself.
                 fw_staging_core1_lockout_begin();
                 save_all_dirty();
+                fw_staging_core1_lockout_end();
                 uprintf("APPLY 2/4: EEPROM flushed with core1 held off\n");
                 apply_step = 2;
                 return;
@@ -891,7 +901,6 @@ void housekeeping_task_user(void) {
                     // cannot vouch for. The board stays usable and the host can retry.
                     uprintf("APPLY: refusing to overwrite firmware from a bad staged image\n");
                     fw_staging_cancel_apply();
-                    fw_staging_core1_lockout_end();
                     apply_step = 0;
                     return;
                 }
@@ -903,9 +912,12 @@ void housekeeping_task_user(void) {
                 // log, the copy was entered and did not come back.
                 apply_step = 0;
                 fw_staging_apply_and_reboot();
-                // Only reached when the apply was refused (no valid staged image); it
-                // disarms itself there, so hand core1 back rather than leaving the RLE
-                // service down on a board that is going to keep running.
+                // Only reached when the apply was refused (no valid staged image /
+                // failed flash CRC); it disarms itself there and the board keeps
+                // running. Stage 2 already handed core1 back, and the refusal checks
+                // sit above the PSM halt inside do_apply, so this is a no-op today --
+                // kept because it is the one path where a future halt-then-refuse
+                // would otherwise leave the RLE service down for good.
                 fw_staging_core1_lockout_end();
                 break;
         }

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -839,8 +839,15 @@ void housekeeping_task_user(void) {
     // marker a main loop to go out on, so the log names the stage that wedged.
     // (2) EVERY stage below touches flash or the split link, and they must not be
     // interleaved with the rest of housekeeping while core1 is locked out.
+    // ⚠️ FUNCTION-SCOPE, not inside the `if`: the sequence below only advances
+    // while the apply is armed, and BOTH fw_staging_begin_target() and
+    // fw_staging_begin_deferred_target() clear s_commit_pending. A host that
+    // abandons an update and starts a fresh one mid-sequence would otherwise
+    // leave this stuck at 1-3, and the NEXT apply would resume there -- skipping
+    // clear_keyboard() (a key down at that moment auto-repeats on the host until
+    // USB drops) and save_all_dirty(). The else-branch below puts it back.
+    static uint8_t apply_step = 0;
     if (fw_staging_commit_pending()) {
-        static uint8_t apply_step = 0;
         switch (apply_step) {
             case 0:
                 // Release anything still held. From here the main loop never scans the
@@ -921,6 +928,11 @@ void housekeeping_task_user(void) {
                 fw_staging_core1_lockout_end();
                 break;
         }
+    } else if (apply_step != 0) {
+        // Disarmed from another path (a new BEGIN) part-way through. Start the
+        // next apply from stage 0 rather than resuming mid-sequence.
+        uprintf("APPLY: disarmed at stage %u — sequence reset\n", (unsigned)apply_step);
+        apply_step = 0;
     }
     if (fw_staging_reboot_pending()) {
         clear_keyboard();   // same as above: no further matrix scan before the reset


### PR DESCRIPTION
## Summary

Fixes **#258** — a HID firmware update reported complete success and then bricked both halves, recoverable only by BOOTSEL + UF2.

`fw_staging_do_apply()` copies each page through a static buffer using `ram_word_copy()`, which takes a `uint32_t *` and therefore compiles to `ldmia`/`stmia`. The buffer was declared `static uint8_t page_buf[FLASH_PAGE_SIZE]` — alignment **1** — so the linker packed it at whatever byte offset the preceding `.bss` symbol left. In a failing build it landed at `0x20039ce3`:

```
0x20034f6c holds 0x20039ce3          <- page_buf
20034cf0:  movs   r2, r7             <- r2 = 0x20039ce3
20034cfc:  stmia  r2!, {r1}          <- word store to an address = 3 (mod 4)
```

Cortex-M0+ has no unaligned access support. That `STMIA` raises a HardFault, taken with `PRIMASK` set inside a function that never returns — the core locks up on the very first page with the running image already part-erased.

**The fix is the declaration**, `uint32_t[FLASH_PAGE_SIZE / 4]` rather than an `aligned(4)` attribute, so the guarantee lives in the type and no later `.bss` change or stray cast can undo it.

### Why the bisect blamed a PR that touches nothing in the applier

`fw_staging_do_apply` is byte-identical across `v0.15.18 → v0.16.0` — same address, same size, same instructions. #234 did not change the applier's code, it changed `.bss`: the macro label cache shifted `page_buf` off a 4-byte boundary. Where the buffer lands is a **per-build property**, so alignment 1 is a 1-in-4 chance of being safe, re-rolled by every commit that alters `.bss`. Earlier releases that worked were lucky, not correct.

Measured by rebuilding the release tags and reading the symbol address — three of these have field results, and all three match:

| Release | `page_buf` | mod 4 | Predicted | Field |
|---|---|---|---|---|
| v0.15.2 | `0x20039920` | 0 | safe | ✅ works |
| v0.15.14 | `0x20039928` | 0 | safe | ✅ works |
| v0.16.9 | `0x200398f3` | 3 | **bricks** | — |
| v0.16.10 | `0x200398f3` | 3 | **bricks** | ❌ hangs |

The hazard has been present since **v0.9.7**, the first release carrying `fw_staging.c` (verified across all 16 tags containing it).

### Also in this PR

Hardening the investigation surfaced, each a real gap:

- The apply returned **silently** on a bad staging magic without clearing `s_commit_pending`, so housekeeping re-entered it forever with the orange cue up and nothing on the console.
- **Nothing verified the staged image against flash** before overwriting the running firmware — COMMIT only ever checked bytes as they arrived in RAM.
- The EEPROM flush on the apply path ran flash writes with **core1 live**, and the applier never waited for core1 to actually reach reset before touching flash.
- The apply is now a four-stage state machine, one stage per housekeeping pass, so console markers flush before the copy begins.

Plus the diagnostics that found this: an in-flash progress log placed **past the image**, so it survives the BOOTSEL recovery needed to read it (the watchdog scratch does not survive a power cycle), and bracket markers around the first sector. A few flash pages per apply, and they turn a silent lockup into a line naming the exact call. Happy to strip them if you'd rather not ship them.

The `release.yml` commit is the asset-naming fix referenced in #258 — every release shipped its assets under the same filename, so a browser saved `... (3).bin` and the wrong image got flashed while believing it was another version. That cost a whole misleading data point in the bisect.

## Version bump label

`bump:minor` would suit — it is a bug fix, but a load-bearing one plus new applier behaviour. Patch (no label) is fine if you prefer.

## Testing

- [x] Compiled successfully — all three flavours: `POLYKYBD_DOOM_PACK=yes` (shipping shape), `POLYKYBD_DOOM=yes` (the monolith, tightest RAM, release-only) and split42
- [x] Flashed and tested on hardware — full HID update applied and rebooted on its own, both halves back, split link up:
      ```
      APPLY 3/4: staged 494920 B (121 sectors) crc want=fefef42a got=fefef42a -> OK
      apply: copy log - 121 sectors done
      apply: last self-apply COMPLETED its copy (121 sectors, 494920 B)
      apply: written image MATCHED the staged source exactly
      ```
- [x] `qmk lint --strict` on both keyboards, `ci-validate-keyboard-targets`, `ci-validate-aliases`
- [x] Unit suites: `fw_up_verdict` (27), `polykybd_macro_decode` (23), `polykybd_font_bbox` (34)
- [ ] Protocol unchanged — no host change needed

## ⚠️ Upgrade path

**The applier that runs during an update belongs to the firmware already installed, not the one being installed.** A board on an affected build cannot take this fix over HID — that update runs the old broken applier and bricks. It must be installed once via **BOOTSEL + UF2**; HID updates work normally from there. Since alignment was a coin flip per build, the release notes should warn every user rather than name a version range — that includes local and CI builds, not only tagged releases.

## Not covered here

A HIL test performing a real HID update with apply, asserting the board re-enumerates. This bug was reachable from any `.bss` change and invisible to every existing check; the rig's firmware-update test stages but never applies. That needs an ephemeral signing key in CI (the `build-doom` pattern) since an unsigned image stops at the physical ACCEPT prompt, and is being done separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LeoBsy75UBvecXehCiAoWg)_

## Summary by Sourcery

Harden the HID firmware self-apply flow against alignment faults, invalid staged images, concurrent flash access, and opaque recovery failures.

Bug Fixes:
- Prevent HID firmware self-apply failures caused by an unaligned page buffer.
- Validate staged firmware contents in flash before overwriting the running image.
- Prevent apply retries on invalid staging data and coordinate flash operations safely with the second core.

Enhancements:
- Split firmware application into observable housekeeping stages and add persistent progress, completion, and failure diagnostics.
- Add boot-time reporting for self-apply progress and dynamic-keymap storage resets.
- Protect staging and apply-log boundaries with compile-time validation.

Deployment:
- Include firmware versions in release asset filenames while preserving updater-compatible suffixes.

Documentation:
- Document the self-apply alignment hazard and the diagnostic guidance for investigating data-layout-dependent firmware failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added firmware self-apply diagnostics, including progress, completion, and mismatch reporting after reboot.
  * Added boot-time reporting for firmware update outcomes and dynamic keymap storage status.
  * Firmware updates now verify staged data before applying and self-check the written image afterward.
  * Firmware application is safer and more reliable through staged processing and coordinated system lockout.
  * Release assets now include the release version in firmware filenames while preserving required file suffixes.

* **Bug Fixes**
  * Fixed a firmware self-apply issue that could cause updates to fail and leave the device unresponsive.
  * Prevented invalid or corrupted staged firmware from being applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->