### PR TITLE
fix: host's unicode-mode push changed only the keycap legend, not the mode (+ a volatile mode, protocol 17)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1640,6 +1640,25 @@ keycode; `process_record_user()` calls it last, before `display_wakeup()`.
   `data[2]` id, `data[3]` 0xFF query else length, `data[4..]` text). All three sit
   behind ONE host feature gate — a host that could read the info header but not the
   bodies would render an editor over data it cannot fetch. See "Dynamic macros" below.
+  **v17** adds the **VOLATILE flag** to `SET_UNICODE_MODE` (cmd `20`, `data[3]`):
+  non-zero applies the mode in RAM only, leaving EEPROM alone. It exists because at
+  Windows logon the host cannot tell "WinCompose is not installed" from "WinCompose
+  has not started yet" — so it applies its early reading volatile (plain `Windows`
+  IS how the keyboard should type while WinCompose is absent) and re-asserts it
+  persistently once it can tell the two apart. Without it, every logon on a
+  WinCompose machine wrote `Windows` and then `WinCompose` back over it.
+  ⚠️ **The wire change is backwards-compatible in one direction only.** An older
+  HOST sends a zero-padded report, so `data[3]` reads 0 = persist — fine. An older
+  FIRMWARE ignores `data[3]` and would silently STORE a mode the caller asked not to
+  store, which is precisely the transient value the flag exists to keep out of
+  EEPROM — so the host gates it (`FEATURE_MIN_PROTOCOL["unicode_mode_volatile"]`) and
+  falls back to withholding the ambiguous reading entirely.
+  ⚠️ QMK has **no `set_unicode_input_mode_noeeprom()`**; `unicode_config` is `extern`
+  and `unicode_input_mode_set_kb()` is the notification the keycap legend rides on,
+  so `apply_unicode_mode()` in `hid_com.c` is the persisting path minus one call —
+  **no upstream patch**. Note the persisting path never needed help: QMK's
+  `eeprom_update_byte` already skips a write when the byte matches, so re-asserting
+  the SAME mode has always been free; only the transient wrong value is new.
   **Bump `FW_VERSION` +
   `PROTOCOL_VERSION` (config.h) and `__protocol__` (PolyKybdHost `_version.py`) in
   lockstep.** ⚠️ The old note here said "the host connect gate is exact-match"; it is

--- a/keyboards/polykybd/config.h
+++ b/keyboards/polykybd/config.h
@@ -223,7 +223,7 @@
 //      only and live in the `latinbig` font-pack bundle; without it (or for a
 //      non-latin legend) the render falls back to small, so the setting is
 //      always safe to accept.
-#define PROTOCOL_VERSION 16
+#define PROTOCOL_VERSION 17
 
 #define FULL_BRIGHT 50
 #define MIN_BRIGHT 1

