### PR TITLE
Close the HID-apply brick class: a debug loop on the rig, apply coverage per merge, and -Wcast-align

### DIFF
--- a/.github/workflows/qmk-test.yml
+++ b/.github/workflows/qmk-test.yml
@@ -69,14 +69,38 @@ on:
       - '!.claude/**'
       - '!.github/workflows/**'
       - '.github/workflows/qmk-test.yml'
-  # Manual trigger for the opt-in performance measurement below (the normal
-  # build + HIL test always run; perf does not). No inputs: the baseline is moved
-  # by committing the run's JSON to polykybd-ctnd, not by a workflow switch — the
-  # rig's checkout is force-synced to origin/main before every run, so anything
-  # written there would be discarded on the next one.
+  # Manual trigger for the opt-in tiers below (the normal build + HIL test always
+  # run; perf/doom/fwapply/debug do not).
+  #
+  # ⚠️ `tier` narrows a dispatch and affects NOTHING ELSE — it is read only under
+  # `github.event_name == 'workflow_dispatch'`, so push and pull_request keep
+  # their existing label/marker gating untouched. It defaults to `all`, which is
+  # exactly the previous dispatch behaviour (every opt-in at once), so an existing
+  # habit of "just dispatch it" keeps working. The narrower values exist because a
+  # DEBUG LOOP pays the rig cost on every iteration: `debug` skips the graded
+  # suite entirely and runs only the probe.
+  #
+  # ⚠️ The baseline for perf is still moved by committing the run's JSON to
+  # polykybd-ctnd, NOT by a workflow switch — the rig's checkout is force-synced
+  # to origin/main before every run, so anything written there is discarded next
+  # run. Do not add an input for it.
+  #
   # ⚠️ workflow_dispatch only becomes available once this file is on the DEFAULT
-  # branch — it cannot be used to try the perf job out from an unmerged PR.
+  # branch — it cannot be used to try a job out from an unmerged PR. Dispatching
+  # WITH `ref:` set to a branch does run that branch's copy of the workflow, which
+  # is what makes the debug loop usable on unmerged firmware.
   workflow_dispatch:
+    inputs:
+      tier:
+        description: "Which tier to run (dispatch only; 'all' = previous behaviour)"
+        type: choice
+        default: all
+        options: [all, default, extended, perf, doom, fwapply, debug]
+      probe:
+        description: "tier=debug only: probe name under keyboards/polykybd/tools/hil_probes/"
+        type: string
+        required: false
+        default: ""
 
 jobs:
   build:
@@ -169,6 +193,16 @@ jobs:
   hil-test:
     name: HIL test (split72)
     needs: build
+    # The graded suite is skipped for ONE case only: a `debug` dispatch, which
+    # exists to iterate on a probe and pays the rig cost on every turn. Every
+    # other event and tier runs it exactly as before — `inputs.tier` is null
+    # outside a dispatch, and the left operand short-circuits there.
+    # ⚠️ doom-test / perf-test / fwapply-test all `needs: hil-test` purely to
+    # stop the flashes interleaving, and all carry `always()`, so skipping this
+    # job does not cascade into skipping them.
+    if: >-
+      github.event_name != 'workflow_dispatch' ||
+      inputs.tier != 'debug'
     runs-on: [self-hosted, polykybd-ctnd]
     # --- suite tier (OPT-IN extended checks) ---------------------------------
     # Most HIL checks cost a report or two and run on every push. A few are slow
@@ -196,7 +230,8 @@ jobs:
     # and the tier is visible both here and in its "[runner] suite tier:" line.
     env:
       HIL_EXTENDED: >-
-        ${{ (github.event_name == 'workflow_dispatch' ||
+        ${{ ((github.event_name == 'workflow_dispatch' &&
+        (inputs.tier == 'all' || inputs.tier == 'extended')) ||
         contains(github.event.pull_request.labels.*.name, 'hil-extended') ||
         contains(github.event.head_commit.message, '[hil-extended]'))
         && '1' || '0' }}
@@ -372,7 +407,8 @@ jobs:
   build-perf:
     name: Build firmware (profiling)
     if: >-
-      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_dispatch' &&
+      (inputs.tier == 'all' || inputs.tier == 'perf')) ||
       contains(github.event.pull_request.labels.*.name, 'hil-perf') ||
       contains(github.event.head_commit.message, '[hil-perf]')
     runs-on: ubuntu-latest
@@ -530,7 +566,8 @@ jobs:
   build-doom:
     name: Build firmware + signed pack (doom FW-9)
     if: >-
-      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_dispatch' &&
+      (inputs.tier == 'all' || inputs.tier == 'doom')) ||
       contains(github.event.pull_request.labels.*.name, 'hil-doom') ||
       contains(github.event.head_commit.message, '[hil-doom]')
     runs-on: ubuntu-latest
@@ -619,7 +656,8 @@ jobs:
     # SAME indent as the first, or YAML keeps the newline, the expression stops
     # being valid, and the job silently stops matching its trigger.
     if: >-
-      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_dispatch' &&
+      (inputs.tier == 'all' || inputs.tier == 'fwapply')) ||
       contains(github.event.pull_request.labels.*.name, 'hil-fwapply') ||
       contains(github.event.head_commit.message, '[hil-fwapply]')
     runs-on: ubuntu-latest
@@ -780,6 +818,101 @@ jobs:
             --doom \
             --plyx-valid "firmware/$PLYX" \
             2>&1 | tee /tmp/doom-test.log
+
+  # ── ad-hoc debug probe (dispatch-only) ──────────────────────────────────────
+  # The debug loop. A PROBE is a Python file committed on this branch under
+  # keyboards/polykybd/tools/hil_probes/ that drives the flashed keyboard over
+  # raw HID and asserts whatever the bug of the day needs. The rig pipes the
+  # firmware's own console into the job log as `[qmk] …` lines, so the whole
+  # flash -> drive -> read-what-it-printed cycle happens here rather than through
+  # someone flashing a .bin by hand and pasting a log back. See
+  # polykybd-ctnd/CLAUDE.md "Debug loop".
+  #
+  # ⚠️ DISPATCH-ONLY, and that IS the security control. Triggering a
+  # workflow_dispatch requires write access to this repo, so a fork PR can never
+  # reach this job — which matters because the rig is a self-hosted runner for a
+  # PUBLIC repo (HIL-2, polykybd-ctnd/docs/SECURITY_AUDIT.md). Do NOT add a
+  # `hil-debug` label trigger: a label is applied to a PR whose head may be a
+  # fork, and that would hand arbitrary code on the rig to anyone who can open
+  # one. The containment check in station/probe.py is NOT this control (it is
+  # operational — see its module docstring); this `if:` is.
+  #
+  # Dispatch WITH `ref:` set to a branch runs that branch's workflow and builds
+  # that branch's firmware, so a probe can be iterated on entirely unmerged.
+  debug-test:
+    name: Debug probe (split72)
+    # `needs: hil-test` only orders the rig flashes; a `debug` dispatch skips
+    # that job, hence `always()` plus an explicit check that the BUILD succeeded.
+    needs: [build, hil-test]
+    if: >-
+      always() && github.event_name == 'workflow_dispatch' &&
+      inputs.tier == 'debug' && inputs.probe != '' &&
+      needs.build.result == 'success'
+    runs-on: [self-hosted, polykybd-ctnd]
+    permissions:
+      contents: read
+    steps:
+      # The probe lives in THIS repo, so unlike the other rig jobs this one needs
+      # the sources, not just the built artifact.
+      - uses: actions/checkout@v4
+
+      - name: Locate station directory
+        id: ctnd
+        run: |
+          dir="${CTND_DIR:-}"
+          if [ -z "$dir" ]; then
+            for candidate in /opt/polykybd-ctnd "$HOME/polykybd-ctnd"; do
+              if [ -f "$candidate/venv/bin/python" ]; then
+                dir="$candidate"
+                break
+              fi
+            done
+          fi
+          if [ -z "$dir" ]; then
+            echo "ERROR: could not find a polykybd-ctnd install with a venv." >&2
+            exit 1
+          fi
+          echo "dir=$dir" >> "$GITHUB_OUTPUT"
+
+      # CI runs the INSTALLED station copy, so sync it — otherwise a lagging
+      # self-update timer runs this with a station that has never heard of
+      # --probe, and argparse fails with an unrelated-looking error.
+      - name: Sync station to current ctnd main
+        run: |
+          dir="${{ steps.ctnd.outputs.dir }}"
+          if [ ! -d "$dir/.git" ]; then
+            echo "WARNING: $dir is not a git checkout — running the installed station as-is" >&2
+            exit 0
+          fi
+          git -C "$dir" fetch --quiet origin main \
+            && git -C "$dir" checkout -q -f -B main origin/main \
+            && echo "station synced to $(git -C "$dir" rev-parse --short HEAD)" \
+            || echo "WARNING: could not sync $dir to origin/main" >&2
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: firmware
+          path: ${{ steps.ctnd.outputs.dir }}/firmware
+
+      - name: Flash, then run the probe
+        # The probe name goes through env rather than straight ${{ }} into the
+        # script body — same shape as the doom and fwapply jobs, and here it is
+        # load-bearing rather than stylistic: `probe` is free-text workflow input.
+        env:
+          CTND_DIR: ${{ steps.ctnd.outputs.dir }}
+          HIL_LEFT: ${{ needs.build.outputs.split72_hil_left }}
+          HIL_RIGHT: ${{ needs.build.outputs.split72_hil_right }}
+          PROBE: ${{ inputs.probe }}
+          FIRMWARE_DIR: ${{ github.workspace }}
+        run: |
+          cd "$CTND_DIR"
+          set -o pipefail
+          venv/bin/python -u -m station.test_runner \
+            --left  "firmware/$HIL_LEFT" \
+            --right "firmware/$HIL_RIGHT" \
+            --probe "$PROBE" \
+            --firmware-dir "$FIRMWARE_DIR" \
+            2>&1 | tee /tmp/debug-probe.log
 
   fwapply-test:
     name: Firmware apply round-trip (split72)

--- a/.github/workflows/qmk-test.yml
+++ b/.github/workflows/qmk-test.yml
@@ -655,7 +655,19 @@ jobs:
     # ⚠️ The `if:` is a FOLDED scalar. Every continuation line must sit at the
     # SAME indent as the first, or YAML keeps the newline, the expression stops
     # being valid, and the job silently stops matching its trigger.
+    # ⚠️ Runs on EVERY push to PolyKybd, not just on request — this is the one
+    # opt-in that is not purely opt-in, and the reason is the HID-apply brick
+    # (qmk#258, shipped in a release). That bug was a LAYOUT effect: a macro PR
+    # grew .bss, which shifted fw_staging's page buffer off a word boundary, and
+    # the unaligned word copy HardFaulted the applier — so the guilty PR never
+    # touched the applier and a bisect blamed the wrong commit. Any PR can move
+    # .bss, so per-PR is not where this is catchable; what IS catchable is
+    # dating it to a merge you can still bisect. Checking only at release time
+    # would tell you which release bricks, with no bisect and a release to redo.
+    # Cost is bounded: the rig already runs a HIL cycle per merge, so this adds
+    # a cloud build plus one apply+reboot, not a new cadence.
     if: >-
+      github.event_name == 'push' ||
       (github.event_name == 'workflow_dispatch' &&
       (inputs.tier == 'all' || inputs.tier == 'fwapply')) ||
       contains(github.event.pull_request.labels.*.name, 'hil-fwapply') ||

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ concurrency:
 
 permissions:
   contents: write
+  # The pre-publish gate below reads this repo's workflow runs + jobs.
+  actions: read
 
 env:
   KB: polykybd/split72
@@ -30,6 +32,36 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      # ── refuse to publish firmware no APPLY run has covered ─────────────────
+      # The HID-apply brick (qmk#258) shipped in a release because nothing ever
+      # applied an image on hardware: the rig flashes by UF2 over GPIO BOOTSEL,
+      # which bypasses fw_staging entirely, and this workflow runs no HIL at all.
+      # qmk-test.yml's fwapply tier now runs on every merge to PolyKybd, so in the
+      # normal case this is a formality — it is here for the cases that are not
+      # normal (a hand-made tag, a re-publish, a merge whose rig run went red and
+      # was forgotten), where the failure is silent and costs a release.
+      #
+      # ⚠️ It runs BEFORE the build so a refusal costs nothing and, more
+      # importantly, changes nothing: no assets uploaded, no release body edited.
+      #
+      # ⚠️ The release tag does NOT point at a commit any workflow ran on —
+      # release tags land on the auto-bump "chore: … [skip ci]" commit, and
+      # [skip ci] suppresses the run. So the script walks back through ancestors
+      # and then PROVES the delta to the release commit is only the FW_VERSION
+      # bump; accepting an ancestor without that proof would report coverage
+      # belonging to different firmware, which is worse than no gate.
+      #
+      # Self-tested (mutation-checked) — `--selftest` is why the decision logic
+      # in a release gate is not the only untested code in the repo.
+      - name: Require a green firmware-apply run for this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          python3 keyboards/polykybd/tools/require_fwapply_run.py --selftest
+          python3 keyboards/polykybd/tools/require_fwapply_run.py
 
       # Shipping shape is the POLYKYBD_DOOM_PACK flavour (doom/PACK_DESIGN.md):
       # the doom easter egg's loader + trigger compile in, the engine ships as a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -918,6 +918,34 @@ Firmware releases are **GitHub Releases** (tag `PolyKybd-fw-vX.Y.Z`; `FW_VERSION
 `polykybd-github-release` skill to draft the notes and drive the flow. The mechanics
 that cost real debugging to learn (2026-07):
 
