### PR TITLE
fix(eden): roll the scanline phase so the dim idle legend stops burning fixed rows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1496,11 +1496,37 @@ new ISO codes append at the next free slot; private pseudo-codes with no ISO
     source is what actually caught it.
 - **Composable plotter modes** (`disp_array.c/.h`, static flags toggled around a
   draw): `kdisp_set_gfx_erase(bool)` makes the glyph plotter **clear** pixels
-  instead of setting them, and `kdisp_set_gfx_scanline(bool)` lights **only even
-  *absolute buffer* rows** — the gate is `(y + yo + yy) & 1`, i.e. the final buffer
-  y, **NOT** a glyph-local row, so two glyphs at different y still interleave to one
-  consistent scanline pattern. Used to render the Eden idle legend as a dim
-  half-density overlay. Always pair the set with a reset (`(false)`) after the draw.
+  instead of setting them, and `kdisp_set_gfx_scanline(bool, phase)` /
+  `kdisp_set_gfx_scanline2(bool, phase)` light only every other row (1-on/1-off) or
+  2-on/2-off bands. The gate is on the **ABSOLUTE buffer y**, not a glyph-local
+  row, so two glyphs at different y still interleave into one consistent pattern.
+  Used to render the Eden idle legend as a dim half-density overlay. Always pair the
+  set with a reset (`(false, 0)`) after the draw.
+  - ⚠️ **`phase` exists because that absolute gate is a BURN-IN trap, and the drift
+    offset does not spring it for you.** Left at a fixed phase the fine mode lights
+    the even panel rows and only ever the even panel rows — every idle session, for
+    the life of the board — so half the panel takes the legend's entire share of the
+    wear and the other half takes none. `kdisp_set_draw_offset()` does not spread
+    it: it moves the **cursor** (`gfx_text_run`), i.e. it slides the glyph past a
+    *stationary* stripe pattern, changing which rows OF THE GLYPH are dropped while
+    the lit PANEL rows never move. Only rolling the phase moves the stripes. It is a
+    parameter of the enable rather than a setter of its own so that a caller cannot
+    turn the mode on without answering that question, and so a phase cannot leak
+    into the next keycap of the same pass.
+  - **The Eden legend rolls it off the SAME `epoch` as its position drift**
+    (`poly_keymap.c`, a third salt `0x2000` on `jitter_axis`, so it is uncorrelated
+    with dx/dy): the stripe flip then lands on the very frame the letter jumps
+    anyway, which is what keeps it invisible instead of a shimmer. The boot splash
+    passes phase 0 deliberately — it runs for a few seconds, so a fixed alignment
+    costs nothing and a rolling one would read as flicker across the reveal.
+  - ⚠️ **`disp_array.c` has no unit suite** (it owns the scratch buffer), so the
+    phase table was checked by compiling `scanline_skip_row()` standalone: phase 0
+    reproduces the old pattern **exactly** (so nothing that passes 0 changed), fine
+    phase 1 is its exact complement (every panel row reachable across the two),
+    coarse phase 0..3 gives four distinct band alignments, an out-of-range phase is
+    masked, and `(false, …)` ignores it. Do the same rather than eyeballing it — the
+    modes are invisible from every preview tool (`oled_preview.py` models no plotter
+    mode) and on hardware only over months.
 - **To draw an INVERTED keycap, render it inverted — do NOT reach for
   `kdisp_invert()`.** That is a panel-level SSD1306 command, and `split72.c`'s
   `matrix_scan_kb` already toggles it on every press and un-toggles on release,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1604,7 +1604,7 @@ new ISO codes append at the next free slot; private pseudo-codes with no ISO
     bypassed — `s_gfx_erase` and `s_gfx_scanline` were the SAME shape, and the
     scanline one was live.** Both are static plotter modes that only the two char
     writers honoured, so under `IDLE_STYLE_EDEN` — which draws the resting legend
