### PR TITLE
docs: LUT-tuning learnings from the legend pass, plus a skill for the loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,6 +212,23 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
       notice — a Sourcery refusal is itself a review object carrying the head sha,
       so the sha alone reads as reviewed. Never infer from a check run or from
       this paragraph.
+      - ⚠️ **That pair-check has a FALSE NEGATIVE in the other direction, so it is
+        not sufficient either: a CLEAN CodeRabbit review produces NO REVIEW OBJECT
+        AT ALL.** It says *"No actionable comments were generated 🎉"* by editing
+        its existing summary comment, so `get_reviews` is empty for that head and
+        the check reads a clean pass as unreviewed (measured on qmk#268,
+        2026-09-03). A refusal is an object that means nothing; a clean pass is no
+        object that means everything. Read the summary comment's BODY — its
+        `📥 Commits` range and whether it says *skipped* / *no actionable comments*
+        — alongside `get_reviews`. Full write-up in `PolyKybdHost/CLAUDE.md`.
+      - ⚠️ **A commit whose only reviewable file is GENERATED is skipped outright,
+        so a per-language DATA pass is structurally unreviewable.** *"Review skipped
+        as selected files did not have any reviewable changes"* — twice on qmk#268,
+        where the diff was the cog-generated `lang_lut.c` plus `lang_lut.xlsx`, and
+        the workbook is excluded by CodeRabbit's `!**/*.xlsx` path filter. No banner,
+        no quota, nothing wrong: just no review. On such a change the verification
+        has to be your own — assert the generated diff is confined to what you meant,
+        and measure the rendered result.
   - **cppcheck has no quota, no star threshold and no file-count limit** — and
     is not an LLM, so it doesn't share the others' blind spots. That is why it
     was added, and it matters more now that it is the only automated reviewer
@@ -424,6 +441,14 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
     drift check, not proof of binary equivalence: if anything outside `config.h` shows
     up, rebuild on the merged base rather than reasoning about whether it mattered.
 - **Docker is NOT usable** in the remote container (no daemon) — use the native toolchain above, not the qmk docker image.
+- ⚠️ **NEVER run two `qmk compile` invocations at once — every flavour of a board
+  shares ONE `.build/` tree, and the collision presents as a CODE error.** Backgrounding
+  the pack build and starting the monolith beside it made the pack link die on
+  `undefined reference to doom_shim_menu_key_tile` (2026-09-03) — a symbol the pack
+  flavour genuinely does not define locally, so it reads exactly like a real
+  missing-shim bug rather than two builds overwriting each other's objects in
+  `.build/obj_polykybd_split72_default`. Serially, both link clean and nothing else
+  changes. `build_pack.sh` is safe because it sequences the two flavours itself.
 - The `firmware-size-diff` skill builds HEAD vs working tree and diffs sizes / `.text`.
 - ⚠️ **In the session container `qmk` is at `/root/.qmk_venv/bin/qmk` and is NOT on
   `PATH`.** `build_pack.sh` (and anything else shelling out to `qmk`) dies with
@@ -1516,6 +1541,29 @@ new ISO codes append at the next free slot; private pseudo-codes with no ISO
   the old compiled-in `{ &flag_font }` path did. `kdisp_gfx_glyph_font(fonts, n, cp,
   &out_font)` returns the glyph **and** its owning font in one scan for exactly this
   (`kdisp_gfx_glyph` is the `out_font = NULL` wrapper).
