### PR TITLE
ci: opt-in HIL job that drives a real HID firmware update through APPLY

### DIFF
--- a/.github/workflows/qmk-test.yml
+++ b/.github/workflows/qmk-test.yml
@@ -634,6 +634,14 @@ jobs:
         with:
           submodules: recursive
 
+      # ⚠️ The SHA goes in the FILENAME. Every test build reports the same
+      # FW_VERSION (it only moves on the post-merge auto-bump), so images from
+      # different commits are otherwise indistinguishable once flashed -- which
+      # has already cost a full hardware round on this project. See CLAUDE.md,
+      # "Deliverable for testing is the .bin".
+      - id: sha
+        run: echo "short=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
+
       # ⚠️ EPHEMERAL key, never the production FW_SIGNING_KEY — that secret is
       # confined to release.yml and must not be reachable from a PR-triggered
       # workflow. Same pattern as build-doom: the throwaway pubkey is baked into
@@ -652,21 +660,23 @@ jobs:
       - name: Build split72 (HIL left/master)
         uses: docker://qmkfm/qmk_cli
         with:
-          args: qmk compile -kb polykybd/split72 -km default -e POLYKYBD_DOOM_PACK=yes -e POLYKYBD_HIL=left -e TARGET=polykybd_split72_fwapply_hil_left
+          args: qmk compile -kb polykybd/split72 -km default -e POLYKYBD_DOOM_PACK=yes -e POLYKYBD_HIL=left -e TARGET=polykybd_split72_fwapply_${{ steps.sha.outputs.short }}_hil_left
 
       - name: Build split72 (HIL right/slave)
         uses: docker://qmkfm/qmk_cli
         with:
-          args: qmk compile -kb polykybd/split72 -km default -e POLYKYBD_DOOM_PACK=yes -e POLYKYBD_HIL=right -e TARGET=polykybd_split72_fwapply_hil_right
+          args: qmk compile -kb polykybd/split72 -km default -e POLYKYBD_DOOM_PACK=yes -e POLYKYBD_HIL=right -e TARGET=polykybd_split72_fwapply_${{ steps.sha.outputs.short }}_hil_right
 
       # The rig stages the raw image, not the UF2 wrapper, and applies it to a
       # master already running it — so this .bin must come from the SAME ELF as
       # the left .uf2 above. The runner re-checks that against the flashed UF2
       # and refuses to apply anything else; this step is what makes that pass.
       - name: Extract and sign the master image
+        env:
+          SHA: ${{ steps.sha.outputs.short }}
         run: |
-          ELF=.build/polykybd_split72_fwapply_hil_left.elf
-          BIN=polykybd_split72_fwapply_hil_left.bin
+          ELF=".build/polykybd_split72_fwapply_${SHA}_hil_left.elf"
+          BIN="polykybd_split72_fwapply_${SHA}_hil_left.bin"
           # The docker builds run as root, so the workspace artifacts land
           # root-owned and the host runner user cannot write beside them.
           sudo chown -R "$(id -u):$(id -g)" .build
@@ -685,17 +695,17 @@ jobs:
 
       - id: names
         run: |
-          echo "hil_left=$(ls polykybd_split72_fwapply_hil_left*.uf2 2>/dev/null | head -1)" >> "$GITHUB_OUTPUT"
-          echo "hil_right=$(ls polykybd_split72_fwapply_hil_right*.uf2 2>/dev/null | head -1)" >> "$GITHUB_OUTPUT"
-          echo "apply_bin=polykybd_split72_fwapply_hil_left.bin" >> "$GITHUB_OUTPUT"
+          echo "hil_left=$(ls polykybd_split72_fwapply_*_hil_left*.uf2 2>/dev/null | head -1)" >> "$GITHUB_OUTPUT"
+          echo "hil_right=$(ls polykybd_split72_fwapply_*_hil_right*.uf2 2>/dev/null | head -1)" >> "$GITHUB_OUTPUT"
+          echo "apply_bin=polykybd_split72_fwapply_${{ steps.sha.outputs.short }}_hil_left.bin" >> "$GITHUB_OUTPUT"
 
       - uses: actions/upload-artifact@v4
         with:
           name: firmware-fwapply
           path: |