-    `kdisp_set_gfx_scanline(true)` as a dim half-density ghost — the text came out
+    `kdisp_set_gfx_scanline(true, phase)` as a dim half-density ghost — the text came out
     half-density while the composited art stayed fully lit. Measured over the shipped
     legends, three carry composite art AND are reachable as a resting legend (i.e. at
     idle), all three on the split72 default keymap: `ICON_SCRLOCK_ON/OFF` (`KC_SCRL`,
@@ -2271,10 +2271,13 @@ converges into the "EDEN" letters. It has **two lifetimes**, sharing one engine:
   equivalent (0 can never exceed an unsigned threshold) and most pixels are 0 at this
   faint density.
 - **The idle legend** (the resting key label drawn over the comet haze) is rendered
-  **LIT + scanline** (`kdisp_set_gfx_scanline(true)` around the text draw), not
+  **LIT + scanline** (`kdisp_set_gfx_scanline(true, phase)` around the text draw), not
   erased — the scanline halves the lit pixels so the legend reads as a dim overlay
   while still drifting via `roll_idle_offset()`. (ERASE mode was tried but looked
-  worse with the drifting glyphs.)
+  worse with the drifting glyphs.) ⚠️ The `phase` is not optional here — it is rolled
+  off the same `epoch` as the drift, because the scanline gate is on ABSOLUTE buffer
+  y and a fixed phase would light the same panel rows forever; see the plotter-mode
+  note in the per-keycap rendering gotchas.
 - **split72-only.** `anim/startup_anim.c` gates on
   `#if defined(KEYBOARD_polykybd_split72)` (else no-op stubs) because it needs the
   generated per-board geometry header `anim/startup_anim_geom.h` (key OLED

--- a/keyboards/polykybd/base/disp_array.c
+++ b/keyboards/polykybd/base/disp_array.c
@@ -118,32 +118,54 @@ void kdisp_set_gfx_erase(bool erase) {
 }
 
 // Scanline dimming mode for the glyph plotter — a half-brightness "present but
-// dim" look. 0 = off, 1 = fine (light even buffer rows only, 1-on/1-off), 2 =
-// coarse (light rows in 2-on/2-off bands). Gated on ABSOLUTE buffer y (not
-// glyph-local) so the bands stay aligned as a legend drifts / across glyphs.
-// The Eden idle screensaver uses the fine mode; the boot splash uses the coarse
-// mode, which on the big 24pt letters reads as an intentional dim rather than a
-// fine shimmer. Restore to 0 after the draw.
+// dim" look. 0 = off, 1 = fine (1-on/1-off), 2 = coarse (2-on/2-off bands).
+// Gated on ABSOLUTE buffer y (not glyph-local) so the bands stay aligned as a
+// legend drifts and across the glyphs of one legend. The Eden idle screensaver
+// uses the fine mode; the boot splash uses the coarse mode, which on the big
+// 24pt letters reads as an intentional dim rather than a fine shimmer. Restore
+// to 0 after the draw.
 static uint8_t s_gfx_scanline = 0;
+
+// Which absolute rows the bands sit on: 0..1 selects the two alignments of the
+// fine mode, 0..3 the four of the coarse one.
+//
+// ⚠️ This exists because the gate is on ABSOLUTE y and the mode's whole purpose
+// is ANTI-BURN-IN. Without it the fine mode lights the even panel rows and only
+// ever the even panel rows — for this idle session and every session after it —
+// so the odd rows carry no wear at all and the even ones carry the legend's
+// entire share. The drift offset does NOT spread that: kdisp_set_draw_offset
+// moves the CURSOR (gfx_text_run), i.e. it slides the glyph past a stationary
+// stripe pattern, changing which rows OF THE GLYPH are dropped while the lit
+// PANEL rows stay put. Rolling the phase is what moves the stripes themselves.
+static uint8_t s_gfx_scanline_phase = 0;
 
 // Returns true if absolute buffer row `abs_y` must stay dark in the active
 // scanline mode.
 static inline bool scanline_skip_row(int abs_y) {
+    const int y = abs_y + (int)s_gfx_scanline_phase;
     switch (s_gfx_scanline) {
-        case 1:  return (abs_y & 1);   // 1-on/1-off: skip odd rows
-        case 2:  return (abs_y & 2);   // 2-on/2-off: skip rows 2,3 of each 4
+        case 1:  return (y & 1);   // 1-on/1-off: phase 0 skips odd rows, 1 skips even
+        case 2:  return (y & 2);   // 2-on/2-off: phase 0..3 = four band alignments
         default: return false;
     }
 }
 
-void kdisp_set_gfx_scanline(bool scanline) {
-    s_gfx_scanline = scanline ? 1 : 0;
+// `phase` shifts the bands along the panel and is ignored when turning the mode
+// off. It is a parameter rather than a separate setter deliberately: enabling and
+// choosing the alignment are one decision, so a caller cannot enable the mode
+// without answering the burn-in question above, and a phase cannot leak into the
+// next keycap of the same pass (the mask restores with (false, 0) like any other
+// plotter mode). Pass 0 for the historical fixed-stripe behaviour.
+void kdisp_set_gfx_scanline(bool scanline, uint8_t phase) {
+    s_gfx_scanline       = scanline ? 1 : 0;
+    s_gfx_scanline_phase = scanline ? (uint8_t)(phase & 1u) : 0;
 }
 
 // Coarse 2-on/2-off variant — a better fit than the fine scanline for large
 // glyphs (the boot-splash logo), where 1-on/1-off stripes read as flicker.
-void kdisp_set_gfx_scanline2(bool scanline) {
-    s_gfx_scanline = scanline ? 2 : 0;
+void kdisp_set_gfx_scanline2(bool scanline, uint8_t phase) {
+    s_gfx_scanline       = scanline ? 2 : 0;
+    s_gfx_scanline_phase = scanline ? (uint8_t)(phase & 3u) : 0;
 }
 
 // Plot one INK pixel, honouring the two static plotter modes.

--- a/keyboards/polykybd/base/disp_array.h
+++ b/keyboards/polykybd/base/disp_array.h
@@ -33,15 +33,22 @@ void kdisp_set_draw_offset(int8_t ox, int8_t oy);
 // Remember to restore it to false after the draw.
 void kdisp_set_gfx_erase(bool erase);
 
-// When set, the glyph plotter only lights pixels on even buffer rows — a scanline
-// half-brightness look used by the Eden idle screensaver's lit legend. Restore to
-// false after the draw.
-void kdisp_set_gfx_scanline(bool scanline);
+// When set, the glyph plotter lights only every other buffer row — a scanline
+// half-brightness look used by the Eden idle screensaver's lit legend. Restore
+// with (false, 0) after the draw.
+//
+// The gate is on ABSOLUTE buffer y, so `phase` (0..1) picks WHICH panel rows the
+// stripes land on. An anti-burn-in caller must roll it: at a fixed phase the same
+// physical rows light forever, and the draw offset cannot spread that (it moves
+// the glyph past a stationary pattern, not the pattern). Pass 0 only where the
+// draw is transient — a boot splash — or where a stable pattern is the point.
+void kdisp_set_gfx_scanline(bool scanline, uint8_t phase);
 
 // Coarser 2-on/2-off scanline band (vs the 1-on/1-off of kdisp_set_gfx_scanline).
 // Reads as a cleaner intentional dim on large glyphs (the boot-splash logo), where
-// the fine scanline looks like flicker. Restore to false after the draw.
-void kdisp_set_gfx_scanline2(bool scanline);
+// the fine scanline looks like flicker. `phase` is 0..3 here — four band
+// alignments rather than two. Restore with (false, 0) after the draw.
+void kdisp_set_gfx_scanline2(bool scanline, uint8_t phase);
 
 // kdisp_gfx_glyph / kdisp_gfx_glyph_font (glyph lookup, NULL when uncovered, gap
 // glyphs skipped) are declared in font_lookup.h, included above.

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -2983,8 +2983,8 @@ bool eden_idle_erase_legend(uint8_t disp_idx) {
     if (text == NULL || text[0] == 0) {
         return false;   // no text legend — leave the plain comet field on this key
     }
-    // Draw the legend LIT but with a scanline half-brightness effect (only even buffer
-    // rows lit) so it reads lighter over the comet field, at a slowly-drifting position
+    // Draw the legend LIT but with a scanline half-brightness effect (every other buffer
+    // row lit) so it reads lighter over the comet field, at a slowly-drifting position
     // within its own on-screen slack. roll_idle_offset() picks a uniform random offset
     // inside the glyph's free space (fully on-screen, per-glyph — the same helper the
     // jitter idle style uses); the seed changes once per EDEN_LEGEND_DRIFT_MS so every
@@ -2997,13 +2997,25 @@ bool eden_idle_erase_legend(uint8_t disp_idx) {
     main_legend_t plan;
     plan_main_legend(text, BUFFER_X, 23, scratch, (uint8_t)(GLYPH_SIZE_MAX_LEN + 1), &plan);
     uint32_t epoch = timer_read32() / EDEN_LEGEND_DRIFT_MS;
+    uint32_t seed  = epoch * 2654435761u + disp_idx;
     int8_t dx, dy;
-    roll_idle_offset(plan.text, plan.x, plan.y, epoch * 2654435761u + disp_idx, &dx, &dy);
-    kdisp_set_gfx_scanline(true);
+    roll_idle_offset(plan.text, plan.x, plan.y, seed, &dx, &dy);
+    // ⚠️ The scanline phase has to roll TOO, and the drift offset above does NOT do
+    // it: scanline_skip_row() gates on absolute buffer y, so the drift slides the
+    // glyph past a stationary stripe pattern — it changes which rows OF THE GLYPH are
+    // dropped while the lit PANEL rows never move. Left at a fixed phase this lights
+    // the even panel rows and only ever the even panel rows, for every idle session
+    // the board will ever have: half the panel takes the legend's entire share of the
+    // wear and the other half takes none, which is the fixed-pixel burn an idle style
+    // exists to prevent. A third salt on the same jitter hash (so uncorrelated with
+    // dx/dy) flips it, and rolling it on the same `epoch` puts the flip on the frame
+    // the letter jumps anyway — invisible, rather than a shimmer.
+    uint8_t sl_phase = (uint8_t)jitter_axis(seed, 0x2000u, 0, 1);
+    kdisp_set_gfx_scanline(true, sl_phase);
     kdisp_set_draw_offset(dx, dy);
     kdisp_write_gfx_text(g_all_fonts, g_all_font_count, plan.x, plan.y, plan.text);
     kdisp_set_draw_offset(0, 0);
-    kdisp_set_gfx_scanline(false);
+    kdisp_set_gfx_scanline(false, 0);
     return true;
 }
 

--- a/keyboards/polykybd/poly_util.c
+++ b/keyboards/polykybd/poly_util.c
@@ -133,9 +133,12 @@ void display_message_progressive(uint8_t row, uint8_t col, const uint32_t* messa
                     // Not-yet-solid letters render dim via the coarse 2-on/2-off
                     // scanline — cleaner than the fine 1-on/1-off on the big
                     // 24pt splash glyphs, which flickered.
-                    kdisp_set_gfx_scanline2(visible >= solid_count);
+                    // Phase 0: the splash is a few seconds at boot, so a fixed
+                    // band alignment costs nothing and a rolling one would read as
+                    // shimmer across the reveal.
+                    kdisp_set_gfx_scanline2(visible >= solid_count, 0);
                     kdisp_write_gfx_text(displayFont, 1, 49, 38, text);
-                    kdisp_set_gfx_scanline2(false);
+                    kdisp_set_gfx_scanline2(false, 0);
                     visible++;
                 }
                 index++;


### PR DESCRIPTION
## Summary

`scanline_skip_row()` gates on the **absolute buffer y**, so the Eden idle legend lit the even panel rows and *only ever* the even panel rows — for every idle session the board will ever have. Half the panel took the legend's entire share of the wear and the other half took none, which is the fixed-pixel burn an idle style exists to prevent.

The position drift does **not** spread that, which is the part that is easy to get backwards: `kdisp_set_draw_offset()` moves the **cursor** (`gfx_text_run`), i.e. it slides the glyph past a *stationary* stripe pattern — it changes which rows *of the glyph* are dropped while the lit *panel* rows never move. Only rolling the phase moves the stripes.

**The fix** gives the gate a phase:

```c
static inline bool scanline_skip_row(int abs_y) {
    const int y = abs_y + (int)s_gfx_scanline_phase;
    switch (s_gfx_scanline) {
        case 1:  return (y & 1);   // phase 0 skips odd rows, 1 skips even
        case 2:  return (y & 2);   // phase 0..3 = four band alignments
        default: return false;
    }
}
```

Design notes worth knowing before touching it again:

- **Phase is a parameter of the enable** (`kdisp_set_gfx_scanline(bool, uint8_t)`), not a setter of its own. A caller then cannot switch the mode on without answering the burn-in question, and a phase cannot leak into the next keycap of the same pass — both setters restore with `(false, 0)` like any other plotter mode.
- **The Eden legend derives it from the same `epoch` as its drift**, via a third salt (`0x2000`) on the existing `jitter_axis` so it is uncorrelated with `dx`/`dy`. The flip therefore lands on the very frame the letter jumps anyway, which is what keeps it invisible instead of a shimmer.
- **The boot splash passes phase 0 deliberately.** It runs for a few seconds, so a fixed band alignment costs nothing and a rolling one would read as flicker across the reveal.
- **The comet field underneath was never affected** — `startup_anim.c` writes the buffer directly (`buf[...] |= ...`), bypassing `kdisp_plot_ink`, so the background has always been full-density and moving. Only the legend was stripe-locked, which is also why this would have taken years to become visible rather than being noticeable now.

### Verification

`disp_array.c` has no unit suite (it owns the scratch buffer) and the modes are invisible from every preview tool — `oled_preview.py` models no plotter mode — so the phase table was checked by compiling `scanline_skip_row()` standalone rather than by reading it:

```
fine phase 0    #.#.#.#.#.#.#.#.     <- byte-identical to the old pattern
fine phase 1    .#.#.#.#.#.#.#.#     <- exact complement; 0 panel rows unreachable across the two
coarse 0..3     ##..  #..##  ..##  .##.    <- four distinct band alignments
off             ################     <- phase ignored
phase 255       masked to range
```

Phase 0 reproducing the old output exactly is what makes the boot-splash call site a provable no-op. The phase draw is uniform (71846 / 72154 over 144000 draws) and flips on 5012 of 9999 consecutive epochs.

### Size

Pack flavour `.text` **+104 B**, `.data`/`.bss` unchanged. `__overlay_pool_base__` is still pinned at `0x20000000`, so a shipped `.plyx` stays paired. Monolith `.heap` free **2772 → 2764 B** — 8 bytes of alignment for the 1-byte static; the 2772 baseline matches what `CLAUDE.md` already records, which cross-checks the baseline build.

## Version bump label

None — bug fix, patch bump.

## Testing
- [x] Compiled successfully — split72 `default`, `POLYKYBD_DOOM_PACK=yes` and the monolith `POLYKYBD_DOOM=yes`, plus split42, all clean under `-Werror`; `qmk lint --strict` passes on both boards
- [ ] Flashed and tested on hardware — a test `.bin` at `54b8fd64` has been handed over but not yet flashed
- [x] If protocol changed: n/a — no wire-format or `PROTOCOL_VERSION` change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdD3GUnj9eofccrEYP3Hbe

---
_Generated by [Claude Code](https://claude.ai/code/session_01WdD3GUnj9eofccrEYP3Hbe)_

## Summary by Sourcery

Roll the Eden idle legend’s scanline phase with its position drift to distribute wear across the display and prevent fixed-row burn-in.

Bug Fixes:
- Prevent fixed-row burn-in in the Eden idle legend by rolling the scanline pattern across panel rows.
- Preserve the boot splash’s stable scanline appearance with an explicit zero phase.

Enhancements:
- Extend scanline rendering modes with phase-aware alignment and ensure scanline state is reset after each draw.
- Synchronize Eden scanline phase changes with existing legend drift to avoid visible shimmer.

Documentation:
- Document scanline phase behavior, burn-in considerations, and validation guidance.

Tests:
- Validate fine and coarse scanline phase patterns, disabled-mode behavior, and phase masking with standalone compilation checks.
- Build supported firmware variants with warnings treated as errors and pass strict QMK linting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Scanline display modes now support phase offsets, allowing dimmed band patterns to shift across panel rows.
  - Eden’s idle legend varies the scanline alignment as it moves, helping reduce fixed-pixel burn-in.
  - Fine and coarse scanline patterns support multiple alignments for more flexible display effects.

- **Bug Fixes**
  - Improved scanline behavior so the same panel rows are not consistently dimmed during Eden idle animations.

- **Documentation**
  - Updated display rendering documentation to explain scanline phases and alignment choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->