+  - ⚠️ **The same shift makes a LONE Latin-1 symbol sit as low as a descender, and
+    that is what "this glyph renders under the baseline" means in practice.** The
+    two notes above frame the yAdvance gap as a *multi-glyph* hazard (`à»ñ`); the
+    single-glyph corollary is separate and is a per-cell tuning matter. `_Base_` is
+    yAdvance 37 and `_SupAndExtA_` is 44, so **every** Latin-1 supplement glyph is
+    drawn 7 px lower than a base-face letter: measured against the base face's own
+    ink bottom, `§ £ ± ¢ ¥ ½ ¼ ¾ © ®` all land where a `y` descender does, and
+    `µ ¦ ¸` deeper still. It is not a bug in any one glyph — it is the whole font.
+    - **The fix is the cursor nudge in the LUT cell**, `\f` = 2 px up (`\b` = 2 px
+      left), so a −6 px lift is `U"\f\f\f" <TOKEN>` prepended to the cell. That is
+      what the hand-tuned cells already used; the 2026-09-03 pass normalised
+      `§ £ ± µ` to exactly three across all 117 cells that draw them, having found
+      them spread over **five** different values (0, −2, −4, −6, −8).
+    - ⚠️ **The panel clamp can EAT the nudge, so measure the realised move rather
+      than the requested one.** A glyph already jammed against the south edge spends
+      part of the lift merely releasing that clamp: of 92 element positions that
+      moved, 13 moved 1–4 px instead of 6 (`af-ZA`/`se-NO` `KC_3` by 1 px). Nothing
+      reports this — the cell says −6 and the keycap moved 1.
+    - **Survey before tuning, per distinct codepoint, not per cell**: resolve every
+      single-glyph cell, take `Renderer.bbox([cp])`, and rank by `ymax`. Symbols the
+      font pushes down separate cleanly from real descenders (`g j p q y`, Arabic,
+      Hebrew nikud, brackets) that way, and it is the only way to see that a glyph
+      is inconsistently nudged across layouts.
 - **GFXfont bitmaps are COLUMN-NATIVE (OLED page format) since the PolyColGfx
   rollout (font-pack ABI 2).** 1 byte = 8 *vertical* pixels, so the firmware blits a
   whole column-byte into the SSD1306 page memory at once. `cb = (h + 7) >> 3`