-            polykybd_split72_fwapply_hil_*.uf2
-            polykybd_split72_fwapply_hil_left.bin
-            polykybd_split72_fwapply_hil_left.bin.sig
+            polykybd_split72_fwapply_*_hil_*.uf2
+            polykybd_split72_fwapply_*_hil_left.bin
+            polykybd_split72_fwapply_*_hil_left.bin.sig
 
   doom-test:
     name: DOOM engine-pack signature (split72)

--- a/.github/workflows/qmk-test.yml
+++ b/.github/workflows/qmk-test.yml
@@ -613,6 +613,90 @@ jobs:
             doom_pack_signed_v*.plyx
           retention-days: 7
 
+  build-fwapply:
+    name: Build signed HIL images (firmware apply)
+    # ⚠️ The `if:` is a FOLDED scalar. Every continuation line must sit at the
+    # SAME indent as the first, or YAML keeps the newline, the expression stops
+    # being valid, and the job silently stops matching its trigger.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'hil-fwapply') ||
+      contains(github.event.head_commit.message, '[hil-fwapply]')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      hil_left: ${{ steps.names.outputs.hil_left }}
+      hil_right: ${{ steps.names.outputs.hil_right }}
+      apply_bin: ${{ steps.names.outputs.apply_bin }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      # ⚠️ EPHEMERAL key, never the production FW_SIGNING_KEY — that secret is
+      # confined to release.yml and must not be reachable from a PR-triggered
+      # workflow. Same pattern as build-doom: the throwaway pubkey is baked into
+      # base/fw_pubkey.h before the builds, so the images trust exactly this key
+      # and nothing else. The images are disposable (a non-shipping pubkey) and
+      # the next ordinary run reflashes the rig with the real ones.
+      - name: Generate an ephemeral signing key
+        run: |
+          python3 -m pip install --quiet cryptography
+          python3 keyboards/polykybd/tools/gen_signing_key.py \
+            --out-privkey /tmp/fwapply_ephemeral_key.bin \
+            --out-pubkey keyboards/polykybd/base/fw_pubkey.h \
+            --force
+          echo "ephemeral pubkey baked into base/fw_pubkey.h"
+
+      - name: Build split72 (HIL left/master)
+        uses: docker://qmkfm/qmk_cli
+        with:
+          args: qmk compile -kb polykybd/split72 -km default -e POLYKYBD_DOOM_PACK=yes -e POLYKYBD_HIL=left -e TARGET=polykybd_split72_fwapply_hil_left
+
+      - name: Build split72 (HIL right/slave)
+        uses: docker://qmkfm/qmk_cli
+        with:
+          args: qmk compile -kb polykybd/split72 -km default -e POLYKYBD_DOOM_PACK=yes -e POLYKYBD_HIL=right -e TARGET=polykybd_split72_fwapply_hil_right
+
+      # The rig stages the raw image, not the UF2 wrapper, and applies it to a
+      # master already running it — so this .bin must come from the SAME ELF as
+      # the left .uf2 above. The runner re-checks that against the flashed UF2
+      # and refuses to apply anything else; this step is what makes that pass.
+      - name: Extract and sign the master image
+        run: |
+          ELF=.build/polykybd_split72_fwapply_hil_left.elf
+          BIN=polykybd_split72_fwapply_hil_left.bin
+          # The docker builds run as root, so the workspace artifacts land
+          # root-owned and the host runner user cannot write beside them.
+          sudo chown -R "$(id -u):$(id -g)" .build
+          arm-none-eabi-objcopy -O binary "$ELF" "$BIN" 2>/dev/null \
+            || docker run --rm -v "$PWD:/w" -w /w qmkfm/qmk_cli \
+                 arm-none-eabi-objcopy -O binary "$ELF" "$BIN"
+          sudo chown "$(id -u):$(id -g)" "$BIN"
+          python3 keyboards/polykybd/tools/sign_firmware.py \
+            --privkey /tmp/fwapply_ephemeral_key.bin "$BIN"
+          rm -f /tmp/fwapply_ephemeral_key.bin
+          if [ ! -s "$BIN.sig" ]; then
+            echo "::error::signing produced no $BIN.sig — the rig would SKIP the apply"
+            exit 1
+          fi
+          echo "signed $BIN ($(stat -c%s "$BIN") bytes) -> $BIN.sig ($(stat -c%s "$BIN.sig") bytes)"
+
+      - id: names
+        run: |
+          echo "hil_left=$(ls polykybd_split72_fwapply_hil_left*.uf2 2>/dev/null | head -1)" >> "$GITHUB_OUTPUT"
+          echo "hil_right=$(ls polykybd_split72_fwapply_hil_right*.uf2 2>/dev/null | head -1)" >> "$GITHUB_OUTPUT"
+          echo "apply_bin=polykybd_split72_fwapply_hil_left.bin" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: firmware-fwapply
+          path: |
+            polykybd_split72_fwapply_hil_*.uf2
+            polykybd_split72_fwapply_hil_left.bin
+            polykybd_split72_fwapply_hil_left.bin.sig
+
   doom-test:
     name: DOOM engine-pack signature (split72)
     # Ordered after hil-test so the two rig jobs can't interleave their flashes
@@ -686,3 +770,72 @@ jobs:
             --doom \
             --plyx-valid "firmware/$PLYX" \
             2>&1 | tee /tmp/doom-test.log
+
+  fwapply-test:
+    name: Firmware apply round-trip (split72)
+    # Ordered after the other rig jobs so the flashes cannot interleave — the rig
+    # runs one job at a time, and this one reflashes both halves with its own
+    # ephemeral-key images. `always()` so it still runs when hil-test/doom-test
+    # were skipped (a bare hil-fwapply label does not start the main pipeline).
+    needs: [build-fwapply, hil-test, doom-test]
+    if: always() && needs.build-fwapply.result == 'success'
+    runs-on: [self-hosted, polykybd-ctnd]
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Locate station directory
+        id: ctnd
+        run: |
+          dir="${CTND_DIR:-}"
+          if [ -z "$dir" ]; then
+            for candidate in /opt/polykybd-ctnd "$HOME/polykybd-ctnd"; do
+              if [ -f "$candidate/venv/bin/python" ]; then
+                dir="$candidate"
+                break
+              fi
+            done
+          fi
+          if [ -z "$dir" ]; then
+            echo "ERROR: could not find a polykybd-ctnd install with a venv." >&2
+            exit 1
+          fi
+          echo "dir=$dir" >> "$GITHUB_OUTPUT"
+
+      # CI runs the INSTALLED station copy, so sync it — otherwise a lagging
+      # self-update timer runs this with a station that has never heard of
+      # --apply-bin, and the whole job silently tests nothing.
+      - name: Sync station to current ctnd main
+        run: |
+          dir="${{ steps.ctnd.outputs.dir }}"
+          if [ ! -d "$dir/.git" ]; then
+            echo "WARNING: $dir is not a git checkout — running the installed station as-is" >&2
+            exit 0
+          fi
+          git -C "$dir" fetch --quiet origin main \
+            && git -C "$dir" checkout -q -f -B main origin/main \
+            && echo "station synced to $(git -C "$dir" rev-parse --short HEAD)" \
+            || echo "WARNING: could not sync $dir to origin/main" >&2
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: firmware-fwapply
+          path: ${{ steps.ctnd.outputs.dir }}/firmware
+
+      - name: Flash, then drive a real HID update through APPLY
+        # Filenames go through env vars rather than straight ${{ }} interpolation
+        # into the script body — the same shape the doom job uses.
+        env:
+          CTND_DIR: ${{ steps.ctnd.outputs.dir }}
+          HIL_LEFT: ${{ needs.build-fwapply.outputs.hil_left }}
+          HIL_RIGHT: ${{ needs.build-fwapply.outputs.hil_right }}
+          APPLY_BIN: ${{ needs.build-fwapply.outputs.apply_bin }}
+        run: |
+          cd "$CTND_DIR"
+          set -o pipefail
+          venv/bin/python -u -m station.test_runner \
+            --left  "firmware/$HIL_LEFT" \
+            --right "firmware/$HIL_RIGHT" \
+            --apply-bin "firmware/$APPLY_BIN" \
+            --extended \
+            2>&1 | tee /tmp/fwapply-test.log


### PR DESCRIPTION
## Summary

Closes the CI gap named in **#258**. The rig's firmware-update test stops at COMMIT by design, so the **applier** — the code that actually overwrites the running firmware — has never executed in CI. That is exactly where #258 hid, and it is not a gap source review could have covered: the cause was a `uint8_t` page buffer whose *link-time address* happened to be unaligned, so nothing in the applier changed. Any commit that alters `.bss` can re-roll it.

Adds an opt-in pair, mirroring `build-doom` / `doom-test`:

- **`build-fwapply`** — builds the HIL image pair and signs the master image.
- **`fwapply-test`** — the rig stages it over HID, **applies** it, and requires the keyboard to re-enumerate and report the applied version.

Opt in with the **`hil-fwapply`** label, `[hil-fwapply]` in a pushed commit message, or a `workflow_dispatch` — the same three routes as `hil-perf` and `hil-doom`.

## Two things it has to get right

**The signing key is ephemeral.** Generated per run and baked into `base/fw_pubkey.h` before the builds, exactly as `build-doom` does. The production `FW_SIGNING_KEY` stays confined to `release.yml` and must never be reachable from a PR-triggered workflow. Signing is not optional here: an unsigned image stops at the keyboard's physical ACCEPT/REJECT prompt, and the rig has no fingers — so without a signature the apply is unreachable and the job would test nothing.

**The `.bin` comes from the same ELF as the left `.uf2`.** The rig applies it to a master already running it, which is the only reason applying is safe on the rig at all — any other image reboots the master onto VBUS master-detection and both halves then enumerate as master until the next UF2 flash. The runner re-checks this against the UF2 it actually flashed and refuses anything else; this job is what makes that check *pass* rather than a promise that it will.

## Depends on the rig side

Needs thpoll83/polykybd-ctnd#83, which adds `--apply-bin` and `firmware_apply_roundtrip`. **Merge that first** — CI runs the *installed* station copy, so until it is on the rig's `main` this job invokes a flag the station has never heard of. The job syncs the station to `origin/main` before running for that reason, but the sync can only fetch what has landed.

## Verification

- [x] YAML parses; every job's folded `if:` scalar checked for an embedded newline — the failure mode where a prettier indent silently stops a job matching its trigger. `hil-test`'s `HIL_EXTENDED` re-checked too, unchanged.
- [x] Job graph: `build-fwapply` → `fwapply-test`, ordered `needs: [build-fwapply, hil-test, doom-test]` with `always()` so the rig never has two jobs flashing at once, and it still runs when the others were skipped.
- [x] The existing trigger `paths` list is untouched, so ordinary firmware PRs are unaffected.
- [ ] Not yet exercised on the rig — it cannot be until the ctnd side merges. First run should be a `workflow_dispatch`, which satisfies every opt-in at once.

## Note

`arm-none-eabi-objcopy` is not on the `ubuntu-latest` image, so the extract step falls back to running it inside `qmkfm/qmk_cli`. If the runner image ever gains it, the fallback simply stops being used.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LeoBsy75UBvecXehCiAoWg)_

## Summary by Sourcery

Add an opt-in CI hardware test that validates a complete signed firmware update through APPLY and confirms the keyboard returns with the new firmware.

New Features:
- Add an opt-in hardware-in-the-loop workflow that builds signed firmware images and drives a real HID update through the APPLY stage.
- Trigger firmware-apply testing via workflow dispatch, the `hil-fwapply` label, or a commit-message marker.

Enhancements:
- Serialize the firmware-apply rig test after existing HIL jobs and verify the target station is synchronized before running.
- Use an ephemeral signing key and ensure the applied binary is extracted from the same master ELF as the flashed firmware.

Build:
- Build and package HIL firmware artifacts, including the signed master binary required for the apply round trip.

CI:
- Add GitHub Actions jobs for building firmware-apply artifacts and running the opt-in self-hosted round-trip test.

Tests:
- Exercise firmware flashing, HID update application, keyboard re-enumeration, and applied-version reporting on the hardware rig.