### PR TITLE
ci: drop the unreachable PolyKybd/** push pattern, and record why a merge can produce no run

### DIFF
--- a/.github/workflows/polykybd-unit-test.yml
+++ b/.github/workflows/polykybd-unit-test.yml
@@ -14,9 +14,11 @@ permissions:
 
 on:
   push:
+    # `PolyKybd` only -- a `PolyKybd/**` branch is UNCREATABLE while `PolyKybd`
+    # itself is a branch (git refuses a ref that is a prefix of another ref).
+    # See the longer note in qmk-test.yml.
     branches:
       - PolyKybd
-      - 'PolyKybd/**'
   pull_request:
     paths:
       - 'keyboards/polykybd/**'

--- a/.github/workflows/qmk-test.yml
+++ b/.github/workflows/qmk-test.yml
@@ -2,7 +2,17 @@ name: Build and HIL Test
 
 on:
   push:
-    branches: [PolyKybd, "PolyKybd/**"]
+    # ⚠️ `PolyKybd` ONLY. A `PolyKybd/**` pattern was carried here for a long
+    # time and could never match anything: git forbids a ref that is a PREFIX
+    # of another ref, so while `refs/heads/PolyKybd` exists as a branch,
+    # `refs/heads/PolyKybd/<anything>` cannot be created at all --
+    #   fatal: cannot lock ref 'refs/heads/PolyKybd/x': 'refs/heads/PolyKybd'
+    #          exists; cannot create 'refs/heads/PolyKybd/x'
+    # `git ls-remote --heads origin 'refs/heads/PolyKybd/*'` confirms none has
+    # ever existed. It read as a staging-branch escape hatch and was not one:
+    # anyone reaching for `PolyKybd/staging` gets git's refusal, and a
+    # differently-named branch then silently runs nothing.
+    branches: [PolyKybd]
     # A change that cannot alter the firmware should not occupy the HIL rig for
     # a full flash-and-test cycle (the rig runs one job at a time, so such a
     # push delays every real build queued behind it).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -682,12 +682,28 @@ inherited-upstream noise:
       gate (`tools/require_fwapply_run.py`) refuses to publish firmware no apply
       run has covered, so a dropped push event costs a **manual dispatch at release
       time**, not a bricked release. That is the gate doing exactly its job.
-    - **Recovery: dispatch *Build and HIL Test* with `tier: fwapply`.** ✅ A
-      dispatch takes a **branch**, so the run lands on the branch TIP — the
-      auto-bump commit, which is precisely the sha a release tag lands on. The gate
-      then finds coverage on the release sha **directly** and never needs its
-      walk-back-through-ancestors path. Verified 2026-09-01, run #959: build ✅,
-      HIL suite ✅ 2m55, apply round-trip ✅ 3m40 (its first-ever execution).
+    - **Recovery: dispatch *Build and HIL Test* with `tier: fwapply`.** Verified
+      2026-09-01, run #959: build ✅, HIL suite ✅ 2m55, apply round-trip ✅ 3m40
+      (its first-ever execution).
+      ⚠️ **WHICH ref you dispatch on decides whether the gate can ever see it, and
+      "the branch" is only right IMMEDIATELY after the merge.** A dispatch attaches
+      the run to whatever its `ref` points at. Dispatching on `PolyKybd` therefore
+      covers the release sha **only while the tip is still that version's own bump
+      commit** — true if you do it right after the merge, as above, and false as
+      soon as another PR lands. It is not a general recipe, because the two ends
+      move in opposite directions: `publish_release.py` tags the **oldest** commit
+      declaring the version (`commit_for_version()`, deliberately not the head),
+      while `require_fwapply_run.py` only ever walks **ancestors** of the release
+      sha, bounded by `MAX_BUMP_COMMITS`. A run on a *descendant* is invisible to
+      it, so a late branch-tip dispatch produces a green run the gate still refuses.
+      **Once the branch has moved on, dispatch on the release TAG instead** — the
+      API takes a branch *or* a tag, and the tag exists by then (publishing creates
+      it, and the gate runs on `release: published`), so the run attaches to the
+      release sha itself. ⚠️ Untested here, and it carries its own trap: a dispatch
+      runs the workflow **as of that ref**, so a tag predating the `tier` input has
+      no `fwapply` value to select. (Caught by Greptile on #265 — the original
+      wording generalised one true observation into a rule that only held on the
+      day it was written.)
     - ⚠️ **So don't read "runs unasked on every merge" as a guarantee.** After a
       merge you care about, confirm a run actually exists for the merge sha —
       `actions_list list_workflow_runs` filtered `event: push` — rather than

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -540,10 +540,16 @@ inherited-upstream noise:
     do it too. **A dispatch is also the way to exercise the doom set when there is no
     open PR to label** (used 2026-08-29, run #894, right after the trilogy merged). The commit-message form is the natural release-time route — a release push
     is a push — but it only fires where the workflow listens for pushes at all,
-    i.e. `PolyKybd` and `PolyKybd/**`; the same marker in a commit pushed to a
-    `claude/**` branch starts nothing. What dispatch buys is needing no label
-    bookkeeping, which also sidesteps the two-labels-in-one-call trap below (that
-    fires two runs).
+    i.e. **`PolyKybd`, and only `PolyKybd`**; the same marker in a commit pushed to
+    a `claude/**` branch starts nothing. ⚠️ The trigger used to read `[PolyKybd,
+    "PolyKybd/**"]` and that second pattern was **unreachable**: git refuses a ref
+    that is a PREFIX of another ref, so `refs/heads/PolyKybd/<x>` cannot exist while
+    `refs/heads/PolyKybd` does (`git ls-remote --heads origin 'refs/heads/PolyKybd/*'`
+    → 0, ever). It read as a staging-branch escape hatch and was not one — git
+    refuses to create the branch, and a differently-named one silently runs nothing.
+    Dropped from `qmk-test.yml` and `polykybd-unit-test.yml` (2026-09-01).
+    What dispatch buys is needing no label bookkeeping, which also sidesteps
+    the two-labels-in-one-call trap below (that fires two runs).
     Whichever route, the combination is safe: `perf-test` has `needs: [build-perf,
     hil-test]`, so the rig runs the suite first and measures afterwards rather than
     interleaving two flashes. Measured on run #805 (2026-08-20): ~3 min of rig time
@@ -650,6 +656,43 @@ inherited-upstream noise:
     baked pubkey does not match, so the keyboard raises the A/ACCEPT prompt, which
     the rig cancels). Benign on the rig, which recovers itself — but it is why an
     ephemeral-key build must never be handed to a user to flash.
+  - ⚠️ **"On every push" is only as good as GitHub DELIVERING the push event, and it
+    does not always — measured, on the very merge that added this tier.** Merging
+    #264 (`43cc2559`, 2026-09-01) created **no push-event workflow run at all**:
+    not `qmk-test`, not `cppcheck`, not `polykybd-unit-test`. That last one is the
+    decisive part — it has **no `paths:` filter whatsoever**, and it had fired on
+    #263's `CLAUDE.md`-only merge hours earlier, yet stayed silent on a merge
+    carrying nine C files. So this was not a paths filter, and not ours. Ruled out
+    too: no GitHub Actions incident that day (the one Git Operations incident ran
+    15:00–16:01 UTC, hours earlier); the merge was a **direct click** on *Merge
+    pull request* by the repo owner — confirmed with them, not inferred — so
+    neither the GITHUB_TOKEN no-recursive-runs rule nor the reported
+    auto-merge-skips-CI-on-the-target-branch behaviour applies; and every previous
+    merge is followed by the same `[skip ci]` auto-bump at +13–16 s, so the bump
+    cannot be it either.
+    ⚠️ **`merged_by` alone CANNOT settle that** — an auto-merge is still attributed
+    to whoever enabled it, so the field reads identically either way. The only
+    signals are the timing (auto-merge fires within seconds of the last check
+    turning green; this one landed 10 minutes later) and asking the person.
+    The run object simply never existed. GitHub's own troubleshooting says a
+    workflow that does not trigger "silently does nothing", and dropped runs under
+    load are a documented class — so treat this as a **delivery** failure, not a
+    config bug, and do not go looking for a mechanism in the workflow.
+    - **The design already absorbs it, which is the reassuring half.** The release
+      gate (`tools/require_fwapply_run.py`) refuses to publish firmware no apply
+      run has covered, so a dropped push event costs a **manual dispatch at release
+      time**, not a bricked release. That is the gate doing exactly its job.
+    - **Recovery: dispatch *Build and HIL Test* with `tier: fwapply`.** ✅ A
+      dispatch takes a **branch**, so the run lands on the branch TIP — the
+      auto-bump commit, which is precisely the sha a release tag lands on. The gate
+      then finds coverage on the release sha **directly** and never needs its
+      walk-back-through-ancestors path. Verified 2026-09-01, run #959: build ✅,
+      HIL suite ✅ 2m55, apply round-trip ✅ 3m40 (its first-ever execution).
+    - ⚠️ **So don't read "runs unasked on every merge" as a guarantee.** After a
+      merge you care about, confirm a run actually exists for the merge sha —
+      `actions_list list_workflow_runs` filtered `event: push` — rather than
+      assuming. A missing run looks identical to a repo where nothing was
+      configured.
 
 - ✅ **The DEBUG LOOP: a firmware bug can now be chased on the rig with nobody
   flashing a `.bin`.** Dispatch `qmk-test.yml` on a branch with **`tier: debug`,
@@ -808,8 +851,8 @@ inherited-upstream noise:
   *different* mechanism from the push/pull_request duplication below.
 - ⚠️ **A workflow yields TWO check runs — `push` and `pull_request` — whenever the
   branch matches BOTH triggers, and re-running one does NOT touch the other.**
-  Here that mostly doesn't happen: `qmk-test.yml` pushes only on `PolyKybd`/
-  `PolyKybd/**`, `unit_test.yml` only on `master`/`develop`, and `lint`/`labeler`
+  Here that mostly doesn't happen: `qmk-test.yml` pushes only on `PolyKybd`,
+  `unit_test.yml` only on `master`/`develop`, and `lint`/`labeler`
   are PR-only — so a `claude/**` PR gets a single run per workflow. **The sibling
   repos differ**: wincompose's `build.yml` pushes on `main` *and* `claude/**` on
   top of `pull_request`, so every branch PR there carries two, and that is where

--- a/keyboards/polykybd/tools/hil_probes/README.md
+++ b/keyboards/polykybd/tools/hil_probes/README.md
@@ -54,8 +54,8 @@ def probe(raw, log):
 ```
 
 ⚠️ **Iterate on a branch with no open PR.** A push to a `claude/**` branch starts
-nothing on its own (`qmk-test.yml` listens for pushes only on `PolyKybd` and
-`PolyKybd/**`), so the dispatch is the only thing that occupies the rig. Open a
+nothing on its own (`qmk-test.yml` listens for pushes only on `PolyKybd`), so
+the dispatch is the only thing that occupies the rig. Open a
 PR and every probe edit *also* runs the full build + HIL pipeline behind your
 dispatch — the rig runs one job at a time, so that is double the wait per turn.
 Open the PR when the investigation is done.


### PR DESCRIPTION
## Summary

Two findings from chasing why merging #264 started **no CI at all** — no build, no rig, no cppcheck, no unit tests. One is a real (if small) config defect; the other is not ours, and is recorded rather than "fixed".

### 1. `PolyKybd/**` in the push triggers could never match anything

Git refuses a ref that is a **prefix** of another ref, so while `refs/heads/PolyKybd` exists as a branch, `refs/heads/PolyKybd/<x>` cannot be created at all:

```
fatal: cannot lock ref 'refs/heads/PolyKybd/ci-event-probe':
       'refs/heads/PolyKybd' exists; cannot create 'refs/heads/PolyKybd/ci-event-probe'
```

`git ls-remote --heads origin 'refs/heads/PolyKybd/*'` returns **0** — not one has ever existed, in either workflow's lifetime.

This is the fails-open shape the repo keeps getting caught by. It reads as a staging-branch escape hatch and is not one: anyone reaching for `PolyKybd/staging` to get a rig run before merging gets git's refusal, and a differently-named branch then silently runs nothing. Removed from `qmk-test.yml` and `polykybd-unit-test.yml`, each with a comment carrying git's actual error so it does not come back. `keyboards/polykybd/tools/hil_probes/README.md` described it as live too and is fixed.

### 2. The merge produced no push-event run — and it is not our config

`43cc2559` created **no push-event workflow run at all**. The decisive evidence is `polykybd-unit-test.yml`: it has **no `paths:` filter whatsoever**, and it had fired on #263's `CLAUDE.md`-only merge hours earlier, yet stayed silent on a merge carrying nine C files.

Ruled out, each with evidence rather than assertion:

| candidate | why not |
|---|---|
| paths filters | the no-filter workflow also stayed silent |
| GitHub Actions incident | none that day; the one Git Operations incident ran 15:00–16:01 UTC, hours earlier |
| `GITHUB_TOKEN` no-recursive-runs | the merge was a **direct click** on *Merge pull request* by the repo owner — confirmed, not inferred |
| auto-merge skipping target-branch CI | same; and it landed 10 min after the last check, not seconds |
| the `[skip ci]` auto-bump | every previous merge carries the identical bump at +13–16 s and still fired |

The run object simply never existed. GitHub's own troubleshooting says a workflow that does not trigger "silently does nothing", and dropped runs under load are a documented class — so this is a **delivery** failure, and looking for a mechanism inside the workflow is wasted effort.

⚠️ The note also flags that **`merged_by` alone cannot settle the auto-merge question** — an auto-merge is still attributed to whoever enabled it, so that field reads identically either way. Only the timing and asking the person distinguish them.

**Why record instead of fix:** the design already absorbs this. `tools/require_fwapply_run.py` refuses to publish firmware no apply run has covered, so a dropped push event costs a **manual dispatch at release time** rather than a release nobody checked.

**Recovery, verified:** dispatch *Build and HIL Test* with `tier: fwapply`. Run [#959](https://github.com/thpoll83/qmk_firmware/actions/runs/33551555868): build ✅, HIL suite ✅ 2m55, **apply round-trip ✅ 3m40 on its first-ever execution**. `PolyKybd` is covered.

⚠️ **The recovery note's *ref* was wrong as first written, and Greptile caught it** (P1, fixed in `5ed3f2e`). It said the dispatch lands on "precisely the sha a release tag lands on" — true only because that dispatch went in minutes after the merge, while the tip still *was* the 0.17.0 bump commit. In general the two ends move in opposite directions: `publish_release.py` `commit_for_version()` tags the **oldest** commit declaring the version, while `require_fwapply_run.py` walks **ancestors only**, bounded by `MAX_BUMP_COMMITS`. A late branch-tip dispatch therefore yields a green run the gate cannot see — the recovery *appearing* to succeed while the release stays blocked. Corrected, with the release **tag** as the general ref and its own untested-caveat recorded.

## Version bump label

*(none)* — patch. No firmware source is touched; this is CI triggers and prose only. Note it still bumps `FW_VERSION` to 0.17.1 on merge, as every docs-only merge does — worth holding this PR if you want the release you cut to be **0.17.0**, the version that now carries the verified apply coverage.

## Testing

- [x] Both workflows re-parsed after editing: `push.branches` is now `['PolyKybd']` in each, and the `>-` folded scalars (`HIL_EXTENDED` and the opt-in `if:` blocks) confirmed **newline-free** — the silent break this repo has been bitten by.
- [x] The dead pattern verified dead **empirically**: attempted the branch creation, captured git's refusal, then confirmed against the remote that none has ever existed.
- [x] `CLAUDE.md` edits grepped back by name afterwards — including prose that merely *shared* a rewritten line, which is how this file loses text silently.
- [x] Both Greptile findings verified against the actual source (`commit_for_version()`'s docstring, the gate's ancestor walk) before being taken.
- [x] No CRLF, trailing newlines present, no added line over the file's wrap.
- [ ] Compiled / flashed — **not applicable and deliberately not claimed**: no firmware source changed.

## ⚠️ Correction to an earlier version of this description

This body previously claimed the PR "will show almost no checks … every one of the three path filters excludes it." **That was wrong**, and wrong against this repo's own documented rule: `qmk-test.yml`'s paths list *ends* with the positive `.github/workflows/qmk-test.yml`, precisely so a change to the gate is still built and rig-tested. This PR edits that file, so `qmk-test` **should** run — and it did on the second push.

Which leaves a fact I am flagging rather than explaining: **no `qmk-test` run exists for the first head `2db1c6a8`**, though its diff already contained `qmk-test.yml`. `cppcheck` and `polykybd-unit-test` are fully explained by paths (no `keyboards/polykybd/**` file until the second push). If the trailing positive works — and the second push is evidence it does, since nothing else in that diff is includable — then this is a **second** missing run today, ~70 minutes after the one this PR documents.

Deliberately **not** written into `CLAUDE.md` yet. Two observations with a plausible common cause are not a mechanism, and this session has already had to walk back two claims that generalised too early. Worth watching across the next few merges before anything is asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LeoBsy75UBvecXehCiAoWg