--- a/keyboards/polykybd/hid_com.c
+++ b/keyboards/polykybd/hid_com.c
@@ -167,6 +167,34 @@ bool legacy_command_kb(uint8_t *data, uint8_t length) {
 
 // Handles HID commands: device ID, language change, overlay reception, mapping, and display control.
 // Global variables: hid_keycode, hid_modifier, hid_roi, hid_bit_index, hid_bit_index_bridge
+/**
+ * Apply a unicode input mode, optionally WITHOUT writing it to EEPROM.
+ *
+ * QMK's set_unicode_input_mode() always persists, and there is no noeeprom
+ * variant — but `unicode_config` is extern and unicode_input_mode_set_kb() is
+ * the notification the keycap legend rides on, so the volatile half is the
+ * persisting one minus a single call. No upstream patch.
+ *
+ * Why volatile exists: at Windows logon the host races WinCompose's own
+ * autostart, and an absent wincompose.exe is equally consistent with "not
+ * installed" and "not started yet". The host therefore applies its early
+ * reading volatile and re-asserts it persistently once it can tell the two
+ * apart. Without this, every logon on a WinCompose machine wrote Windows and
+ * then WinCompose back over it — two EEPROM writes to end where it started.
+ *
+ * NOTE the persisting path is unchanged: eeprom_update_byte() already skips a
+ * write when the byte matches, so re-asserting the SAME mode has always been
+ * free. It is only the transient wrong value that this avoids storing.
+ */
+static void apply_unicode_mode(uint8_t mode, bool persist) {
+    if (persist) {
+        set_unicode_input_mode(mode);
+        return;
+    }
+    unicode_config.input_mode = mode;
+    unicode_input_mode_set_kb(mode);
+}
+
 void raw_hid_receive(uint8_t *data, uint8_t length) {
     // Board name in the GET_ID reply — each variant header (QMK_KEYBOARD_H) may
     // define POLY_KB_NAME; default to "Split72" so split72 (which doesn't define
@@ -699,29 +727,37 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                 // report: the legend read "Win ON" at startup while emoji still went out
                 // as WinCompose sequences, and pressing the Win key (the real setter)
                 // was what finally made them agree and broke emoji.
+                //
+                // data[3] (protocol 17+) is the VOLATILE flag: non-zero applies the
+                // mode in RAM only. It exists because at Windows logon the host
+                // cannot tell "WinCompose is not installed" from "WinCompose has not
+                // started yet" — see apply_unicode_mode() below. An older host sends
+                // a zero-padded report, so data[3] is 0 = persist, which is the
+                // behaviour it expects.
+                const bool persist = (data[HID_DATA_IDX + 1] == 0);
                 switch(data[HID_DATA_IDX]) {
                     case 0: //Linux = 0
-                        set_unicode_input_mode(UNICODE_MODE_LINUX);
+                        apply_unicode_mode(UNICODE_MODE_LINUX, persist);
                         memset(data, 0, length);
                         hid_reply(data, 0x14, true);
                         break;
                     case 1: //Mac = 1
-                        set_unicode_input_mode(UNICODE_MODE_MACOS);
+                        apply_unicode_mode(UNICODE_MODE_MACOS, persist);
                         memset(data, 0, length);
                         hid_reply(data, 0x14, true);
                         break;
                     case 2: //Windows = 2
-                        set_unicode_input_mode(UNICODE_MODE_WINDOWS);
+                        apply_unicode_mode(UNICODE_MODE_WINDOWS, persist);
                         memset(data, 0, length);
                         hid_reply(data, 0x14, true);
                         break;
                     case 3: //WinCompose = 3
-                        set_unicode_input_mode(UNICODE_MODE_WINCOMPOSE);
+                        apply_unicode_mode(UNICODE_MODE_WINCOMPOSE, persist);
                         memset(data, 0, length);
                         hid_reply(data, 0x14, true);
                         break;
                     case 4: //BSD = 4
-                        set_unicode_input_mode(UNICODE_MODE_BSD);
+                        apply_unicode_mode(UNICODE_MODE_BSD, persist);
                         memset(data, 0, length);
                         hid_reply(data, 0x14, true);
                         break;

--- a/keyboards/polykybd/hid_com.c
+++ b/keyboards/polykybd/hid_com.c
@@ -690,29 +690,38 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
                 }
                 break;
             case 20: //set unicode input mode
+                // set_unicode_input_mode() is the SETTER. unicode_input_mode_set_user()
+                // is the notification CALLBACK QMK fires from it, and our override
+                // (poly_keymap.c) only mirrors the value into local_state->unicode_mode
+                // for the keycap legend — so calling it directly relabelled the language
+                // layer's Win/WinC/Lnx keys while unicode_config.input_mode, which
+                // decides how codepoints are actually typed, kept its old value. Field
+                // report: the legend read "Win ON" at startup while emoji still went out
+                // as WinCompose sequences, and pressing the Win key (the real setter)
+                // was what finally made them agree and broke emoji.
                 switch(data[HID_DATA_IDX]) {
                     case 0: //Linux = 0
-                        unicode_input_mode_set_user(UNICODE_MODE_LINUX);
+                        set_unicode_input_mode(UNICODE_MODE_LINUX);
                         memset(data, 0, length);
                         hid_reply(data, 0x14, true);
                         break;
                     case 1: //Mac = 1
-                        unicode_input_mode_set_user(UNICODE_MODE_MACOS);
+                        set_unicode_input_mode(UNICODE_MODE_MACOS);
                         memset(data, 0, length);
                         hid_reply(data, 0x14, true);
                         break;
                     case 2: //Windows = 2
-                        unicode_input_mode_set_user(UNICODE_MODE_WINDOWS);
+                        set_unicode_input_mode(UNICODE_MODE_WINDOWS);
                         memset(data, 0, length);
                         hid_reply(data, 0x14, true);
                         break;
                     case 3: //WinCompose = 3
-                        unicode_input_mode_set_user(UNICODE_MODE_WINCOMPOSE);
+                        set_unicode_input_mode(UNICODE_MODE_WINCOMPOSE);
                         memset(data, 0, length);
                         hid_reply(data, 0x14, true);
                         break;
                     case 4: //BSD = 4
-                        unicode_input_mode_set_user(UNICODE_MODE_BSD);
+                        set_unicode_input_mode(UNICODE_MODE_BSD);
                         memset(data, 0, length);
                         hid_reply(data, 0x14, true);
                         break;

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -4651,7 +4651,13 @@ bool display_wakeup(keyrecord_t* record) {
     return accept_keypress;
 }
 
-// Updates local unicode input mode state and requests display refresh on mode change.
+// QMK's notification CALLBACK, fired from set_unicode_input_mode() /
+// unicode_input_mode_init() / the cycle keys. It mirrors the mode into the synced
+// state so the language layer's Mac/Lnx/Win/WinC/BSD keycaps can draw their ON/OFF
+// switch, and nothing else.
+// WARNING: never call this to CHANGE the mode — it does not touch
+// unicode_config.input_mode, so the keycaps would advertise a mode the keyboard
+// does not type in. Use set_unicode_input_mode() (see hid_com.c case 20).
 void unicode_input_mode_set_user(uint8_t unicode_mode) {
     access_local_state()->unicode_mode = unicode_mode;
     request_disp_refresh();


### PR DESCRIPTION
## Summary

HID cmd 20 (set unicode input mode) called `unicode_input_mode_set_user()`. That is QMK's notification **callback**, not the setter — our override of it in `poly_keymap.c` does exactly one thing: mirror the value into `local_state->unicode_mode` so the language layer's Mac/Lnx/Win/WinC/BSD keycaps can draw their ON/OFF switch. `unicode_config.input_mode`, which decides how codepoints are actually typed, was never touched.

So a host push relabelled those keys and changed nothing else. Reported from the field: at startup the language layer showed **Win ON** while emoji still worked — i.e. the keyboard was really in WinCompose mode — and pressing the Win key, the one path that goes through the real setter, made behaviour follow the legend and broke emoji.

The fix is `set_unicode_input_mode()`, which sets `unicode_config.input_mode`, persists it, and *then* fires the callback, so the legend and the behaviour cannot disagree. `unicode_input_mode_set_user()` is now documented as a callback that must never be called to change the mode.

### A volatile mode (cmd 20 `data[3]`, protocol 17)

At Windows logon the host cannot tell **"WinCompose is not installed"** from **"WinCompose has not started yet"** — an absent `wincompose.exe` is the same observation either way. That left it choosing between storing a reading it could not trust and withholding one that was probably right, so every logon on a WinCompose machine wrote `Windows` and then `WinCompose` back over it: two EEPROM writes and a keycap flicker to end where it started.

`data[3]` non-zero now applies the mode in **RAM only**. The host applies its early reading volatile — while WinCompose is absent, plain `Windows` genuinely *is* how the keyboard should type, so applying it is correct — and re-asserts it persistently once the logon window closes. If WinCompose turns up first, the stored mode was never disturbed.

- QMK has **no `set_unicode_input_mode_noeeprom()`**, but `unicode_config` is `extern` and `unicode_input_mode_set_kb()` is the notification the keycap legend rides on, so `apply_unicode_mode()` is the persisting path minus one call. **No upstream patch.**
- The persisting path is unchanged and never needed help: `eeprom_update_byte` already skips a write when the byte matches, so re-asserting the **same** mode has always been free. Only the transient wrong value is new.
- ⚠️ **The wire change is backwards-compatible in one direction only.** An older *host* sends a zero-padded report, so `data[3]` reads 0 = persist. An older *firmware* ignores `data[3]` and would silently **store** a mode the caller asked not to store — exactly the value the flag exists to keep out of EEPROM — so the host gates it on protocol 17 and falls back to withholding the ambiguous reading.

### Why the host also needed a fix

The wrong value came from the host: at logon autostart brings PolyKybdHost up before WinCompose, so its one-shot probe finds no `wincompose.exe` and pushes plain Windows. That half is thpoll83/PolyKybdHost#220, which also drives the volatile flag.

⚠️ **Release ordering matters.** This firmware fix alone, against a host that still loses that race, makes the startup symptom *worse*: the wrong "Windows" push would then actually take effect, so emoji would be broken at startup rather than merely mislabelled. Ship the host release first, or both together. The reverse order is harmless — a fixed host talking to old firmware gates the volatile path off and falls back to holding.

## Version bump label

**`bump:minor`** — applied. ⚠️ Deliberately **not** `bump:protocol`: `PROTOCOL_VERSION` is bumped 16 → 17 **in-source** here, so the label would double-bump it.

## Testing
- [x] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`, and `split42`)
- [ ] Flashed and tested on hardware
- [x] If protocol changed: `PROTOCOL_VERSION` 16 → 17 in `config.h`, `__protocol__` 16 → 17 in the host, gated as `FEATURE_MIN_PROTOCOL["unicode_mode_volatile"]`, documented in `CLAUDE.md`

Not verifiable from a container: the behaviour change is what the keyboard *types*, so it needs a hardware round. What to look for — with the host fix in place, the language layer should read **WinC ON** at startup and emoji should keep working; selecting WinC explicitly should now be a no-op rather than a state change. For the volatile half: after a logon, the mode should end up **WinCompose** with no visible mid-boot change beyond a single early Win→WinC correction, and a power cycle should come back on the mode the keyboard settled on.

⚠️ `HIL test (split72)` has been queued since 07:34Z without starting — the rig runner looks offline, not a failure of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGvdTNMVqudn5m5TFpS1yE