### PR TITLE
ci: opt the fwapply run into the rig's post-apply slave check

### DIFF
--- a/.github/workflows/qmk-test.yml
+++ b/.github/workflows/qmk-test.yml
@@ -990,11 +990,41 @@ jobs:
       - name: Flash, then drive a real HID update through APPLY
         # Filenames go through env vars rather than straight ${{ }} interpolation
         # into the script body — the same shape the doom job uses.
+        #
+        # HIL_RESLAVE opts this run into the rig's post-apply slave re-flash: the
+        # apply necessarily converts the rig's slave into a second master (it
+        # installs the master's bridged bytes, and the halves run per-side images
+        # by construction), so the in-apply link check can only report UNVERIFIED
+        # there. Re-flashing the slave and measuring answers the question that IS
+        # answerable — can the APPLIED master image bring a split link back up.
+        #
+        # ⚠️ OFF on a plain push, which is the whole point. This step runs on
+        # EVERY merge to PolyKybd, and release.yml's require_fwapply_run.py gates
+        # publishing on this job's conclusion being success — so anything that can
+        # fail here can refuse a release, and the rig-side check has never
+        # executed. Prove it with a dispatch first (tier: fwapply), then decide.
+        #
+        # ⚠️ An ENV VAR, deliberately, not the station's --reflash-slave flag. CI
+        # runs the INSTALLED station synced to ctnd main, so a station that
+        # predates the feature would die on an unknown argparse flag — failing the
+        # job that gates releases. An unknown env var is ignored, so an old
+        # station simply skips the check. Same reason the doom job passes its
+        # filenames through env.
         env:
           CTND_DIR: ${{ steps.ctnd.outputs.dir }}
           HIL_LEFT: ${{ needs.build-fwapply.outputs.hil_left }}
           HIL_RIGHT: ${{ needs.build-fwapply.outputs.hil_right }}
           APPLY_BIN: ${{ needs.build-fwapply.outputs.apply_bin }}
+          # ⚠️ FOLDED SCALAR: every continuation line MUST sit at the same indent
+          # as the first, or YAML keeps a literal newline inside the expression
+          # and the value silently stops being a valid GitHub expression. That is
+          # why this block looks under-indented. Renders 'true'/'false', both of
+          # which the station parses (HIL_RESLAVE accepts 1/true/yes).
+          HIL_RESLAVE: >-
+            ${{ (github.event_name == 'workflow_dispatch' &&
+            (inputs.tier == 'all' || inputs.tier == 'fwapply')) ||
+            contains(github.event.pull_request.labels.*.name, 'hil-fwapply') ||
+            contains(github.event.head_commit.message, '[hil-fwapply]') }}
         run: |
           cd "$CTND_DIR"
           set -o pipefail

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -720,6 +720,23 @@ inherited-upstream noise:
   - **The cost is bounded**: the rig already runs a HIL cycle per merge, so this
     adds a cloud build plus one apply+reboot, not a new cadence. PRs are untouched
     — the tier stays opt-in there, so no PR pipeline gets slower.
+  - **The rig's post-apply SLAVE check is a separate opt-in on the same signals**
+    (`hil-fwapply` label, `[hil-fwapply]` in a pushed commit, `tier: fwapply`/`all`
+    dispatch), carried as **`HIL_RESLAVE`** in the step's `env:`. An apply converts
+    the rig's slave into a second master — it installs the master's bridged bytes,
+    and the halves run per-side images by construction — so the link check inside
+    the apply can only report UNVERIFIED there. With the opt-in, ctnd re-flashes
+    `*_hil_right.uf2` and measures, which answers the answerable half: **can the
+    APPLIED master image bring a split link back up.**
+    - ⚠️ **OFF on a plain push, deliberately.** This job runs on every merge, and
+      `require_fwapply_run.py` gates publishing on its conclusion being `success`
+      — so anything that can fail here can refuse a release, and the rig-side
+      check has never executed. Prove it with a dispatch, then decide.
+    - ⚠️ **Passed as an ENV VAR, not ctnd's `--reflash-slave` flag.** CI runs the
+      INSTALLED station synced to ctnd `main`, so a station predating the feature
+      would die on an unknown argparse flag — failing the release gate. An unknown
+      env var is ignored, so an old station just skips the check. That also
+      removes the merge-order constraint between the two repos.
   - ⚠️ **`--apply-bin` is destructive by design and safe only because the image is
     the one already running** — the rig checks that pairing rather than assuming
     it. And it is safe *at all* only because a brick on the rig is self-recovering


