### PR TITLE
CLAUDE.md: the bump label must be on the PR at open, not requested in the body

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1205,6 +1205,17 @@ that cost real debugging to learn (2026-07):
     *two* orderings to get right — the label before the qmk merge, and the docs merge
     after the release (already noted in `polykybd-docs/CLAUDE.md`). Getting the second
     right does not save you from the first.
+  - ⚠️ **"Before the merge" means AT OPEN — a label applied any later races the
+    merge, and the merge wins.** qmk#271 and host#212 (2026-09-04) both asked for
+    `bump:minor` in the PR body and both merged without it (fw **0.18.3** and host
+    **0.14.17** instead of 0.19.0 / 0.15.0). The label I put on #212 the moment
+    #271's merge came through landed **12 seconds after** #212 was merged: a person
+    merging a reviewed stack clicks through it in a minute and does not re-read the
+    body, and `bump-version.yml` reads the labels at merge time. A request in the
+    body is documentation, not a label. `create_pull_request` cannot set labels, so
+    the rule is **`issue_write` with `labels: ["bump:minor"]` right after opening**,
+    before announcing the PR — and mention the label in the body only as a record of
+    what is already set.
   - **Recovering** is a choice, not a fix: either correct the docs to the version that
     actually bumped, or land a `bump:minor` PR that does **not** itself edit `config.h`
     (the workflow bumps *after* merge, so an edited version file would be bumped on top


### PR DESCRIPTION
## Summary

Docs only. Adds one sub-bullet to the § Releases note "A MISSING bump label is silent": the label has to be on the PR when it is **opened**, not requested in the body. Both crash-diagnostics PRs (#271 here, PolyKybdHost#212) asked for `bump:minor` in their bodies and merged without it (firmware went to 0.18.3 instead of 0.19.0, host to 0.14.17 instead of 0.15.0); the label applied as the merges were happening landed 12 seconds after #212 merged. `create_pull_request` cannot set labels, so the recorded rule is `issue_write` with `labels:` right after opening.

Companion one-liner in PolyKybdHost (pointing at this note). The path filter keeps the build and rig off this PR.

## Version bump label

None (docs only; the automatic patch bump is fine).

## Testing
- [x] Markdown only — no build, no firmware change
- [x] The edited section renders in place; nothing else in the file touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UbVXatR5kZAqk79jKUfXMd

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbVXatR5kZAqk79jKUfXMd)_

## Summary by Sourcery

Document the requirement to apply release bump labels when opening pull requests so merge-time version bumps are selected correctly.

Enhancements:
- Clarify that required version-bump labels must be applied immediately after a pull request is opened, rather than merely requested in its body, to prevent incorrect release versions.

Documentation:
- Document the timing and procedure for applying release bump labels in CLAUDE.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the release process for version-bump labels.
  * Added guidance to apply the appropriate label when opening a pull request to ensure the requested version change is recognized during merging.
  * Documented a prior timing issue and recommended recording the requested bump in the pull request description as supplementary context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->