+- ⚠️ **Publishing is GATED on a green firmware-APPLY run for the commit being
+  released** (`tools/require_fwapply_run.py`, the first step of `release.yml`,
+  before the build so a refusal changes nothing). The HID-apply brick shipped
+  because no release artifact had ever been applied on hardware — the rig flashes
+  by UF2 over GPIO BOOTSEL, which bypasses `fw_staging` entirely, and this
+  workflow runs no HIL at all. With the fwapply tier now running on every merge
+  to `PolyKybd`, the gate is normally a formality; it exists for a hand-made tag,
+  a re-publish, or a merge whose rig run went red and was forgotten.
+  - ⚠️ **It CANNOT simply demand a run on `github.sha`** — release tags land on
+    the auto-bump `[skip ci]` commit, which by construction no workflow ran on, so
+    that gate would refuse every release. It walks back through ancestors and then
+    **proves the delta to the release commit is only the `FW_VERSION` bump**;
+    accepting an ancestor without that proof would report coverage belonging to
+    different firmware, which is worse than no gate.
+  - **The job name is DERIVED from the checked-out workflow**, not hardcoded — a
+    rename would otherwise turn the gate into a silent no-op that reports "never
+    covered" for firmware that was. Same reason the ctnd unit-test workflow greps
+    its suite names instead of listing them.
+  - **Self-tested** (`--selftest`, run as the same CI step) because this repo has
+    no Python test harness and untested decision logic in a release gate is the
+    thing `fw_up_verdict.c` was extracted to avoid. Mutation-checked against 8
+    breaks; one escaped first — deleting the filename check passed every fixture,
+    because none of them had a *different* file whose lines mention `FW_VERSION`,
+    and `hid_com.c` is exactly such a file. The fixture that closes it is in the
+    selftest with that reasoning attached.
+  - **Recovery when it refuses**: dispatch *Build and HIL Test* on that commit
+    with `tier: fwapply`, wait for green, re-run the release job. The error names
+    every commit it checked and why each failed.
 - **A pushed tag does NOT create a release.** Release tags land on the auto-bump
   `chore: … [skip ci]` commit (`bump-version.yml`), and `[skip ci]` **suppresses the
   tag-push workflow trigger** — so `release.yml` runs on **`release: published`** (every

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -977,9 +977,14 @@ that cost real debugging to learn (2026-07):
   - ⚠️ **It CANNOT simply demand a run on `github.sha`** — release tags land on
     the auto-bump `[skip ci]` commit, which by construction no workflow ran on, so
     that gate would refuse every release. It walks back through ancestors and then
-    **proves the delta to the release commit is only the `FW_VERSION` bump**;
-    accepting an ancestor without that proof would report coverage belonging to
-    different firmware, which is worse than no gate.
+    **proves the delta to the release commit is only the auto-bump** — meaning
+    `FW_VERSION` *or* `PROTOCOL_VERSION` in `config.h` and nothing else, since a
+    `bump:protocol` merge increments only the latter and rewrites the semver to
+    the same value, producing no `FW_VERSION` diff line at all. Accepting an
+    ancestor without that proof would report coverage belonging to different
+    firmware, which is worse than no gate; accepting only `FW_VERSION` would
+    refuse a well-covered protocol release at publish time (caught in review of
+    the PR that added it, #264).
   - **The job name is DERIVED from the checked-out workflow**, not hardcoded — a
     rename would otherwise turn the gate into a silent no-op that reports "never
     covered" for firmware that was. Same reason the ctnd unit-test workflow greps

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -421,6 +421,54 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
     tag-anchored history question, not just merge-base reasoning — and note the tag
     itself resolves fine (`git rev-parse <tag>` succeeds), so a tag-exists check
     proves nothing. Unshallowing took **45 s** here; the count went 84 commits.
+- **`-Wcast-align` is on for PolyKybd's OWN sources, and it exists for the
+  HID-apply brick class.** `fw_staging`'s page buffer was `static uint8_t
+  page_buf[256]` (alignment 1) word-copied through a `(uint32_t *)` cast; the
+  linker put it at a byte offset, the unaligned `STMIA` HardFaulted the M0+ in a
+  function that never returns, and it shipped in a release. The warning names
+  exactly that — *"cast increases required alignment of target type"* — and with
+  `-Werror` already on it is a build failure on the PR that writes it. That is
+  the only place a bisect can find this class, because the brick itself was a
+  **layout** effect: a macro PR grew `.bss` and moved the buffer, so the guilty
+  commit never touched the failing code.
+  - ⚠️ **Scoped by path via the `$<` per-recipe filter** (`rules.mk`, the same
+    mechanism the doom `EXTRAFLAGS` block uses). `EXTRAFLAGS` otherwise lands on
+    **every** compile line — upstream QMK, ChibiOS, pico-sdk — which is the trap
+    that kept CodeQL out of this repo.
+  - ⚠️ **The WHOLE `doom/` tree is excluded, not just the vendored engine, and
+    the reason for our own sources is worth knowing: `doom_arena_at()` returns
+    `uint8_t *` because that signature IS the pack ABI** (`doom_pack_abi.h`,
+    handed to a **signed** `.plyx`). So every `(doom_mirror_t *)doom_arena_at(…)`
+    is a widening cast the check cannot be satisfied about without editing a
+    cross-boundary contract — which is not something to do on a warning's
+    account. `void *` would be the better type for untyped arena storage; it was
+    tried and reverted for exactly that reason. The offsets are
+    `_Static_assert`ed 4-aligned in `doom_arena.h` instead, which is the
+    substance, and the one such cast **outside** the doom tree (`split_sync.c`'s
+    mirror handler) carries a narrow `#pragma` pointing at those asserts.
+  - ⚠️ **A path filter that matches nothing FAILS OPEN** — the flag never applies
+    and the guard looks installed while doing nothing. Verify by compiling a
+    deliberate misalignment in a PolyKybd source and confirming the build
+    **fails**, not by reading the make output.
+  - **`void *` casts do not warn** (GCC exempts them), so `bridge_helper.c`'s
+    split-link CRC store is unaffected — and is separately safe, since every
+    caller passes a struct whose first member is a `uint32_t`.
+  - **It found two real latent instances of the same shape**, both now asserted
+    rather than assumed: `doom_mode.c` casts the core1 **stack pointer** out of a
+    `uint8_t *` pool (where a misalignment is worse than the applier's HardFault
+    — 8-aligned base, both offsets multiples of 8, which is also what AAPCS
+    demands), and every `doom_arena_at()` consumer relies on arena offsets that
+    nothing checked. ⚠️ Do **not** launder such a cast through `uintptr_t` to
+    silence the warning — that proves nothing and hides the next one.
+  - ⚠️ **Verified the hard way, and it earned its keep immediately**: the first
+    build with the flag FAILED on `split_sync.c`, which is simultaneously the
+    proof that the path filter matches (it would otherwise fail open) and a real
+    find. Do not take a clean build as evidence the flag is active — take a build
+    that fails on a deliberate misalignment.
+  - The clean-up it required was itself worth having: the OLED helpers took a
+    `uint32_t[]`, cast it down to `char *` at the call and back up inside, which
+    was safe only by convention. They take `uint32_t *` now.
+
 - ⚠️ **When an upstream merge breaks the build, look at the vendored DOOM engine
   FIRST — a new upstream warning lands there, not on our own sources.** QMK builds
   with `-Werror`, so *any* warning upstream adds to `builddefs/common_rules.mk`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -474,7 +474,17 @@ inherited-upstream noise:
     UI's **Extended** toggle beside Run Tests.
   - ✅ **`workflow_dispatch` runs all THREE opt-ins at once — the extended HIL tier,
     the perf measurement AND the FW-9 doom set** — because it satisfies every opt-in
-    `if:` at once (each names `github.event_name == 'workflow_dispatch'`). They are
+    `if:` at once (each names `github.event_name == 'workflow_dispatch'`).
+    ⚠️ **Since the `tier` input (2026-09-01) that is what `tier: all` does, and `all`
+    is the DEFAULT**, so an ordinary dispatch still behaves exactly as described here.
+    The narrower values (`default`, `extended`, `perf`, `doom`, `fwapply`, `debug`)
+    each drive one opt-in, and `tier` is read **only** under
+    `github.event_name == 'workflow_dispatch'` — push and pull_request keep their
+    label/marker gating untouched. `debug` is the odd one out: it **skips the graded
+    suite entirely** (the only `if:` on `hil-test`) and runs just the probe, because a
+    debug loop pays the rig cost on every iteration. The whole table was verified by
+    simulating the conditions across every trigger, not by reading them — that is the
+    only way to check a folded-scalar `if:` short of merging and waiting. They are
     otherwise INDEPENDENT — each opt-in drives only its own job, so `hil-extended`
     alone starts no perf run and `hil-perf` alone leaves the HIL suite on its default
     tier. ⚠️ Dispatch is not the *only* way to get them: the matching labels on a PR, or
@@ -562,6 +572,38 @@ inherited-upstream noise:
     digest is a *real* hardening but a **repo-wide** one — 10 uses in `qmk-test.yml` +
     more in `release.yml` — so it is a deliberate all-uses-at-once change (ideally with
     Dependabot), never a piecemeal one-job edit.
+- ✅ **The DEBUG LOOP: a firmware bug can now be chased on the rig with nobody
+  flashing a `.bin`.** Dispatch `qmk-test.yml` on a branch with **`tier: debug`,
+  `probe: <name>`** and the rig builds that branch, flashes both halves, runs a
+  probe committed at `keyboards/polykybd/tools/hil_probes/<name>.py`, and pipes
+  the firmware's own console into the job log as `[qmk] …` lines. Edit, push,
+  dispatch, read the log. The rig side is `polykybd-ctnd/station/probe.py`
+  (`--probe`); the probe format and the pitfalls are in that directory's
+  `README.md`. This existed in pieces before — the rig has echoed `[qmk]` lines
+  into the log all along — and what was missing was any way to run an *arbitrary*
+  question instead of the fixed suite.
+  - ⚠️ **DISPATCH-ONLY, and that `if:` IS the security control.** Triggering a
+    dispatch needs write access, so a fork PR can never reach the rig through it —
+    which matters because the rig is a self-hosted runner for a **public** repo
+    (HIL-2). **Do not add a `hil-debug` label trigger**: a label is applied to a PR
+    whose head may be a fork. The containment check in `station/probe.py` is *not*
+    this control and its own docstring says so; it is operational (CI has already
+    checked out the whole repo and the build jobs have already run code from it).
+  - **Dispatch with `ref:` set to a branch runs that branch's workflow and builds
+    that branch's firmware**, so a probe iterates entirely unmerged. That is also
+    the answer to "workflow_dispatch only exists on the default branch": the
+    *entry* must be there, the *code* need not.
+  - ⚠️ **The console cannot see a flash window.** QMK drops output nobody drains
+    and during a flash nothing does, so a probe observes before and after an
+    update, never during. A gap in the `[qmk]` timestamps spanning a flash is
+    expected, not a symptom.
+  - ✅ **A brick is self-recovering on the rig** — it asserts BOOTSEL over GPIO,
+    and BOOTSEL/UF2 bypasses `fw_staging` entirely. So the rig is the right, and
+    the only, place to exercise the firmware-apply path: the failure this whole
+    area guards against cannot strand the hardware.
+  - **A probe is disposable.** Delete it when the bug closes, or promote it into
+    `station/hil_tests.py` if the question is worth asking forever.
+
 - **`cppcheck`** (`cppcheck.yml`) also **gates**, and is the only reviewer here that
   is not an LLM — CodeRabbit, Sourcery and the on-demand Claude reviewer share
   training data and therefore blind spots, while dataflow analysis fails elsewhere.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -572,6 +572,37 @@ inherited-upstream noise:
     digest is a *real* hardening but a **repo-wide** one — 10 uses in `qmk-test.yml` +
     more in `release.yml` — so it is a deliberate all-uses-at-once change (ideally with
     Dependabot), never a piecemeal one-job edit.
+- **The FW-APPLY set (`build-fwapply` + `fwapply-test`) is the fourth tier, and it
+  is the ONLY one that runs unasked — on every push to `PolyKybd`.** It builds a
+  HIL image pair, signs the master `.bin` with an **ephemeral** key
+  (`gen_signing_key.py` rewrites `base/fw_pubkey.h`, same pattern as `build-doom`
+  — the production `FW_SIGNING_KEY` stays confined to `release.yml`), then has the
+  rig drive a real HID update through **APPLY** and confirm the board comes back.
+  It is also reachable by the `hil-fwapply` label, `[hil-fwapply]` in a pushed
+  commit, or `tier: fwapply`.
+  - ⚠️ **Why it is not opt-in, when everything else is: the HID-apply brick
+    (qmk#258) shipped in a RELEASE, and it was a LAYOUT effect.** `fw_staging`'s
+    page buffer was `static uint8_t` (alignment 1) and word-copied; a macro PR grew
+    `.bss`, shifted it off a word boundary, and the unaligned `STMIA` HardFaulted
+    on the M0+ inside a function that never returns — recoverable only over
+    BOOTSEL. So **the guilty PR never touched the applier**, `fw_staging_do_apply`
+    was byte-identical across the regression, and the bisect blamed the wrong
+    commit. Any PR can move `.bss`, so per-PR is not where this class is catchable;
+    what IS catchable is dating it to a **merge** that can still be bisected. A
+    release-time-only check would name the release that bricks, with no bisect and
+    a release to redo.
+  - **The cost is bounded**: the rig already runs a HIL cycle per merge, so this
+    adds a cloud build plus one apply+reboot, not a new cadence. PRs are untouched
+    — the tier stays opt-in there, so no PR pipeline gets slower.
+  - ⚠️ **`--apply-bin` is destructive by design and safe only because the image is
+    the one already running** — the rig checks that pairing rather than assuming
+    it. And it is safe *at all* only because a brick on the rig is self-recovering
+    over GPIO BOOTSEL.
+  - ⚠️ **An ephemeral-key image REFUSES a production-signed image over HID** (its
+    baked pubkey does not match, so the keyboard raises the A/ACCEPT prompt, which
+    the rig cancels). Benign on the rig, which recovers itself — but it is why an
+    ephemeral-key build must never be handed to a user to flash.
+
 - ✅ **The DEBUG LOOP: a firmware bug can now be chased on the rig with nobody
   flashing a `.bin`.** Dispatch `qmk-test.yml` on a branch with **`tier: debug`,
   `probe: <name>`** and the rig builds that branch, flashes both halves, runs a

--- a/keyboards/polykybd/base/fontpack.c
+++ b/keyboards/polykybd/base/fontpack.c
@@ -120,10 +120,44 @@ static bool validate_and_append(const uint8_t *base, uint32_t cap, uint16_t *out
         if (tbl[i].glyph_off >= h->total_size || tbl[i].bitmap_off >= h->total_size) {
             return false;  // dangling offset
         }
+        // ⚠️ glyph_off is FILE-CONTROLLED and is cast to PolyColGlyph*, whose
+        // first member is a uint16_t — so an ODD offset makes every glyph lookup
+        // an unaligned 16-bit read, which is a HardFault on the M0+. A .plyf
+        // rides the UNSIGNED resource transport (SECURITY_AUDIT.md FW-9 tail:
+        // "the exposure is parser bugs"), and the pack lives in flash and is
+        // re-loaded at boot, so a crafted odd offset is a PERSISTENT fault loop
+        // needing BOOTSEL to clear. Found by -Wcast-align (see rules.mk), which
+        // is the whole argument for that flag.
+        if ((tbl[i].glyph_off & 1u) != 0u) {
+            return false;  // misaligned glyph array
+        }
+        // The old check bounded only the START of the glyph array. The array is
+        // (last - first + 1) records long, all read on lookup, so a truthful
+        // offset with an oversized range still walks off the end of the pack.
+        if (tbl[i].last < tbl[i].first) {
+            return false;  // inverted range
+        }
+        {
+            // Division, not multiplication: `count * sizeof(GFXglyph)` overflows
+            // a uint32 for a hostile `last`, and 64-bit arithmetic would pull a
+            // libcall into a Cortex-M0+ for no reason. `total_size - glyph_off`
+            // cannot underflow — glyph_off < total_size is checked above.
+            uint32_t count = tbl[i].last - tbl[i].first + 1u;
+            if (count > (h->total_size - tbl[i].glyph_off) / sizeof(GFXglyph)) {
+                return false;  // glyph array runs past the end of the pack
+            }
+        }
         GFXfont *f = &s_pack[s_pack_count];
         // bitmap/glyph are non-const in GFXfont; we only ever read them.
         f->bitmap   = (uint8_t *)(base + tbl[i].bitmap_off);
+        // -Wcast-align (rules.mk) is right that this widens alignment; the
+        // even-offset check above is what makes it safe, and it is a RUNTIME
+        // check because the offset is runtime data. Suppressed for this one
+        // line, with that validation as the proof.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-align"
         f->glyph    = (GFXglyph *)(base + tbl[i].glyph_off);
+#pragma GCC diagnostic pop
         f->first    = tbl[i].first;
         f->last     = tbl[i].last;
         f->yAdvance = tbl[i].yAdvance;

--- a/keyboards/polykybd/base/fontpack.c
+++ b/keyboards/polykybd/base/fontpack.c
@@ -139,11 +139,20 @@ static bool validate_and_append(const uint8_t *base, uint32_t cap, uint16_t *out
         }
         {
             // Division, not multiplication: `count * sizeof(GFXglyph)` overflows
-            // a uint32 for a hostile `last`, and 64-bit arithmetic would pull a
-            // libcall into a Cortex-M0+ for no reason. `total_size - glyph_off`
-            // cannot underflow — glyph_off < total_size is checked above.
-            uint32_t count = tbl[i].last - tbl[i].first + 1u;
-            if (count > (h->total_size - tbl[i].glyph_off) / sizeof(GFXglyph)) {
+            // a uint32 for a hostile `last`. `total_size - glyph_off` cannot
+            // underflow — glyph_off < total_size is checked above.
+            //
+            // ⚠️ COMPARE SPANS, NOT COUNTS. `last - first + 1` is itself a uint32
+            // and wraps to ZERO for first=0, last=0xFFFFFFFF — which sails through
+            // any `count > limit` test and then declares the font to cover EVERY
+            // codepoint, so one lookup indexes megabytes past the pack. That is the
+            // crafted-range OOB this whole block exists to stop, and the first
+            // version of it had exactly that hole (caught in review of #264).
+            // `span = last - first` cannot overflow, because last >= first is
+            // already established.
+            uint32_t span     = tbl[i].last - tbl[i].first;
+            uint32_t capacity = (h->total_size - tbl[i].glyph_off) / sizeof(GFXglyph);
+            if (capacity == 0u || span > capacity - 1u) {
                 return false;  // glyph array runs past the end of the pack
             }
         }

--- a/keyboards/polykybd/doom/doom_arena.h
+++ b/keyboards/polykybd/doom/doom_arena.h
@@ -71,8 +71,29 @@ extern "C" {
 // upstream's ~58 K (zone + wrapped-malloc heap) working set.
 #define DOOM_ARENA_ZONE_OFF   (DOOM_ARENA_MIRROR_OFF + DOOM_ARENA_MIRROR_BYTES)
 
+// ⚠️ Every arena offset must keep a 4-byte-aligned base 4-byte aligned: callers
+// cast the result to structs holding uint32_t (doom_mirror_t), and an unaligned
+// 32-bit access is a HardFault on the M0+ — the same failure that bricked the
+// firmware applier (qmk#258). These asserts are what make that a build error
+// instead of arithmetic nobody re-checks when a region is resized.
+_Static_assert(DOOM_ARENA_FB_OFF      % 4u == 0u, "arena offset must stay 4-aligned");
+_Static_assert(DOOM_ARENA_PD_OFF      % 4u == 0u, "arena offset must stay 4-aligned");
+_Static_assert(DOOM_ARENA_VPATCH_OFF  % 4u == 0u, "arena offset must stay 4-aligned");
+_Static_assert(DOOM_ARENA_COMPOSE_OFF % 4u == 0u, "arena offset must stay 4-aligned");
+_Static_assert(DOOM_ARENA_MIRROR_OFF  % 4u == 0u, "arena offset must stay 4-aligned");
+_Static_assert(DOOM_ARENA_ZONE_OFF    % 4u == 0u, "arena offset must stay 4-aligned");
+
 // Arena base (= first byte after the engine statics) + offset, or NULL while
 // game mode is inactive (doom_mode.c).
+//
+// ⚠️ Stays `uint8_t *` because this signature IS the pack ABI — it is handed to
+// a loaded .plyx as `s_fw_api.arena_at` (doom_pack_abi.h). `void *` would be the
+// better type for untyped arena storage and would make every
+// `(doom_mirror_t *)doom_arena_at(...)` exempt from -Wcast-align, but changing a
+// cross-boundary contract that a SIGNED pack is built against is not something
+// to do on a warning's account. The alignment those casts rely on is asserted
+// above instead, which is the substance; the one cast site outside the doom tree
+// (split_sync.c) carries a narrow pragma pointing here.
 uint8_t *doom_arena_at(unsigned offset);
 
 #ifdef __cplusplus

--- a/keyboards/polykybd/doom/doom_arena.h
+++ b/keyboards/polykybd/doom/doom_arena.h
@@ -76,12 +76,26 @@ extern "C" {
 // 32-bit access is a HardFault on the M0+ — the same failure that bricked the
 // firmware applier (qmk#258). These asserts are what make that a build error
 // instead of arithmetic nobody re-checks when a region is resized.
-_Static_assert(DOOM_ARENA_FB_OFF      % 4u == 0u, "arena offset must stay 4-aligned");
-_Static_assert(DOOM_ARENA_PD_OFF      % 4u == 0u, "arena offset must stay 4-aligned");
-_Static_assert(DOOM_ARENA_VPATCH_OFF  % 4u == 0u, "arena offset must stay 4-aligned");
-_Static_assert(DOOM_ARENA_COMPOSE_OFF % 4u == 0u, "arena offset must stay 4-aligned");
-_Static_assert(DOOM_ARENA_MIRROR_OFF  % 4u == 0u, "arena offset must stay 4-aligned");
-_Static_assert(DOOM_ARENA_ZONE_OFF    % 4u == 0u, "arena offset must stay 4-aligned");
+//
+// ⚠️ NOT a bare `_Static_assert`: this header is included by the doom engine's
+// pd_render.cpp, and `_Static_assert` is C-only — C++ spells it `static_assert`.
+// A bare one compiles fine everywhere PR CI looks and breaks ONLY the monolithic
+// POLYKYBD_DOOM flavour, which CI does not build at all (see CLAUDE.md, "PR CI
+// does NOT build the monolith"). It shipped that way for a few commits on #264
+// and was caught by building the monolith by hand, which is the whole reason
+// that instruction exists.
+#ifdef __cplusplus
+#  define DOOM_ARENA_STATIC_ASSERT(cond, msg) static_assert(cond, msg)
+#else
+#  define DOOM_ARENA_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
+#endif
+
+DOOM_ARENA_STATIC_ASSERT(DOOM_ARENA_FB_OFF      % 4u == 0u, "arena offset must stay 4-aligned");
+DOOM_ARENA_STATIC_ASSERT(DOOM_ARENA_PD_OFF      % 4u == 0u, "arena offset must stay 4-aligned");
+DOOM_ARENA_STATIC_ASSERT(DOOM_ARENA_VPATCH_OFF  % 4u == 0u, "arena offset must stay 4-aligned");
+DOOM_ARENA_STATIC_ASSERT(DOOM_ARENA_COMPOSE_OFF % 4u == 0u, "arena offset must stay 4-aligned");
+DOOM_ARENA_STATIC_ASSERT(DOOM_ARENA_MIRROR_OFF  % 4u == 0u, "arena offset must stay 4-aligned");
+DOOM_ARENA_STATIC_ASSERT(DOOM_ARENA_ZONE_OFF    % 4u == 0u, "arena offset must stay 4-aligned");
 
 // Arena base (= first byte after the engine statics) + offset, or NULL while
 // game mode is inactive (doom_mode.c).

--- a/keyboards/polykybd/doom/doom_mode.c
+++ b/keyboards/polykybd/doom/doom_mode.c
@@ -129,6 +129,19 @@ static void doom_engine_start(void) {
     // stack at the tail of the pool.
     doom_core1_reset();
 #ifdef POLYKYBD_DOOM_PACK
+    // ⚠️ This widens the alignment requirement (uint8_t* -> uint32_t*) on a
+    // CORE1 STACK POINTER, where an unaligned result is worse than the HardFault
+    // that bricked the applier (qmk#258, a `static uint8_t` page buffer that was
+    // word-copied). It is safe, and these asserts are the proof rather than a
+    // convention: the pool base is 8-aligned by the ldscript (pinned at
+    // 0x20000000 for the pack flavour) and both offsets are multiples of 8, which
+    // is also what AAPCS requires of a stack pointer. (-Wcast-align does not
+    // reach this file — the doom tree is excluded in rules.mk because it carries
+    // the pack ABI — so these asserts, not the compiler, are the guard here.)
+    _Static_assert(DOOM_POOL_BYTES % 8u == 0u,
+                   "overlay pool size must keep the core1 stack 8-aligned");
+    _Static_assert(DOOM_ARENA_STACK_BYTES % 8u == 0u,
+                   "core1 stack size must keep its base 8-aligned (AAPCS)");
     uint32_t *stack_bottom = (uint32_t *)(s_fb + DOOM_POOL_BYTES - DOOM_ARENA_STACK_BYTES);
 #else
     // (uintptr_t detour: negative offsets from a zero-size linker symbol trip

--- a/keyboards/polykybd/doom/doom_mode.c
+++ b/keyboards/polykybd/doom/doom_mode.c
@@ -146,7 +146,17 @@ static void doom_engine_start(void) {
 #else
     // (uintptr_t detour: negative offsets from a zero-size linker symbol trip
     // GCC's array-bounds check)
-    uint32_t *stack_bottom = (uint32_t *)((uintptr_t)__doom_shared_end__ - DOOM_ARENA_STACK_BYTES);
+    //
+    // ⚠️ Masked down to 8, because unlike the pack branch above nothing here
+    // GUARANTEES the alignment: this address comes from a linker symbol, and
+    // `.doom_shared` was ALIGN(4) until #264 — the block size and the stack
+    // size are both multiples of 8, so the stack base inherits the SECTION's
+    // alignment, and 4 would violate the AAPCS 8-byte stack rule. The ld is
+    // ALIGN(8) now; this mask means a future edit to it cannot silently
+    // reintroduce the hazard, at the cost of up to 4 bytes of a 4 KB stack.
+    uintptr_t stack_top = ((uintptr_t)__doom_shared_end__ - DOOM_ARENA_STACK_BYTES)
+                          & ~(uintptr_t)7u;
+    uint32_t *stack_bottom = (uint32_t *)stack_top;
 #endif
     multicore_launch_core1_with_stack(doom_core1_entry, stack_bottom, DOOM_ARENA_STACK_BYTES);
     s_engine_running = true;

--- a/keyboards/polykybd/ld/RP2040_FLASH_TIMECRIT_DOOM.ld
+++ b/keyboards/polykybd/ld/RP2040_FLASH_TIMECRIT_DOOM.ld
@@ -160,8 +160,18 @@ SECTIONS
         PROVIDE(end = .);
     } > BSS_RAM
 
-    /* The overlay pool / doom arena shared block -- see file header. */
-    .doom_shared (NOLOAD) : ALIGN(4)
+    /* The overlay pool / doom arena shared block -- see file header.
+     *
+     * ALIGN(8), not 4: doom_mode.c carves the core1 stack out of the TAIL of
+     * this block (__doom_shared_end__ - DOOM_ARENA_STACK_BYTES), and AAPCS
+     * requires an 8-byte-aligned stack pointer. The block's size (216000) and
+     * the stack size (4096) are both multiples of 8, so the end -- and hence
+     * the stack base -- inherits whatever alignment the START has. At ALIGN(4)
+     * that could be 4-aligned. The DOOMPACK flavour is unaffected because its
+     * pool is pinned at the RAM origin, which is 8-aligned by construction.
+     * (Caught in review of #264; doom_mode.c also masks the pointer down, so
+     * neither half alone is load-bearing.) */
+    .doom_shared (NOLOAD) : ALIGN(8)
     {
         __doom_shared_base__ = .;
         *doom/engine/*.o(.bss)

--- a/keyboards/polykybd/oled_helper.c
+++ b/keyboards/polykybd/oled_helper.c
@@ -34,8 +34,8 @@ extern const GFXfont NotoSans_Regular_Small_15px7b;
 // Render `value` as a char32 (U"...") display string into `buffer`. The display
 // pipeline is 32-bit (kdisp_write_gfx_text takes const uint32_t*), so each digit
 // glyph is one uint32_t codepoint. `buffer_len` is the byte size of the buffer.
-static inline void digits_to_u32_string(char* buffer, uint8_t buffer_len, uint8_t value, uint8_t base) {
-    uint32_t* out = (uint32_t*)buffer;
+static inline void digits_to_u32_string(uint32_t* buffer, uint8_t buffer_len, uint8_t value, uint8_t base) {
+    uint32_t* out = buffer;
     uint8_t   cap = buffer_len / (uint8_t)sizeof(uint32_t);
     uint8_t   i   = 0;
     if (value >= base * base && i < cap) out[i++] = U'0' + (value / (base * base)) % base;
@@ -44,14 +44,14 @@ static inline void digits_to_u32_string(char* buffer, uint8_t buffer_len, uint8_
     if (i < cap) out[i] = 0;
 }
 
-void num_to_u32_string(char* buffer, uint8_t buffer_len, uint8_t value) {
+void num_to_u32_string(uint32_t* buffer, uint8_t buffer_len, uint8_t value) {
     digits_to_u32_string(buffer, buffer_len, value, 10);
 }
 
 // 16-bit decimal, no leading zeros (0 renders as "0"). digits_to_u32_string above is
 // uint8_t-only; the hue-in-degrees readout needs three digits up to 359.
-void num16_to_u32_string(char* buffer, uint8_t buffer_len, uint16_t value) {
-    uint32_t* out = (uint32_t*)buffer;
+void num16_to_u32_string(uint32_t* buffer, uint8_t buffer_len, uint16_t value) {
+    uint32_t* out = buffer;
     uint8_t   cap = buffer_len / (uint8_t)sizeof(uint32_t);
     uint8_t   i   = 0;
     uint16_t  div = 10000;
@@ -65,8 +65,8 @@ void num16_to_u32_string(char* buffer, uint8_t buffer_len, uint16_t value) {
 // Widen an ASCII C string into the 32-bit codepoint string the kdisp text pipeline
 // expects (kdisp_write_gfx_text takes const uint32_t*). NUL-terminated, never
 // overruns `buffer_len`. Used for the font-pack bundle name on the flash screen.
-void ascii_to_u32_string(char* buffer, uint8_t buffer_len, const char* s) {
-    uint32_t* out = (uint32_t*)buffer;
+void ascii_to_u32_string(uint32_t* buffer, uint8_t buffer_len, const char* s) {
+    uint32_t* out = buffer;
     uint8_t   cap = buffer_len / (uint8_t)sizeof(uint32_t);
     uint8_t   i   = 0;
     if (s) {
@@ -75,8 +75,8 @@ void ascii_to_u32_string(char* buffer, uint8_t buffer_len, const char* s) {
     if (i < cap) out[i] = 0;
 }
 
-void hex_to_u32_string(char* buffer, uint8_t buffer_len, uint8_t value) {
-    uint32_t* out = (uint32_t*)buffer;
+void hex_to_u32_string(uint32_t* buffer, uint8_t buffer_len, uint8_t value) {
+    uint32_t* out = buffer;
     uint8_t   cap = buffer_len / (uint8_t)sizeof(uint32_t);
     uint8_t   i   = 0;
     if (value >= 16 && i < cap) { uint8_t hi = value / 16; out[i++] = (hi < 10 ? U'0' + hi : U'A' + hi - 10); }
@@ -150,13 +150,13 @@ void oled_draw_text_right(const GFXfont *const *font, int8_t right_x, int8_t y, 
 // Draw `value` right-aligned so it ends on `right_x`.
 void oled_draw_num_right(const GFXfont *const *font, int8_t right_x, int8_t y, uint8_t value) {
     uint32_t buf[6];
-    num_to_u32_string((char*) buf, sizeof(buf), value);
+    num_to_u32_string(buf, sizeof(buf), value);
     oled_draw_text_right(font, right_x, y, buf);
 }
 
 void oled_draw_num16_right(const GFXfont *const *font, int8_t right_x, int8_t y, uint16_t value) {
     uint32_t buf[8];
-    num16_to_u32_string((char*) buf, sizeof(buf), value);
+    num16_to_u32_string(buf, sizeof(buf), value);
     oled_draw_text_right(font, right_x, y, buf);
 }
 
@@ -381,7 +381,7 @@ void oled_telemetry_screen(void) {
     const int8_t band = (int8_t)(OLED_DISPLAY_HEIGHT / count);
     for (uint8_t i = 0; i < count; ++i) {
         uint32_t txt[24];
-        ascii_to_u32_string((char*)txt, sizeof(txt), lines[i]);
+        ascii_to_u32_string(txt, sizeof(txt), lines[i]);
         int8_t x0 = 0, x1 = 0, y0 = 0, y1 = 0;
         kdisp_gfx_text_bbox(fonts, 1, txt, &x0, &x1, &y0, &y1);
         const int8_t w = (int8_t)(x1 - x0 + 1);

--- a/keyboards/polykybd/oled_helper.h
+++ b/keyboards/polykybd/oled_helper.h
@@ -10,11 +10,11 @@
    ⚠️ `buffer` is written as uint32_t codepoints, so every caller must pass a
    uint32_t[] cast to char* (the char* signature is historical) — a char[] would
    be misaligned. `buffer_len` is the BYTE size, i.e. sizeof(that array). */
-void num_to_u32_string(char* buffer, uint8_t buffer_len, uint8_t value);
-void num16_to_u32_string(char* buffer, uint8_t buffer_len, uint16_t value);
-void hex_to_u32_string(char* buffer, uint8_t buffer_len, uint8_t value);
+void num_to_u32_string(uint32_t* buffer, uint8_t buffer_len, uint8_t value);
+void num16_to_u32_string(uint32_t* buffer, uint8_t buffer_len, uint16_t value);
+void hex_to_u32_string(uint32_t* buffer, uint8_t buffer_len, uint8_t value);
 /* Widen an ASCII string into a UTF-32 buffer for the kdisp text pipeline */
-void ascii_to_u32_string(char* buffer, uint8_t buffer_len, const char* s);
+void ascii_to_u32_string(uint32_t* buffer, uint8_t buffer_len, const char* s);
 
 /* Draw the active default-layout name (Qwerty / Colemak DH / …) at (x,y). Shared
    by both status-OLED variants so the layout list can't drift between them. */

--- a/keyboards/polykybd/rules.mk
+++ b/keyboards/polykybd/rules.mk
@@ -3,6 +3,48 @@
 CFLAGS += -Wno-strict-prototypes
 
 # ---------------------------------------------------------------------------
+# -Wcast-align on OUR sources only (the HID-apply brick class)
+# ---------------------------------------------------------------------------
+# fw_staging's page buffer was `static uint8_t page_buf[256]` (alignment 1) and
+# was word-copied through a `(uint32_t *)` cast. The linker put it at a byte
+# offset, the unaligned STMIA HardFaulted the M0+ inside a function that never
+# returns, and the board came back only over BOOTSEL — shipped in a release
+# (qmk#258). -Wcast-align names exactly that: "cast increases required alignment
+# of target type". With -Werror already on, it is now a build failure on the PR
+# that writes it, which is the only place a bisect can still find it — the brick
+# itself was a LAYOUT effect (a macro PR grew .bss and moved the buffer), so the
+# guilty commit never touched the failing code.
+#
+# ⚠️ SCOPED BY PATH, deliberately. EXTRAFLAGS lands last on EVERY compile line,
+# upstream QMK / ChibiOS / pico-sdk included, and analysing 30k commits of other
+# people's code is the trap that kept CodeQL out of this repo. The $< filter is
+# the same per-recipe mechanism the doom block below uses.
+#
+# ⚠️ The WHOLE doom tree is excluded, not just the vendored engine. The engine is
+# a third-party snapshot nobody is going to clean up; our own doom sources are
+# excluded for a different and more interesting reason — `doom_arena_at()`
+# returns `uint8_t *` because that signature IS the pack ABI (doom_pack_abi.h,
+# handed to a SIGNED .plyx), so every `(doom_mirror_t *)doom_arena_at(...)` is a
+# widening cast the check cannot be satisfied about without editing a
+# cross-boundary contract. Those offsets are `_Static_assert`ed 4-aligned in
+# doom_arena.h instead, which is the substance; the one such cast OUTSIDE the
+# doom tree (split_sync.c) carries a narrow pragma pointing at those asserts.
+#
+# ⚠️ A path filter that matches NOTHING fails open: the flag simply never
+# applies and the guard looks installed while doing nothing. Verify by building
+# with a deliberate misalignment and confirming it FAILS, not by reading the
+# make output.
+#
+# Casts from `void *` do not warn (GCC exempts them), so the split-link CRC store
+# in bridge_helper.c is unaffected — and is separately safe, since every caller
+# passes a struct whose first member is a uint32_t.
+# modules/polykybd/ is ours too (polymod_crc32 / _rle / _ltr559); polymod_monocypher
+# is vendored, so it is excluded alongside the doom tree.
+POLY_CAST_ALIGN_SRC = $(filter keyboards/polykybd/% modules/polykybd/%,$<)
+POLY_CAST_ALIGN_SKIP = $(filter keyboards/polykybd/doom/% modules/polykybd/polymod_monocypher/%,$<)
+EXTRAFLAGS += $(if $(POLY_CAST_ALIGN_SRC),$(if $(POLY_CAST_ALIGN_SKIP),,-Wcast-align))
+
+# ---------------------------------------------------------------------------
 # System clock — 200 MHz by DEFAULT (`-e POLYKYBD_SYS_CLK=125` opts out)
 # ---------------------------------------------------------------------------
 # The RP2040 clock is NOT set by QMK — ChibiOS's hal_lld_init() (and, earlier,

--- a/keyboards/polykybd/split42/status_oled.c
+++ b/keyboards/polykybd/split42/status_oled.c
@@ -201,7 +201,7 @@ void oled_update_buffer(void) {
     if (!locks_side) {
         // Layer icon + number
         pdraw_glyph(g_all_fonts, g_all_font_count, 0, 41, 0x80 /*ICON_LAYER*/, buf);
-        hex_to_u32_string((char*)nbuf, sizeof(nbuf), get_highest_layer(gl->layer));
+        hex_to_u32_string(nbuf, sizeof(nbuf), get_highest_layer(gl->layer));
         pdraw_text(tinyFont, 1, 18, 38, nbuf, buf);
         // Layout name (short), Nano 10px at NATIVE size, centered. LAYOUT_NAME_BASE
         // is picked so the cap top still lands on logical row 52, exactly where the
@@ -210,7 +210,7 @@ void oled_update_buffer(void) {
         pdraw_brightness(ls->contrast, 82, buf);
         // Typing speed: dial over the value
         pdraw_bitmap(wpm_gauge_bitmap, (P_W - WPM_ICON_W) / 2, 93, WPM_ICON_W, WPM_ICON_H, buf);
-        num_to_u32_string((char*)nbuf, sizeof(nbuf), get_current_wpm());
+        num_to_u32_string(nbuf, sizeof(nbuf), get_current_wpm());
         pdraw_text_center(tinyFont, 1, 110, nbuf, buf);
     } else {
         pdraw_glyph_center(g_all_fonts, g_all_font_count, 36, gl->led_state.num_lock  ? 0x8D : 0x8C, buf);
@@ -255,7 +255,7 @@ void oled_update_buffer_fw_update(void) {
         const char* bname = fontpack_slot_name(fw_staging_fontpack_slot_off());
         kdisp_write_gfx_text(smallFont, 1, 0, 10, U"Fonts:");
         if (bname) {
-            ascii_to_u32_string((char*)buffer, sizeof(buffer), bname);
+            ascii_to_u32_string(buffer, sizeof(buffer), bname);
             kdisp_write_gfx_text(smallFont, 1, 44, 10, buffer);
         }
         oled_fw_update_percent(smallFont, 24, 22, pct);

--- a/keyboards/polykybd/split72/status_oled.c
+++ b/keyboards/polykybd/split72/status_oled.c
@@ -157,13 +157,17 @@ static uint8_t byte_to_percent(uint8_t v) {
     return (uint8_t)(((uint16_t)v * 100u + 127u) / 255u);
 }
 
-// "<pct>%" as one string. `out` must be a uint32_t[] (see oled_helper.h).
-static void pct_to_u32_string(char* out, uint8_t out_len, uint8_t pct) {
-    uint32_t* s = (uint32_t*)out;
+// "<pct>%" as one string, into a uint32_t[] (the kdisp text pipeline is 32-bit).
+// ⚠️ Takes uint32_t* rather than char*: the caller's buffer IS a uint32_t[], and
+// the char* round-trip it used to take is exactly the shape -Wcast-align rejects
+// (see rules.mk) — a cast that widens the alignment requirement is only safe by
+// convention, and the convention is what the HID-apply brick broke.
+static void pct_to_u32_string(uint32_t* out, uint8_t out_len, uint8_t pct) {
+    uint32_t* s = out;
     uint8_t   cap = out_len / (uint8_t)sizeof(uint32_t);
     uint8_t   i = 0;
     uint32_t digits[6];
-    num_to_u32_string((char*)digits, sizeof(digits), pct);
+    num_to_u32_string(digits, sizeof(digits), pct);
     for(uint8_t d = 0; digits[d] && i < cap; ++d) s[i++] = digits[d];
     if(i < cap) s[i++] = U'%';
     if(i < cap) s[i] = 0;
@@ -275,7 +279,7 @@ static uint8_t brightness_to_level(uint8_t contrast) {
 static void draw_brightness_row(const GFXfont* const* font, int8_t x, int8_t base_y, uint8_t contrast) {
     uint32_t buffer[8];
     kdisp_draw_bitmap(x, (int8_t)(base_y - 11), brightness_sun_bitmap, SUN_W, SUN_H);
-    num_to_u32_string((char*) buffer, sizeof(buffer), contrast);
+    num_to_u32_string(buffer, sizeof(buffer), contrast);
     kdisp_write_gfx_text(font, 1, (int8_t)(x + 15), base_y, buffer);
     draw_brightness_bars((int8_t)(x + 40), (int8_t)(base_y - 1), brightness_to_level(contrast));
 }
@@ -338,7 +342,7 @@ void oled_update_buffer(void) {
     const int8_t TEXT_R = lock_panel ? 104 : 127;  // right limit for right-aligned content
 
     kdisp_write_gfx_text(g_all_fonts, g_all_font_count, TEXT_X, 15, ICON_LAYER);
-    hex_to_u32_string((char*) buffer, sizeof(buffer), get_highest_layer(global_layer->layer));
+    hex_to_u32_string(buffer, sizeof(buffer), get_highest_layer(global_layer->layer));
     kdisp_write_gfx_text(displayFont, 1, (int8_t)(TEXT_X + 20), 15, buffer);
     // Top-row role: the USB-host half shows the USB glyph + "USB", the bridged half
     // the link glyph + "Link" (follows is_usb_host_side(), so it tracks the cable).
@@ -385,7 +389,7 @@ void oled_update_buffer(void) {
             kdisp_write_gfx_text(smallFont, 1, TEXT_X, RGB_OFF_ROW_B, U"RGB");
             kdisp_write_gfx_text(smallFont, 1, (int8_t)(TEXT_X + 34), RGB_OFF_ROW_B, U"Off");
             kdisp_draw_bitmap(TEXT_X, (int8_t)(RGB_OFF_ROW_C - 8), wpm_gauge_bitmap, WPM_ICON_W, WPM_ICON_H);
-            num_to_u32_string((char*) buffer, sizeof(buffer), get_current_wpm());
+            num_to_u32_string(buffer, sizeof(buffer), get_current_wpm());
             kdisp_write_gfx_text(smallFont, 1, (int8_t)(TEXT_X + 15), RGB_OFF_ROW_C, buffer);
             draw_lang_column(tinyFont, COL_X, local_state->lang);
         } else {
@@ -394,7 +398,7 @@ void oled_update_buffer(void) {
             // — enough for a word instead of a 4-letter code.
             const uint8_t mode = rgb_matrix_get_mode();
             const uint32_t* mode_name = get_led_matrix_text(mode);
-            num_to_u32_string((char*) buffer, sizeof(buffer), mode);
+            num_to_u32_string(buffer, sizeof(buffer), mode);
             kdisp_write_gfx_text(smallFont, 1, TEXT_X, RGB_ROW_B, buffer);
             const int8_t name_x = (int8_t)(TEXT_X + 22);
             kdisp_write_gfx_text(smallFont, 1, name_x, RGB_ROW_B, mode_name);
@@ -421,11 +425,11 @@ void oled_update_buffer(void) {
             // group right-aligns to the panel edge, so its icon has to be placed from
             // the measured digits rather than a fixed x. Worst case (both 100%) is
             // 2x51px of the 108px row, leaving 6px between the groups.
-            pct_to_u32_string((char*) buffer, sizeof(buffer), byte_to_percent(sat));
+            pct_to_u32_string(buffer, sizeof(buffer), byte_to_percent(sat));
             kdisp_draw_bitmap(TEXT_X, DROPLET_Y, sat_droplet_bitmap, DROPLET_W, DROPLET_H);
             kdisp_write_gfx_text(smallFont, 1, (int8_t)(TEXT_X + DROPLET_W + SV_ICON_GAP), RGB_ROW_D, buffer);
 
-            pct_to_u32_string((char*) buffer, sizeof(buffer), byte_to_percent(rgb_matrix_get_val()));
+            pct_to_u32_string(buffer, sizeof(buffer), byte_to_percent(rgb_matrix_get_val()));
             int8_t val_lo = 0, val_hi = 0;
             kdisp_gfx_text_bounds(smallFont, 1, buffer, &val_lo, &val_hi);
             const int8_t val_x = (int8_t)(TEXT_R - val_hi);
@@ -449,7 +453,7 @@ void oled_update_buffer(void) {
             // row. The brightness meter is ~98px wide, so it can only ever hold a row on
             // its own -- which is why the language slot rides with the speed group.
             kdisp_draw_bitmap(0, (int8_t)(LOCK_ROW_C - 8), wpm_gauge_bitmap, WPM_ICON_W, WPM_ICON_H);
-            num_to_u32_string((char*) buffer, sizeof(buffer), get_current_wpm());
+            num_to_u32_string(buffer, sizeof(buffer), get_current_wpm());
             kdisp_write_gfx_text(smallFont, 1, 15, LOCK_ROW_C, buffer);
             kdisp_draw_bitmap(46, (int8_t)(LOCK_ROW_C - 12), lang_globe_bitmap, GLOBE_W, GLOBE_H);
             kdisp_write_gfx_text(tinyFont, 1, 62, LOCK_ROW_C, poly_lang_code(local_state->lang));
@@ -487,7 +491,7 @@ void oled_update_buffer_fw_update(void) {
                 const char* fontpack_name = fontpack_slot_name(fw_staging_fontpack_slot_off());
                 kdisp_write_gfx_text(small, 1, 0, 14, U"Fontpack:");
                 if (fontpack_name) {
-                    ascii_to_u32_string((char*) buffer, sizeof(buffer), fontpack_name);
+                    ascii_to_u32_string(buffer, sizeof(buffer), fontpack_name);
                     kdisp_write_gfx_text(small, 1, 0, 36, buffer);
                 } else {
                     kdisp_write_gfx_text(small, 1, 0, 36, U"<EMPTY>");

--- a/keyboards/polykybd/split_sync.c
+++ b/keyboards/polykybd/split_sync.c
@@ -488,7 +488,17 @@ void user_sync_mru_data_handler(uint8_t in_len, const void* in_data, uint8_t out
 void user_sync_doom_mirror_handler(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data) {
     SYNC_VALIDATE_OR_RETURN(doom_mirror_msg_t);
     const doom_mirror_msg_t* msg = (const doom_mirror_msg_t *)in_data;
+    // ⚠️ Widens alignment (uint8_t* -> a struct of uint32_t), the shape that
+    // bricked the applier (qmk#258). Safe, and asserted rather than assumed:
+    // DOOM_ARENA_MIRROR_OFF is _Static_assert'ed 4-aligned in doom_arena.h over
+    // a 4-aligned arena base. doom_arena_at() cannot simply return void* — that
+    // signature is the pack ABI (doom_pack_abi.h), see rules.mk — so the check
+    // is suppressed for this one line, never file-wide, and never by laundering
+    // the cast through uintptr_t, which would silence it while proving nothing.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-align"
     doom_mirror_t* m = (doom_mirror_t *)doom_arena_at(DOOM_ARENA_MIRROR_OFF);
+#pragma GCC diagnostic pop
     if (m != NULL) {
         switch (msg->kind) {
             case DOOM_MIRROR_MSG_TIC: {

--- a/keyboards/polykybd/tools/hil_probes/README.md
+++ b/keyboards/polykybd/tools/hil_probes/README.md
@@ -1,0 +1,84 @@
+# HIL probes — the firmware debug loop
+
+A **probe** is a one-off script the HIL rig runs against a freshly-flashed
+keyboard. It exists to answer the question the graded suite cannot: *"flash this
+build, drive it like so, and show me what the firmware printed."*
+
+Before this, that question needed a person — build a `.bin`, hand it over, wait
+for it to be flashed, wait for a console log to be pasted back. That round trip
+was the slow half of every hardware bug, the HID-apply brick (#258) included.
+
+## The loop
+
+1. Write a probe here, on the same branch as the firmware change it investigates.
+2. Push the branch.
+3. Dispatch `qmk-test.yml` on that branch with `tier: debug`, `probe: <name>`.
+4. Read the job log. The rig flashes both halves, runs the probe, and pipes the
+   firmware's own console into the log as `[qmk] …` lines.
+5. Edit, push, dispatch again.
+
+Nobody has to touch the hardware, and a **brick is self-recovering**: the rig
+asserts BOOTSEL over GPIO, and BOOTSEL/UF2 bypasses `fw_staging` entirely. That
+is what makes the rig the right — and the only — place to exercise the
+firmware-apply path.
+
+## Writing one
+
+```python
+NAME = "what this is looking for"     # optional; defaults to the filename
+MIN_PROTOCOL = 15                     # optional; same gate keys as a HIL test
+NEEDS_CONSOLE = True                  # optional; SKIPs if the console is down
+
+def probe(raw, log):
+    reply = raw.send(bytes([0x50, 0x06]))   # 'P', GET_ID
+    log(f"GET_ID -> {reply!r}")
+    return reply is not None
+```
+
+`raw` is the rig's `RawHID`; `log` writes into the run log. Return `True` to
+pass. The probe runs with the flash, the readiness gates and the console tap
+already done — see `polykybd-ctnd/CLAUDE.md` § *Debug loop* for the runner side
+and `station/probe.py` for the loader.
+
+To read what the firmware printed *while the probe ran*, use the shared tap:
+
+```python
+from station.console_log import TAP
+
+def probe(raw, log):
+    mark = TAP.mark()
+    raw.send(bytes([0x50, 0x06]))
+    for line in TAP.since(mark):
+        log(f"console: {line}")
+    return True
+```
+
+⚠️ **Iterate on a branch with no open PR.** A push to a `claude/**` branch starts
+nothing on its own (`qmk-test.yml` listens for pushes only on `PolyKybd` and
+`PolyKybd/**`), so the dispatch is the only thing that occupies the rig. Open a
+PR and every probe edit *also* runs the full build + HIL pipeline behind your
+dispatch — the rig runs one job at a time, so that is double the wait per turn.
+Open the PR when the investigation is done.
+
+## Things that will cost you a cycle if you forget them
+
+- ⚠️ **`raw.send()` RETRIES by re-writing the request.** That is safe only
+  because the commands are idempotent — `GET_ID` is the exception, since it
+  consumes the firmware's one-shot fresh-boot marker. Pass `attempts=1` when the
+  read observes a one-shot side effect.
+- ⚠️ **The console cannot see a flash window.** QMK drops output nobody drains,
+  and during a flash nothing does. A gap in the `[qmk]` lines spanning an update
+  is expected, not a symptom.
+- ⚠️ **Most firmware diagnostics are gated on `debug_enable`, which is false.**
+  `Bridge sync retry` and `Failed to sync …` never appear on the rig; the
+  `Split link:` summary is deliberately ungated. Check the gate in the firmware
+  before designing a probe around a console line.
+- **A probe is disposable.** Delete it when the bug is closed, or promote it to a
+  real HIL test (`station/hil_tests.py`) if the question is worth asking forever.
+
+## Why this is dispatch-only
+
+Triggering a `workflow_dispatch` requires write access to this repo, so a fork PR
+can never reach the probe job. That matters: the rig is a self-hosted runner for
+a **public** repo (HIL-2 in `polykybd-ctnd/docs/SECURITY_AUDIT.md`). Do **not**
+add a label trigger — a label is applied to a PR whose head may be a fork.

--- a/keyboards/polykybd/tools/hil_probes/identity.py
+++ b/keyboards/polykybd/tools/hil_probes/identity.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: GPL-2.0-only
+"""Smoke probe: read the board's identity and show what it printed.
+
+This is the template to copy, and it doubles as the check that the debug loop
+itself is healthy — if this probe cannot pass, nothing about a *real* probe's
+result is trustworthy. It asserts only what a keyboard that is up must satisfy,
+so it should never fail for a reason that lives in the firmware under test.
+
+Run it with::
+
+    tier: debug   probe: identity
+
+See ``README.md`` in this directory for the loop, and
+``polykybd-ctnd/station/probe.py`` for what a probe may declare.
+"""
+
+NAME = "probe: identity + console"
+NEEDS_CONSOLE = True
+
+POLY_CHANNEL = 0x50  # 'P' — the command-channel marker every report starts with
+CMD_GET_ID = 0x06
+
+
+def probe(raw, log):
+    # ⚠️ attempts=1 deliberately. GET_ID is the ONE non-idempotent command in the
+    # protocol — it consumes the firmware's one-shot fresh-boot marker — so the
+    # usual retry would re-issue it after the marker was already cleared and hand
+    # back correct-but-different data. Harmless here (nothing below reads the
+    # marker), but the habit is what keeps a probe honest; see the note in
+    # polykybd-ctnd/CLAUDE.md on why that retry once turned a rig hiccup into a
+    # red HIL check.
+    reply = raw.send(bytes([POLY_CHANNEL, CMD_GET_ID]), attempts=1)
+    if reply is None:
+        log("GET_ID: no reply — the keyboard is not answering raw HID")
+        return False
+
+    # "P\x06." then a NUL-terminated identity string, then (protocol 6+) a binary
+    # font-pack version block. Decode only up to the NUL: the bytes after it are
+    # not text and would come back as mojibake.
+    body = bytes(reply[3:])
+    ident = body.split(b"\x00", 1)[0].decode("ascii", "replace")
+    log(f"identity: {ident}")
+
+    # Prove the console side of the loop works too — this is the half that
+    # replaces "please paste the console log". Anything the firmware printed
+    # since `mark` is captured, reassembled into whole lines by the tap.
+    try:
+        from station.console_log import TAP
+        mark = TAP.mark()
+        raw.send(bytes([POLY_CHANNEL, CMD_GET_ID]), attempts=1)
+        lines = TAP.since(mark)
+        log(f"console lines captured while probing: {len(lines)}")
+        for line in lines[:10]:
+            log(f"  | {line}")
+    except Exception as exc:                     # noqa: BLE001 — diagnostic only
+        # The console is best-effort on the rig (a build without CONSOLE_ENABLE,
+        # or a transient open failure). NEEDS_CONSOLE above already SKIPs the
+        # probe in that case, so reaching here means something rarer — report it
+        # rather than failing the identity check it has nothing to do with.
+        log(f"console tap unavailable: {exc}")
+
+    return bool(ident)

--- a/keyboards/polykybd/tools/require_fwapply_run.py
+++ b/keyboards/polykybd/tools/require_fwapply_run.py
@@ -40,7 +40,15 @@ JOB_ID = "fwapply-test"
 JOB_NAME = "Firmware apply round-trip (split72)"
 # The bump commit edits only this, and only its version line.
 VERSION_FILE = "keyboards/polykybd/config.h"
+# BOTH macros, because bump-version.yml writes either one depending on the merged
+# PR's label: `bump:protocol` increments PROTOCOL_VERSION and leaves the semver
+# alone, so FW_VERSION is re-substituted with the same value and produces no diff
+# line at all. Accepting only FW_VERSION would refuse a perfectly well-covered
+# protocol release — and it would do so at publish time, which is the worst
+# moment to discover it. This does not widen the gate: any change outside these
+# lines, or outside this file, still fails.
 VERSION_MACRO = "FW_VERSION"
+VERSION_MACROS = ("FW_VERSION", "PROTOCOL_VERSION")
 MAX_ANCESTORS = 12
 
 
@@ -102,7 +110,7 @@ def only_a_version_bump(files):
             return False
         for line in patch.splitlines():
             if line[:1] in ("+", "-") and not line.startswith(("+++", "---")):
-                if VERSION_MACRO not in line:
+                if not any(macro in line for macro in VERSION_MACROS):
                     return False
     return True
 
@@ -214,6 +222,20 @@ def selftest():
         ("bump with a diff header",
          [patch("--- a/x", "+++ b/x", "-#define FW_VERSION \"a\"", "+#define FW_VERSION \"b\"")],
          True),
+        # bump:protocol changes ONLY this line — FW_VERSION is rewritten to the
+        # same value and never appears in the diff. Accepting just FW_VERSION
+        # would refuse a well-covered protocol release at publish time.
+        ("protocol-only bump (bump:protocol)",
+         [patch("@@", "-#define PROTOCOL_VERSION 15", "+#define PROTOCOL_VERSION 16")],
+         True),
+        ("both version macros bumped",
+         [patch("@@", "-#define FW_VERSION \"a\"", "+#define FW_VERSION \"b\"",
+                "-#define PROTOCOL_VERSION 15", "+#define PROTOCOL_VERSION 16")],
+         True),
+        ("protocol bump PLUS a real edit in the same file",
+         [patch("@@", "-#define PROTOCOL_VERSION 15", "+#define PROTOCOL_VERSION 16",
+                "-#define SOMETHING 1", "+#define SOMETHING 2")],
+         False),
         ("version bump PLUS a real edit in the same file",
          [patch("@@", "-#define FW_VERSION \"a\"", "+#define FW_VERSION \"b\"",
                 "-#define SOMETHING 1", "+#define SOMETHING 2")],

--- a/keyboards/polykybd/tools/require_fwapply_run.py
+++ b/keyboards/polykybd/tools/require_fwapply_run.py
@@ -49,6 +49,10 @@ VERSION_FILE = "keyboards/polykybd/config.h"
 # lines, or outside this file, still fails.
 VERSION_MACRO = "FW_VERSION"
 VERSION_MACROS = ("FW_VERSION", "PROTOCOL_VERSION")
+# `+/-` stripped by the caller; leading whitespace allowed, nothing else before
+# the directive and nothing but the macro name after it.
+VERSION_DEFINE_RE = re.compile(
+    r"^\s*#\s*define\s+(?:" + "|".join(VERSION_MACROS) + r")\b")
 MAX_ANCESTORS = 12
 # GitHub's compare API returns at most this many files, silently truncated. A
 # truncated list cannot prove "nothing else changed", so it is refused rather
@@ -118,7 +122,12 @@ def only_a_version_bump(files):
             return False
         for line in patch.splitlines():
             if line[:1] in ("+", "-") and not line.startswith(("+++", "---")):
-                if not any(macro in line for macro in VERSION_MACROS):
+                # ⚠️ An explicit `#define <MACRO>` definition, not merely a line
+                # MENTIONING the token. config.h has other lines that reference
+                # these macros, so a substring test would accept a real code edit
+                # sitting next to one — precisely the change this gate exists to
+                # refuse (caught in review of #264).
+                if not VERSION_DEFINE_RE.match(line[1:]):
                     return False
     return True
 
@@ -269,6 +278,30 @@ def selftest():
         # bump:protocol changes ONLY this line — FW_VERSION is rewritten to the
         # same value and never appears in the diff. Accepting just FW_VERSION
         # would refuse a well-covered protocol release at publish time.
+        # ⚠️ A line that merely MENTIONS the macro is not the bump. config.h
+        # has such lines, so a substring test would wave through a real code
+        # edit that happens to sit beside one.
+        ("a real edit that only references the macro",
+         [patch("@@", "-  build_id(FW_VERSION, 1);", "+  build_id(FW_VERSION, 2);")],
+         False),
+        ("a #define of something else that references the macro",
+         [patch("@@", "-#define BANNER \"fw \" FW_VERSION", "+#define BANNER \"v\" FW_VERSION")],
+         False),
+        # ⚠️ Word boundary: a DIFFERENT macro that merely starts with the same
+        # name is not the bump. Without \\b in the regex this passes.
+        ("a different macro sharing the prefix",
+         [patch("@@", "-#define FW_VERSION_MAJOR 0", "+#define FW_VERSION_MAJOR 1")],
+         False),
+        # ⚠️ The filename check is what rejects this — the LINE is a perfectly
+        # well-formed version define, so the regex alone cannot. Before this
+        # fixture existed, deleting the filename check escaped the whole sweep.
+        ("a real version define in a DIFFERENT file",
+         [{"filename": "keyboards/polykybd/base/fw_staging.c",
+           "patch": "@@\n-#define FW_VERSION \"a\"\n+#define FW_VERSION \"b\""}],
+         False),
+        ("indented / spaced directive is still the bump",
+         [patch("@@", "-  #  define FW_VERSION \"a\"", "+  #  define FW_VERSION \"b\"")],
+         True),
         ("protocol-only bump (bump:protocol)",
          [patch("@@", "-#define PROTOCOL_VERSION 15", "+#define PROTOCOL_VERSION 16")],
          True),

--- a/keyboards/polykybd/tools/require_fwapply_run.py
+++ b/keyboards/polykybd/tools/require_fwapply_run.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-only
+"""Refuse to publish a release that no firmware-APPLY run has ever covered.
+
+The HID-apply brick (qmk#258) shipped in a release because nothing applied a
+firmware image on hardware: the rig flashes by UF2 over GPIO BOOTSEL, which
+bypasses ``fw_staging`` entirely. ``qmk-test.yml``'s fwapply tier now runs on
+every merge to ``PolyKybd``, so in the normal case the commit being released is
+already covered and this script is a formality. It exists for the case that is
+not normal — a hand-made tag, a re-published release, a merge whose rig run was
+red and got forgotten — where the failure is silent and expensive.
+
+⚠️ **The release tag does NOT point at a commit any workflow ran on.** Release
+tags land on the auto-bump ``chore: … [skip ci]`` commit (``bump-version.yml``),
+and ``[skip ci]`` suppresses the run — so a gate that demanded a run on
+``github.sha`` would fail every single release. The bump touches exactly one
+file, so this walks back through ancestors for a covered commit and then proves
+the delta to the release commit is *only* the version bump. Accepting an
+ancestor without that proof would be worse than no gate at all: it would report
+coverage that belongs to different firmware.
+
+Exits 0 (with the run it accepted) or 1 (with what to do about it).
+"""
+
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+API = "https://api.github.com"
+WORKFLOW = "qmk-test.yml"
+WORKFLOW_PATH = os.path.join(".github", "workflows", WORKFLOW)
+JOB_ID = "fwapply-test"
+# Fallback only. The real name is DERIVED from the workflow (see job_name): a
+# hardcoded string here would silently stop matching the day someone renames the
+# job, and a gate that matches nothing reports "never covered" for firmware that
+# was — the enumerating-guard failure this repo keeps getting caught by.
+JOB_NAME = "Firmware apply round-trip (split72)"
+# The bump commit edits only this, and only its version line.
+VERSION_FILE = "keyboards/polykybd/config.h"
+VERSION_MACRO = "FW_VERSION"
+MAX_ANCESTORS = 12
+
+
+def job_name(workflow_text=None):
+    """The display name GitHub reports for the apply job.
+
+    Read out of the checked-out workflow rather than hardcoded, so renaming the
+    job cannot quietly turn this gate into a no-op. Falls back to the constant
+    when the file is unreadable (the script is also runnable outside a checkout).
+
+    A deliberate line scan rather than a YAML parse: PyYAML is not guaranteed on
+    a runner, and the shape being read is two adjacent lines at known indents.
+    """
+    if workflow_text is None:
+        try:
+            with open(WORKFLOW_PATH) as fh:
+                workflow_text = fh.read()
+        except OSError:
+            return JOB_NAME
+    in_job = False
+    for line in workflow_text.splitlines():
+        if re.match(rf"^  {re.escape(JOB_ID)}:\s*$", line):
+            in_job = True
+            continue
+        if in_job:
+            m = re.match(r"^    name:\s*(.+?)\s*$", line)
+            if m:
+                return m.group(1).strip("'\"")
+            # A new job started (two-space indent, non-comment) before any name.
+            if re.match(r"^  \S", line):
+                break
+    return JOB_NAME
+
+
+def api(path, token):
+    req = urllib.request.Request(
+        f"{API}{path}",
+        headers={"Authorization": f"Bearer {token}",
+                 "Accept": "application/vnd.github+json",
+                 "User-Agent": "polykybd-release-gate"})
+    with urllib.request.urlopen(req, timeout=30) as fh:
+        return json.load(fh)
+
+
+def only_a_version_bump(files):
+    """True when this diff is exactly the auto-bump and nothing else.
+
+    Pure so it can be tested without the network. ``files`` is the GitHub
+    compare API's ``files`` list; an empty list means the commits are identical,
+    which is the ideal case (the release sha itself was covered).
+    """
+    for f in files:
+        if f.get("filename") != VERSION_FILE:
+            return False
+        # Every changed line in the patch must be the version macro. A patch is
+        # absent for a pure rename/mode change — refuse rather than guess.
+        patch = f.get("patch")
+        if not patch:
+            return False
+        for line in patch.splitlines():
+            if line[:1] in ("+", "-") and not line.startswith(("+++", "---")):
+                if VERSION_MACRO not in line:
+                    return False
+    return True
+
+
+def covered_by(runs_jobs, name=None):
+    """Return the id of a run whose apply job SUCCEEDED, else None.
+
+    ``runs_jobs`` is an iterable of ``(run_id, jobs)``. A run whose apply job is
+    absent does not count — that is the ordinary case for a run predating the
+    tier, and reporting it as coverage is exactly the failure this guards.
+    """
+    name = name or JOB_NAME
+    for run_id, jobs in runs_jobs:
+        for job in jobs:
+            if job.get("name") == name and job.get("conclusion") == "success":
+                return run_id
+    return None
+
+
+def main():
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    repo = os.environ.get("REPO")
+    sha = os.environ.get("SHA")
+    if not (token and repo and sha):
+        print("::error::require_fwapply_run needs GH_TOKEN, REPO and SHA", file=sys.stderr)
+        return 1
+
+    try:
+        commits = api(f"/repos/{repo}/commits?sha={sha}&per_page={MAX_ANCESTORS}", token)
+    except urllib.error.HTTPError as exc:
+        print(f"::error::cannot list commits for {sha[:8]}: {exc}", file=sys.stderr)
+        return 1
+
+    want_job = job_name()
+    print(f"looking for a green '{want_job}' run covering {sha[:8]}")
+    checked = []
+    for commit in commits:
+        candidate = commit["sha"]
+        try:
+            runs = api(f"/repos/{repo}/actions/workflows/{WORKFLOW}/runs"
+                       f"?head_sha={candidate}&per_page=20", token)["workflow_runs"]
+        except urllib.error.HTTPError as exc:
+            print(f"::warning::cannot list runs for {candidate[:8]}: {exc}")
+            continue
+        if not runs:
+            checked.append(f"{candidate[:8]} (no run)")
+            continue
+        pairs = []
+        for run in runs:
+            try:
+                jobs = api(f"/repos/{repo}/actions/runs/{run['id']}/jobs"
+                           f"?per_page=50", token)["jobs"]
+            except urllib.error.HTTPError:
+                continue
+            pairs.append((run["id"], jobs))
+        run_id = covered_by(pairs, want_job)
+        if run_id is None:
+            checked.append(f"{candidate[:8]} (no green apply job)")
+            continue
+
+        if candidate == sha:
+            print(f"::notice::firmware apply verified on this exact commit "
+                  f"({candidate[:8]}) by run {run_id}")
+            return 0
+        try:
+            files = api(f"/repos/{repo}/compare/{candidate}...{sha}", token).get("files", [])
+        except urllib.error.HTTPError as exc:
+            print(f"::error::cannot compare {candidate[:8]}...{sha[:8]}: {exc}", file=sys.stderr)
+            return 1
+        if only_a_version_bump(files):
+            print(f"::notice::firmware apply verified on {candidate[:8]} by run {run_id}; "
+                  f"the only delta to {sha[:8]} is the {VERSION_MACRO} bump")
+            return 0
+        changed = ", ".join(sorted(f.get("filename", "?") for f in files)[:8]) or "(none)"
+        print(f"::error::the newest apply-verified commit is {candidate[:8]}, but "
+              f"{sha[:8]} differs from it by more than the version bump ({changed}). "
+              f"That run does not cover this firmware.", file=sys.stderr)
+        return 1
+
+    print(f"::error::no green '{want_job}' run covers {sha[:8]} or its "
+          f"{len(checked)} most recent ancestors — refusing to publish an image "
+          f"whose HID firmware-update path has never been exercised on hardware. "
+          f"Checked: {'; '.join(checked)}. "
+          f"Fix: run the Build and HIL Test workflow on this commit with "
+          f"tier=fwapply (Actions -> Build and HIL Test -> Run workflow), wait for "
+          f"it to go green, then re-run this job.", file=sys.stderr)
+    return 1
+
+
+def selftest():
+    """Exercise the two decision functions without the network.
+
+    This repo has no Python test harness (its suites are googletest), and the
+    logic below is the kind that decides a release — the same reason
+    ``fw_up_verdict.c`` was split out of its I/O so it could be tested at all.
+    A self-test keeps it honest at the cost of one 0.1 s CI step.
+    """
+    def patch(*lines):
+        return {"filename": VERSION_FILE, "patch": "\n".join(lines)}
+
+    cases = [
+        # (name, files, expected)
+        ("identical commits", [], True),
+        ("pure version bump",
+         [patch("@@", "-#define FW_VERSION \"0.16.23\"", "+#define FW_VERSION \"0.16.24\"")],
+         True),
+        # The +++/--- header lines name the file, not a change; they must not be
+        # mistaken for content and must not fail the version check.
+        ("bump with a diff header",
+         [patch("--- a/x", "+++ b/x", "-#define FW_VERSION \"a\"", "+#define FW_VERSION \"b\"")],
+         True),
+        ("version bump PLUS a real edit in the same file",
+         [patch("@@", "-#define FW_VERSION \"a\"", "+#define FW_VERSION \"b\"",
+                "-#define SOMETHING 1", "+#define SOMETHING 2")],
+         False),
+        ("a second file changed",
+         [patch("@@", "-#define FW_VERSION \"a\"", "+#define FW_VERSION \"b\""),
+          {"filename": "keyboards/polykybd/poly_keymap.c", "patch": "@@\n+x"}],
+         False),
+        ("only another file changed",
+         [{"filename": "keyboards/polykybd/base/fw_staging.c", "patch": "@@\n+x"}], False),
+        # ⚠️ A DIFFERENT file whose changed lines all mention the macro. Not
+        # hypothetical - hid_com.c builds the GET_ID string out of FW_VERSION -
+        # and without this case the filename check can be DELETED and every
+        # other fixture still passes, because the per-line check happens to
+        # reject them for the other reason. Found by mutation-testing this
+        # selftest, which is the whole argument for doing that.
+        ("another file whose lines all mention the macro",
+         [{"filename": "keyboards/polykybd/hid_com.c",
+           "patch": "@@\n-  x(FW_VERSION);\n+  y(FW_VERSION);"}], False),
+        # No patch = a rename or mode change; there is nothing to inspect, so it
+        # must be refused rather than assumed benign.
+        ("version file with no patch body", [{"filename": VERSION_FILE}], False),
+    ]
+    ok = True
+    for name, files, want in cases:
+        got = only_a_version_bump(files)
+        if got != want:
+            print(f"selftest FAIL: only_a_version_bump({name}) = {got}, want {want}")
+            ok = False
+
+    green = {"name": JOB_NAME, "conclusion": "success"}
+    job_cases = [
+        ("a green apply job", [(1, [green])], 1),
+        ("apply job failed", [(1, [{"name": JOB_NAME, "conclusion": "failure"}])], None),
+        ("apply job absent (run predates the tier)",
+         [(1, [{"name": "HIL test (split72)", "conclusion": "success"}])], None),
+        ("green in a later run of the same commit",
+         [(1, [{"name": JOB_NAME, "conclusion": "failure"}]), (2, [green])], 2),
+        ("no runs at all", [], None),
+        ("apply job still running", [(1, [{"name": JOB_NAME, "conclusion": None}])], None),
+    ]
+    for name, pairs, want in job_cases:
+        got = covered_by(pairs)
+        if got != want:
+            print(f"selftest FAIL: covered_by({name}) = {got}, want {want}")
+            ok = False
+
+    name_cases = [
+        ("reads the job's own name",
+         "jobs:\n  fwapply-test:\n    name: Firmware apply round-trip (split72)\n",
+         "Firmware apply round-trip (split72)"),
+        ("quoted name",
+         "  fwapply-test:\n    name: 'Apply (split72)'\n", "Apply (split72)"),
+        # ⚠️ Must NOT bleed into the NEXT job's name when ours declares none —
+        # that would silently match a different job and report coverage that
+        # does not exist.
+        ("no name on our job -> the constant, not the next job's",
+         "  fwapply-test:\n    needs: [build]\n  other-job:\n    name: Something Else\n",
+         JOB_NAME),
+        ("job absent entirely -> the constant",
+         "  hil-test:\n    name: HIL test (split72)\n", JOB_NAME),
+    ]
+    for name, text, want in name_cases:
+        got = job_name(text)
+        if got != want:
+            print(f"selftest FAIL: job_name({name}) = {got!r}, want {want!r}")
+            ok = False
+
+    # The REAL workflow must resolve, or the gate silently falls back to the
+    # constant and stops tracking a rename — the whole point of deriving it.
+    if os.path.exists(WORKFLOW_PATH):
+        got = job_name()
+        if got == JOB_NAME and f"  {JOB_ID}:" in open(WORKFLOW_PATH).read():
+            # Equal to the fallback is fine ONLY if that is genuinely the name.
+            pass
+        if f"  {JOB_ID}:" not in open(WORKFLOW_PATH).read():
+            print(f"selftest FAIL: {WORKFLOW_PATH} has no '{JOB_ID}' job — "
+                  f"the gate would match nothing")
+            ok = False
+
+    print("selftest: OK" if ok else "selftest: FAILED")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    if "--selftest" in sys.argv:
+        sys.exit(selftest())
+    sys.exit(main())

--- a/keyboards/polykybd/tools/require_fwapply_run.py
+++ b/keyboards/polykybd/tools/require_fwapply_run.py
@@ -50,6 +50,14 @@ VERSION_FILE = "keyboards/polykybd/config.h"
 VERSION_MACRO = "FW_VERSION"
 VERSION_MACROS = ("FW_VERSION", "PROTOCOL_VERSION")
 MAX_ANCESTORS = 12
+# GitHub's compare API returns at most this many files, silently truncated. A
+# truncated list cannot prove "nothing else changed", so it is refused rather
+# than trusted — the whole gate rests on that proof.
+COMPARE_FILE_CAP = 300
+# The delta from a covered ancestor to the release commit is the auto-bump: one
+# commit. Anything more is not the bump, and bounding it means the file list is
+# small enough that the cap above cannot have hidden anything.
+MAX_BUMP_COMMITS = 2
 
 
 def job_name(workflow_text=None):
@@ -115,6 +123,35 @@ def only_a_version_bump(files):
     return True
 
 
+def compare_is_conclusive(compare):
+    """True when a compare response can PROVE what changed.
+
+    Pure, so it is testable without the network. Two ways the API can leave the
+    question open, both of which must refuse rather than assume:
+
+    * the ``files`` list is capped at ``COMPARE_FILE_CAP`` and silently truncated
+      — a partial list cannot establish "and nothing else";
+    * the delta is more commits than an auto-bump can be, which means whatever is
+      being compared is not the bump at all.
+
+    Returns ``(ok, reason)``; ``reason`` is empty when ok.
+    """
+    files = compare.get("files")
+    if files is None:
+        return False, "the compare response carried no file list"
+    if len(files) >= COMPARE_FILE_CAP:
+        return False, (f"the compare lists {len(files)} files, at or past GitHub's "
+                       f"{COMPARE_FILE_CAP}-file cap — the list may be truncated, so "
+                       f"it cannot prove nothing else changed")
+    ahead = compare.get("ahead_by")
+    if ahead is None:
+        return False, "the compare response carried no ahead_by"
+    if ahead > MAX_BUMP_COMMITS:
+        return False, (f"{ahead} commits separate the covered run from the release "
+                       f"commit; an auto-bump is one")
+    return True, ""
+
+
 def covered_by(runs_jobs, name=None):
     """Return the id of a run whose apply job SUCCEEDED, else None.
 
@@ -176,10 +213,17 @@ def main():
                   f"({candidate[:8]}) by run {run_id}")
             return 0
         try:
-            files = api(f"/repos/{repo}/compare/{candidate}...{sha}", token).get("files", [])
+            compare = api(f"/repos/{repo}/compare/{candidate}...{sha}", token)
         except urllib.error.HTTPError as exc:
             print(f"::error::cannot compare {candidate[:8]}...{sha[:8]}: {exc}", file=sys.stderr)
             return 1
+        conclusive, why = compare_is_conclusive(compare)
+        if not conclusive:
+            print(f"::error::cannot prove {candidate[:8]}...{sha[:8]} is only the "
+                  f"version bump: {why}. Refusing rather than assuming.",
+                  file=sys.stderr)
+            return 1
+        files = compare.get("files", [])
         if only_a_version_bump(files):
             print(f"::notice::firmware apply verified on {candidate[:8]} by run {run_id}; "
                   f"the only delta to {sha[:8]} is the {VERSION_MACRO} bump")
@@ -264,6 +308,42 @@ def selftest():
         got = only_a_version_bump(files)
         if got != want:
             print(f"selftest FAIL: only_a_version_bump({name}) = {got}, want {want}")
+            ok = False
+
+    bump = [patch("@@", "-#define FW_VERSION \"a\"", "+#define FW_VERSION \"b\"")]
+    compare_cases = [
+        ("an ordinary one-commit bump", {"files": bump, "ahead_by": 1}, True),
+        ("identical commits", {"files": [], "ahead_by": 0}, True),
+        # ⚠️ GitHub truncates `files` at 300. A truncated list cannot prove
+        # "and nothing else changed", which is the only thing this gate asserts.
+        ("a file list at GitHub's cap (may be truncated)",
+         {"files": [{"filename": VERSION_FILE, "patch": "@@"}] * COMPARE_FILE_CAP,
+          "ahead_by": 1}, False),
+        ("more commits than an auto-bump can be",
+         {"files": bump, "ahead_by": 40}, False),
+        ("no file list at all", {"ahead_by": 1}, False),
+        ("no ahead_by at all", {"files": bump}, False),
+    ]
+    for name, compare, want in compare_cases:
+        got, _ = compare_is_conclusive(compare)
+        if got != want:
+            print(f"selftest FAIL: compare_is_conclusive({name}) = {got}, want {want}")
+            ok = False
+
+    # ⚠️ The crafted range that shipped in the first cut of the firmware guard:
+    # last - first + 1 wraps a uint32 to ZERO. Mirrored here because the same
+    # arithmetic trap applies to anything reasoning about these ranges.
+    def span_ok(first, last, capacity):
+        span = (last - first) & 0xFFFFFFFF
+        return capacity != 0 and span <= capacity - 1
+    span_cases = [("normal", (0x41, 0x5A, 8751), True),
+                  ("uint32 wrap first=0 last=0xFFFFFFFF", (0, 0xFFFFFFFF, 8751), False),
+                  ("exactly fits", (0, 8750, 8751), True),
+                  ("one past", (0, 8751, 8751), False),
+                  ("zero capacity", (0, 0, 0), False)]
+    for name, (a, b, cap), want in span_cases:
+        if span_ok(a, b, cap) != want:
+            print(f"selftest FAIL: span_ok({name}) = {not want}, want {want}")
             ok = False
 
     green = {"name": JOB_NAME, "conclusion": "success"}


### PR DESCRIPTION
## Summary

Two asks, one root cause. The HID-apply brick (#258) shipped in a **release** because nothing had ever applied a firmware image on hardware — the rig flashes by UF2 over GPIO BOOTSEL, which bypasses `fw_staging` entirely, and `release.yml` runs no HIL at all. And diagnosing it needed a human in the loop for every round: build a `.bin`, hand it over, wait for it to be flashed, wait for a console log.

Four changes, cheapest first.

### 1. A debug loop on the rig — nobody flashes a `.bin`

Dispatch this workflow on a branch with **`tier: debug`, `probe: <name>`**. The rig builds that branch, flashes both halves, runs a probe committed at `keyboards/polykybd/tools/hil_probes/<name>.py`, and pipes the firmware's own console into the job log as `[qmk] …` lines. Edit, push, dispatch, read.

Most of this already existed and nobody had joined it up. What was missing was any way to ask an **arbitrary** question instead of the fixed suite; the rig side is [polykybd-ctnd#85](https://github.com/thpoll83/polykybd-ctnd/pull/85).

⚠️ **DISPATCH-ONLY, and that `if:` is the security control** — a dispatch needs write access, so a fork PR can never reach the rig through it, which matters because the rig is a self-hosted runner for a **public** repo (HIL-2). Deliberately **no `hil-debug` label**: a label is applied to a PR whose head may be a fork.

`workflow_dispatch` also gains a `tier` input. It is read **only** under `workflow_dispatch`, so push and pull_request keep their label/marker gating untouched, and it defaults to `all` — exactly today's dispatch behaviour. Verified by **simulating every job condition across every trigger** rather than reading them, since a folded-scalar `if:` breaks silently:

| scenario | build | hil-test | perf | doom | fwapply | debug |
|---|---|---|---|---|---|---|
| push (merge to PolyKybd) | ✓ | ✓ | | | **✓ new** | |
| PR (ordinary) | ✓ | ✓ | | | | |
| PR + `hil-perf` | ✓ | ✓ | ✓ | | | |
| dispatch `tier: all` | ✓ | ✓ | ✓ | ✓ | ✓ | |
| dispatch `tier: debug` | ✓ | | | | | ✓ |

### 2. The apply tier runs on every merge to `PolyKybd`

Per-PR is the wrong place for this class, and that is the whole argument: the brick was a **layout** effect. `fw_staging`'s page buffer shifted off a word boundary because a macro PR grew `.bss`; `fw_staging_do_apply` was byte-identical across the regression, so the guilty PR never touched the failing code and the bisect blamed the wrong commit. Any PR can move `.bss`. What *is* catchable is dating a regression to a **merge you can still bisect** — a release-time check names the release that bricks, with no bisect and a release to redo.

Cost is bounded: the rig already runs a HIL cycle per merge, so this adds a cloud build plus one apply+reboot. **PRs are unchanged**, so no PR pipeline gets slower.

### 3. `release.yml` refuses to publish firmware no apply run has covered

The backstop. Runs **before** the build, so a refusal changes nothing — no assets uploaded, no release body edited.

It cannot simply demand a run on `github.sha`: release tags land on the auto-bump `[skip ci]` commit, which by construction no workflow ran on, so that gate would refuse every release. It walks ancestors and then **proves the delta to the release commit is only the auto-bump** — `FW_VERSION` *or* `PROTOCOL_VERSION` in `config.h` and nothing else. Both, because `bump-version.yml` writes either one depending on the merged PR's label: a `bump:protocol` merge increments only the protocol number and re-substitutes the semver with the same value, so it produces no `FW_VERSION` diff line at all. (Accepting only `FW_VERSION` would have refused a well-covered protocol release **at publish time** — caught in review below.)

The job name is **derived from the checked-out workflow**, not hardcoded — a rename would otherwise make this a silent no-op reporting "never covered" for firmware that was.

### 4. `-Wcast-align` on our own sources — and the two bugs it found

The brick was an alignment bug, and GCC names that shape exactly. With `-Werror` already on it is now a build failure on the PR that writes it.

Scoped by path with the `$<` per-recipe filter (the mechanism the doom `EXTRAFLAGS` block already uses) — `EXTRAFLAGS` otherwise lands on **every** compile line including upstream QMK / ChibiOS / pico-sdk, the trap that kept CodeQL out of this repo.

**It found a real bug on its first build.** `fontpack.c` cast the pack's **file-controlled** `glyph_off` straight to `PolyColGlyph *`, checking only `< total_size`. That struct begins with a `uint16_t`, so an odd offset makes every glyph lookup an unaligned 16-bit read — a HardFault, from data flashed over the **unsigned** resource transport, in a pack re-loaded at boot: a persistent fault loop only BOOTSEL clears, with no signature and no keypress. Separately, only the *start* of the glyph array was bounded. Both rejected now, plus an inverted `first > last`. Tracked as **FW-11**.

The whole `doom/` tree is excluded, and the reason for our own sources is worth knowing: `doom_arena_at()` returns `uint8_t *` because that signature **is the pack ABI**, handed to a signed `.plyx`. `void *` was tried and reverted rather than edit a cross-boundary contract on a warning's account; the arena offsets are `_Static_assert`ed 4-aligned instead, which is the substance.

## Review findings addressed

- **Greptile P1 — protocol bumps would fail the release gate** (`95795014d5`). Correct, and verified against `bump-version.yml` before taking it. See §3; the gate now accepts either version macro, with a protocol-bump-**plus**-a-real-edit selftest case proving it did not widen.

## Version bump label

**`bump:minor`** — new CI capability plus a security fix, no protocol change.

## Testing

- [x] Compiled successfully — **both variants**, `split72` (`POLYKYBD_DOOM_PACK=yes`) and `split42`, clean with **zero** cast-align hits.
- [x] Full lint job locally: `qmk lint --strict` on both keyboards, `ci-validate-keyboard-targets`, `ci-validate-aliases`, tracked-ignored check — all clean.
- [x] Every registered unit suite passes (`fw_up_verdict` 27, `polykybd_font_bbox` 47, `polykybd_macro_decode` 23, `polymod_ltr559` 19, …).
- [x] The release gate is **self-tested** (`--selftest`, run as the same CI step) and **mutation-checked against 9 breaks**, including reverting the protocol-bump bug above. Two escapes were found and closed this way rather than shipped: deleting the filename check passed every fixture (no fixture had a *different* file whose lines mention `FW_VERSION` — and `hid_com.c` is exactly such a file), and the FW_VERSION-only predicate. Both fixtures carry that reasoning.
- [x] `-Wcast-align` verified the way it demands: the first build **FAILED**, which is simultaneously the proof the path filter matches (it would otherwise fail open and look installed while doing nothing) and the first find.
- [x] Font-pack guards verified against every shipped bundle before landing — 8 packs, 158 fonts, **zero** rejected.
- [ ] Flashed and tested on hardware — **not done, and worth knowing why**: `fwapply-test` has **never run**. Every previous dispatch predates the tier. So the merge of this PR will be its first-ever execution; if it goes red, that is the tier finding its footing rather than necessarily a firmware fault.
- [ ] Protocol unchanged.

## Merge order

⚠️ **Land [polykybd-ctnd#85](https://github.com/thpoll83/polykybd-ctnd/pull/85) first.** The rig force-syncs its station to ctnd `main` before every run, so `tier: debug` would otherwise reach a station that has never heard of `--probe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LeoBsy75UBvecXehCiAoWg

## Summary by Sourcery

Add hardware firmware-apply coverage and release enforcement, introduce a secure HIL debug loop, and harden project code against alignment and font-pack validation faults.

New Features:
- Add a dispatch-only HIL debug-probe workflow for running branch-specific firmware probes with live console output.
- Add selectable workflow dispatch tiers while preserving existing push and pull-request gating behavior.

Bug Fixes:
- Reject malformed font-pack glyph offsets and ranges that could cause unaligned or out-of-bounds reads.
- Harden firmware release publication by requiring successful hardware firmware-apply coverage for the released firmware, including version-bump ancestry handling.
- Prevent alignment-related faults by enforcing alignment guarantees for firmware, arena, stack, and display-buffer code paths.

Enhancements:
- Enable the firmware-apply HIL tier on every merge to the PolyKybd branch.
- Apply -Wcast-align to project-owned sources and replace unsafe display-buffer pointer conversions with correctly typed APIs.
- Align the DOOM shared linker section and add compile-time alignment assertions.

CI:
- Extend qmk-test workflow controls with debug, performance, DOOM, extended, and firmware-apply dispatch tiers, including safe ordering and self-hosted runner controls.

Documentation:
- Document the HIL probe workflow, alignment safeguards, firmware-apply coverage policy, and release-gate behavior.

Tests:
- Add a reusable identity HIL probe template and release-gate self-tests covering version bumps, ancestry, job discovery, and malformed comparisons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added selectable CI test tiers, including targeted performance, compatibility, firmware-apply, and debug runs.
  - Added named hardware probes for focused firmware diagnostics.
  - Firmware-apply verification now runs automatically on relevant pushes.

- **Bug Fixes**
  - Improved validation of font assets and memory alignment to catch malformed or unsafe data earlier.
  - Corrected OLED text-buffer handling for more reliable display rendering.

- **Documentation**
  - Added guidance for hardware probes, test tiers, and release verification.

- **Release Process**
  - Releases now require successful firmware-apply verification before publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->