### PR DESCRIPTION
## Summary

Workflow + `CLAUDE.md` only — **no firmware sources touched**. Pairs with **thpoll83/polykybd-ctnd#90**, which implements the rig-side check.

### The gap it closes

An apply converts the rig's slave into a **second master**: the slave installs its own *staged* image, and the staged bytes are the ones the master bridged during CHUNK. On a real keyboard both halves run one identical image and the role comes from VBUS at runtime, so that is correct; here the halves run **different** images by construction (`POLYKYBD_HIL=left`/`right`). So the link check inside `firmware_apply_roundtrip` can only ever report UNVERIFIED, and the run asserts nothing about the other half.

With this opt-in, ctnd re-flashes `*_hil_right.uf2` and measures — answering the half that *is* answerable: **can the APPLIED master image bring a split link back up.** A master that returned subtly wrong (broken transport, mis-sized shared-memory struct, dead PIO) fails there and passes every other assertion in the round-trip. That is the shape of the 2026-09-03 field report, where the master enumerated perfectly and the link stayed silent.

### ⚠️ OFF on a plain push, deliberately

This step runs on **every merge to `PolyKybd`**, and `release.yml`'s `require_fwapply_run.py` gates publishing on this job's conclusion being `success` — so anything that can fail here can **refuse a release**, and the rig-side check has never executed. It opts in on the same signals the tier already uses: the `hil-fwapply` label, `[hil-fwapply]` in a pushed commit, or a `tier: fwapply`/`all` dispatch. Prove it with a dispatch, then decide whether to make it unconditional.

### ⚠️ An ENV VAR, not ctnd's `--reflash-slave` flag

CI runs the **installed** station synced to ctnd `main`, so a station predating the feature would die on an unknown argparse flag — failing the job that gates releases. An unknown env var is ignored, so an old station simply skips the check. This also removes the merge-order constraint between the two repos: either can land first.

## Version bump label

*(none)* — CI/docs only, patch bump is correct.

## Testing

- [x] Compiled successfully — n/a, no firmware source changed. The workflow's own paths filter includes `.github/workflows/qmk-test.yml`, so this PR *does* run the build + rig.
- [ ] Flashed and tested on hardware — n/a here; the proof run is a `tier: fwapply` dispatch after both PRs land.
- [x] If protocol changed: n/a, no protocol change.

Verified rather than eyeballed, since this is the folded-scalar shape `CLAUDE.md` warns about (a continuation line indented deeper silently keeps a newline and the value stops being a valid GitHub expression):

- `HIL_RESLAVE` parses to a **single line**, and the four sibling folded blocks (`build`, `build-perf`, `build-doom` `if:`, `hil-test`'s `HIL_EXTENDED`) are unchanged.
- The expression was **simulated across all eight reachable trigger shapes**:

| trigger | `HIL_RESLAVE` |
|---|---|
| merge push to `PolyKybd` | `false` |
| push with `[hil-fwapply]` | `true` |
| PR labelled `hil-fwapply` | `true` |
| PR labelled `hil-extended` only | `false` |
| dispatch `tier: fwapply` | `true` |
| dispatch `tier: all` | `true` |
| dispatch `tier: default` | `false` |
| dispatch `tier: extended` | `false` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LeoBsy75UBvecXehCiAoWg

---
_Generated by [Claude Code](https://claude.ai/code/session_01LeoBsy75UBvecXehCiAoWg)_

## Summary by Sourcery

Add an opt-in post-apply split-link verification to the firmware apply HIL workflow.

New Features:
- Add an opt-in post-apply HIL check that re-flashes the slave image and verifies the applied master can restore the split link.

Enhancements:
- Enable the check only for fwapply-specific labels, commit markers, or workflow dispatch tiers while leaving ordinary merge runs unchanged.
- Pass the opt-in through an environment variable for compatibility with stations that do not yet support the corresponding command-line option.

CI:
- Update the QMK test workflow to conditionally enable the post-apply slave verification.

Documentation:
- Document the post-apply check's trigger conditions and compatibility behavior in CLAUDE.md.