--- a/keyboards/polykybd/.claude/skills/tune-lang-lut-cells/SKILL.md
+++ b/keyboards/polykybd/.claude/skills/tune-lang-lut-cells/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: tune-lang-lut-cells
+description: Change the per-language keycap LUT across MANY layouts at once — a category offset for every layout, a glyph nudged the same way everywhere, a cell body rewritten wherever it appears — and prove the result. Use when asked to "set X for all languages", "populate the default offsets", "this glyph sits too low / too high on every layout", "make the nudges uniform", "apply these tuner values", or after a render change leaves the hand-tuned cells inconsistent. Drives lang_lut.xlsx through apply_tuner.py's surgical sheet2.xml path, re-cogs, confines the generated diff, and MEASURES the realised pixel effect. NOT for placing a new element on a keycap (that is keycap-layout-preview), NOT for adding a language (add-polykybd-language), and NOT for a single cell you can edit by hand.
+---
+
+# Bulk-tuning the language LUT
+
+`lang_lut.xlsx` holds ~160 layouts × 54 key rows × 4 variations plus a block of
+per-category settings rows. A tuning pass touches tens to hundreds of cells at
+once, and every step below has a way of failing that leaves the tree looking
+correct — so this is a measure-it loop, not an edit.
+
+⚠️ **A data-only commit here is reviewed by NOBODY.** CodeRabbit skips it
+(*"selected files did not have any reviewable changes"* — the only reviewable file
+is the cog-generated `lang_lut.c`, and `.xlsx` is excluded by its path filter), and
+cppcheck sees no C change. §6 is therefore the entire review.
+
+Run the Python from `PolyKybdHost` (`.venv/bin/python`); the workbook lives in
+`qmk_firmware/keyboards/polykybd/lang/`.
+
+## 1. Survey first — never edit what you have not counted
+
+The point of the survey is that "some layouts already have it" is almost always an
+understatement. Resolve every candidate cell and histogram what is actually there.
+
+```python
+import sys, re; sys.path.insert(0, 'tools')
+import oled_preview as op
+pk   = '/home/user/qmk_firmware/keyboards/polykybd'
+named = op.load_named_glyphs(f'{pk}/lang/named_glyphs.h')
+L     = op.Lang(f'{pk}/lang/lang_lut.xlsx', named)
+R     = op.load_renderer(f'{pk}/base/fonts')          # NOT Renderer(load_all_fonts(...)) - see §5
+# key rows are 2..55; variation = (col-2)%4  ->  0 base / 1 shift / 2 caps / 3 altgr
+```
+
+For a **glyph** pass, match the cell shape before trusting a count — assert every
+hit is `[U"<ops>" ]TOKEN` and bail on anything else, so a multi-glyph legend can
+never be rewritten by a rule written for a lone symbol.
+
+For a **depth** question ("which glyphs sit under the baseline"), rank distinct
+codepoints by `R.bbox([cp])[3]` and group by the owning font's
+`f.yAdvance - R.base_yadv`. That separates a font-shifted symbol from a real
+descender; a per-cell scan cannot.
+
+## 2. Write through apply_tuner.py
+
+`PolyKybdHost/tools/apply_tuner.py` edits `xl/worksheets/sheet2.xml` **in place**,
+so the other sheets' formula caches survive. Never round-trip the workbook through
+`openpyxl.save()`.
+
+- **Offsets / settings rows** → generate its export grammar and run the CLI:
+  `[offset] <letter|num|sym> <small|shift|altgr|held> <H|V> = <n>`, under a
+  `=== <lang> ===` header. `--dry-run` first, always.
+- **Key cells in the `caps` column** → ⚠️ the grammar has no `caps` (its regex is
+  `base|shift|altgr`, matching what the tuner emits). **Import the module** and call
+  `A.set_cell(xml, r, c, A.str_cell(ref, new))` yourself rather than widening a
+  grammar nothing exercises.
+
+## 3. Verify the workbook before re-cogging
+
+⚠️ **openpyxl's two readers disagree when a renumbering pass has gone wrong**, and
+the streaming one says everything is fine. Compare them over the edited rows and
+require that the **eager** reader holds no value the streaming one lacks (the
+reverse is a pre-existing shared-string quirk on the legend row and must be
+tolerated, or the guard can never be green).
+
+## 4. Re-cog, then confine the diff
+
+```bash
+cd keyboards/polykybd/lang && /root/.qmk_venv/bin/python -m cogapp -r lang_lut.c
+```
+
+Then **assert the generated diff contains only what you meant** — this is the check
+that replaces a reviewer:
+
+```bash
+git diff -U0 keyboards/polykybd/lang/lang_lut.c | grep '^+' | grep -v '^++' \
+  | grep -cv '<the token or pattern you changed>'     # must be 0
+git diff -U0 keyboards/polykybd/lang/lang_lut.c | grep -c '^@@'   # expect 1 contiguous hunk
+```
+
+⚠️ Line counts will not match cell counts — the emitter writes one line per
+(language, row) carrying all four variations.
+
+## 5. Measure the REALISED effect, not the requested one
+
+The number in the cell is not the number on the keycap.
+
+- **The panel clamp eats part of a nudge** when the glyph is already jammed against
+  an edge: a −6 px lift came out 1–4 px on 13 of 92 elements, all previously pinned
+  at the south edge. Render before and after (`op.render_key(..., report=rep)`,
+  `rep['box']`) and report the distribution, not the intent.
+- **Check off-panel ink both sides** (`rep['oob']`) — it must not grow.
+- Fetch the "before" workbook from git rather than reconstructing it:
+  `git show HEAD:keyboards/polykybd/lang/lang_lut.xlsx` into a temp file, then build
+  a second `op.Lang` on it.
+
+⚠️ Two renderer traps:
+- `op.load_renderer(base/fonts)` — plain `Renderer(load_all_fonts(d))` omits the
+  standalone mid face, so `HINT_MID` silently renders full size.
+- `R.draw(setpix, cps, x, y)` takes **buffer** coordinates and `plot` subtracts
+  `BUFFER_X` (28). Drawing at `x=2` puts everything off the viewport and you get a
+  blank sheet that looks like a broken font.
+
+## 6. Gates
+
+```bash
+export QMK_HOME=$PWD && export PATH="/root/.qmk_venv/bin:$PATH"
+qmk compile -kb polykybd/split72 -km default -e POLYKYBD_DOOM_PACK=yes
+qmk compile -kb polykybd/split72 -km default -e POLYKYBD_DOOM=yes   # RAM-tight; CI never builds it
+qmk compile -kb polykybd/split42 -km default
+qmk lint --strict --keyboard polykybd/split72 && qmk lint --strict --keyboard polykybd/split42
+qmk ci-validate-keyboard-targets && qmk ci-validate-aliases
+```
+
+⚠️ **Run them SERIALLY.** Every flavour shares one `.build/` tree, so a
+backgrounded build beside another one corrupts the link — and it presents as a
+missing symbol (`undefined reference to doom_shim_menu_key_tile`), not as a
+collision.
+
+## Pitfalls
+
+- **A settings row must be INSERTED, not appended** (`lang/_insert_settings_row.py`),
+  and the row number lives in four places in `sheet2.xml` — two outside `<sheetData>`.
+- **`HIDE_KEY` (−128) is a position sentinel, not a delta.** A delta row (the held
+  offsets) takes real negatives, and the firmware maps `HIDE_KEY` to 0 there.
+- **Say what did NOT move.** A pass that reports only the changed cells hides the
+  layouts the clamp pinned, which are exactly the ones a human should look at.
+- **Hand over a rendered sheet**, not just numbers, when the question was visual.

