### PR TITLE
fix(tools): the telemetry preview could render a link panel the firmware cannot produce

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -841,6 +841,23 @@ that cost real debugging to learn (2026-07):
 - **Version bump is label-driven**: the merged PR's `bump:major`/`bump:minor`/
   `bump:protocol` label (else patch) drives `bump-version.yml`. Protocol PRs often bump
   `PROTOCOL_VERSION` in-source and *omit* `bump:protocol` (the label would double-bump).
+  - ⚠️ **A MISSING bump label is silent, and it can make the LIVE DOCS wrong within
+    minutes — apply the label before the merge, not after.** The label is read at merge
+    time and there is no second chance: the bump lands as a `chore:` commit and the
+    version is then whatever it produced. On 2026-09-01 qmk#259 merged without its
+    intended `bump:minor`, so `FW_VERSION` went to **0.16.21**; docs#68 merged three
+    seconds later naming **v0.17.0** in a `<SupportedSince>` tag and an upgrade note,
+    and `polykybd-docs` deploys on push — so the public site was promising a version
+    that would never exist while the firmware had not even been released yet.
+  - **The asymmetry is what makes it bite**: a docs PR ships the moment it merges, a
+    firmware PR only bumps a number and waits for a release. So a cross-repo pair has
+    *two* orderings to get right — the label before the qmk merge, and the docs merge
+    after the release (already noted in `polykybd-docs/CLAUDE.md`). Getting the second
+    right does not save you from the first.
+  - **Recovering** is a choice, not a fix: either correct the docs to the version that
+    actually bumped, or land a `bump:minor` PR that does **not** itself edit `config.h`
+    (the workflow bumps *after* merge, so an edited version file would be bumped on top
+    of) — the same cosmetic-realignment move described in the host repo's note.
 - ⚠️ **From Claude Code on the web you can neither push tags (git proxy returns 403 on
   `refs/tags/*`) nor create a release (no `gh` CLI, no create-release MCP tool)** — stage
   the notes on the branch and hand the user `python scripts/publish_release.py`.
@@ -1527,6 +1544,22 @@ matching the flash / confirm / apply screens there.
   case (`--link 1000,4294967295 --uptime "999d 23h"`), not at the default.
 - `tools/status_oled_preview.py --telemetry` renders it (both halves, `--diag` for the
   clipping check) — the same mirror-the-C treatment `build_fw_confirm_panel` gets.
+  - ⚠️ **Mirror the C's GUARDS, not just its formatting — a preview's INPUT DOMAIN can
+    be wider than the device's reachable state space.** `oled_telemetry_screen()` tests
+    `ls.attempts == 0U` and prints `Lnk idle` **before** it computes a rate (and
+    `poly_link_err_permille()` returns 0 at zero attempts anyway), so a percentage over
+    zero frames is a reading no keyboard can display. The preview mirrored only the
+    `link is None` case, so `--link 0,0` rendered `Lnk 0.0% 0` and `--link 250,0`
+    rendered `Lnk 25.0% 0` — the preview depicting the impossible, which is the
+    direction it exists to catch. This is the **sibling** of the "A PREVIEW THAT MIRRORS
+    THE IMPLEMENTATION AGREES BY CONSTRUCTION" note below, not the same thing: there the
+    preview and the C are wrong identically; here the preview can render a state the C
+    cannot reach.
+  - **Fix the RENDERER, not just the argparse validator** — the `status-oled-layout`
+    skill imports `build_telemetry_panel()` directly and never sees argparse. The
+    validator is the second half (it refuses a non-zero rate over zero frames, an input
+    describing no device), not the first. Check it by rendering: `--link 0,0` and
+    `--link idle` must produce **byte-identical** PNGs.
 
 **split42: PORTRAIT status OLED (2026-07).** The split42 panel is 128×32 physical
 but **mounted rotated 90°**, so the user reads it as **32 wide × 128 tall**. The poly
@@ -1811,9 +1844,30 @@ change generalise well beyond this setting:
   156 → 157, well inside the 256-byte reservation, so **no keymap relocation and no
   user reset**.
 - **Verify the gate in the compiled object, not the preprocessor.** `g_idle_style`
