### PR TITLE
crash_test: prove the fault path on hardware, and stop losing the slave's record

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2552,6 +2552,39 @@ run on it (`test_no_crash_record`). What is worth knowing:
     the FW-2 prompt and `doom_begin()` follow: a crash is a path that does not
     return, so the held chord would otherwise auto-repeat on the host — for a
     full 8 s on the watchdog trigger, before the board even reboots.
+  - ✅ **PROVEN ON HARDWARE 2026-09-04 (fw 0.18.4), triggers 1 and 2** — the
+    fault path this section called unverified. Trigger 1's `pc` landed on the
+    faulting store ITSELF (`crash_test.c:53`, `601a str r2,[r3,#0]`), not its
+    successor, so one `addr2line` names the line. The disassembly also shows GCC
+    emitting the `ldr` read-back of `s_addr` before the store, i.e. the volatile
+    laundering held and the fault was not optimised away. Three readings that
+    generalise to ANY fault record, not just these two:
+    - **`psr` bit 24 (T) is a free discriminator, and both directions are now
+      measured.** Trigger 1 (faulted executing an instruction) returned
+      `psr=0xa1000000`, T **set**; trigger 2 (a `blx` to a bit-0-clear address)
+      returned `psr=0x00000000`, T **clear**. So the record separates "faulted on
+      an instruction" from "faulted trying to enter ARM state" with no symbols at
+      all — the stacked xPSR is the state BEFORE the exception.
+    - ⚠️ **`lr` is trustworthy only when the fault is AT a call.** Trigger 2
+      faulted on the `blx`, so LR still held the return address that `blx` had
+      just written and resolved to the calling line (`crash_test.c:66`). Trigger 1
+      faulted a few instructions later, so LR was a stale leftover from the
+      previous `bl` and resolved to `chThdSleep` — the `wait_ms(25)` in
+      `release_the_chord()`, nowhere near the bug. The tell is whether
+      `addr2line lr` lands adjacent to `pc`'s function; ARMv6-M stacks no call
+      chain, so this is never a backtrace.
+    - ⚠️ **`addr2line` maps a DATA address to a symbol and it reads like an
+      answer.** Trigger 2's `pc=0x20000000` resolved to `__overlay_pool_base__`
+      (`overlay.c:42`) — the overlay pool, which is not code. **Check the RANGE
+      first**: code is XIP flash `0x10……`, SRAM is `0x20……`, so a `pc` in SRAM
+      means "branched into nowhere" whatever symbol addr2line prints.
+  - ⚠️ **`reason` carries a STICKY `HAD_POR`, so the host renders a watchdog
+    reboot as "reset reason: POR, watchdog forced".** Both hardware records read
+    `reason=0x21` = `HAD_POR | WD_FORCE` on a board that had been up 148 s and
+    363 s and was never power-cycled — the fault handler's `watchdog_reboot()`
+    brought it back. `WD_FORCE` set with `WD_TIMER` clear is the informative half
+    (and is the qmk#271 discriminator working); leading with POR reads as a power
+    cycle and would send a real diagnosis the wrong way.
 
 ### Idle anti-burn-in styles (`poly_keymap.c`)
 When the keyboard idles, the keycap legends would otherwise burn the **same**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2548,10 +2548,34 @@ run on it (`test_no_crash_record`). What is worth knowing:
   - ⚠️ **Every address is laundered through a `volatile`.** A plain
     `*(uint32_t *)1 = x` is undefined behaviour GCC may delete outright, and a
     deleted fault is a test that silently proves nothing.
+    - ⚠️ **The mechanism that actually bit was NOT deletion — it was
+      LEGALISATION, and it is quieter.** Trigger 6 wrote its address as a
+      compile-time constant (`((uintptr_t)&core1_decomp_count) + 1u`), so GCC
+      could see the misalignment and split the `volatile uint32_t` store into
+      **four `strb`** — which never fault on ARMv6-M. Core1 wrote `EF BE AD DE`
+      and carried on, so the trigger did nothing at all and reported nothing
+      (measured 2026-09-04). A deleted store leaves no instructions to find; a
+      legalised one leaves plausible-looking code that simply cannot fault. The
+      laundering is what hides the alignment from the optimiser, and it is
+      required even where the address is not literally a constant expression.
+    - **Check it in the DISASSEMBLY, not the source**: the fault site must be a
+      single `str`, and the address must be reloaded from the volatile
+      (`ldr r4,[r2]` then `str r3,[r4,#0]`). Any `strb` on that path means the
+      trigger is inert.
   - **`clear_keyboard()` + a 25 ms settle before every trigger**, the same rule
     the FW-2 prompt and `doom_begin()` follow: a crash is a path that does not
     return, so the held chord would otherwise auto-repeat on the host — for a
     full 8 s on the watchdog trigger, before the board even reboots.
+  - ⚠️ **Trigger 7 cannot rely on the master OBSERVING the slave's reboot as a
+    link drop.** `slave_data_crash_pull_tick()` re-pulls only on a false->true
+    transition of `is_transport_connected()`, which needs
+    `SPLIT_MAX_CONNECTION_ERRORS` (200) consecutive failures to accumulate
+    *before* the slave is back — a race, not a guarantee. So the request opens a
+    bounded forced-retry window (`CRASH_FORCE_WINDOW_MS`, 30 s) instead.
+    ⚠️ Do **not** "re-arm" by clearing `s_tries` at request time, which was tried
+    first: with the link still reading connected, that spends all three ordinary
+    tries into a half-rebooted slave and then gives up forever — the opposite of
+    the intent. The window is additive; the drop path still re-arms normally.
   - ✅ **PROVEN ON HARDWARE 2026-09-04 (fw 0.18.4), triggers 1 and 2** — the
     fault path this section called unverified. Trigger 1's `pc` landed on the
     faulting store ITSELF (`crash_test.c:53`, `601a str r2,[r3,#0]`), not its

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2532,6 +2532,26 @@ run on it (`test_no_crash_record`). What is worth knowing:
   unverified is the **fault path itself**: the naked handler, the stacked frame
   and the `watchdog_reboot()` out of it. The `debug-firmware-on-rig` skill with a
   probe that dereferences a bad pointer over HID is the way to close that.
+  - **`-e POLYKYBD_CRASH_TEST=yes` is the by-hand route** (`crash_test.c`, a
+    TEST-ONLY flag — a normal build compiles inline no-ops and pays nothing).
+    Hold Ctrl+Shift+Alt and press a digit: **1** unaligned word store (the
+    qmk#258 brick, reproduced), **2** a branch to an address with bit 0 clear,
+    **3** a main-loop hang (~8 s to the watchdog), **4** `crash_record_halt()`,
+    **5** a pended SPARE NVIC IRQ, i.e. the `_unhandled_exception` funnel rather
+    than HardFault, **6** the same fault on **core1** (shared vector table;
+    PRIMASK does not mask a HardFault, so `core` reads 1), **7** the **slave**,
+    over a `SLAVE_DATA_CRASH_TEST` pull that deliberately never answers.
+  - ⚠️ **The chord tests each modifier FAMILY, not a combined mask.**
+    `MOD_MASK_CTRL` covers left and right, so `(mods & (CTRL|SHIFT|ALT)) == that`
+    demands all SIX keys and can never fire off a normal keymap — written that
+    way first, caught before the build.
+  - ⚠️ **Every address is laundered through a `volatile`.** A plain
+    `*(uint32_t *)1 = x` is undefined behaviour GCC may delete outright, and a
+    deleted fault is a test that silently proves nothing.
+  - **`clear_keyboard()` + a 25 ms settle before every trigger**, the same rule
+    the FW-2 prompt and `doom_begin()` follow: a crash is a path that does not
+    return, so the held chord would otherwise auto-repeat on the host — for a
+    full 8 s on the watchdog trigger, before the board even reboots.
 
 ### Idle anti-burn-in styles (`poly_keymap.c`)
 When the keyboard idles, the keycap legends would otherwise burn the **same**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2566,6 +2566,19 @@ run on it (`test_no_crash_record`). What is worth knowing:
     the FW-2 prompt and `doom_begin()` follow: a crash is a path that does not
     return, so the held chord would otherwise auto-repeat on the host — for a
     full 8 s on the watchdog trigger, before the board even reboots.
+  - ⚠️ **A pull that lands BEFORE the slave has archived used to count as DONE.**
+    `crash_record_note_slave()` returns true for an empty reply as well (it
+    clears the master's cached copy), so testing it alone closed the pull for
+    that link-up with nothing reported — and right after a slave reboot the
+    empty reply is the normal first answer. Only a reply with
+    `CRASH_HID_FLAG_PRESENT` ends it now. Pre-existing, not specific to the
+    crash test: it applied to the ordinary post-reboot pull too.
+  - ⚠️ **The slave's line was printed exactly ONCE, so a single dropped console
+    read lost the record for good.** The master's own line survives that because
+    the boot banner repeats it; the slave's arrives long after those repeats have
+    stopped, which is why it is not in the banner. It now schedules a few repeats
+    of its own (`crash_record_emit_slave_line()`), which is safe because the host
+    dedupes identical lines — the same property the banner's repeats rely on.
   - ⚠️ **Trigger 7 cannot rely on the master OBSERVING the slave's reboot as a
     link drop.** `slave_data_crash_pull_tick()` re-pulls only on a false->true
     transition of `is_transport_connected()`, which needs

--- a/keyboards/polykybd/base/crash_record.c
+++ b/keyboards/polykybd/base/crash_record.c
@@ -423,8 +423,18 @@ void crash_record_emit_lines(void) {
     // Only a FRESH record is announced: the archive is a history for polyctl /
     // the HID command, not something to re-report at every boot forever.
     if (s_fresh && s_have_archive) emit_one(&s_archive, "master");
-    // The slave's line is printed ONCE, at the pull (crash_record_note_slave):
-    // the link can come up long after the banner re-emits have stopped.
+    // The slave's line is NOT here: the link can come up long after the banner
+    // re-emits have stopped, so it is scheduled separately from the pull -- see
+    // crash_record_emit_slave_line().
+}
+
+// The master's own line rides the boot banner, which repeats, so a console that
+// misses one read still gets it. The slave's had exactly one chance, and a single
+// dropped read lost the record for good. The pull schedules a few repeats through
+// here instead; the host dedupes identical lines, which is what makes the banner's
+// own repeats safe too.
+void crash_record_emit_slave_line(void) {
+    if (s_have_slave && s_slave_fresh) emit_one(&s_slave, "slave");
 }
 
 static uint8_t fill_body(uint8_t *out, uint8_t out_len, bool present, bool fresh,

--- a/keyboards/polykybd/base/crash_record.h
+++ b/keyboards/polykybd/base/crash_record.h
@@ -173,6 +173,9 @@ void crash_record_slave_reply(uint8_t *out, uint8_t out_len);
 // Returns false when the body did not decode (short / bad CRC).
 bool crash_record_note_slave(const uint8_t *body, uint8_t len);
 
+// Re-print the slave's line (no-op unless a fresh slave record is held).
+void crash_record_emit_slave_line(void);
+
 // --- the watchdog -----------------------------------------------------------
 
 // Arm the hardware watchdog. Call at the END of keyboard_post_init_user() -- the

--- a/keyboards/polykybd/crash_test.c
+++ b/keyboards/polykybd/crash_test.c
@@ -1,0 +1,154 @@
+// Copyright 2026 thpoll83
+// SPDX-License-Identifier: GPL-2.0-or-later
+// See crash_test.h.
+#include "crash_test.h"
+
+#ifdef POLYKYBD_CRASH_TEST
+
+#include "quantum.h"
+#include "split_util.h"   // is_keyboard_master()
+#include "print.h"
+#include "base/crash_record.h"
+#include "multicore_exec.h"
+#include "slave_data.h"
+
+// The chord: Ctrl AND Shift AND Alt held, then a digit. Tested per FAMILY --
+// MOD_MASK_CTRL covers left and right, so `(mods & (CTRL|SHIFT|ALT)) == that`
+// would demand all SIX keys at once and could never fire off a normal keymap.
+static bool chord_held(void) {
+    const uint8_t m = get_mods();
+    return (m & MOD_MASK_CTRL) && (m & MOD_MASK_SHIFT) && (m & MOD_MASK_ALT);
+}
+
+// Every address below is laundered through a volatile so the compiler cannot
+// reason about it: a plain `*(uint32_t *)1 = x` is undefined behaviour GCC is
+// entitled to delete, and a deleted fault is a test that silently proves nothing.
+static volatile uintptr_t s_addr;
+static volatile uint32_t  s_target;
+
+// Cortex-M0+ NVIC, by address rather than CMSIS name: this file has no business
+// pulling in a core header for two stores.
+#define POLY_NVIC_ISER (*(volatile uint32_t *)(uintptr_t)0xE000E100u)
+#define POLY_NVIC_ISPR (*(volatile uint32_t *)(uintptr_t)0xE000E200u)
+// RP2040 IRQ 31 is one of the six SPARE lines (26..31): nothing drives it, so it
+// reaches the weak vector, i.e. vectors.S's shared body -> _unhandled_exception.
+#define SPARE_IRQ 31u
+
+// A crash is a path that does not return, so the host would keep auto-repeating
+// whatever is held -- and the watchdog trigger holds it for a full 8 s before the
+// board even reboots. Same rule the FW-2 prompt and doom_begin() follow: release
+// everything first, and give USB a moment to actually ship the report.
+static void release_the_chord(void) {
+    clear_keyboard();
+    wait_ms(25);
+}
+
+// --- 1: unaligned 32-bit store ---------------------------------------------
+// The qmk#258 brick, reproduced: ARMv6-M has no unaligned access, so a word STR
+// to an odd address is a HardFault inside whatever function issued it. The
+// stacked PC names that instruction, which is the whole point of the record.
+static void __attribute__((noreturn)) fault_unaligned_store(void) {
+    s_addr = (uintptr_t)&s_target + 1u;
+    volatile uint32_t *p = (volatile uint32_t *)s_addr;
+    *p = 0xDEADBEEFu;
+    for (;;) {}
+}
+
+// --- 2: branch to a bad address ---------------------------------------------
+// Bit 0 clear means ARM state, which the M0+ does not have: the BLX faults on
+// entry, so the stacked PC is the TARGET (0x20000000) and LR points back here.
+// That pairing is what tells a "jumped somewhere wrong" fault apart from a
+// "faulted where it stood" one in the record.
+static void __attribute__((noreturn)) fault_bad_branch(void) {
+    s_addr = 0x20000000u;
+    void (*fn)(void) = (void (*)(void))s_addr;
+    fn();
+    for (;;) {}
+}
+
+// --- 3: main-loop hang ------------------------------------------------------
+// Interrupts stay ON deliberately: USB, the ChibiOS tick and the split link all
+// keep running, and only the main loop stops -- which is exactly the hang class
+// the watchdog exists for. No frame is left behind, so the phase breadcrumb is
+// the entire diagnosis. ~8 s to the reboot (CRASH_WATCHDOG_MS).
+static void __attribute__((noreturn)) fault_hang(void) {
+    for (;;) {
+        __asm volatile("" ::: "memory");
+    }
+}
+
+// --- 4: deliberate halt -----------------------------------------------------
+static void __attribute__((noreturn)) fault_halt(void) {
+    crash_record_halt(0xC0DEu);   // the arg lands in the record's phase_arg
+}
+
+// --- 5: an unhandled vector -------------------------------------------------
+// Not a HardFault: this takes the OTHER funnel, vectors.S's shared body ->
+// _unhandled_exception, where there is no EXC_RETURN to say which stack the
+// frame is on. ICSR.VECTACTIVE (47 = 16 + IRQ 31) is what names it.
+static void __attribute__((noreturn)) fault_unhandled_vector(void) {
+    POLY_NVIC_ISER = (1u << SPARE_IRQ);
+    POLY_NVIC_ISPR = (1u << SPARE_IRQ);
+    __asm volatile("dsb \n isb" ::: "memory");
+    for (;;) {}
+}
+
+// --- 6: a fault on core1 ----------------------------------------------------
+// The vector table is shared, so HardFault_Handler takes it there too (PRIMASK=1
+// on core1 does not mask a HardFault). The record's `core` field should read 1,
+// and this used to be an instant silent lockup -- core1 has no console.
+static bool fault_core1(void) {
+#ifdef USE_CORE1
+    core1_crash_test();
+    return true;
+#else
+    uprintf("crash-test: no USE_CORE1 in this build\n");
+    return false;
+#endif
+}
+
+// --- 7: a fault on the SLAVE half -------------------------------------------
+// Asked for over the split link. The master's pull times out, the slave reboots,
+// the link drops and re-establishes, and slave_data_crash_pull_tick() then pulls
+// the record and prints it as `side=slave` -- the one path that cannot be reached
+// from this half's keyboard at all, since only the master runs process_record.
+static bool fault_slave(void) {
+    if (!is_keyboard_master()) return false;
+    slave_data_request_crash_test();
+    return true;
+}
+
+void crash_test_slave_fault(void) {
+    fault_unaligned_store();
+}
+
+// ---------------------------------------------------------------------------
+bool crash_test_process_record(uint16_t keycode, bool pressed) {
+    if (keycode < KC_1 || keycode > KC_7) return false;
+    if (!chord_held()) return false;
+    if (!pressed) return true;   // swallow the release of a chord we consumed
+
+    const uint8_t which = (uint8_t)(keycode - KC_1 + 1);
+    uprintf("crash-test: trigger %u armed\n", (unsigned)which);
+    release_the_chord();
+
+    switch (which) {
+        case 1: fault_unaligned_store();
+        case 2: fault_bad_branch();
+        case 3: fault_hang();
+        case 4: fault_halt();
+        case 5: fault_unhandled_vector();
+        case 6: (void)fault_core1(); break;   // core1 faults; core0 carries on until the reboot
+        case 7: (void)fault_slave(); break;   // the SLAVE faults; this half stays up
+        default: break;
+    }
+    return true;
+}
+
+void crash_test_announce(void) {
+    uprintf("   CRASH-TEST BUILD -- hold LCtrl+LShift+LAlt and press:\n");
+    uprintf("     1 unaligned store   2 bad branch     3 main-loop hang (~8s)\n");
+    uprintf("     4 deliberate halt   5 unhandled vec  6 core1 fault  7 SLAVE fault\n");
+}
+
+#endif  // POLYKYBD_CRASH_TEST

--- a/keyboards/polykybd/crash_test.c
+++ b/keyboards/polykybd/crash_test.c
@@ -119,6 +119,9 @@ static bool fault_slave(void) {
 }
 
 void crash_test_slave_fault(void) {
+    // Tag the breadcrumb so the slave's record self-identifies as this trigger.
+    // Honest: this really does run inside a split-transaction handler.
+    (void)crash_phase_enter(CRASH_PHASE_BRIDGE, 0x0077);
     fault_unaligned_store();
 }
 

--- a/keyboards/polykybd/crash_test.h
+++ b/keyboards/polykybd/crash_test.h
@@ -1,0 +1,48 @@
+// Copyright 2026 thpoll83
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Deliberate crashes, for exercising the crash record (base/crash_record.h) on
+// real hardware. TEST BUILDS ONLY -- `qmk compile ... -e POLYKYBD_CRASH_TEST=yes`.
+// A normal build compiles the inline no-ops below and pays nothing.
+//
+// Why it exists: every OTHER path in the crash record has been driven end to end
+// (boot capture, the console line, the slave pull, HID cmd 39, the archive), but
+// the FAULT HANDLERS themselves never have -- the only records the hardware has
+// ever produced came from the bootrom's post-UF2 watchdog reboot. So the naked
+// HardFault_Handler, the stacked-frame read, the `_unhandled_exception` funnel,
+// the watchdog-timeout synthesis and the core1/slave paths are all unproven.
+// This makes each of them reachable from a key chord.
+//
+// The chord is LCtrl+LShift+LAlt held + a digit. That combination is not a
+// shortcut anything types, needs no keymap edit (so the keycaps keep their real
+// legends) and works on every base layout, since KC_1..KC_9 sit on all of them.
+// The digit event is SWALLOWED, so the host never sees it.
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef POLYKYBD_CRASH_TEST
+
+// Call from the top of process_record_user(). Returns true when the event was a
+// crash-test chord and must not be processed further -- though for every trigger
+// but an unrecognised digit, it does not return at all.
+bool crash_test_process_record(uint16_t keycode, bool pressed);
+
+// One console line listing the chords. Called from keyboard_post_init_user(),
+// beside crash_record_emit_lines(), so a test build says what it is.
+void crash_test_announce(void);
+
+// Slave side: the fault the master asks for over SLAVE_DATA_CRASH_TEST.
+void crash_test_slave_fault(void) __attribute__((noreturn));
+
+#else
+
+static inline bool crash_test_process_record(uint16_t keycode, bool pressed) {
+    (void)keycode;
+    (void)pressed;
+    return false;
+}
+static inline void crash_test_announce(void) {}
+
+#endif

--- a/keyboards/polykybd/multicore_exec.c
+++ b/keyboards/polykybd/multicore_exec.c
@@ -40,6 +40,9 @@ typedef enum {
     CORE1_CMD_DECOMPRESS     = 0xcafe0001,
     CORE1_CMD_ROI_UPDATE     = 0xcafe0002,
     CORE1_CMD_RESET_BIT_IDX  = 0xcafe0003,
+#ifdef POLYKYBD_CRASH_TEST
+    CORE1_CMD_CRASH_TEST     = 0xcafe00ff,
+#endif
 } fifo_command_t;
 
 // Overlay buffers for core1 processing
@@ -111,6 +114,17 @@ void core1_entry(void) {
                 core1_bit_index = 0;
                 dmb();
                 break;
+#ifdef POLYKYBD_CRASH_TEST
+            case CORE1_CMD_CRASH_TEST: {
+                    // An unaligned word store: ARMv6-M has no unaligned access, so
+                    // this HardFaults right here. The vector table is shared with
+                    // core0 and PRIMASK does not mask a HardFault, so the naked
+                    // HardFault_Handler runs ON CORE1 and the record's `core` field
+                    // reads 1. No uprintf -- core1 has no console and a tiny stack.
+                    volatile uint32_t *bad = (volatile uint32_t *)(uintptr_t)(((uintptr_t)&core1_decomp_count) + 1u);
+                    *bad = 0xDEADBEEFu;
+                } break;
+#endif
             default: break;
         }
     }
@@ -217,4 +231,10 @@ void core1_update_roi(uint8_t keycode, uint8_t mod, uint16_t overlay_idx, const 
     //allow core1 to start decompressing
     multicore_fifo_push_blocking(CORE1_CMD_ROI_UPDATE);
 }
+#ifdef POLYKYBD_CRASH_TEST
+void core1_crash_test(void) {
+    multicore_fifo_push_blocking(CORE1_CMD_CRASH_TEST);
+}
+#endif
+
 #endif

--- a/keyboards/polykybd/multicore_exec.c
+++ b/keyboards/polykybd/multicore_exec.c
@@ -121,7 +121,19 @@ void core1_entry(void) {
                     // core0 and PRIMASK does not mask a HardFault, so the naked
                     // HardFault_Handler runs ON CORE1 and the record's `core` field
                     // reads 1. No uprintf -- core1 has no console and a tiny stack.
-                    volatile uint32_t *bad = (volatile uint32_t *)(uintptr_t)(((uintptr_t)&core1_decomp_count) + 1u);
+                    // ⚠️ The address MUST be laundered through a volatile. Written as a
+                    // compile-time constant, GCC sees the misalignment and LEGALISES the
+                    // store into four strb -- which never fault on ARMv6-M, so core1 wrote
+                    // the bytes and carried on and this trigger silently did nothing
+                    // (measured 2026-09-04). The volatile hides the alignment, forcing a
+                    // real str. Same rule as crash_test.c, different reason from the one
+                    // documented there: not deletion, legalisation.
+                    static volatile uintptr_t bad_addr;
+                    bad_addr = ((uintptr_t)&core1_decomp_count) + 1u;
+                    volatile uint32_t *bad = (volatile uint32_t *)bad_addr;
+                    // Tag the breadcrumb so the resulting record self-identifies as this
+                    // trigger rather than leaving `core=1` as the only evidence.
+                    (void)crash_phase_enter(CRASH_PHASE_CORE1_WAIT, 0x00C1);
                     *bad = 0xDEADBEEFu;
                 } break;
 #endif

--- a/keyboards/polykybd/multicore_exec.h
+++ b/keyboards/polykybd/multicore_exec.h
@@ -29,3 +29,11 @@ void core1_update_roi(uint8_t keycode, uint8_t mod, uint16_t overlay_idx, const 
 // Signals core1 to reset bit index for next region-of-interest update.
 // Global variables: (none - sends FIFO command only)
 void core1_roi_start(void);
+
+#if defined(POLYKYBD_CRASH_TEST) && defined(USE_CORE1)
+// TEST BUILDS ONLY (crash_test.h): ask core1 to fault, so the crash record can be
+// checked on the core that has no console and used to lock up silently. Returns
+// as soon as the command is queued -- core1 faults asynchronously and the fault
+// handler reboots the whole chip from there.
+void core1_crash_test(void);
+#endif

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -67,6 +67,7 @@
 #include "polymod_core1.h"
 #include "boot_diag.h"                    // emit_boot_banner(), splash_progress(), SPLASH_DONE
 #include "base/crash_record.h"            // crash_record_init(), the watchdog, the phase breadcrumb
+#include "crash_test.h"                   // POLYKYBD_CRASH_TEST: deliberate faults (no-op inlines otherwise)
 #include "slave_data.h"                   // slave_data_register(), slave_data_crash_pull_tick()
 #include "polymod_crc32.h"
 
@@ -4044,6 +4045,14 @@ static bool poly_custom_key_action(uint16_t keycode, keyrecord_t* record) {
 
 bool process_record_user(uint16_t keycode, keyrecord_t* record) {
 
+    // TEST BUILDS ONLY (-e POLYKYBD_CRASH_TEST=yes): the deliberate-crash chord.
+    // FIRST, so it works even while another mode below would swallow the event --
+    // the whole point is to be able to fault the board on demand. Compiles to an
+    // inline `return false` in every normal build.
+    if (crash_test_process_record(keycode, record->event.pressed)) {
+        return false;
+    }
+
     // While the ONE-SHOT startup ("Eden") animation is playing, swallow every key
     // event — no typing is wanted (or needed) during the intro. Keys from both
     // halves funnel through the master's process_record before USB reporting, so
@@ -4728,6 +4737,7 @@ void keyboard_post_init_user(void) {
 
     emit_boot_banner();   // one-shot at boot; housekeeping re-emits for a late console
     crash_record_emit_lines();   // `crash: side=master ...` when this boot followed a crash
+    crash_test_announce();       // TEST BUILDS ONLY: list the deliberate-crash chords
 
     // Boot-splash progress: reaching post_init proves QMK's split/USB init got
     // past the point where the fw-apply "slave not rebooted" hang stalls. Reveal

--- a/keyboards/polykybd/rules.mk
+++ b/keyboards/polykybd/rules.mk
@@ -402,3 +402,21 @@ endif
 # would be forgeable by the attacker it is meant to stop. BOOTSEL/UF2 also remains
 # unaffected (it bypasses fw_staging entirely), so this can never brick a board.
 OPT_DEFS += -DFW_REQUIRE_SIGNATURE
+
+# ---------------------------------------------------------------------------
+# Deliberate crashes, for exercising base/crash_record.* on real hardware
+# ---------------------------------------------------------------------------
+# `qmk compile ... -e POLYKYBD_CRASH_TEST=yes` compiles crash_test.c and makes a
+# key chord (LCtrl+LShift+LAlt + a digit) fault the board on purpose. Every other
+# part of the crash record has been driven end to end already; the FAULT HANDLERS
+# themselves never have, so the naked HardFault_Handler, the stacked-frame read,
+# the _unhandled_exception funnel, the watchdog-timeout synthesis and the
+# core1/slave paths are all unproven. This is how they get proven.
+#
+# ⚠️ TEST BUILDS ONLY -- never ship this in a release image. A normal build
+# compiles the inline no-ops in crash_test.h and pays nothing.
+ifeq ($(strip $(POLYKYBD_CRASH_TEST)), yes)
+    OPT_DEFS += -DPOLYKYBD_CRASH_TEST
+    SRC += crash_test.c
+    $(eval $(call POLY_APPLY_WARN,crash_test.c))
+endif

--- a/keyboards/polykybd/slave_data.c
+++ b/keyboards/polykybd/slave_data.c
@@ -52,11 +52,24 @@ void slave_data_register(void) {
 #define CRASH_PULL_TRIES       3u
 #define CRASH_PULL_SPACING_MS  2000u
 
-void slave_data_crash_pull_tick(void) {
-    static bool     s_linked = false;
-    static uint8_t  s_tries  = 0;
-    static uint32_t s_last   = 0;
+#ifdef POLYKYBD_CRASH_TEST
+// A crash-test request KNOWS a slave record is coming, so it must not depend on
+// the master OBSERVING a link drop: whether a slave reboot presents as a
+// disconnect at all depends on SPLIT_MAX_CONNECTION_ERRORS (200) accumulating
+// before the slave is back, which is a race. Keep retrying for a bounded window
+// instead of spending the three ordinary tries into a half-rebooted slave.
+#    define CRASH_FORCE_WINDOW_MS 30000u
+static bool     s_forcing     = false;
+static uint32_t s_force_start = 0;
+#endif
 
+// File scope rather than function statics so the crash-test request below can
+// re-arm the pull directly (see slave_data_request_crash_test).
+static bool     s_linked = false;
+static uint8_t  s_tries  = 0;
+static uint32_t s_last   = 0;
+
+void slave_data_crash_pull_tick(void) {
     if (!is_usb_host_side()) return;
 
     const bool linked = is_transport_connected();
@@ -72,7 +85,12 @@ void slave_data_crash_pull_tick(void) {
         s_last   = timer_read32();
         return;   // give the freshly-linked slave one spacing before the first pull
     }
-    if (s_tries >= CRASH_PULL_TRIES) return;
+    bool forcing = false;
+#ifdef POLYKYBD_CRASH_TEST
+    if (s_forcing && timer_elapsed32(s_force_start) >= CRASH_FORCE_WINDOW_MS) s_forcing = false;
+    forcing = s_forcing;
+#endif
+    if (!forcing && s_tries >= CRASH_PULL_TRIES) return;
     if (timer_elapsed32(s_last) < CRASH_PULL_SPACING_MS) return;
     s_last = timer_read32();
     s_tries++;
@@ -85,11 +103,22 @@ void slave_data_crash_pull_tick(void) {
     crash_phase_leave(tag);
     if (ok && crash_record_note_slave(reply, sizeof(reply))) {
         s_tries = CRASH_PULL_TRIES;   // done for this link-up
+#ifdef POLYKYBD_CRASH_TEST
+        s_forcing = false;
+#endif
     }
 }
 
 #ifdef POLYKYBD_CRASH_TEST
 void slave_data_request_crash_test(void) {
+    // Open the forced retry window (see CRASH_FORCE_WINDOW_MS). Deliberately does
+    // NOT touch s_linked/s_tries: clearing s_tries here would spend the three
+    // ordinary tries into a slave that is still rebooting, and the drop-detection
+    // path already re-arms those correctly if the master does see the disconnect.
+    s_forcing     = true;
+    s_force_start = timer_read32();
+    s_last        = timer_read32();   // give the slave one spacing to reboot first
+
     uint8_t kind = SLAVE_DATA_CRASH_TEST;
     uint8_t reply[CRASH_HID_BODY_LEN];
     memset(reply, 0, sizeof(reply));

--- a/keyboards/polykybd/slave_data.c
+++ b/keyboards/polykybd/slave_data.c
@@ -9,6 +9,7 @@
 #include "split_util.h"        // is_transport_connected()
 #include "bridge_helper.h"     // is_usb_host_side()
 #include "base/crash_record.h"
+#include "print.h"           // uprintf (the crash-test pull diagnostic)
 #ifdef POLYKYBD_CRASH_TEST
 #    include "crash_test.h"
 #endif
@@ -51,6 +52,10 @@ void slave_data_register(void) {
 // ---------------------------------------------------------------------------
 #define CRASH_PULL_TRIES       3u
 #define CRASH_PULL_SPACING_MS  2000u
+#define SLAVE_EMIT_REPEATS     4u
+#define SLAVE_EMIT_SPACING_MS  1500u
+static uint8_t  s_emits   = 0;
+static uint32_t s_emit_at = 0;
 
 #ifdef POLYKYBD_CRASH_TEST
 // A crash-test request KNOWS a slave record is coming, so it must not depend on
@@ -71,6 +76,12 @@ static uint32_t s_last   = 0;
 
 void slave_data_crash_pull_tick(void) {
     if (!is_usb_host_side()) return;
+
+    if (s_emits > 0 && timer_elapsed32(s_emit_at) >= SLAVE_EMIT_SPACING_MS) {
+        s_emit_at = timer_read32();
+        s_emits--;
+        crash_record_emit_slave_line();
+    }
 
     const bool linked = is_transport_connected();
     if (!linked) {
@@ -101,8 +112,30 @@ void slave_data_crash_pull_tick(void) {
     uint32_t tag = crash_phase_enter(CRASH_PHASE_BRIDGE, USER_SYNC_SLAVE_DATA);
     bool ok = transaction_rpc_exec(USER_SYNC_SLAVE_DATA, sizeof(kind), &kind, sizeof(reply), reply);
     crash_phase_leave(tag);
-    if (ok && crash_record_note_slave(reply, sizeof(reply))) {
+    const bool noted   = ok && crash_record_note_slave(reply, sizeof(reply));
+    const bool present = noted && (reply[0] & CRASH_HID_FLAG_PRESENT) != 0;
+#ifdef POLYKYBD_CRASH_TEST
+    // One line per forced pull, so a round on hardware says WHICH half of this
+    // is failing instead of leaving four indistinguishable silences: the RPC not
+    // landing, the slave holding no record, a record that is not fresh, or a
+    // record that was reported and the console missed.
+    if (forcing) {
+        uprintf("crash-test: slave pull #%u ok=%u flags=0x%02X\n",
+                (unsigned)s_tries, (unsigned)ok, (unsigned)(ok ? reply[0] : 0u));
+    }
+#endif
+    // ONLY a record actually present ends the pull. crash_record_note_slave()
+    // returns true for an empty reply too (it clears the master's cached copy),
+    // so testing it alone let a pull that landed BEFORE the slave had archived
+    // -- the normal case right after a slave reboot -- count as done and close
+    // the window with nothing reported.
+    if (present) {
         s_tries = CRASH_PULL_TRIES;   // done for this link-up
+        // Schedule a few repeats of the slave's line. It is printed once at the
+        // pull and the console can drop a read, which loses the record for good;
+        // the master's own line survives that because the boot banner repeats it.
+        s_emits    = SLAVE_EMIT_REPEATS;
+        s_emit_at  = timer_read32();
 #ifdef POLYKYBD_CRASH_TEST
         s_forcing = false;
 #endif

--- a/keyboards/polykybd/slave_data.c
+++ b/keyboards/polykybd/slave_data.c
@@ -9,6 +9,9 @@
 #include "split_util.h"        // is_transport_connected()
 #include "bridge_helper.h"     // is_usb_host_side()
 #include "base/crash_record.h"
+#ifdef POLYKYBD_CRASH_TEST
+#    include "crash_test.h"
+#endif
 #ifdef POLYKYBD_LTR559_DRIVE
 #    include "ltr559_policy.h"
 #endif
@@ -27,6 +30,10 @@ static void user_sync_slave_data_handler(uint8_t in_len, const void *in_data, ui
         case SLAVE_DATA_CRASH:
             crash_record_slave_reply((uint8_t *)out_data, out_len);
             break;
+#ifdef POLYKYBD_CRASH_TEST
+        case SLAVE_DATA_CRASH_TEST:
+            crash_test_slave_fault();   // does not return: records and reboots
+#endif
         default:
             break;  // unknown kind: leave the reply buffer as-is
     }
@@ -80,3 +87,14 @@ void slave_data_crash_pull_tick(void) {
         s_tries = CRASH_PULL_TRIES;   // done for this link-up
     }
 }
+
+#ifdef POLYKYBD_CRASH_TEST
+void slave_data_request_crash_test(void) {
+    uint8_t kind = SLAVE_DATA_CRASH_TEST;
+    uint8_t reply[CRASH_HID_BODY_LEN];
+    memset(reply, 0, sizeof(reply));
+    // Expected to return false: the slave faults inside the handler, so the
+    // transaction times out after its retries. Nothing to do with the result.
+    (void)transaction_rpc_exec(USER_SYNC_SLAVE_DATA, sizeof(kind), &kind, sizeof(reply), reply);
+}
+#endif

--- a/keyboards/polykybd/slave_data.h
+++ b/keyboards/polykybd/slave_data.h
@@ -16,6 +16,9 @@
 enum slave_data_kind {
     SLAVE_DATA_SENSOR = 0,  // ltr559_sync_t: {avg lux, proximity}   (POLYKYBD_LTR559_DRIVE)
     SLAVE_DATA_CRASH  = 1,  // crash_record: [flags][poly_crash_record_t] (crash_record.h)
+#ifdef POLYKYBD_CRASH_TEST
+    SLAVE_DATA_CRASH_TEST = 2,  // TEST BUILDS ONLY: fault on the slave, never answers
+#endif
 };
 
 // Registers the split handler. Call once from keyboard_post_init_user(),
@@ -27,3 +30,11 @@ void slave_data_register(void);
 // link-up (bounded retries, spaced out) and hand it to crash_record_note_slave().
 // No-op on the slave.
 void slave_data_crash_pull_tick(void);
+
+#ifdef POLYKYBD_CRASH_TEST
+// TEST BUILDS ONLY (crash_test.h). Master side: ask the slave to fault. The pull
+// necessarily FAILS -- the slave reboots instead of answering -- which is the
+// point: the link then drops and re-establishes, and slave_data_crash_pull_tick()
+// pulls the resulting record and prints it as `side=slave`.
+void slave_data_request_crash_test(void);
+#endif


### PR DESCRIPTION
## Summary

The crash record shipped without its **fault path** ever having been exercised deliberately — the rig had driven the whole reporting chain end to end, but only through a UF2 false positive, so the naked HardFault handler, the stacked frame and the `watchdog_reboot()` out of it were unverified. This adds a TEST-ONLY build that faults the board on a key chord, and fixes the two things that testing found.

**`-e POLYKYBD_CRASH_TEST=yes`** (`crash_test.c`) — a normal build compiles inline no-ops and pays nothing. Hold Ctrl+Shift+Alt and press a digit:

| | fault |
|---|---|
| 1 | unaligned word store (the qmk#258 brick, reproduced) |
| 2 | a branch to an address with bit 0 clear |
| 3 | a main-loop hang (~8 s to the watchdog) |
| 4 | `crash_record_halt()` |
| 5 | a pended SPARE NVIC IRQ — the `_unhandled_exception` funnel rather than HardFault |
| 6 | the same fault on **core1** |
| 7 | the **slave**, over a `SLAVE_DATA_CRASH_TEST` pull that never answers |

**All seven confirmed on hardware (fw 0.18.4).** Three readings that generalise to any fault record, not just these:

- **`psr` bit 24 (T) is a free discriminator**, and both directions are measured: trigger 1 faulted executing an instruction (`psr=0xa1000000`, T set), trigger 2 faulted entering ARM state (`psr=0x00000000`, T clear).
- **`lr` is trustworthy only when the fault is AT a call.** Trigger 2's resolved to the calling line; trigger 1's was a stale leftover pointing at `chThdSleep`, nowhere near the bug. ARMv6-M stacks no call chain, so this is never a backtrace.
- **`addr2line` maps a DATA address to a symbol and it reads like an answer** — trigger 2's `pc=0x20000000` resolved to `__overlay_pool_base__`. Check the range first: code is `0x10……`, SRAM is `0x20……`.

## What testing found

**Trigger 6 did nothing at all, silently.** The unaligned store was written as a compile-time constant, so GCC could see the misalignment and **legalised** the `volatile uint32_t` store into four `strb` — which never fault on ARMv6-M. Core1 wrote the bytes and carried on. That is the rule `CLAUDE.md` already carried for `crash_test.c`, broken one file over, and by a different mechanism than the one documented there: not *deletion* (UB removed) but *legalisation* (UB made harmless). A deleted store leaves no instructions to find; a legalised one leaves plausible-looking code that cannot fault. Laundered through a volatile now, and checked in the disassembly rather than the source.

**Trigger 7 faulted and rebooted the slave, and nothing was ever reported.** Two independent ways that record vanishes, **both pre-existing and neither specific to the crash test**:

- A pull that lands **before the slave has archived** counted as done. `crash_record_note_slave()` returns true for an empty reply too — it clears the master's cached copy — so testing it alone ended the pull for that link-up with nothing reported, and an empty reply is exactly what a still-rebooting slave answers. Only `CRASH_HID_FLAG_PRESENT` ends it now.
- The slave's line was printed **exactly once**, so a single dropped console read lost it permanently. The master's own line survives that because the boot banner repeats it; the slave's arrives long after those repeats have stopped, which is why it is not in the banner. It schedules its own repeats now, safe because the host dedupes identical lines — the property the banner already relies on.

The pull also no longer depends on the master *observing* the reboot as a link drop: whether it does depends on `SPLIT_MAX_CONNECTION_ERRORS` (200) accumulating before the slave is back, which is a race. A bounded 30 s forced window covers it. ⚠️ Do not "re-arm" by clearing `s_tries` at request time — that was tried first and is worse than the bug: with the link still reading connected it spends all three ordinary tries into a half-rebooted slave and then gives up forever.

## Version bump label

`bump:minor` — new (test-only) build flag plus two behavioural fixes to the crash-record pull. Set on the PR at open.

## Testing
- [x] Compiled successfully — `split72` pack + crash-test flavours and `split42` all link
- [x] Flashed and tested on hardware — all 7 triggers produce a correct record, verified against a byte-identical rebuild of the delivered `.bin`
- [x] No protocol change

Verified in the compiled image, not the source: the core1 fault site is a single `str` with the address reloaded from the volatile (`ldr r4,[r2]` → `str r3,[r4,#0]`), zero `strb` on that path.

Host side: [thpoll83/PolyKybdHost#214](https://github.com/thpoll83/PolyKybdHost/pull/214) (independent — no protocol change, neither PR needs the other).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NJRRmozniHP9cr1i8fcwFr

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJRRmozniHP9cr1i8fcwFr)_

## Summary by Sourcery

Add an opt-in hardware crash-test suite and harden slave crash-record retrieval and reporting.

New Features:
- Add an opt-in crash-test build that triggers representative fault, watchdog, unhandled-exception, core1, and slave crash-record paths from a keyboard chord.

Bug Fixes:
- Prevent incomplete slave replies from prematurely ending crash-record pulls.
- Make slave crash records resilient to dropped console reads by repeating their output.
- Use a bounded forced retry window for test-triggered slave reboot recovery.

Enhancements:
- Ensure deliberate fault stores remain genuine faulting word stores across compiler optimization and provide test-build diagnostics.

Build:
- Add the POLYKYBD_CRASH_TEST build flag and test-only source integration without affecting normal builds.

Documentation:
- Document the crash-test triggers, hardware validation findings, and interpretation of captured fault-record fields.

Tests:
- Validate all seven crash scenarios on hardware, including core1 and slave fault paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in crash-testing mode with seven keyboard-triggered fault scenarios, including main-processor, secondary-core, interrupt, hang, and split-device faults.
  * Added crash-test announcements and improved reporting of secondary-device crash records, including repeated output when needed.
* **Bug Fixes**
  * Improved reliability of crash-record retrieval and display after split-device recovery.
* **Documentation**
  * Documented crash-testing procedures, available triggers, expected diagnostics, and hardware verification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->