--- a/keyboards/polykybd/.claude/skills/tune-lang-lut-cells/SKILL.md
+++ b/keyboards/polykybd/.claude/skills/tune-lang-lut-cells/SKILL.md
@@ -67,7 +67,8 @@ tolerated, or the guard can never be green).
 ## 4. Re-cog, then confine the diff
 
 ```bash
-cd keyboards/polykybd/lang && /root/.qmk_venv/bin/python -m cogapp -r lang_lut.c
+# subshell: §6 does `export QMK_HOME=$PWD`, so this must NOT leave you in lang/
+(cd keyboards/polykybd/lang && /root/.qmk_venv/bin/python -m cogapp -r lang_lut.c)
 ```
 
 Then **assert the generated diff contains only what you meant** — this is the check
@@ -103,6 +104,8 @@ The number in the cell is not the number on the keycap.
   blank sheet that looks like a broken font.
 
 ## 6. Gates
+
+From the **firmware root** (`QMK_HOME` is taken from `$PWD`):
 
 ```bash
 export QMK_HOME=$PWD && export PATH="/root/.qmk_venv/bin:$PATH"

--- a/keyboards/polykybd/.claude/skills/tune-lang-lut-cells/SKILL.md
+++ b/keyboards/polykybd/.claude/skills/tune-lang-lut-cells/SKILL.md
@@ -24,9 +24,13 @@ The point of the survey is that "some layouts already have it" is almost always 
 understatement. Resolve every candidate cell and histogram what is actually there.
 
 ```python
-import sys, re; sys.path.insert(0, 'tools')
+import os, sys, re, subprocess; sys.path.insert(0, 'tools')
 import oled_preview as op
-pk   = '/home/user/qmk_firmware/keyboards/polykybd'
+# derive the firmware root rather than hard-coding it - this skill lives inside it,
+# and a sibling checkout under another path is the normal case for anyone else.
+qmk  = subprocess.run(['git', 'rev-parse', '--show-toplevel'], cwd=os.environ.get(
+       'QMK_HOME', '.'), capture_output=True, text=True).stdout.strip()
+pk   = os.path.join(qmk, 'keyboards', 'polykybd')
 named = op.load_named_glyphs(f'{pk}/lang/named_glyphs.h')
 L     = op.Lang(f'{pk}/lang/lang_lut.xlsx', named)
 R     = op.load_renderer(f'{pk}/base/fonts')          # NOT Renderer(load_all_fonts(...)) - see §5
@@ -66,21 +70,38 @@ tolerated, or the guard can never be green).
 
 ## 4. Re-cog, then confine the diff
 
+⚠️ **Run `run_cog.sh`, not `cog -r lang_lut.c`.** The workbook feeds **seven**
+generated files — `lang/lang_lut.c`, `lang/lang_lut.h`, `lang/named_glyphs.h`,
+`poly_keymap.c`, `keycode_helper.h`, `uni.h` and `hid_com.c` — and which of them a
+given edit reaches depends on what you touched: an offset row reaches only
+`lang_lut.c`, a named glyph or a language-list change reaches several. Regenerating
+one file leaves the rest stale with nothing to say so. `run_cog.sh` is **idempotent**
+(verified: a full run on a clean tree changes nothing), so running all seven costs
+only seconds and removes the judgement call.
+
 ```bash
-# subshell: §6 does `export QMK_HOME=$PWD`, so this must NOT leave you in lang/
-(cd keyboards/polykybd/lang && /root/.qmk_venv/bin/python -m cogapp -r lang_lut.c)
+# subshell: §6 does `export QMK_HOME=$PWD`, so this must NOT leave you in polykybd/
+(cd keyboards/polykybd && PATH="/root/.qmk_venv/bin:$PATH" ./run_cog.sh)
 ```
 
 Then **assert the generated diff contains only what you meant** — this is the check
 that replaces a reviewer:
 
 ```bash
-git diff -U0 keyboards/polykybd/lang/lang_lut.c | grep '^+' | grep -v '^++' \
-  | grep -cv '<the token or pattern you changed>'     # must be 0
-git diff -U0 keyboards/polykybd/lang/lang_lut.c | grep -c '^@@'   # expect 1 contiguous hunk
+# EVERY generated file run_cog.sh touches, and BOTH directions: a line that
+# disappeared is as much a surprise as one that appeared.
+git diff -U0 -- keyboards/polykybd/lang/ keyboards/polykybd/*.c keyboards/polykybd/*.h \
+  | grep -E '^[+-]' | grep -Ev '^(\+\+\+|---)' \
+  | grep -cvE '<the token or pattern you changed>'    # must be 0
 ```
 