-  lands in `.data` on split72 (`objdump -s -j .data.g_idle_style` → `03`) and in
-  `.bss` on split42 (zero = PULSE) — one command per board, against the image that
-  actually ships.
+  lands in `.data` on split72 (initialiser `03` = EDEN) and in `.bss` on split42
+  (zero = PULSE) — one check per board, against the image that actually ships.
+  - ⚠️ **`objdump -s -j .data.<sym>` is NOT that check — it prints only the
+    file-format header and looks like an empty section.** GCC merges the symbol into
+    plain `.data` here, so no per-symbol section exists. ⚠️ `nm` is misleading too:
+    it reported `g_idle_style` as type **`t`** (text) for a symbol whose address is
+    inside `.data`'s VMA range. **Classify by ADDRESS against the section VMAs, then
+    read the byte** — which also gives you the value, not just the section:
+    ```bash
+    arm-none-eabi-nm -S <elf> | grep -w g_idle_style        # -> ADDR SIZE TYPE NAME
+    arm-none-eabi-objdump -h <elf> | awk '$2==".data"{print $4}'   # .data VMA
+    arm-none-eabi-objcopy -O binary --only-section=.data <elf> /tmp/data.bin
+    od -An -tu1 -j $(( ADDR - VMA )) -N1 /tmp/data.bin
+    ```
+    `.data` membership alone already proves it is not PULSE — a zero-initialised
+    static would be in `.bss`.
+- ⚠️ **A `static inline` helper is often emitted OUT-OF-LINE, so "grep the caller for
+  the flag address" reads as "the fix didn't take".** Verifying `kdisp_plot_ink`, all
+  five composite primitives showed **0** references to `s_gfx_erase`/`s_gfx_scanline`
+  — and were correct: GCC emitted the helper as a real local function and they `bl`
+  it. Grep for the **call**, not the data address:
+  `objdump -d <elf> | grep -c "bl.*<kdisp_plot_ink>"`. Same family as the note above:
+  when checking a change in the image, find the thing that MOVED, not the thing you
+  wrote.
 
 - **`IDLE_STYLE_PULSE` (0, legacy; the default on boards without Eden):** `kdisp_idle()` only modulates each
   keycap's SSD1306 contrast register (a per-key out-of-phase "breathing"). The

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1555,11 +1555,21 @@ matching the flash / confirm / apply screens there.
     THE IMPLEMENTATION AGREES BY CONSTRUCTION" note below, not the same thing: there the
     preview and the C are wrong identically; here the preview can render a state the C
     cannot reach.
-  - **Fix the RENDERER, not just the argparse validator** — the `status-oled-layout`
-    skill imports `build_telemetry_panel()` directly and never sees argparse. The
-    validator is the second half (it refuses a non-zero rate over zero frames, an input
-    describing no device), not the first. Check it by rendering: `--link 0,0` and
-    `--link idle` must produce **byte-identical** PNGs.
+  - **Fix the RENDERER, not just the argparse validator** — these panel builders are a
+    LIBRARY surface, not only a CLI. `status-oled-layout`'s `measure_bands.py` does
+    `import status_oled_preview as P` and calls `P.build_panel(...)` directly, so a
+    guard living in `link_arg()` is simply absent for an importing caller.
+    `build_telemetry_panel()` has no such caller *yet* — it is reached only from the
+    tool's own `main()` — which is exactly why the guard has to go in the renderer
+    now rather than after one appears. The validator is the second half (it refuses a
+    non-zero rate over zero frames, an input describing no device), not the first.
+    Check it by rendering: `--link 0,0` and `--link idle` must produce
+    **byte-identical** PNGs.
+    - ⚠️ This bullet previously asserted that the skill imports `build_telemetry_panel()`
+      itself. It does not — one `grep` settles it — and a note about verifying claims is
+      the worst place to leave an unverified one. Caught by Greptile on #262, which is
+      the cross-file consistency check an LLM reviewer is genuinely good at and a linter
+      cannot do at all.
 
 **split42: PORTRAIT status OLED (2026-07).** The split42 panel is 128×32 physical
 but **mounted rotated 90°**, so the user reads it as **32 wide × 128 tall**. The poly

