### PR TITLE
Record firmware crashes and report them on the next boot (protocol v16, cmd 39)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2331,6 +2331,81 @@ An image that fails that check is **not refused outright** — the keyboard asks
   build without `POLYKYBD_DOOM_PACK`. `.whx` / `.plyf` ride the same unsigned
   transport but are data, not code.
 
+### Crash diagnostics: the crash record, the watchdog and the phase breadcrumb (`base/crash_record.*`)
+
+A HardFault, an unhandled exception or a main-loop hang used to leave **nothing**:
+the M0+ HardFault vector fell into ChibiOS's `b .` loop, the board sat dead until
+a replug, and the only evidence was "it stopped". Now every one of those is
+**recorded, rebooted through, and announced on the next boot** — on the console
+(`crash: side=master kind=hardfault core=0 pc=0x… lr=0x… sp=0x… psr=0x… icsr=0x…
+phase=3:0x0015 up=123456ms n=1 reason=0x22 fw=0.18.0`, one line, in the boot
+banner and its re-emits), over HID (**cmd 39**, protocol **v16**), and for the
+slave over the split link (the master pulls it and prints `side=slave`). The host
+turns the console line into a dialog (`PolyKybdHost/CLAUDE.md`), the rig fails the
+run on it (`test_no_crash_record`). What is worth knowing:
+
+- **The record lives in a NOLOAD RAM block** (`s_ram`, section `.ram0.crash_record`
+  via ChibiOS's `rules_memory.ld` — the same trick as the bootloader magic) so it
+  survives the `watchdog_reboot()` the handler ends with. It does NOT survive a
+  power cycle, which is why `crash_record_init()` **archives it to flash** at boot:
+  one 4 KB sector at `FW_CRASH_LOG_OFFSET` (`FW_APPLY_LOG_OFFSET - 4096`), page-
+  appended, erased only when full or on cmd 39 sub-op 2. `FW_UP_MAX_SIZE` shrank
+  by that sector (`0x1F7000 → 0x1F6000`; the host mirror in `hid_fw_up.py` moved
+  with it).
+  - **Verify the placement in the ELF, not the linker script**: `nm` must show
+    `s_ram` inside `.ram0` and `.ram0_init` must be **size 0** (nothing initialises
+    it). `objdump -h` on the split72 build: `.ram0 00000040 @ 2003e12c`, `.ram0_init
+    00000000`. And the vector table at `0x10000100` slot 3 must be OUR
+    `HardFault_Handler` (`…dddd` = `1000dddc|1`), with slots 4+ still the shared
+    weak body that `bl`s `_unhandled_exception` — which is now our strong override,
+    so both routes land in `crash_record.c`.
+- **The M0+ has only HardFault** — no BusFault/UsageFault, no CFSR/BFAR/MMFAR. So
+  the record is the **stacked frame** (pc/lr/xpsr from the exception frame, sp =
+  the frame address, `ICSR` for the active vector) plus what the firmware itself
+  knew: the **phase breadcrumb** and uptime. The handler is naked asm: `tst lr,#4`
+  picks PSP/MSP, then C. ⚠️ `frame_readable()` bounds the frame to SRAM before
+  touching it — a corrupt SP would otherwise re-fault INSIDE the handler and the
+  record would never be written.
+- **The phase breadcrumb is what makes a watchdog timeout diagnosable.** A hang
+  has no fault frame, so `crash_phase_enter(phase, arg)` / `crash_phase_leave(tag)`
+  tag the code the main loop is in: `HID` (arg = cmd id, `hid_com.c`), `BRIDGE`
+  (arg = transaction id, `send_to_bridge`), `CORE1_WAIT` (the two decompress waits
+  in `multicore_exec.c`), `FLASH`, `SUSPEND`, `APPLY`, and `LOOP` re-armed every
+  housekeeping pass. On `WATCHDOG.REASON.TIMER` with no fault record,
+  `crash_record_init()` synthesises a `kind=watchdog` record **from the phase left
+  in RAM** — the phase is written directly into the NOLOAD block for exactly that.
+  ⚠️ The enum is mirrored in the host's `PHASE_NAMES` (`crash_report.py`); keep the
+  numbers in step (the `CRASH_PHASE_RENDER` slot was removed before shipping, so
+  SUSPEND=7, APPLY=8).
+- **The watchdog is 8 s** (`CRASH_WATCHDOG_MS`), started after the boot splash
+  and fed from **housekeeping and the suspend loop only**. Two places disarm it,
+  and both are load-bearing: `shutdown_user()` (the bootloader jump / `mcu_reset`
+  would otherwise be racing an 8 s timer) and `fw_staging.c` right before
+  `fw_staging_do_apply()` (the self-apply never returns to housekeeping; a
+  watchdog reset mid-copy is the brick this whole area guards against). A new
+  blocking path longer than 8 s needs a `crash_watchdog_feed()` inside it — or
+  the record it produces will say so, which is the point.
+- **A crash loop halts instead of looping forever**: `consecutive` counts
+  back-to-back records and past `CRASH_LOOP_LIMIT` (5) the handler parks in `wfi`
+  (`kind=halt`) rather than rebooting — recoverable over BOOTSEL, and the archive
+  still says what it was doing.
+- **The slave's record rides `USER_SYNC_SLAVE_DATA`**, which is now generic and
+  unconditional: `slave_data.c` owns the op dispatch (`SLAVE_DATA_SENSOR` = the
+  LTR-559 pull that used to be the whole handler, `SLAVE_DATA_CRASH`), and the
+  master pulls the crash body once per link-up, three tries 2 s apart. ⚠️ It is
+  printed **once, at the pull**, not with the banner re-emits — the link can come
+  up long after those stop.
+- **cmd 39**: `data[2]` 0 = this half's archived record, 1 = the slave's, 2 =
+  clear, else NACK. Body `[flags][48-byte poly_crash_record_t]`, flags bit0
+  present / bit1 **fresh** (recorded by the boot before this one). Only a fresh
+  record is announced on the console; the archive is history for `polyctl crash
+  show`. `_Static_assert(sizeof == 48)` pins the struct the host unpacks with
+  `struct.Struct("<IBBBBIIIIIIHH8sI")`.
+- **Not yet exercised on hardware as of writing** — the mechanism compiled clean
+  on split72/split42/monolith and the rig tests are in place, but no deliberate
+  fault has been driven through it. The `debug-firmware-on-rig` skill with a probe
+  that dereferences a bad pointer over HID is the way to close that.
+
 ### Idle anti-burn-in styles (`poly_keymap.c`)
 When the keyboard idles, the keycap legends would otherwise burn the **same**
 pixels in. **Four** styles (EEPROM `poly_eeconf_t.idle_style`, HID cmd 28, enum

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2354,7 +2354,10 @@ run on it (`test_no_crash_record`). What is worth knowing:
   with it).
   - ⚠️ **The archive write happens in `crash_record_archive_pending()`, AFTER
     `multicore_launch_core1()` — not inside `crash_record_init()`, which runs
-    first.** The flash write takes the `fw_staging` core1 lockout, and releasing
+    first.** (First means the top of `keyboard_pre_init_user()`: QMK's own
+    matrix / split / OLED init runs between the two hooks, so capturing there
+    tags a fault anywhere in this boot `phase=boot` and has the previous record
+    safe before it can recur — CodeRabbit on #271.) The flash write takes the `fw_staging` core1 lockout, and releasing
     that lockout does a bounded RELAUNCH of core1. Done before post_init's own
     launch, core1 is already running when the unbounded FIFO handshake starts and
     the keyboard hangs on the boot after every crash — the exact opposite of what
@@ -2395,8 +2398,16 @@ run on it (`test_no_crash_record`). What is worth knowing:
   the record it produces will say so, which is the point.
 - **A crash loop halts instead of looping forever**: `consecutive` counts
   back-to-back records and past `CRASH_LOOP_LIMIT` (5) the handler parks in `wfi`
-  (`kind=halt`) rather than rebooting — recoverable over BOOTSEL, and the archive
-  still says what it was doing.
+  rather than rebooting — recoverable over BOOTSEL, and the archive still says
+  what it was doing. Two details, both found in review of #271: the halt
+  **disarms the watchdog first** (still armed from `crash_watchdog_start()`, it
+  would otherwise reset the chip 8 s later and turn the halt into a reboot storm
+  with a pause — CodeRabbit), and `crash_watchdog_start()`, i.e. a boot that got
+  all the way through post_init, **resets the counter to 0** — what the field's
+  comment always promised and the code did not do, so five unrelated crashes
+  across weeks of uptime would have halted the board. The halt is for a firmware
+  that never finishes booting; one that crashes at runtime reboots and announces
+  itself each time.
 - **The slave's record rides `USER_SYNC_SLAVE_DATA`**, which is now generic and
   unconditional: `slave_data.c` owns the op dispatch (`SLAVE_DATA_SENSOR` = the
   LTR-559 pull that used to be the whole handler, `SLAVE_DATA_CRASH`), and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2352,17 +2352,29 @@ run on it (`test_no_crash_record`). What is worth knowing:
   appended, erased only when full or on cmd 39 sub-op 2. `FW_UP_MAX_SIZE` shrank
   by that sector (`0x1F7000 → 0x1F6000`; the host mirror in `hid_fw_up.py` moved
   with it).
-  - ⚠️ **The archive write happens in `crash_record_archive_pending()`, AFTER
-    `multicore_launch_core1()` — not inside `crash_record_init()`, which runs
-    first.** (First means the top of `keyboard_pre_init_user()`: QMK's own
-    matrix / split / OLED init runs between the two hooks, so capturing there
-    tags a fault anywhere in this boot `phase=boot` and has the previous record
-    safe before it can recur — CodeRabbit on #271.) The flash write takes the `fw_staging` core1 lockout, and releasing
-    that lockout does a bounded RELAUNCH of core1. Done before post_init's own
-    launch, core1 is already running when the unbounded FIFO handshake starts and
-    the keyboard hangs on the boot after every crash — the exact opposite of what
-    the record exists for. Caught by Greptile on #271 before it ever reached
-    hardware; the split (capture early, archive after the launch) is the fix.
+  - ⚠️ **The archive is written INSIDE `crash_record_init()`, at the top of
+    `keyboard_pre_init_user()`, WITHOUT the `fw_staging` core1 lockout — and
+    both halves of that sentence are load-bearing.** It went through three
+    shapes in review of #271, each catching the previous one:
+    1. Archive from init, under the lockout, in post_init after QMK's init.
+       Greptile: releasing the lockout does a bounded RELAUNCH of core1, so run
+       before post_init's own `multicore_launch_core1()` the unbounded FIFO
+       handshake finds core1 already running and blocks forever — a keyboard
+       that hangs on the boot after every crash.
+    2. Capture in `pre_init` (CodeRabbit: QMK's matrix / split / OLED init runs
+       between the two hooks, so a fault there must be tagged `phase=boot` with
+       the previous record already safe), park the copy in `.bss`, write it
+       from `crash_record_archive_pending()` after the launch. CodeRabbit again:
+       a reset in that boot window loses the parked copy, and a fault that
+       recurs there **every** boot never archives at all — precisely the record
+       worth having.
+    3. Write it at `pre_init`, no lockout. Sound because at that point core1 has
+       **never been launched** — it is parked in the bootrom, fetching nothing
+       from XIP — so there is nothing to halt and no relaunch to trigger.
+       `flash_guarded()` takes a `lockout` flag: `false` from init only, `true`
+       from the runtime `crash_record_clear()` erase, where core1 is serving RLE
+       from flash and must be parked. **Never move `crash_record_init()` after
+       the core1 launch** — the no-lockout write is only correct ahead of it.
   - **Verify the placement in the ELF, not the linker script**: `nm` must show
     `s_ram` inside `.ram0` and `.ram0_init` must be **size 0** (nothing initialises
     it). `objdump -h` on the split72 build: `.ram0 00000040 @ 2003e12c`, `.ram0_init

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2400,6 +2400,22 @@ run on it (`test_no_crash_record`). What is worth knowing:
   ⚠️ The enum is mirrored in the host's `PHASE_NAMES` (`crash_report.py`); keep the
   numbers in step (the `CRASH_PHASE_RENDER` slot was removed before shipping, so
   SUSPEND=7, APPLY=8).
+  - ⚠️ **`WATCHDOG.REASON.TIMER` alone is NOT a hang — the bootrom's reboot after
+    a UF2 copy is a watchdog reboot too, so the FIRST BOOT AFTER EVERY BOOTSEL
+    FLASH reads TIMER.** Found by the rig the first time the crash tests ran
+    (run 33809919200, 2026-09-03): both halves reported a fresh
+    `kind=watchdog phase=2:0x0000 up=0ms n=3 reason=0x12` — `0x12` is
+    `HAD_RUN | WD_TIMER`, i.e. the rig's RUN-pin reset followed by the bootrom's
+    post-copy reboot, and `n=3` because the NOLOAD block survives a reflash, so
+    the pre-fix firmware had counted three consecutive rig flashes as three
+    consecutive hangs (two more and it would have **halted** the rig in `wfi`).
+    The discriminator is the SDK's own: `watchdog_enable()` leaves
+    `0x6ab73121` in scratch4 and every deliberate reboot path clears it (the
+    bootrom, `watchdog_reboot()`, our inlined self-apply reset, and now
+    `crash_watchdog_stop()`), so `watchdog_enable_caused_reboot()` is true only
+    for a timeout of the watchdog `crash_watchdog_start()` armed. Reading
+    `REASON` without it would have made every UF2 flash — the recovery path this
+    whole feature points users at — open with a phantom crash dialog.
 - **The watchdog is 8 s** (`CRASH_WATCHDOG_MS`), started after the boot splash
   and fed from **housekeeping and the suspend loop only**. Two places disarm it,
   and both are load-bearing: `shutdown_user()` (the bootloader jump / `mcu_reset`
@@ -2432,10 +2448,14 @@ run on it (`test_no_crash_record`). What is worth knowing:
   record is announced on the console; the archive is history for `polyctl crash
   show`. `_Static_assert(sizeof == 48)` pins the struct the host unpacks with
   `struct.Struct("<IBBBBIIIIIIHH8sI")`.
-- **Not yet exercised on hardware as of writing** — the mechanism compiled clean
-  on split72/split42/monolith and the rig tests are in place, but no deliberate
-  fault has been driven through it. The `debug-firmware-on-rig` skill with a probe
-  that dereferences a bad pointer over HID is the way to close that.
+- **Exercised on the rig by accident, not by a deliberate fault.** The UF2
+  false positive above (run 33809919200) drove the whole reporting chain end to
+  end on real hardware — boot-time capture, the console line on both halves, the
+  slave pull over the split link, cmd 39 read on master and slave, and the
+  clear — before any fault had been injected on purpose. What is still
+  unverified is the **fault path itself**: the naked handler, the stacked frame
+  and the `watchdog_reboot()` out of it. The `debug-firmware-on-rig` skill with a
+  probe that dereferences a bad pointer over HID is the way to close that.
 
 ### Idle anti-burn-in styles (`poly_keymap.c`)
 When the keyboard idles, the keycap legends would otherwise burn the **same**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2347,11 +2347,19 @@ run on it (`test_no_crash_record`). What is worth knowing:
 - **The record lives in a NOLOAD RAM block** (`s_ram`, section `.ram0.crash_record`
   via ChibiOS's `rules_memory.ld` — the same trick as the bootloader magic) so it
   survives the `watchdog_reboot()` the handler ends with. It does NOT survive a
-  power cycle, which is why `crash_record_init()` **archives it to flash** at boot:
+  power cycle, which is why it is **archived to flash** at boot:
   one 4 KB sector at `FW_CRASH_LOG_OFFSET` (`FW_APPLY_LOG_OFFSET - 4096`), page-
   appended, erased only when full or on cmd 39 sub-op 2. `FW_UP_MAX_SIZE` shrank
   by that sector (`0x1F7000 → 0x1F6000`; the host mirror in `hid_fw_up.py` moved
   with it).
+  - ⚠️ **The archive write happens in `crash_record_archive_pending()`, AFTER
+    `multicore_launch_core1()` — not inside `crash_record_init()`, which runs
+    first.** The flash write takes the `fw_staging` core1 lockout, and releasing
+    that lockout does a bounded RELAUNCH of core1. Done before post_init's own
+    launch, core1 is already running when the unbounded FIFO handshake starts and
+    the keyboard hangs on the boot after every crash — the exact opposite of what
+    the record exists for. Caught by Greptile on #271 before it ever reached
+    hardware; the split (capture early, archive after the launch) is the fix.
   - **Verify the placement in the ELF, not the linker script**: `nm` must show
     `s_ram` inside `.ram0` and `.ram0_init` must be **size 0** (nothing initialises
     it). `objdump -h` on the split72 build: `.ram0 00000040 @ 2003e12c`, `.ram0_init

--- a/keyboards/polykybd/base/crash_record.c
+++ b/keyboards/polykybd/base/crash_record.c
@@ -227,9 +227,6 @@ static bool page_erased(uint32_t i) {
     return archive_page(i)->magic == 0xFFFFFFFFu;
 }
 
-// A record init captured but has not yet written to flash (see the header).
-static bool s_archive_pending = false;
-
 static void archive_scan(void) {
     s_have_archive = false;
     for (uint32_t i = 0; i < ARCHIVE_PAGES; i++) {
@@ -242,9 +239,16 @@ static void archive_scan(void) {
     }
 }
 
-static void flash_guarded(bool erase, uint32_t off, const uint8_t *page) {
+// `lockout` = take the fw_staging core1 lockout around the write. Required at
+// runtime (core1 serves RLE from XIP and must be parked while the bootrom
+// rewrites flash). MUST be false from crash_record_init(): at pre_init core1 has
+// never been launched -- it is still parked in the bootrom, fetching nothing
+// from XIP -- so there is nothing to halt, and the lockout's RELEASE would do a
+// bounded relaunch of core1 that leaves post_init's unbounded
+// multicore_launch_core1() handshake blocked forever.
+static void flash_guarded(bool erase, uint32_t off, const uint8_t *page, bool lockout) {
     uint32_t tag = crash_phase_enter(CRASH_PHASE_FLASH, erase ? 2 : 1);
-    fw_staging_core1_lockout_begin();
+    if (lockout) fw_staging_core1_lockout_begin();
     uint32_t irq = save_and_disable_interrupts();
     if (erase) {
         flash_range_erase(off, FLASH_SECTOR_SIZE);
@@ -252,23 +256,23 @@ static void flash_guarded(bool erase, uint32_t off, const uint8_t *page) {
         flash_range_program(off, page, FLASH_PAGE_SIZE);
     }
     restore_interrupts(irq);
-    fw_staging_core1_lockout_end();
+    if (lockout) fw_staging_core1_lockout_end();
     crash_phase_leave(tag);
 }
 
-static void archive_append(const poly_crash_record_t *rec) {
+static void archive_append(const poly_crash_record_t *rec, bool lockout) {
     uint32_t slot = ARCHIVE_PAGES;
     for (uint32_t i = 0; i < ARCHIVE_PAGES; i++) {
         if (page_erased(i)) { slot = i; break; }
     }
     if (slot == ARCHIVE_PAGES) {
-        flash_guarded(true, FW_CRASH_LOG_OFFSET, NULL);
+        flash_guarded(true, FW_CRASH_LOG_OFFSET, NULL, lockout);
         slot = 0;
     }
     uint8_t page[FLASH_PAGE_SIZE];
     memset(page, 0xFF, sizeof(page));
     memcpy(page, rec, sizeof(*rec));
-    flash_guarded(false, FW_CRASH_LOG_OFFSET + slot * FLASH_PAGE_SIZE, page);
+    flash_guarded(false, FW_CRASH_LOG_OFFSET + slot * FLASH_PAGE_SIZE, page, lockout);
     s_archive      = *rec;
     s_have_archive = true;
 }
@@ -332,20 +336,21 @@ void crash_record_init(void) {
 
     archive_scan();
     if (have) {
-        // Remembered now, written by crash_record_archive_pending() once core1 is
-        // up -- the flash write must not run before the launch (see the header).
+        // Archived NOW, before anything else in this boot can fault: a copy that
+        // waited in .bss for post_init would be lost to a reset in the boot
+        // window, and a fault that recurs there every boot would never be
+        // archived at all -- exactly the record worth having. No core1 lockout
+        // (see flash_guarded): core1 has not been launched yet.
         // Bounded: a firmware that crashes at every boot would otherwise rewrite
-        // the same story once per boot. The first CRASH_LOOP_LIMIT go in.
-        s_archive         = captured;
-        s_have_archive    = true;
-        s_archive_pending = captured.consecutive <= CRASH_LOOP_LIMIT;
+        // the same story once per boot. The first CRASH_LOOP_LIMIT go in; later
+        // ones are still reported from RAM by the banner.
+        if (captured.consecutive <= CRASH_LOOP_LIMIT) {
+            archive_append(&captured, /*lockout=*/false);
+        } else {
+            s_archive      = captured;
+            s_have_archive = true;
+        }
     }
-}
-
-void crash_record_archive_pending(void) {
-    if (!s_archive_pending) return;
-    s_archive_pending = false;
-    archive_append(&s_archive);
 }
 
 bool crash_record_fresh(void) {
@@ -360,7 +365,7 @@ bool crash_record_archived(poly_crash_record_t *out) {
 
 void crash_record_clear(void) {
     if (!page_erased(0)) {
-        flash_guarded(true, FW_CRASH_LOG_OFFSET, NULL);
+        flash_guarded(true, FW_CRASH_LOG_OFFSET, NULL, /*lockout=*/true);
     }
     s_have_archive = false;
     s_fresh        = false;

--- a/keyboards/polykybd/base/crash_record.c
+++ b/keyboards/polykybd/base/crash_record.c
@@ -283,7 +283,10 @@ static uint8_t read_reset_reason(void) {
 
 void crash_record_init(void) {
     const uint8_t reason = read_reset_reason();
+    // Zeroed at declaration: only the `have` branches fill it, and cppcheck
+    // cannot see that guard (uninitStructMember).
     poly_crash_record_t captured;
+    memset(&captured, 0, sizeof(captured));
     bool have = false;
 
     if (s_ram.magic != CRASH_RAM_MAGIC) {
@@ -296,7 +299,6 @@ void crash_record_init(void) {
         // The loop stopped feeding the watchdog and nothing recorded why: a hang.
         // Synthesise a record from the breadcrumb the loop left behind -- that
         // tag is the entire diagnosis of a hang, since no frame exists.
-        memset(&captured, 0, sizeof(captured));
         captured.magic       = CRASH_RECORD_MAGIC;
         captured.kind        = CRASH_KIND_WATCHDOG;
         captured.core        = 0;

--- a/keyboards/polykybd/base/crash_record.c
+++ b/keyboards/polykybd/base/crash_record.c
@@ -223,6 +223,9 @@ static bool page_erased(uint32_t i) {
     return archive_page(i)->magic == 0xFFFFFFFFu;
 }
 
+// A record init captured but has not yet written to flash (see the header).
+static bool s_archive_pending = false;
+
 static void archive_scan(void) {
     s_have_archive = false;
     for (uint32_t i = 0; i < ARCHIVE_PAGES; i++) {
@@ -325,15 +328,20 @@ void crash_record_init(void) {
 
     archive_scan();
     if (have) {
+        // Remembered now, written by crash_record_archive_pending() once core1 is
+        // up -- the flash write must not run before the launch (see the header).
         // Bounded: a firmware that crashes at every boot would otherwise rewrite
         // the same story once per boot. The first CRASH_LOOP_LIMIT go in.
-        if (captured.consecutive <= CRASH_LOOP_LIMIT) {
-            archive_append(&captured);
-        } else {
-            s_archive      = captured;
-            s_have_archive = true;
-        }
+        s_archive         = captured;
+        s_have_archive    = true;
+        s_archive_pending = captured.consecutive <= CRASH_LOOP_LIMIT;
     }
+}
+
+void crash_record_archive_pending(void) {
+    if (!s_archive_pending) return;
+    s_archive_pending = false;
+    archive_append(&s_archive);
 }
 
 bool crash_record_fresh(void) {

--- a/keyboards/polykybd/base/crash_record.c
+++ b/keyboards/polykybd/base/crash_record.c
@@ -125,8 +125,12 @@ static void __attribute__((noreturn)) record_and_reboot(uint8_t kind, const uint
     rec_fill(&s_ram.rec, kind, frame, sp);
     __asm volatile("dsb" ::: "memory");
     if (s_ram.rec.consecutive > CRASH_LOOP_LIMIT) {
-        // Crash loop: stop rebooting. The record is in RAM for the next
-        // RUN-pin / watchdog reset to archive, and the previous ones are in flash.
+        // Crash loop: stop rebooting. The watchdog may still be armed from this
+        // boot's crash_watchdog_start(); left alone it would reset the chip in
+        // CRASH_WATCHDOG_MS and turn the halt into a reboot storm with an 8 s
+        // pause. Disarm it. The record stays in RAM for the next RUN-pin reset
+        // to archive, and the previous ones are in flash.
+        crash_watchdog_stop();
         while (1) { __asm volatile("wfi"); }
     }
     // Full-chip reset via the watchdog (what mcu_reset() does) -- a plain
@@ -454,7 +458,13 @@ bool crash_record_note_slave(const uint8_t *body, uint8_t len) {
 // The watchdog
 // ---------------------------------------------------------------------------
 void crash_watchdog_start(void) {
-    s_ram.phase = CRASH_PHASE_LOOP;
+    // The boot got all the way through post_init, so whatever crashed before
+    // was not a boot loop: the back-to-back count starts over, as the field's
+    // own comment promises. A firmware that crashes at RUNTIME on every boot
+    // therefore reboots (and announces itself on each banner) rather than
+    // halting; the halt is for one that never gets this far.
+    s_ram.consecutive = 0;
+    s_ram.phase       = CRASH_PHASE_LOOP;
     watchdog_enable(CRASH_WATCHDOG_MS, true);
 }
 

--- a/keyboards/polykybd/base/crash_record.c
+++ b/keyboards/polykybd/base/crash_record.c
@@ -306,10 +306,20 @@ void crash_record_init(void) {
     } else if (rec_valid(&s_ram.rec)) {
         captured = s_ram.rec;
         have     = true;
-    } else if (reason & CRASH_RESET_WD_TIMER) {
+    } else if ((reason & CRASH_RESET_WD_TIMER) && watchdog_enable_caused_reboot()) {
         // The loop stopped feeding the watchdog and nothing recorded why: a hang.
         // Synthesise a record from the breadcrumb the loop left behind -- that
         // tag is the entire diagnosis of a hang, since no frame exists.
+        //
+        // REASON.TIMER alone is NOT that: the bootrom's own reboot after a UF2
+        // copy is a watchdog_reboot() with a delay, so the first boot after
+        // every BOOTSEL flash reads TIMER too (the rig's flash-per-run did, and
+        // reported a hang on both halves at n=3 -- run 33809919200). What
+        // separates the two is the marker watchdog_enable() leaves in scratch4:
+        // our crash_watchdog_start() sets it, and every deliberate reboot --
+        // the bootrom's, watchdog_reboot(0,0,0) in mcu_reset() and the crash
+        // handler, the inlined self-apply reset, crash_watchdog_stop() -- clears
+        // it. That is exactly what watchdog_enable_caused_reboot() tests.
         captured.magic       = CRASH_RECORD_MAGIC;
         captured.kind        = CRASH_KIND_WATCHDOG;
         captured.core        = 0;
@@ -479,4 +489,8 @@ void crash_watchdog_feed(void) {
 
 void crash_watchdog_stop(void) {
     hw_clear_bits(&watchdog_hw->ctrl, WATCHDOG_CTRL_ENABLE_BITS);
+    // Drop the watchdog_enable() marker too, so whatever deliberate reset follows
+    // (mcu_reset, a bootloader jump, the self-apply) cannot read as a hang at the
+    // next boot -- see the WD_TIMER branch in crash_record_init().
+    watchdog_hw->scratch[4] = 0;
 }

--- a/keyboards/polykybd/base/crash_record.c
+++ b/keyboards/polykybd/base/crash_record.c
@@ -1,0 +1,457 @@
+// Copyright 2026 thpoll83
+// SPDX-License-Identifier: GPL-2.0-or-later
+// See crash_record.h for the design.
+#include "crash_record.h"
+
+#include "quantum.h"          // FW_VERSION
+#include "print.h"
+#include "fw_staging.h"       // FW_CRASH_LOG_OFFSET, fw_staging_core1_lockout_*()
+#include "polymod_crc32.h"
+
+#include "hardware/flash.h"
+#include "hardware/sync.h"
+#include "hardware/watchdog.h"
+#include "hardware/structs/watchdog.h"
+#include "hardware/structs/vreg_and_chip_reset.h"
+#include "hardware/structs/sio.h"
+#include "hardware/structs/scb.h"
+#include "hardware/structs/timer.h"
+
+#include <string.h>
+#include <stdio.h>
+
+// ---------------------------------------------------------------------------
+// The NOLOAD block. `.ram0.*` is placed after __ram0_noinit__ by ChibiOS's
+// rules_memory.ld (both PolyKybd ldscripts include it), so crt0 neither loads
+// nor clears it -- exactly how the double-tap bootloader keeps its magic word
+// across a reset. Random after a power-on, hence the magic and the CRC.
+// ---------------------------------------------------------------------------
+#define CRASH_RAM_MAGIC 0x5AFEB007u
+
+// Reboot at most this many times in a row on the strength of a crash record.
+// Past it the fault handler records and then HALTS (today's behaviour), so a
+// firmware that faults at every boot presents as a dead board rather than a
+// keyboard that flickers through a reboot storm. The archive keeps the record.
+#define CRASH_LOOP_LIMIT 5u
+
+typedef struct {
+    uint32_t          magic;
+    uint32_t          consecutive;   // crashes in a row so far (0 after a clean boot)
+    volatile uint16_t phase;
+    volatile uint16_t phase_arg;
+    poly_crash_record_t rec;         // rec.magic == CRASH_RECORD_MAGIC while a crash is pending
+} crash_ram_t;
+
+static crash_ram_t s_ram __attribute__((section(".ram0.crash_record"), aligned(4)));
+
+// Per-boot state (ordinary .bss).
+static bool                 s_fresh        = false;   // this boot captured a record
+static bool                 s_have_archive = false;
+static poly_crash_record_t  s_archive;                 // last archived record (flash copy)
+static bool                 s_have_slave   = false;
+static bool                 s_slave_fresh  = false;
+static poly_crash_record_t  s_slave;                   // last record pulled from the slave
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+static uint32_t rec_crc(const poly_crash_record_t *r) {
+    return crc32_1byte(r, (uint16_t)offsetof(poly_crash_record_t, crc), 0);
+}
+
+static bool rec_valid(const poly_crash_record_t *r) {
+    return r->magic == CRASH_RECORD_MAGIC && r->crc == rec_crc(r);
+}
+
+static void ram_block_reset(void) {
+    memset(&s_ram, 0, sizeof(s_ram));
+    s_ram.magic = CRASH_RAM_MAGIC;
+    s_ram.phase = CRASH_PHASE_BOOT;
+}
+
+static uint32_t uptime_ms_raw(void) {
+    // The hardware timer, not QMK's timer_read32(): this runs inside a fault
+    // handler where the OS tick may be exactly what is broken.
+    return timer_hw->timerawl / 1000u;
+}
+
+// A stack pointer that does not point into SRAM (a stack overflow, a corrupted
+// PSP) must not be dereferenced from inside the fault handler -- that would fault
+// again and lock the core up with the record half-written.
+static bool frame_readable(const uint32_t *frame) {
+    uint32_t a = (uint32_t)frame;
+    return frame != NULL && a >= 0x20000000u && a + 32u <= 0x20042000u && (a & 3u) == 0u;
+}
+
+static void copy_fw(char *dst) {
+    const char *v = FW_VERSION;
+    size_t      n = strlen(v);
+    if (n > CRASH_FW_LEN) n = CRASH_FW_LEN;
+    memset(dst, 0, CRASH_FW_LEN);
+    memcpy(dst, v, n);
+}
+
+// Fill the record fields shared by every kind. Interrupts are assumed OFF.
+static void rec_fill(poly_crash_record_t *r, uint8_t kind, const uint32_t *frame, uint32_t sp) {
+    memset(r, 0, sizeof(*r));
+    r->magic     = CRASH_RECORD_MAGIC;
+    r->kind      = kind;
+    r->core      = (uint8_t)sio_hw->cpuid;
+    r->consecutive = (uint8_t)((s_ram.magic == CRASH_RAM_MAGIC ? s_ram.consecutive : 0u) + 1u);
+    if (frame_readable(frame)) {
+        // Cortex-M exception frame: r0 r1 r2 r3 r12 lr pc xpsr
+        r->lr   = frame[5];
+        r->pc   = frame[6];
+        r->xpsr = frame[7];
+    }
+    r->sp        = sp;
+    r->icsr      = scb_hw->icsr;
+    r->uptime_ms = uptime_ms_raw();
+    r->phase     = (s_ram.magic == CRASH_RAM_MAGIC) ? s_ram.phase : CRASH_PHASE_UNKNOWN;
+    r->phase_arg = (s_ram.magic == CRASH_RAM_MAGIC) ? s_ram.phase_arg : 0;
+    copy_fw(r->fw);
+    r->crc = rec_crc(r);
+}
+
+// Record into the NOLOAD block and reboot the whole chip. Never returns.
+static void __attribute__((noreturn)) record_and_reboot(uint8_t kind, const uint32_t *frame, uint32_t sp) {
+    __asm volatile("cpsid i" ::: "memory");
+    if (s_ram.magic != CRASH_RAM_MAGIC) {
+        // Power-on garbage or a fault before init: start the block fresh so the
+        // record at least carries a sane counter.
+        memset(&s_ram, 0, sizeof(s_ram));
+        s_ram.magic = CRASH_RAM_MAGIC;
+    }
+    rec_fill(&s_ram.rec, kind, frame, sp);
+    __asm volatile("dsb" ::: "memory");
+    if (s_ram.rec.consecutive > CRASH_LOOP_LIMIT) {
+        // Crash loop: stop rebooting. The record is in RAM for the next
+        // RUN-pin / watchdog reset to archive, and the previous ones are in flash.
+        while (1) { __asm volatile("wfi"); }
+    }
+    // Full-chip reset via the watchdog (what mcu_reset() does) -- a plain
+    // NVIC_SystemReset leaves peripherals half-reset on the RP2040 and hangs at
+    // early boot (see poly_util.c). scratch4 = 0 -> normal flash boot.
+    watchdog_reboot(0, 0, 0);
+    while (1) { }
+}
+
+// ---------------------------------------------------------------------------
+// The fault handlers
+// ---------------------------------------------------------------------------
+
+// Called from HardFault_Handler with the active stack's frame and EXC_RETURN.
+void crash_record_fault(const uint32_t *frame, uint32_t exc_return) __attribute__((noreturn, used));
+void crash_record_fault(const uint32_t *frame, uint32_t exc_return) {
+    (void)exc_return;
+    record_and_reboot(CRASH_KIND_HARDFAULT, frame, (uint32_t)frame);
+}
+
+// ChibiOS's vectors.S declares HardFault_Handler weak (a `b .` loop); this strong
+// definition takes the vector on BOTH cores (core1 launches on the same table).
+// Naked: pick the stack the frame is on from EXC_RETURN bit 2, then tail-call.
+__attribute__((naked, noreturn)) void HardFault_Handler(void) {
+    __asm volatile(
+        "movs r0, #4          \n"
+        "mov  r1, lr          \n"
+        "tst  r0, r1          \n"
+        "beq  1f              \n"
+        "mrs  r0, psp         \n"
+        "b    2f              \n"
+        "1: mrs r0, msp       \n"
+        "2: mov r1, lr        \n"
+        "ldr  r2, =crash_record_fault \n"
+        "bx   r2              \n"
+        ".ltorg               \n");
+}
+
+// Every other unhandled vector (SVC, PendSV, SysTick, an unused IRQ) funnels
+// through vectors.S's shared body, which `bl`s here -- so EXC_RETURN is gone,
+// but the frame is still on whichever stack was active. Prefer the process
+// stack when it points into SRAM (ChibiOS runs threads on PSP); the vector
+// number in ICSR is the reliable part of this record either way.
+void crash_record_unhandled(uint32_t msp, uint32_t psp) __attribute__((noreturn, used));
+void crash_record_unhandled(uint32_t msp, uint32_t psp) {
+    const bool psp_sane = (psp >= 0x20000000u) && (psp < 0x20042000u) && ((psp & 3u) == 0u);
+    uint32_t   sp       = psp_sane ? psp : msp;
+    record_and_reboot(CRASH_KIND_UNHANDLED, (const uint32_t *)sp, sp);
+}
+
+__attribute__((naked, noreturn)) void _unhandled_exception(void) {
+    __asm volatile(
+        "mrs  r0, msp         \n"
+        "mrs  r1, psp         \n"
+        "ldr  r2, =crash_record_unhandled \n"
+        "bx   r2              \n"
+        ".ltorg               \n");
+}
+
+void crash_record_halt(uint16_t arg) {
+    // A deliberate stop: no frame, but keep the caller's own tag as the detail.
+    if (s_ram.magic == CRASH_RAM_MAGIC) s_ram.phase_arg = arg;
+    record_and_reboot(CRASH_KIND_HALT, NULL, 0);
+}
+
+// ---------------------------------------------------------------------------
+// The phase breadcrumb
+// ---------------------------------------------------------------------------
+uint32_t crash_phase_enter(uint16_t phase, uint16_t arg) {
+    uint32_t prev = ((uint32_t)s_ram.phase << 16) | s_ram.phase_arg;
+    s_ram.phase_arg = arg;
+    s_ram.phase     = phase;
+    return prev;
+}
+
+void crash_phase_leave(uint32_t prev) {
+    s_ram.phase_arg = (uint16_t)(prev & 0xFFFFu);
+    s_ram.phase     = (uint16_t)(prev >> 16);
+}
+
+// ---------------------------------------------------------------------------
+// The flash archive: one 4 KB sector, appended a 256-byte page at a time, erased
+// and restarted when full. Reading is "the last valid page"; writing is "the
+// first erased page". A crash loop of any length therefore costs one erase per
+// 16 crashes, not one per boot.
+// ---------------------------------------------------------------------------
+#define ARCHIVE_PAGES (FLASH_SECTOR_SIZE / FLASH_PAGE_SIZE)
+
+static const poly_crash_record_t *archive_page(uint32_t i) {
+    return (const poly_crash_record_t *)(XIP_BASE + FW_CRASH_LOG_OFFSET + i * FLASH_PAGE_SIZE);
+}
+
+static bool page_erased(uint32_t i) {
+    return archive_page(i)->magic == 0xFFFFFFFFu;
+}
+
+static void archive_scan(void) {
+    s_have_archive = false;
+    for (uint32_t i = 0; i < ARCHIVE_PAGES; i++) {
+        const poly_crash_record_t *p = archive_page(i);
+        if (page_erased(i)) break;
+        if (rec_valid(p)) {
+            s_archive      = *p;
+            s_have_archive = true;
+        }
+    }
+}
+
+static void flash_guarded(bool erase, uint32_t off, const uint8_t *page) {
+    uint32_t tag = crash_phase_enter(CRASH_PHASE_FLASH, erase ? 2 : 1);
+    fw_staging_core1_lockout_begin();
+    uint32_t irq = save_and_disable_interrupts();
+    if (erase) {
+        flash_range_erase(off, FLASH_SECTOR_SIZE);
+    } else {
+        flash_range_program(off, page, FLASH_PAGE_SIZE);
+    }
+    restore_interrupts(irq);
+    fw_staging_core1_lockout_end();
+    crash_phase_leave(tag);
+}
+
+static void archive_append(const poly_crash_record_t *rec) {
+    uint32_t slot = ARCHIVE_PAGES;
+    for (uint32_t i = 0; i < ARCHIVE_PAGES; i++) {
+        if (page_erased(i)) { slot = i; break; }
+    }
+    if (slot == ARCHIVE_PAGES) {
+        flash_guarded(true, FW_CRASH_LOG_OFFSET, NULL);
+        slot = 0;
+    }
+    uint8_t page[FLASH_PAGE_SIZE];
+    memset(page, 0xFF, sizeof(page));
+    memcpy(page, rec, sizeof(*rec));
+    flash_guarded(false, FW_CRASH_LOG_OFFSET + slot * FLASH_PAGE_SIZE, page);
+    s_archive      = *rec;
+    s_have_archive = true;
+}
+
+// ---------------------------------------------------------------------------
+// Boot-time capture
+// ---------------------------------------------------------------------------
+static uint8_t read_reset_reason(void) {
+    uint8_t  bits = 0;
+    uint32_t chip = vreg_and_chip_reset_hw->chip_reset;
+    if (chip & VREG_AND_CHIP_RESET_CHIP_RESET_HAD_POR_BITS)         bits |= CRASH_RESET_HAD_POR;
+    if (chip & VREG_AND_CHIP_RESET_CHIP_RESET_HAD_RUN_BITS)         bits |= CRASH_RESET_HAD_RUN;
+    if (chip & VREG_AND_CHIP_RESET_CHIP_RESET_HAD_PSM_RESTART_BITS) bits |= CRASH_RESET_HAD_PSM;
+    uint32_t wd = watchdog_hw->reason;
+    if (wd & WATCHDOG_REASON_TIMER_BITS) bits |= CRASH_RESET_WD_TIMER;
+    if (wd & WATCHDOG_REASON_FORCE_BITS) bits |= CRASH_RESET_WD_FORCE;
+    return bits;
+}
+
+void crash_record_init(void) {
+    const uint8_t reason = read_reset_reason();
+    poly_crash_record_t captured;
+    bool have = false;
+
+    if (s_ram.magic != CRASH_RAM_MAGIC) {
+        // Power-on (or the first boot of this firmware): nothing to report.
+        ram_block_reset();
+    } else if (rec_valid(&s_ram.rec)) {
+        captured = s_ram.rec;
+        have     = true;
+    } else if (reason & CRASH_RESET_WD_TIMER) {
+        // The loop stopped feeding the watchdog and nothing recorded why: a hang.
+        // Synthesise a record from the breadcrumb the loop left behind -- that
+        // tag is the entire diagnosis of a hang, since no frame exists.
+        memset(&captured, 0, sizeof(captured));
+        captured.magic       = CRASH_RECORD_MAGIC;
+        captured.kind        = CRASH_KIND_WATCHDOG;
+        captured.core        = 0;
+        captured.consecutive = (uint8_t)(s_ram.consecutive + 1u);
+        captured.phase       = s_ram.phase;
+        captured.phase_arg   = s_ram.phase_arg;
+        copy_fw(captured.fw);
+        have = true;
+    }
+
+    if (have) {
+        captured.reset_reason = reason;
+        captured.crc          = rec_crc(&captured);
+        s_ram.consecutive     = captured.consecutive;
+        s_fresh               = true;
+    } else {
+        s_ram.consecutive = 0;
+    }
+    // The RAM copy has done its job either way; a stale one must never be
+    // re-reported by a later boot.
+    memset(&s_ram.rec, 0, sizeof(s_ram.rec));
+    s_ram.phase     = CRASH_PHASE_BOOT;
+    s_ram.phase_arg = 0;
+
+    archive_scan();
+    if (have) {
+        // Bounded: a firmware that crashes at every boot would otherwise rewrite
+        // the same story once per boot. The first CRASH_LOOP_LIMIT go in.
+        if (captured.consecutive <= CRASH_LOOP_LIMIT) {
+            archive_append(&captured);
+        } else {
+            s_archive      = captured;
+            s_have_archive = true;
+        }
+    }
+}
+
+bool crash_record_fresh(void) {
+    return s_fresh;
+}
+
+bool crash_record_archived(poly_crash_record_t *out) {
+    if (!s_have_archive) return false;
+    if (out) *out = s_archive;
+    return true;
+}
+
+void crash_record_clear(void) {
+    if (!page_erased(0)) {
+        flash_guarded(true, FW_CRASH_LOG_OFFSET, NULL);
+    }
+    s_have_archive = false;
+    s_fresh        = false;
+    s_have_slave   = false;
+    s_slave_fresh  = false;
+    memset(&s_archive, 0, sizeof(s_archive));
+    memset(&s_slave, 0, sizeof(s_slave));
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+static const char *kind_name(uint8_t kind) {
+    switch (kind) {
+        case CRASH_KIND_HARDFAULT: return "hardfault";
+        case CRASH_KIND_UNHANDLED: return "unhandled";
+        case CRASH_KIND_WATCHDOG:  return "watchdog";
+        case CRASH_KIND_HALT:      return "halt";
+        default:                   return "none";
+    }
+}
+
+int crash_record_format(const poly_crash_record_t *rec, const char *side, char *buf, size_t n) {
+    char fw[CRASH_FW_LEN + 1];
+    memcpy(fw, rec->fw, CRASH_FW_LEN);
+    fw[CRASH_FW_LEN] = '\0';
+    return snprintf(buf, n,
+                    "crash: side=%s kind=%s core=%u pc=0x%08lx lr=0x%08lx sp=0x%08lx "
+                    "psr=0x%08lx icsr=0x%08lx phase=%u:0x%04x up=%lums n=%u reason=0x%02x fw=%s",
+                    side, kind_name(rec->kind), (unsigned)rec->core,
+                    (unsigned long)rec->pc, (unsigned long)rec->lr, (unsigned long)rec->sp,
+                    (unsigned long)rec->xpsr, (unsigned long)rec->icsr,
+                    (unsigned)rec->phase, (unsigned)rec->phase_arg,
+                    (unsigned long)rec->uptime_ms, (unsigned)rec->consecutive,
+                    (unsigned)rec->reset_reason, fw);
+}
+
+static void emit_one(const poly_crash_record_t *rec, const char *side) {
+    char line[192];
+    crash_record_format(rec, side, line, sizeof(line));
+    uprintf("   %s\n", line);
+}
+
+void crash_record_emit_lines(void) {
+    // Only a FRESH record is announced: the archive is a history for polyctl /
+    // the HID command, not something to re-report at every boot forever.
+    if (s_fresh && s_have_archive) emit_one(&s_archive, "master");
+    // The slave's line is printed ONCE, at the pull (crash_record_note_slave):
+    // the link can come up long after the banner re-emits have stopped.
+}
+
+static uint8_t fill_body(uint8_t *out, uint8_t out_len, bool present, bool fresh,
+                         const poly_crash_record_t *rec) {
+    if (out_len < CRASH_HID_BODY_LEN) return 0;
+    out[0] = (present ? CRASH_HID_FLAG_PRESENT : 0) | (fresh ? CRASH_HID_FLAG_FRESH : 0);
+    if (present) {
+        memcpy(&out[1], rec, sizeof(*rec));
+    } else {
+        memset(&out[1], 0, sizeof(*rec));
+    }
+    return (uint8_t)CRASH_HID_BODY_LEN;
+}
+
+uint8_t crash_record_hid_body(uint8_t which, uint8_t *out, uint8_t out_len) {
+    if (which == 1) {
+        return fill_body(out, out_len, s_have_slave, s_slave_fresh, &s_slave);
+    }
+    return fill_body(out, out_len, s_have_archive, s_fresh, &s_archive);
+}
+
+// ---------------------------------------------------------------------------
+// The split link
+// ---------------------------------------------------------------------------
+void crash_record_slave_reply(uint8_t *out, uint8_t out_len) {
+    (void)fill_body(out, out_len, s_have_archive, s_fresh, &s_archive);
+}
+
+bool crash_record_note_slave(const uint8_t *body, uint8_t len) {
+    if (len < CRASH_HID_BODY_LEN) return false;
+    if (!(body[0] & CRASH_HID_FLAG_PRESENT)) {
+        s_have_slave = false;
+        return true;
+    }
+    poly_crash_record_t rec;
+    memcpy(&rec, &body[1], sizeof(rec));
+    if (!rec_valid(&rec)) return false;
+    s_slave       = rec;
+    s_have_slave  = true;
+    s_slave_fresh = (body[0] & CRASH_HID_FLAG_FRESH) != 0;
+    if (s_slave_fresh) emit_one(&s_slave, "slave");
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// The watchdog
+// ---------------------------------------------------------------------------
+void crash_watchdog_start(void) {
+    s_ram.phase = CRASH_PHASE_LOOP;
+    watchdog_enable(CRASH_WATCHDOG_MS, true);
+}
+
+void crash_watchdog_feed(void) {
+    watchdog_update();
+}
+
+void crash_watchdog_stop(void) {
+    hw_clear_bits(&watchdog_hw->ctrl, WATCHDOG_CTRL_ENABLE_BITS);
+}

--- a/keyboards/polykybd/base/crash_record.h
+++ b/keyboards/polykybd/base/crash_record.h
@@ -57,7 +57,7 @@ enum crash_kind {
     CRASH_KIND_NONE      = 0,
     CRASH_KIND_HARDFAULT = 1,  // HardFault vector: frame captured from the active stack
     CRASH_KIND_UNHANDLED = 2,  // any other unhandled vector (ICSR names it)
-    CRASH_KIND_WATCHDOG  = 3,  // synthesised at boot from WATCHDOG.REASON.TIMER
+    CRASH_KIND_WATCHDOG  = 3,  // synthesised at boot: REASON.TIMER + the watchdog_enable() marker
     CRASH_KIND_HALT      = 4,  // crash_record_halt(): a deliberate "cannot continue"
 };
 
@@ -184,7 +184,10 @@ void crash_watchdog_feed(void);
 // Disarm before anything that legitimately stops the loop for longer than the
 // timeout and never returns: the firmware self-apply, a bootloader jump, a
 // deliberate reset. Leaving it armed across a BOOTSEL entry would reboot the
-// bootrom out from under a UF2 copy.
+// bootrom out from under a UF2 copy. Also clears the watchdog_enable() marker
+// (scratch4), which is what keeps the reset that follows from being reported as
+// a hang: a WD_TIMER reason counts only while that marker is still in place,
+// because the bootrom's reboot after a UF2 copy is a watchdog reboot as well.
 void crash_watchdog_stop(void);
 
 // Record a deliberate "cannot continue" (kind HALT) and reboot. Never returns.

--- a/keyboards/polykybd/base/crash_record.h
+++ b/keyboards/polykybd/base/crash_record.h
@@ -116,9 +116,12 @@ void     crash_phase_leave(uint32_t prev);
 
 // --- boot-time capture and reporting --------------------------------------
 
-// Call ONCE early in keyboard_post_init_user(), before the boot banner and
-// BEFORE core1 is launched. Reads the reset cause, validates the NOLOAD block,
-// captures a fresh record into RAM and clears the NOLOAD copy. It does NOT touch
+// Call ONCE at the very top of keyboard_pre_init_user() -- before any PolyKybd
+// init and before QMK's own (matrix, split link, status OLED all run between the
+// two hooks), so a fault anywhere in this boot is tagged phase BOOT and the
+// previous record is captured before it can recur. Reads the reset cause,
+// validates the NOLOAD block, captures a fresh record into RAM and clears the
+// NOLOAD copy. It does NOT touch
 // flash: the archive write needs the fw_staging core1 lockout, whose release
 // RELAUNCHES core1 (bounded) -- done before post_init's own
 // multicore_launch_core1() that would leave core1 already running and the

--- a/keyboards/polykybd/base/crash_record.h
+++ b/keyboards/polykybd/base/crash_record.h
@@ -116,11 +116,19 @@ void     crash_phase_leave(uint32_t prev);
 
 // --- boot-time capture and reporting --------------------------------------
 
-// Call ONCE early in keyboard_post_init_user(), before the boot banner. Reads the
-// reset cause, validates the NOLOAD block, archives a fresh record to flash and
-// clears the RAM copy. Safe to call with core1 running (it takes the fw_staging
-// core1 lockout around the flash write).
+// Call ONCE early in keyboard_post_init_user(), before the boot banner and
+// BEFORE core1 is launched. Reads the reset cause, validates the NOLOAD block,
+// captures a fresh record into RAM and clears the NOLOAD copy. It does NOT touch
+// flash: the archive write needs the fw_staging core1 lockout, whose release
+// RELAUNCHES core1 (bounded) -- done before post_init's own
+// multicore_launch_core1() that would leave core1 already running and the
+// unbounded launch handshake blocked forever. Hence the split below.
 void crash_record_init(void);
+
+// Call ONCE right after multicore_launch_core1() in keyboard_post_init_user().
+// Writes the record init captured (if any) to the flash archive, under the
+// normal core1 lockout. A no-op when nothing was captured.
+void crash_record_archive_pending(void);
 
 // True when THIS boot followed a crash (a record was captured by init).
 bool crash_record_fresh(void);

--- a/keyboards/polykybd/base/crash_record.h
+++ b/keyboards/polykybd/base/crash_record.h
@@ -1,0 +1,181 @@
+// Copyright 2026 thpoll83
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Crash diagnostics: what a HardFault, an unhandled exception or a watchdog
+// timeout leaves behind, and how the next boot reports it.
+//
+// The Cortex-M0+ has ONE fault vector (HardFault) and no fault-status or
+// fault-address registers, so the only evidence a fault leaves is the stacked
+// exception frame: r0-r3, r12, LR, the faulting PC and xPSR. Before this module
+// the firmware's HardFault vector was ChibiOS's weak `b .` loop -- a fault on
+// either core was an instant, silent lockup with no trace anywhere, which is how
+// the HID-apply brick (qmk#258) cost ten probe rounds.
+//
+// Three RP2040 facts this design rests on:
+//   1. SRAM survives a watchdog / soft reset, not a power cycle. So the crash
+//      record lives in a NOLOAD RAM block (`.ram0.crash_record`, the same trick
+//      the double-tap bootloader uses for its magic word), guarded by a magic +
+//      CRC because after a power-on the block is random.
+//   2. The reset cause is readable: VREG_AND_CHIP_RESET.CHIP_RESET says POR vs
+//      RUN-pin vs PSM restart, WATCHDOG.REASON says timer vs forced. Nothing in
+//      the firmware read either before this.
+//   3. A watchdog reset resets the whole chip cleanly (it is what mcu_reset()
+//      already uses), so the fault handler can record and REBOOT instead of
+//      hanging -- the board comes back on its own, with the record intact.
+//
+// Lifecycle:
+//   fault / halt / timeout  -> record into the NOLOAD block (+ watchdog reboot)
+//   next boot, crash_record_init()
+//                           -> validate the block, read the reset cause,
+//                              archive the record to one flash sector below the
+//                              apply log (survives a later power cycle / BOOTSEL
+//                              recovery), clear the RAM copy, remember it as
+//                              "fresh" for THIS boot
+//   boot banner             -> `   crash: side=master kind=...` once per crash,
+//                              re-emitted with the banner for a late console
+//   HID cmd 39              -> read the archived record (master or the last
+//                              pulled slave one) / clear the archive
+//   slave                   -> the master pulls the slave's record over
+//                              USER_SYNC_SLAVE_DATA once per link-up and prints
+//                              it as `side=slave`; the slave has no console.
+//
+// The PHASE breadcrumb is the piece that makes a HANG diagnosable: a watchdog
+// timeout leaves no exception frame, so the loop tags what it is doing (which HID
+// command, which split transaction, a core1 wait, a flash program) into the same
+// NOLOAD block, and the timeout record carries the last tag.
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+// --- the record -----------------------------------------------------------
+
+#define CRASH_RECORD_MAGIC 0xC4A5C0DEu
+
+enum crash_kind {
+    CRASH_KIND_NONE      = 0,
+    CRASH_KIND_HARDFAULT = 1,  // HardFault vector: frame captured from the active stack
+    CRASH_KIND_UNHANDLED = 2,  // any other unhandled vector (ICSR names it)
+    CRASH_KIND_WATCHDOG  = 3,  // synthesised at boot from WATCHDOG.REASON.TIMER
+    CRASH_KIND_HALT      = 4,  // crash_record_halt(): a deliberate "cannot continue"
+};
+
+// Reset-cause bits captured at the boot that reported the record.
+#define CRASH_RESET_HAD_POR     (1u << 0)
+#define CRASH_RESET_HAD_RUN     (1u << 1)
+#define CRASH_RESET_HAD_PSM     (1u << 2)
+#define CRASH_RESET_WD_TIMER    (1u << 4)
+#define CRASH_RESET_WD_FORCE    (1u << 5)
+
+#define CRASH_FW_LEN 8
+
+// 48 bytes, packed: fits a HID report beside its header and the slave->master
+// pull beside its flags byte (RPC_S2M_BUFFER_SIZE 72). Field order is the wire
+// order -- PolyKybdHost decodes it with a struct format, so append, never insert.
+typedef struct __attribute__((packed)) {
+    uint32_t magic;         // CRASH_RECORD_MAGIC
+    uint8_t  kind;          // enum crash_kind
+    uint8_t  core;          // SIO CPUID of the core that recorded it
+    uint8_t  consecutive;   // 1 = first crash after a clean boot, 2 = the boot after that crashed too, ...
+    uint8_t  reset_reason;  // CRASH_RESET_* of the boot that reported it (0 while still in RAM)
+    uint32_t pc;            // stacked return address (the faulting instruction, or its successor)
+    uint32_t lr;
+    uint32_t sp;            // the stack pointer the frame was read from
+    uint32_t xpsr;
+    uint32_t icsr;          // SCB->ICSR: VECTACTIVE names the exception
+    uint32_t uptime_ms;     // timer_read32() at the crash (0 for a watchdog record)
+    uint16_t phase;         // enum crash_phase -- what the loop was doing
+    uint16_t phase_arg;     // per-phase detail (HID cmd id, split tid, ...)
+    char     fw[CRASH_FW_LEN];  // FW_VERSION, NUL-padded: names the ELF to addr2line against
+    uint32_t crc;           // crc32 over everything above
+} poly_crash_record_t;
+
+_Static_assert(sizeof(poly_crash_record_t) == 48, "poly_crash_record_t is a wire format");
+
+// --- the phase breadcrumb -------------------------------------------------
+
+enum crash_phase {
+    CRASH_PHASE_UNKNOWN    = 0,
+    CRASH_PHASE_BOOT       = 1,   // post_init not finished
+    CRASH_PHASE_LOOP       = 2,   // main loop, nothing tagged
+    CRASH_PHASE_HID        = 3,   // raw_hid_receive(), arg = command id
+    CRASH_PHASE_BRIDGE     = 4,   // send_to_bridge(), arg = transaction id
+    CRASH_PHASE_CORE1_WAIT = 5,   // core0 spinning on core1's counter
+    CRASH_PHASE_FLASH      = 6,   // flash program/erase, arg = 1 program / 2 erase
+    CRASH_PHASE_SUSPEND    = 7,   // USB suspend loop
+    CRASH_PHASE_APPLY      = 8,   // firmware self-apply (watchdog is OFF here)
+};
+// PolyKybdHost's crash_report.py names these for the dialog -- keep the two in step.
+
+// Tag what the loop is doing. Returns the previous tag so a nested site can
+// restore it: `uint32_t p = crash_phase_enter(...); ...; crash_phase_leave(p);`
+// Two stores into NOLOAD RAM, cheap enough for a per-HID-report site.
+uint32_t crash_phase_enter(uint16_t phase, uint16_t arg);
+void     crash_phase_leave(uint32_t prev);
+
+// --- boot-time capture and reporting --------------------------------------
+
+// Call ONCE early in keyboard_post_init_user(), before the boot banner. Reads the
+// reset cause, validates the NOLOAD block, archives a fresh record to flash and
+// clears the RAM copy. Safe to call with core1 running (it takes the fw_staging
+// core1 lockout around the flash write).
+void crash_record_init(void);
+
+// True when THIS boot followed a crash (a record was captured by init).
+bool crash_record_fresh(void);
+
+// The last archived record (this boot's, or an older one read back from flash).
+// Returns false when the archive is empty.
+bool crash_record_archived(poly_crash_record_t *out);
+
+// Erase the flash archive and forget the fresh flag + the pulled slave copy.
+void crash_record_clear(void);
+
+// One console line describing `rec` for `side` ("master" / "slave"), the exact
+// shape PolyKybdHost and the HIL rig parse:
+//   crash: side=master kind=hardfault core=0 pc=0x10012345 lr=... sp=... psr=... icsr=...
+//          phase=3:0x0015 up=123456ms n=1 reason=0x22 fw=0.18.0
+// Returns the number of characters written (snprintf semantics).
+int crash_record_format(const poly_crash_record_t *rec, const char *side, char *buf, size_t n);
+
+// Print this boot's fresh master record and the pulled slave record (each once
+// per call, only if present). Called from the boot banner and its re-emit tick.
+void crash_record_emit_lines(void);
+
+// Fill a HID cmd-39 reply body: [0] flags, [1..48] record (zeroed when absent).
+//   which: 0 = the master's archive, 1 = the last slave record pulled.
+//   flags: bit0 present, bit1 fresh (recorded by the boot before this one).
+// Returns the number of bytes written (49).
+#define CRASH_HID_FLAG_PRESENT (1u << 0)
+#define CRASH_HID_FLAG_FRESH   (1u << 1)
+#define CRASH_HID_BODY_LEN     (1u + sizeof(poly_crash_record_t))
+uint8_t crash_record_hid_body(uint8_t which, uint8_t *out, uint8_t out_len);
+
+// --- the split link ---------------------------------------------------------
+
+// Slave side: answer the master's USER_SYNC_SLAVE_DATA pull (kind
+// SLAVE_DATA_CRASH). Same body as the HID reply for `which` 0.
+void crash_record_slave_reply(uint8_t *out, uint8_t out_len);
+
+// Master side: called by slave_data.c with the body the slave answered. Stores
+// it as the "slave" record and prints its console line once when it is fresh.
+// Returns false when the body did not decode (short / bad CRC).
+bool crash_record_note_slave(const uint8_t *body, uint8_t len);
+
+// --- the watchdog -----------------------------------------------------------
+
+// Arm the hardware watchdog. Call at the END of keyboard_post_init_user() -- the
+// one-time boot work (a dynamic-keymap discard can block for seconds) runs
+// before it. From then on the main loop must feed it every CRASH_WATCHDOG_MS.
+#define CRASH_WATCHDOG_MS 8000u   // the RP2040 maximum is ~8.3 s
+void crash_watchdog_start(void);
+void crash_watchdog_feed(void);
+// Disarm before anything that legitimately stops the loop for longer than the
+// timeout and never returns: the firmware self-apply, a bootloader jump, a
+// deliberate reset. Leaving it armed across a BOOTSEL entry would reboot the
+// bootrom out from under a UF2 copy.
+void crash_watchdog_stop(void);
+
+// Record a deliberate "cannot continue" (kind HALT) and reboot. Never returns.
+void crash_record_halt(uint16_t arg) __attribute__((noreturn));

--- a/keyboards/polykybd/base/crash_record.h
+++ b/keyboards/polykybd/base/crash_record.h
@@ -120,18 +120,17 @@ void     crash_phase_leave(uint32_t prev);
 // init and before QMK's own (matrix, split link, status OLED all run between the
 // two hooks), so a fault anywhere in this boot is tagged phase BOOT and the
 // previous record is captured before it can recur. Reads the reset cause,
-// validates the NOLOAD block, captures a fresh record into RAM and clears the
-// NOLOAD copy. It does NOT touch
-// flash: the archive write needs the fw_staging core1 lockout, whose release
-// RELAUNCHES core1 (bounded) -- done before post_init's own
-// multicore_launch_core1() that would leave core1 already running and the
-// unbounded launch handshake blocked forever. Hence the split below.
+// validates the NOLOAD block, captures a fresh record into RAM, clears the
+// NOLOAD copy and writes the record to the flash archive right there -- a copy
+// parked in RAM until post_init would be lost to a reset in the boot window,
+// and a fault that recurs there every boot would then never be archived.
+// The write runs WITHOUT the fw_staging core1 lockout, and that is only
+// correct because core1 has never been launched at this point (it is parked in
+// the bootrom, fetching nothing from XIP): the lockout's release does a bounded
+// RELAUNCH of core1, which would leave post_init's unbounded
+// multicore_launch_core1() handshake blocked forever. So this must stay BEFORE
+// that launch; never move it into post_init.
 void crash_record_init(void);
-
-// Call ONCE right after multicore_launch_core1() in keyboard_post_init_user().
-// Writes the record init captured (if any) to the flash archive, under the
-// normal core1 lockout. A no-op when nothing was captured.
-void crash_record_archive_pending(void);
 
 // True when THIS boot followed a crash (a record was captured by init).
 bool crash_record_fresh(void);

--- a/keyboards/polykybd/base/fw_staging.c
+++ b/keyboards/polykybd/base/fw_staging.c
@@ -8,6 +8,7 @@
 #include "polymod_crc32.h"
 #include "monocypher-ed25519.h"   // FW-2: Ed25519 image signature verify (polymod_monocypher)
 #include "fw_pubkey.h"                    // FW-2: FW_SIGNING_PUBKEY (image signing key)
+#include "crash_record.h"                 // crash_watchdog_stop() before the self-apply
 
 #include "hardware/flash.h"
 #include "hardware/sync.h"
@@ -1360,5 +1361,11 @@ void fw_staging_apply_and_reboot(void) {
     uprint("FWAPPLY ------------------------------------------------------------\n");
 
     s_commit_pending = false;
+    // The copy below runs with interrupts off for SECONDS (erase + program of the
+    // whole image) and never returns: a still-armed watchdog would reset the chip
+    // mid-write, and the reset would be archived as a crash. Disarm it here, in
+    // flash-resident code, before the RAM-resident applier takes over.
+    (void)crash_phase_enter(CRASH_PHASE_APPLY, 0);
+    crash_watchdog_stop();
     fw_staging_do_apply(hdr[1]);   // never returns
 }

--- a/keyboards/polykybd/base/fw_staging.h
+++ b/keyboards/polykybd/base/fw_staging.h
@@ -45,7 +45,13 @@
 #define FW_APPLY_LOG_SECTORS   8UL
 #define FW_APPLY_LOG_BYTES     (FW_APPLY_LOG_SECTORS * 4096UL)
 #define FW_APPLY_LOG_OFFSET    (FW_RESOURCE_OFFSET - FW_APPLY_LOG_BYTES)
-#define FW_UP_MAX_SIZE         0x1F7000UL      // max staged image: staging region, minus the 4 KB header and the apply log
+// One sector below the apply log: the crash-record archive (base/crash_record.c).
+// A fault / watchdog record is captured into NOLOAD RAM and copied here at the
+// next boot, so it survives the power cycle a BOOTSEL recovery needs. Appended a
+// page at a time (16 records per erase). Carved out of the staging maximum:
+// FW_UP_MAX_SIZE dropped 0x1F7000 -> 0x1F6000 (PolyKybdHost hid_fw_up.py mirrors it).
+#define FW_CRASH_LOG_OFFSET    (FW_APPLY_LOG_OFFSET - 4096UL)
+#define FW_UP_MAX_SIZE         0x1F6000UL      // max staged image: staging region, minus the 4 KB header, the apply log and the crash log
 #define FW_STAGING_MAGIC       0xD1F1A51BUL
 
 // Bytes per firmware-update chunk (HID and split-RPC payload).

--- a/keyboards/polykybd/boot_diag.c
+++ b/keyboards/polykybd/boot_diag.c
@@ -15,6 +15,7 @@
 #include "layers.h"       // _ADDLANG1 (Intl picker banner line)
 #include "quantum/keymap_introspection.h"   // keycode_at_keymap_location_raw()
 #include "base/fw_staging.h"   // fw_staging_apply_breadcrumb()
+#include "base/crash_record.h" // crash_record_emit_lines()
 #include "base/update.h"       // enum refresh_mode / ALL_AT_ONCE
 #include "base/disp_array.h"   // GFXfont type
 // Only the single splash font is needed. Don't pull in gfx_used_fonts.h — the
@@ -249,6 +250,7 @@ void boot_banner_housekeeping_tick(void) {
             emit_idle_config();
             emit_keymap_storage_line();
             emit_apply_breadcrumb_line();
+            crash_record_emit_lines();   // the previous run's crash, if there was one
             banner_timer = timer_read32();
             banner_repeats++;
         }

--- a/keyboards/polykybd/bridge_helper.c
+++ b/keyboards/polykybd/bridge_helper.c
@@ -9,6 +9,7 @@
 #include "split_sync.h"
 #include "config.h"
 #include "profiling/loop_profile.h"
+#include "base/crash_record.h"   // crash_phase_enter()/leave() around the blocking bridge
 #ifdef POLYKYBD_LOOP_PROFILE
 #    include "hardware/structs/timer.h"   // timer_hw->timerawl — raw 1 MHz us counter
 #endif
@@ -86,7 +87,18 @@ const char* tid_to_str(int8_t tid) {
     }
 }
 
+static uint8_t send_to_bridge_impl(int8_t tid, void* buffer_with4crc_bytes, const uint8_t num_bytes, const uint8_t max_retries);
+
+// Tags the crash-record phase breadcrumb around the blocking bridge: a watchdog
+// timeout inside a split transaction then names the transaction it was in.
 uint8_t send_to_bridge(int8_t tid, void* buffer_with4crc_bytes, const uint8_t num_bytes, const uint8_t max_retries) {
+    uint32_t tag = crash_phase_enter(CRASH_PHASE_BRIDGE, (uint16_t)(uint8_t)tid);
+    uint8_t  ack = send_to_bridge_impl(tid, buffer_with4crc_bytes, num_bytes, max_retries);
+    crash_phase_leave(tag);
+    return ack;
+}
+
+static uint8_t send_to_bridge_impl(int8_t tid, void* buffer_with4crc_bytes, const uint8_t num_bytes, const uint8_t max_retries) {
     poly_sync_reply_t reply;
     uint8_t retry = 0;
 

--- a/keyboards/polykybd/config.h
+++ b/keyboards/polykybd/config.h
@@ -53,12 +53,12 @@
 // ONE slot instead of spending another of the scarce 32. Its first user is the
 // LTR-559: when DRIVEing brightness/idle the master pulls {avg lux, proximity}
 // from the sensor (right) half via transaction_rpc_exec, so it works in either
-// USB orientation. Only compiled in when the sensor can drive (needs the slot).
-#ifdef POLYKYBD_LTR559_DRIVE
-#    define POLY_LTR559_TXN , USER_SYNC_SLAVE_DATA
-#else
-#    define POLY_LTR559_TXN
-#endif
+// USB orientation. Its second user is the crash record (slave_data.h
+// SLAVE_DATA_CRASH): the master pulls the slave's last crash over it, which is
+// the ONLY way a slave crash can reach a console. That is why the slot is now
+// unconditional -- it used to exist only under POLYKYBD_LTR559_DRIVE (the name
+// survives; both shipping boards define that anyway).
+#define POLY_LTR559_TXN , USER_SYNC_SLAVE_DATA
 // ROOT-CAUSE EXPERIMENT (split42, 2026-07-14): 3 dummy split transactions to grow
 // NUM_TOTAL_TRANSACTIONS by 3 WITHOUT the pointing device — the one side effect of
 // SPLIT_POINTING_ENABLE the heartbeat test never reproduced. With pointing the link
@@ -223,7 +223,7 @@
 //      only and live in the `latinbig` font-pack bundle; without it (or for a
 //      non-latin legend) the render falls back to small, so the setting is
 //      always safe to accept.
-#define PROTOCOL_VERSION 15
+#define PROTOCOL_VERSION 16
 
 #define FULL_BRIGHT 50
 #define MIN_BRIGHT 1

--- a/keyboards/polykybd/hid_com.c
+++ b/keyboards/polykybd/hid_com.c
@@ -38,6 +38,7 @@
 #include <string.h>
 #include "poly_keymap.h"
 #include "layer_names.h"
+#include "base/crash_record.h"
 
 
 /*[[[cog
@@ -187,6 +188,9 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
         if (doom_hid_frozen(data[1])) {
             return;
         }
+        // Crash-record breadcrumb: a watchdog timeout inside a handler names the
+        // command. Housekeeping resets the tag to LOOP on its next pass.
+        (void)crash_phase_enter(CRASH_PHASE_HID, data[1]);
         const poly_layer_t* local_layer = get_local_layer();
         poly_sync_t* local_state = access_local_state();
         // Bulk overlay/mapping commands: plain (10), flags on/off (11/12), compressed
@@ -1197,6 +1201,38 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                         data[5 + b] = (uint8_t)((look.icon >> (8 * b)) & 0xFFu);
                     }
                     memcpy(&data[header], look.text, len);
+                    raw_hid_send(data, length);
+                }
+                break;
+            case 39: //crash record: read the last crash / clear the archive (protocol v16+)
+                {
+                    // data[HID_DATA_IDX]: 0 = this half's archived crash record,
+                    //                     1 = the slave's record as last pulled over the link,
+                    //                     2 = clear (erase the flash archive, forget both copies).
+                    // Reply "P\x27." then [flags][48-byte poly_crash_record_t]
+                    // (crash_record_hid_body): flags bit0 present, bit1 fresh -- the boot
+                    // before this one ended in that crash. A clear answers an empty body;
+                    // anything else NACKs. The record's wire layout is base/crash_record.h.
+                    //
+                    // The console line printed with the boot banner is the primary
+                    // channel (the host alerts on it); this is how polyctl and the rig
+                    // fetch the archive later, and the only way to clear it.
+                    const uint8_t which = data[HID_DATA_IDX];
+                    if (which > 2) {
+                        memset(data, 0, length);
+                        hid_reply(data, 0x27, false);
+                        raw_hid_send(data, length);
+                        break;
+                    }
+                    if (which == 2) {
+                        crash_record_clear();
+                        uprint("Crash archive cleared.\n");
+                    }
+                    memset(data, 0, length);
+                    hid_reply(data, 0x27, true);
+                    if (which <= 1) {
+                        crash_record_hid_body(which, &data[3], (uint8_t)(length - 3));
+                    }
                     raw_hid_send(data, length);
                 }
                 break;

--- a/keyboards/polykybd/ltr559_policy.c
+++ b/keyboards/polykybd/ltr559_policy.c
@@ -16,6 +16,7 @@
 #    include "base/com.h"         // STATUS_DISP_ON / DISP_IDLE flags
 #    include "base/update.h"      // update_performed() / request_disp_refresh()
 #    include "doom/doom_mode.h"   // screensaver teardown (inline no-ops without POLYKYBD_DOOM)
+#    include "slave_data.h"       // SLAVE_DATA_SENSOR (the pull channel lives there)
 
 #    ifdef COMMUNITY_MODULE_POLYMOD_LTR559_ENABLE
 #        include "polymod_ltr559.h"
@@ -58,41 +59,19 @@
                                         // separate boot transient, fixed by the
                                         // don't-engage-until-first-reading guard below.)
 
-// USER_SYNC_SLAVE_DATA is a GENERIC op-dispatched slave->master pull channel (see
-// config.h): the master's request is a 1-byte `kind` selecting which slave-side
-// payload to return. Append a new kind + a case below to carry other data over
-// the same one split slot — no new transaction needed. Both halves run the same
-// firmware image, so the per-kind payload structs can change freely (no split
-// versioning); the handler just bounds every copy by out_len.
-enum slave_data_kind {
-    SLAVE_DATA_SENSOR = 0,  // ltr559_sync_t: {avg lux, proximity}
-    // SLAVE_DATA_xxx = 1, ...  // future slave-side data reuses this slot
-};
-
+// The slave->master pull channel itself (USER_SYNC_SLAVE_DATA, op-dispatched on a
+// `kind` byte) lives in slave_data.c; this file only supplies the SENSOR payload.
 typedef struct {
     uint16_t lux;   // 5 s-average lux
     uint16_t prox;  // latest raw proximity (0..2047)
 } ltr559_sync_t;
 
-// Slave side: answer the master's pull for the requested `kind`. Registered on
-// both halves; only ever runs on the slave (the master initiates the exec).
-static void user_sync_slave_data_handler(uint8_t in_len, const void* in_data, uint8_t out_len, void* out_data) {
-    uint8_t kind = (in_len >= 1) ? ((const uint8_t*)in_data)[0] : SLAVE_DATA_SENSOR;
-    switch (kind) {
-        case SLAVE_DATA_SENSOR: {
-            ltr559_sync_t s = { ltr559_avg_lux(), ltr559_prox() };
-            if (out_len >= sizeof(s)) {
-                memcpy(out_data, &s, sizeof(s));
-            }
-            break;
-        }
-        default:
-            break;  // unknown kind: leave the reply buffer as-is
+// Slave side: fill the reply for SLAVE_DATA_SENSOR, bounded by out_len.
+void poly_ltr559_slave_sensor_reply(void* out_data, uint8_t out_len) {
+    ltr559_sync_t s = { ltr559_avg_lux(), ltr559_prox() };
+    if (out_len >= sizeof(s)) {
+        memcpy(out_data, &s, sizeof(s));
     }
-}
-
-void poly_ltr559_register_split_handler(void) {
-    transaction_register_rpc(USER_SYNC_SLAVE_DATA, user_sync_slave_data_handler);
 }
 
 // Master-side: mirror the HID cmd-15 stop-idle path to force the displays awake.

--- a/keyboards/polykybd/ltr559_policy.h
+++ b/keyboards/polykybd/ltr559_policy.h
@@ -12,13 +12,13 @@
 // Everything is gated on POLYKYBD_LTR559_DRIVE, exactly as it was in
 // poly_keymap.c — a board can carry the driver module without this policy.
 
+#include <stdint.h>
+
 #ifdef POLYKYBD_LTR559_DRIVE
-// Registers the generic slave->master pull channel (USER_SYNC_SLAVE_DATA) whose
-// slave-side handler serves {avg lux, proximity}. Call once from
-// keyboard_post_init_user(), alongside the other transaction registrations —
-// the handler stays private to ltr559_policy.c, the same way every other
-// user_sync_* handler stays private to the file that owns its data.
-void poly_ltr559_register_split_handler(void);
+// Slave-side payload for the generic slave->master pull channel
+// (USER_SYNC_SLAVE_DATA, kind SLAVE_DATA_SENSOR): {avg lux, proximity}. The
+// channel and its registration live in slave_data.c; this just fills the reply.
+void poly_ltr559_slave_sensor_reply(void* out_data, uint8_t out_len);
 
 // Master-side auto-brightness + idle-inhibit; call every housekeeping pass
 // (it self-limits to one decision per LTR559_DRIVE_MS).

--- a/keyboards/polykybd/multicore_exec.c
+++ b/keyboards/polykybd/multicore_exec.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "multicore_exec.h"
+#include "base/crash_record.h"
 #include "polykybd.h"
 
 #include "print.h"
@@ -135,9 +136,13 @@ void core1_decompress_fragment(uint8_t keycode, uint8_t mod, uint16_t overlay_id
     // body was burning core0 cycles in a format-and-sink path that starved
     // matrix scan during back-pressure.
     dmb();
+    // Tagged so a watchdog timeout in this spin reads as "core0 waiting on core1"
+    // (the core1-hang class, see CLAUDE.md) rather than as an anonymous hang.
+    uint32_t crash_tag = crash_phase_enter(CRASH_PHASE_CORE1_WAIT, 0);
     while(core0_decomp_count!=core1_decomp_count) {
         dmb();
     }
+    crash_phase_leave(crash_tag);
     //copy data to dedicated buffers
     uint8_t data_len = core1_bit_index==0?COMPRESSED_START:COMPRESSED_MAX;
     core1_max_bitlen = 360 - core1_bit_index/8;
@@ -177,9 +182,13 @@ void core1_roi_start(void) {
 void core1_update_roi(uint8_t keycode, uint8_t mod, uint16_t overlay_idx, const uint8_t* data, const roi_update_data_t* roi, bool visible) {
     // See core1_decompress_fragment for the backpressure rationale.
     dmb();
+    // Tagged so a watchdog timeout in this spin reads as "core0 waiting on core1"
+    // (the core1-hang class, see CLAUDE.md) rather than as an anonymous hang.
+    uint32_t crash_tag = crash_phase_enter(CRASH_PHASE_CORE1_WAIT, 0);
     while(core0_decomp_count!=core1_decomp_count) {
         dmb();
     }
+    crash_phase_leave(crash_tag);
     //copy data to dedicated buffers
     //core1_max_bitlen = 360 - core1_bit_index/8;
     core1_roi = *roi;

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -4683,11 +4683,9 @@ static void boot_trace(const uint32_t* digit) {
 // Initializes keyboard state after reset: enables debug, sets CPI, loads layer/unicode defaults.
 // Global variables: com
 void keyboard_post_init_user(void) {
-    // FIRST: did the previous run end in a crash? Reads the NOLOAD record + the
-    // reset cause, archives it to flash, and remembers it for the banner below.
-    // Before anything that could itself fault, so the record it reports is the
-    // previous run's and not this boot's.
-    crash_record_init();
+    // (The previous run's crash record was captured at the top of
+    // keyboard_pre_init_user(); it is archived after the core1 launch below and
+    // reported by the boot banner.)
     // Labels live in RAM on both halves (the render path reads one per macro keycap per
     // refresh). Each half loads its own EEPROM copy, then the master overwrites the
     // slave's over the link -- so a role swap makes whichever half the host talks to
@@ -4998,6 +4996,14 @@ void keyboard_post_init_user(void) {
 
 // Pre-initialization setup: initializes display hardware, loads EEPROM config, shows splash screen.
 void keyboard_pre_init_user(void) {
+    // FIRST, before any of our own init and before QMK's (matrix, split link and
+    // status OLED all run between here and post_init): did the previous run end
+    // in a crash? Captures the NOLOAD record + reset cause into RAM and stamps
+    // the phase BOOT, so a fault anywhere in this boot is recorded as one and
+    // the previous record is already safe if it recurs. No flash here -- the
+    // archive write waits for crash_record_archive_pending() in post_init.
+    crash_record_init();
+
     // Load the external-flash font pack and assemble g_all_fonts = resident ++
     // pack BEFORE the first render (show_splash_screen() below draws keycaps).
     // No valid pack (erased/corrupt/ABI mismatch) -> resident-only fonts.

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -4772,6 +4772,11 @@ void keyboard_post_init_user(void) {
 #ifdef USE_CORE1
     multicore_launch_core1();
 #endif
+    // Only now: the archive write takes the core1 lockout, whose release does a
+    // bounded RELAUNCH of core1 -- before the launch above that would leave the
+    // unbounded handshake blocked forever (a keyboard that hangs on the boot
+    // after every crash, i.e. the opposite of what the record is for).
+    crash_record_archive_pending();
 #ifdef FW_UP_BOOT_TRACE
     boot_trace(U"3");
 #endif

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -66,6 +66,8 @@
 #include "base/fonts/util_font.h"         // mid (10px) utility-label font
 #include "polymod_core1.h"
 #include "boot_diag.h"                    // emit_boot_banner(), splash_progress(), SPLASH_DONE
+#include "base/crash_record.h"            // crash_record_init(), the watchdog, the phase breadcrumb
+#include "slave_data.h"                   // slave_data_register(), slave_data_crash_pull_tick()
 #include "polymod_crc32.h"
 
 // The LTR-559 driver is the polykybd/polymod_ltr559 community module; the build
@@ -803,11 +805,18 @@ void housekeeping_task_user(void) {
     // Optional loop-timing probe (no-op unless POLYKYBD_LOOP_PROFILE). At the very
     // top so it measures the FULL previous iteration — matrix scan, HID, bridge.
     loop_profile_tick();
+    // The watchdog is fed HERE and in suspend_power_down_kb() and nowhere else: a
+    // main loop that stops reaching housekeeping for CRASH_WATCHDOG_MS is exactly
+    // the hang the crash record exists to catch. The LOOP tag closes whatever
+    // phase the previous pass left open (a HID handler tags on entry only).
+    crash_watchdog_feed();
+    (void)crash_phase_enter(CRASH_PHASE_LOOP, 0);
 #ifdef RGB_MATRIX_ENABLE
     flash_rgb_tick();   // light the matrix while a font-pack/firmware flash runs
 #endif
 
     boot_banner_housekeeping_tick();   // re-emit the boot banner for a late console
+    slave_data_crash_pull_tick();      // master: fetch + print the slave's crash record once per link-up
 
     // Advance a playing macro by at most one step. Deliberately near the TOP of
     // housekeeping and outside every fw_up/idle gate: a macro is user-visible typing,
@@ -4674,6 +4683,11 @@ static void boot_trace(const uint32_t* digit) {
 // Initializes keyboard state after reset: enables debug, sets CPI, loads layer/unicode defaults.
 // Global variables: com
 void keyboard_post_init_user(void) {
+    // FIRST: did the previous run end in a crash? Reads the NOLOAD record + the
+    // reset cause, archives it to flash, and remembers it for the banner below.
+    // Before anything that could itself fault, so the record it reports is the
+    // previous run's and not this boot's.
+    crash_record_init();
     // Labels live in RAM on both halves (the render path reads one per macro keycap per
     // refresh). Each half loads its own EEPROM copy, then the master overwrites the
     // slave's over the link -- so a role swap makes whichever half the host talks to
@@ -4716,6 +4730,7 @@ void keyboard_post_init_user(void) {
     set_side(is_keyboard_left() ? LEFT_SIDE : RIGHT_SIDE);
 
     emit_boot_banner();   // one-shot at boot; housekeeping re-emits for a late console
+    crash_record_emit_lines();   // `crash: side=master ...` when this boot followed a crash
 
     // Boot-splash progress: reaching post_init proves QMK's split/USB init got
     // past the point where the fw-apply "slave not rebooted" hang stalls. Reveal
@@ -4773,9 +4788,7 @@ void keyboard_post_init_user(void) {
     transaction_register_rpc(USER_SYNC_OVERLAY_MAP_DATA,    user_sync_overlay_map_data_handler);
     transaction_register_rpc(USER_SYNC_FLASH_STAGE,         user_sync_flash_stage_handler);
     transaction_register_rpc(USER_SYNC_RESET,               user_sync_reset_handler);
-#ifdef POLYKYBD_LTR559_DRIVE
-    poly_ltr559_register_split_handler();
-#endif
+    slave_data_register();   // USER_SYNC_SLAVE_DATA: LTR-559 sensor pull + the slave crash record
 #ifdef POLY_DUMMY_TXN_TEST
     // Root-cause experiment: register 3 no-op transactions so NUM_TOTAL_TRANSACTIONS
     // grows by 3 (matching the working pointing build) without the pointing device.
@@ -4972,6 +4985,10 @@ void keyboard_post_init_user(void) {
     boot_trace(U"4");
 #endif
     splash_progress(SPLASH_DONE);       // boot complete: full splash, dwell, then legends
+    // LAST: arm the hardware watchdog. Everything above may block for seconds
+    // (the keymap discard, the splash dwell); from here on housekeeping feeds it
+    // every pass and a hang becomes a reset with a `kind=watchdog` crash record.
+    crash_watchdog_start();
 }
 
 // Pre-initialization setup: initializes display hardware, loads EEPROM config, shows splash screen.
@@ -5107,6 +5124,11 @@ void poly_suspend(void) {
 
 // Suspends keyboard: suspends power down, disables RGB, calls housekeeping, resets update timer.
 void suspend_power_down_kb(void) {
+    // QMK's suspend loop (protocol_pre_task) calls this every ~17 ms INSTEAD of
+    // running housekeeping, so the watchdog has to be fed here too or a long
+    // suspend would read as a hang.
+    crash_watchdog_feed();
+    (void)crash_phase_enter(CRASH_PHASE_SUSPEND, 0);
     // USB suspend fires on slave when master enters bootloader; skip to keep displays lit.
     if (get_local_state()->overlay_flags & BOOTLOADER_DISPLAY) {
         return;
@@ -5133,6 +5155,10 @@ void suspend_power_down_kb(void) {
 // suspend would discard any MRU/settings/layer changes still held in RAM.
 bool shutdown_user(bool jump_to_bootloader) {
     save_all_dirty();
+    // Disarm the watchdog before any deliberate reset / bootloader jump. Left
+    // armed across a BOOTSEL entry it would reset the bootrom out from under a
+    // UF2 copy, and a reboot it fired would be archived as a crash.
+    crash_watchdog_stop();
     return true;
 }
 

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -4683,9 +4683,8 @@ static void boot_trace(const uint32_t* digit) {
 // Initializes keyboard state after reset: enables debug, sets CPI, loads layer/unicode defaults.
 // Global variables: com
 void keyboard_post_init_user(void) {
-    // (The previous run's crash record was captured at the top of
-    // keyboard_pre_init_user(); it is archived after the core1 launch below and
-    // reported by the boot banner.)
+    // (The previous run's crash record was captured and archived at the top of
+    // keyboard_pre_init_user(); the boot banner reports it.)
     // Labels live in RAM on both halves (the render path reads one per macro keycap per
     // refresh). Each half loads its own EEPROM copy, then the master overwrites the
     // slave's over the link -- so a role swap makes whichever half the host talks to
@@ -4770,11 +4769,6 @@ void keyboard_post_init_user(void) {
 #ifdef USE_CORE1
     multicore_launch_core1();
 #endif
-    // Only now: the archive write takes the core1 lockout, whose release does a
-    // bounded RELAUNCH of core1 -- before the launch above that would leave the
-    // unbounded handshake blocked forever (a keyboard that hangs on the boot
-    // after every crash, i.e. the opposite of what the record is for).
-    crash_record_archive_pending();
 #ifdef FW_UP_BOOT_TRACE
     boot_trace(U"3");
 #endif
@@ -5000,8 +4994,10 @@ void keyboard_pre_init_user(void) {
     // status OLED all run between here and post_init): did the previous run end
     // in a crash? Captures the NOLOAD record + reset cause into RAM and stamps
     // the phase BOOT, so a fault anywhere in this boot is recorded as one and
-    // the previous record is already safe if it recurs. No flash here -- the
-    // archive write waits for crash_record_archive_pending() in post_init.
+    // the previous record is already archived if it recurs. The flash write
+    // runs here without the core1 lockout, which is only safe because core1 has
+    // not been launched yet (see crash_record.h) -- keep this ahead of
+    // post_init's multicore_launch_core1().
     crash_record_init();
 
     // Load the external-flash font pack and assemble g_all_fonts = resident ++

--- a/keyboards/polykybd/rules.mk
+++ b/keyboards/polykybd/rules.mk
@@ -117,7 +117,7 @@ OS_DETECTION_ENABLE = yes
 # drift the shared keymap exists to prevent. It also gets the strict PolyKybd warning
 # flags applied below, which the per-variant base sources do not. The same argument
 # covers emoji/emoji_layer.c and hints/os_hints.c.
-POLY_SRC := poly_keymap.c layer_names.c boot_diag.c side.c state.c state_store.c split_sync.c split_fw_up.c multicore_exec.c hid_com.c hid_fw_up.c hid_fontpack.c fill_overlay.c poly_util.c matrix_helper.c bridge_helper.c oled_helper.c keycode_helper.c mru.c lang_layer.c anim/startup_anim.c emoji/emoji_layer.c hints/os_hints.c base/fw_up_verdict.c poly_macro.c base/macro_decode.c ltr559_policy.c base/legend_plan.c base/font_lookup.c
+POLY_SRC := poly_keymap.c layer_names.c boot_diag.c side.c state.c state_store.c split_sync.c split_fw_up.c multicore_exec.c hid_com.c hid_fw_up.c hid_fontpack.c fill_overlay.c poly_util.c matrix_helper.c bridge_helper.c oled_helper.c keycode_helper.c mru.c lang_layer.c anim/startup_anim.c emoji/emoji_layer.c hints/os_hints.c base/fw_up_verdict.c poly_macro.c base/macro_decode.c ltr559_policy.c base/legend_plan.c base/font_lookup.c base/crash_record.c slave_data.c
 SRC += $(POLY_SRC)
 
 # emoji/emoji_layer.c is listed here, not in a keymap's rules.mk: the keyboard-level

--- a/keyboards/polykybd/slave_data.c
+++ b/keyboards/polykybd/slave_data.c
@@ -1,0 +1,82 @@
+// Copyright 2026 thpoll83
+// SPDX-License-Identifier: GPL-2.0-or-later
+// See slave_data.h.
+#include "slave_data.h"
+
+#include QMK_KEYBOARD_H
+#include "quantum.h"
+#include "transactions.h"
+#include "split_util.h"        // is_transport_connected()
+#include "bridge_helper.h"     // is_usb_host_side()
+#include "base/crash_record.h"
+#ifdef POLYKYBD_LTR559_DRIVE
+#    include "ltr559_policy.h"
+#endif
+
+#include <string.h>
+
+// Slave side: answer the master's pull for the requested `kind`.
+static void user_sync_slave_data_handler(uint8_t in_len, const void *in_data, uint8_t out_len, void *out_data) {
+    uint8_t kind = (in_len >= 1) ? ((const uint8_t *)in_data)[0] : SLAVE_DATA_SENSOR;
+    switch (kind) {
+#ifdef POLYKYBD_LTR559_DRIVE
+        case SLAVE_DATA_SENSOR:
+            poly_ltr559_slave_sensor_reply(out_data, out_len);
+            break;
+#endif
+        case SLAVE_DATA_CRASH:
+            crash_record_slave_reply((uint8_t *)out_data, out_len);
+            break;
+        default:
+            break;  // unknown kind: leave the reply buffer as-is
+    }
+}
+
+void slave_data_register(void) {
+    transaction_register_rpc(USER_SYNC_SLAVE_DATA, user_sync_slave_data_handler);
+}
+
+// ---------------------------------------------------------------------------
+// The crash-record pull. Once per link establishment: the slave's record is
+// captured at ITS boot and only changes at its next boot, which the master sees
+// as a link drop + re-establishment. Spaced retries because the slave may still
+// be settling right after the transport reports connected.
+// ---------------------------------------------------------------------------
+#define CRASH_PULL_TRIES       3u
+#define CRASH_PULL_SPACING_MS  2000u
+
+void slave_data_crash_pull_tick(void) {
+    static bool     s_linked = false;
+    static uint8_t  s_tries  = 0;
+    static uint32_t s_last   = 0;
+
+    if (!is_usb_host_side()) return;
+
+    const bool linked = is_transport_connected();
+    if (!linked) {
+        // Re-arm for the next link-up (a slave reboot presents exactly like this).
+        s_linked = false;
+        s_tries  = 0;
+        return;
+    }
+    if (!s_linked) {
+        s_linked = true;
+        s_tries  = 0;
+        s_last   = timer_read32();
+        return;   // give the freshly-linked slave one spacing before the first pull
+    }
+    if (s_tries >= CRASH_PULL_TRIES) return;
+    if (timer_elapsed32(s_last) < CRASH_PULL_SPACING_MS) return;
+    s_last = timer_read32();
+    s_tries++;
+
+    uint8_t kind = SLAVE_DATA_CRASH;
+    uint8_t reply[CRASH_HID_BODY_LEN];
+    memset(reply, 0, sizeof(reply));
+    uint32_t tag = crash_phase_enter(CRASH_PHASE_BRIDGE, USER_SYNC_SLAVE_DATA);
+    bool ok = transaction_rpc_exec(USER_SYNC_SLAVE_DATA, sizeof(kind), &kind, sizeof(reply), reply);
+    crash_phase_leave(tag);
+    if (ok && crash_record_note_slave(reply, sizeof(reply))) {
+        s_tries = CRASH_PULL_TRIES;   // done for this link-up
+    }
+}

--- a/keyboards/polykybd/slave_data.h
+++ b/keyboards/polykybd/slave_data.h
@@ -1,0 +1,29 @@
+// Copyright 2026 thpoll83
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// USER_SYNC_SLAVE_DATA: the ONE generic slave->master pull channel (see the
+// transaction-table note in config.h). The master's request is a single `kind`
+// byte selecting which slave-side payload to return; the slave answers into the
+// reply buffer, bounded by out_len. Append a kind + a case in slave_data.c to
+// carry more slave-side data over the same split slot -- no new transaction.
+//
+// Both halves run the same image, so the per-kind payload structs can change
+// freely (no split versioning).
+#pragma once
+
+#include <stdint.h>
+
+enum slave_data_kind {
+    SLAVE_DATA_SENSOR = 0,  // ltr559_sync_t: {avg lux, proximity}   (POLYKYBD_LTR559_DRIVE)
+    SLAVE_DATA_CRASH  = 1,  // crash_record: [flags][poly_crash_record_t] (crash_record.h)
+};
+
+// Registers the split handler. Call once from keyboard_post_init_user(),
+// alongside the other transaction registrations, on BOTH halves (the handler
+// only ever runs on the slave; the master initiates the exec).
+void slave_data_register(void);
+
+// Master side, every housekeeping pass: pull the slave's crash record once per
+// link-up (bounded retries, spaced out) and hand it to crash_record_note_slave().
+// No-op on the slave.
+void slave_data_crash_pull_tick(void);


### PR DESCRIPTION
## Summary

A HardFault, an unhandled exception or a main-loop hang used to leave no trace: the M0+ fault vector fell into ChibiOS's idle loop and the board sat dead until a replug. This PR records every one of those and reports it on the next boot, so the rig or a human can read what happened.

- **`base/crash_record.c/.h`** — a naked `HardFault_Handler` and a strong `_unhandled_exception` capture the stacked frame (pc/lr/sp/xpsr, ICSR vector) into a NOLOAD RAM block (`.ram0.crash_record`, same trick as the bootloader magic), then `watchdog_reboot()`. At the top of `keyboard_pre_init_user()` the record is captured and archived to one 4 KB flash sector at `FW_CRASH_LOG_OFFSET` (below the apply log; `FW_UP_MAX_SIZE` shrinks by 4 KB, mirrored in the host) and announced with the boot banner as one console line: `crash: side=master kind=hardfault core=0 pc=0x… lr=0x… sp=0x… psr=0x… icsr=0x… phase=3:0x0015 up=123456ms n=1 reason=0x22 fw=0.18.0`.
- **Phase breadcrumb + 8 s watchdog** — a hang has no fault frame, so `crash_phase_enter/leave` tag HID commands (arg = cmd id), split transactions (arg = tid), the two core1 waits, flash, suspend, apply and the main loop; a watchdog timeout synthesises a `kind=watchdog` record from the phase left in RAM. The watchdog is fed from housekeeping and the suspend loop only, and disarmed for the bootloader jump and before the firmware self-apply. A timeout only counts while the `watchdog_enable()` scratch4 marker is still in place (`watchdog_enable_caused_reboot()`), because the bootrom's own reboot after a UF2 copy is a watchdog reboot too. Five crashes in a row *during boot* halt in `wfi` instead of looping; a boot that reaches the end of post_init resets the counter.
- **Slave** — `USER_SYNC_SLAVE_DATA` is now a generic op-dispatched slave pull (`slave_data.c`: `SLAVE_DATA_SENSOR` for the LTR-559, `SLAVE_DATA_CRASH`), unconditional. The master pulls the slave's record once per link-up and prints it as `side=slave`.
- **HID cmd 39** (`PROTOCOL_VERSION` 15 → 16): `data[2]` 0 = this half's record, 1 = the slave's, 2 = clear; reply `[flags][48-byte record]`, flags bit0 present / bit1 fresh.

Companion PRs: PolyKybdHost #212 (alert dialog + `polyctl crash`), polykybd-ctnd #89 (`test_no_crash_record` + cmd 39 test, merged), polykybd-docs #70.

## Version bump label

`bump:minor`. `PROTOCOL_VERSION` is already bumped to 16 in `config.h` (host `__protocol__` matches in the companion PR), so **do not** add `bump:protocol` — that would double-bump.

## Testing
- [x] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`) — also split42 and the `POLYKYBD_DOOM=yes` monolith (heap free 2772 → 2600 B)
- [x] ELF checked: vector slot 3 → our `HardFault_Handler`, `s_ram` in `.ram0` with `.ram0_init` size 0
- [x] Rig: the first HIL run with the ctnd crash tests (run 33809919200) drove the whole reporting chain on hardware — boot capture, console line on both halves, slave pull, cmd 39 read + clear — and caught a real bug: the bootrom's post-UF2 reboot read as a `kind=watchdog` hang on every flash (both halves, `n=3` because the NOLOAD counter survives a reflash). Fixed by gating on the SDK's `watchdog_enable()` marker; the next HIL run is the check.
- [ ] A **deliberate** fault through the naked handler on hardware — still open; a `debug-firmware-on-rig` probe that dereferences a bad pointer over HID is the way to close that
- [x] If protocol changed: host updated (PolyKybdHost #212, 33 new tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UbVXatR5kZAqk79jKUfXMd

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbVXatR5kZAqk79jKUfXMd)_

## Summary by Sourcery

Add persistent firmware crash diagnostics that capture failures, reboot safely, and report the cause on the next boot.

New Features:
- Record HardFaults, unhandled exceptions, deliberate halts, and watchdog-detected hangs for reporting after reboot.
- Archive crash records in flash and expose them through console diagnostics, split-side retrieval, and HID command 39.
- Add phase breadcrumbs and crash-loop protection to make watchdog failures diagnosable and prevent repeated boot reboot storms.

Bug Fixes:
- Prevent watchdog resets during firmware self-apply, bootloader transitions, and suspend handling from being misclassified or interrupting legitimate operations.
- Avoid phantom crash reports caused by the bootloader's watchdog reboot after UF2 flashing.

Enhancements:
- Generalize the split slave-data channel to support both sensor data and crash-record retrieval.
- Reserve flash space for crash history and update the firmware update size limit accordingly.

Documentation:
- Document the crash-record lifecycle, watchdog behavior, phase diagnostics, flash archive, and HID protocol.

Chores:
- Bump the firmware protocol version from 15 to 16.