-⚠️ Line counts will not match cell counts — the emitter writes one line per
+⚠️ **Do NOT expect one contiguous hunk** — the count depends entirely on how the
+changed cells are distributed through the emitted tables, and it is not a signal.
+The two passes on 2026-09-03 measured **1** hunk (six settings rows, adjacent in the
+table) and **53** (117 key cells scattered across 19 rows). Judge the *content* of
+the changed lines, not their grouping.
+
+⚠️ Line counts will not match cell counts either — the emitter writes one line per
 (language, row) carrying all four variations.
 
 ## 5. Measure the REALISED effect, not the requested one


### PR DESCRIPTION
## Summary

Documentation and one new skill — **no firmware code changes**, so nothing here can
affect a build or the rig. Everything comes out of the 2026-09-03 legend-tuning pass
(#268).

**`CLAUDE.md`**

- **The single-glyph corollary to the yAdvance gap.** The file already documents the
  baseline-align rule twice, but both times as a *multi-glyph* hazard (`à»ñ`). The
  corollary was missing and is what "this glyph renders under the baseline" actually
  means: `_SupAndExtA_` is yAdvance 44 against `_Base_`'s 37, so **every** lone
  Latin-1 symbol is drawn 7 px lower than a base-face letter — `§ £ ± ¢ ¥ ½ ¼ ¾ © ®`
  all land where a `y` descender does. Records `\f` (2 px) as the per-cell fix, that
  the panel clamp can **eat** part of a nudge (13 of 92 element positions moved 1–4 px
  instead of the requested 6, all previously pinned against the south edge), and that
  the survey has to be per distinct codepoint rather than per cell.
- **Two concurrent `qmk compile` runs share one `.build/` tree** and corrupt each
  other's link. It presents as `undefined reference to doom_shim_menu_key_tile` — a
  symbol the pack flavour genuinely does not define locally — so it reads as a real
  missing-shim bug rather than a collision. Cost a wrong diagnosis during this work.
- **Two CodeRabbit corrections.** The standing `get_reviews` pair-check has a false
  negative pointing the *opposite* way from the refusal case: a **clean** review
  creates no review object at all, only an edit to its existing summary comment. And
  a commit whose only reviewable file is generated is skipped outright, so a
  per-language data pass is structurally unreviewable — both observed twice on #268.

**New skill** `keyboards/polykybd/.claude/skills/tune-lang-lut-cells/` — the
survey → `apply_tuner.py` → both-openpyxl-readers check → re-cog → confine the
generated diff → measure the *realised* pixels → serial gates loop, which was run
twice by hand during #268.

## Version bump label

*(none)* — documentation only, patch bump is correct.

## Testing

- [x] Compiled successfully — not applicable to a docs change, but `qmk lint --strict`
      (split72), `qmk ci-validate-keyboard-targets` and `qmk ci-validate-aliases` all
      pass, and no tracked-ignored file was added under `keyboards/`.
- [ ] Flashed and tested on hardware — n/a, no code change.
- [ ] If protocol changed: n/a, no protocol change.

Note the paths filter means this starts no build and occupies no rig time, which is
the intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LeoBsy75UBvecXehCiAoWg

---
_Generated by [Claude Code](https://claude.ai/code/session_01LeoBsy75UBvecXehCiAoWg)_

## Summary by Sourcery

Document the legend-tuning learnings and add a repeatable skill for safely applying and validating bulk language LUT adjustments.

New Features:
- Add a skill for safely surveying, bulk-tuning, regenerating, validating, and measuring language LUT cell changes.

Enhancements:
- Document Latin-1 baseline alignment and realised pixel-offset behavior, including panel clamping and per-codepoint surveying.
- Document CodeRabbit review limitations for clean and generated-only changes.
- Document that concurrent QMK builds can corrupt the shared build tree and produce misleading linker errors.

Documentation:
- Expand contributor guidance with tuning, review-verification, and serial-build learnings from the legend pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for validating clean CodeRabbit reviews and handling generated-only changes.
  * Documented safe compilation practices to avoid misleading linker errors from concurrent builds.
  * Added notes on Latin-1 glyph positioning, cursor adjustments, panel limits, and per-character measurements.
  * Added a workflow for tuning language keycap lookup tables, validating workbook changes, checking rendered results, and running serial compile and lint checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->