--- a/keyboards/polykybd/tools/status_oled_preview.py
+++ b/keyboards/polykybd/tools/status_oled_preview.py
@@ -217,7 +217,12 @@ def build_telemetry_panel(usb_side, small, fw="0.16.18", proto=15, hw="0x0320",
     l_up = "%s  up %s" % ("USB" if usb_side else "LNK", uptime)
     if not usb_side:
         l_link = "Lnk n/a"
-    elif link is None:
+    elif link is None or link[1] == 0:
+        # ⚠️ frames == 0 is the SAME branch, because the C tests `ls.attempts == 0U`
+        # BEFORE it computes a rate -- so a zero-frame panel showing a percentage is
+        # a reading no keyboard can produce. Mirroring only the None case let
+        # `--link 0,0` render "Lnk 0.0% 0", i.e. the preview drifting from the C in
+        # exactly the direction it exists to catch.
         l_link = "Lnk idle"
     else:
         pm, frames = link
@@ -587,6 +592,12 @@ def main():
         # reading the panel can never show -- same reasoning as the rate bound above.
         if not 0 <= frames <= 0xFFFFFFFF:
             raise argparse.ArgumentTypeError('frames must be 0..4294967295 (the uint32_t counter)')
+        # poly_link_err_permille() returns 0 when attempts is 0, so a non-zero rate
+        # over no frames describes no device. (Zero frames alone is fine -- it is
+        # spelled "idle", which the renderer above produces either way.)
+        if frames == 0 and pm != 0:
+            raise argparse.ArgumentTypeError(
+                'a non-zero err_permille needs frames > 0 (the firmware reports "idle" at 0 frames)')
         return (pm, frames)
 
     ap.add_argument('--link', type=link_arg, default=(4, 1234),


### PR DESCRIPTION
## Summary

Two commits. The first is a **fix that missed the #259 merge by about a minute** — it was pushed in response to a CodeRabbit finding on `7dd4c3f8` and landed after the PR had already merged, so it was orphaned (not in `PolyKybd`, not in any PR). Recovered here per the restart-the-branch procedure in `CLAUDE.md`.

### `0f5d9d19` — the preview mirrored the C's formatting but not its guard

`oled_telemetry_screen()` tests `ls.attempts == 0U` and prints `Lnk idle` **before** it computes a rate, and `poly_link_err_permille()` returns 0 at zero attempts anyway — so a panel showing a percentage over zero frames is a reading no keyboard can ever display.

The preview mirrored only the `link is None` case, so:

| input | preview rendered | firmware would render |
|---|---|---|
| `--link 0,0` | `Lnk 0.0% 0` | `Lnk idle` |
| `--link 250,0` | `Lnk 25.0% 0` | `Lnk idle` |

That is the preview drifting from the C in exactly the direction it exists to catch — a layout could be tuned against a state the panel cannot reach.

Two halves, and **the renderer one is the real fix**: the `status-oled-layout` skill imports `build_telemetry_panel()` directly and never sees argparse.

- `build_telemetry_panel()` — `frames == 0` takes the same branch as `None`, mirroring the C's own test.
- `link_arg()` — a non-zero rate with zero frames is refused outright, since it describes no device. Zero frames alone stays legal and is simply spelled "idle" by the renderer.

**Verified by rendering**, not by reading: `--link 0,0` and `--link idle` now produce **byte-identical PNGs**, while `--link 4,1234` still differs. The worst-case line (`--link 1000,4294967295 --uptime "999d 23h"`) still clips 0 px on both halves.

### `efb45b15` — three session learnings in `CLAUDE.md`

- **Verifying a change in the compiled image.** The recipe this file gave for checking the Eden default *returns nothing* — GCC merges the symbol into plain `.data`, so `objdump -s -j .data.g_idle_style` prints only the file-format header and reads as an empty section; `nm` compounds it by reporting type `t` for a symbol whose address is inside `.data`. Replaced with the check that works (address vs section VMA, then read the byte), plus its sibling: a `static inline` helper is often emitted **out-of-line**, so grepping a caller for the flag address returns 0 and looks like the fix didn't take — grep for the `bl`.
- **A preview's input domain can be wider than the device's reachable state space** — the finding above, generalised, and explicitly distinguished from the existing "a preview that mirrors the implementation agrees by construction" note (there both are wrong identically; here the preview can render what the C cannot reach).
- **A missing bump label is silent and can make the live docs wrong within minutes.** #259 merged without its intended `bump:minor`, so `FW_VERSION` went to `0.16.21` while docs#68 merged three seconds later naming `v0.17.0` — and `polykybd-docs` deploys on push. The asymmetry is the point: a docs PR ships at merge, a firmware PR only bumps a number and waits for a release, so a cross-repo pair has *two* orderings to get right and the existing note covers only one.

## Version bump label

*(none)* — patch. Tooling and documentation only; no firmware source is touched, so the shipped image is byte-identical.

⚠️ Note for whoever merges: the live docs currently name **v0.17.0** while the tree is at **0.16.21**. That is a separate decision (correct the docs, or land a `bump:minor` PR before the release) and this PR deliberately does not settle it.

## Testing

- [x] Compiled successfully — no firmware sources changed; `keyboards/polykybd/**` is untouched apart from the preview tool, so `Build firmware`/`cppcheck` see only the tool and the doc.
- [ ] Flashed and tested on hardware — **not applicable**, nothing in the firmware image changed.
- [ ] If protocol changed: n/a.

Additional verification run locally: preview round-trip (`0,0` ≡ `idle`, `4,1234` differs, `250,0` refused), worst-case clip check 0 px, and `git ls-files -c -i` clean for the lint gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013sYxo4vyR5LhSzgGg5BAwM

---
_Generated by [Claude Code](https://claude.ai/code/session_013sYxo4vyR5LhSzgGg5BAwM)_

## Summary by Sourcery

Make telemetry preview states match firmware-reachable behavior and document the associated verification and release-management lessons.

Bug Fixes:
- Align the telemetry OLED preview with firmware behavior by rendering zero-frame link states as idle and rejecting non-zero error rates without frames.

Enhancements:
- Document lessons for verifying compiled images, validating preview input domains, and coordinating firmware version labels with live documentation.

Documentation:
- Expand project guidance for firmware image verification, preview guard mirroring, and cross-repository version consistency.

Tests:
- Verify equivalent idle telemetry inputs produce byte-identical previews and confirm valid non-idle and worst-case rendering behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated status-OLED preview behavior so unavailable or zero-frame links consistently display as idle.
  * Added validation to reject error rates when no frames have been recorded, matching device behavior.

* **Documentation**
  * Added release guidance to prevent incorrect firmware version announcements and document recovery steps.
  * Clarified status-OLED preview requirements and improved instructions for verifying idle-style firmware behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->