### PR TITLE
docs: the *_set_user setter trap, the never-started HIL job, and an add-gated-hid-command skill

### DIFF
--- a/.claude/skills/add-gated-hid-command/SKILL.md
+++ b/.claude/skills/add-gated-hid-command/SKILL.md
@@ -101,8 +101,11 @@ make test:<name>
 - **Pin the payload BYTES** in `poly_kybd_cmd_test.py` (`self._payload(...)[:4]`),
   including the flag byte's legacy value — that is the only test that catches the
   host and firmware disagreeing about the wire.
-- **Pin the GATE** in `poly_kybd_capabilities_test.py`: the threshold, a refusal
-  below it, and that the *unflagged* form still works below it.
+- **Pin the GATE** in `poly_kybd_capabilities_test.py`: the threshold, and a
+  refusal below it. ⚠️ When you added a FLAG to an existing command, also pin that
+  the **unflagged** form still works below the threshold — the gate is on the flag,
+  not on the command, which is ancient. A brand-new command has no unflagged form:
+  there, everything below the threshold refuses.
 - **Mutation-test** what you added (`mutation-test-suite`). A gate that is never
   exercised is a gate that does not exist.
 

--- a/.claude/skills/add-gated-hid-command/SKILL.md
+++ b/.claude/skills/add-gated-hid-command/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: add-gated-hid-command
+description: Add a new PolyKybd HID command, or a new flag byte on an existing one, end to end across the firmware and the host — the `PROTOCOL_VERSION` bump, the `FEATURE_MIN_PROTOCOL` gate, the device/core/RPC/CLI/GUI wiring, tests on both sides, both-variant builds, the CLAUDE.md protocol entry, and the right bump label. Use when asked to "add a HID command", "add cmd NN", "let the host set/read X on the keyboard", "add a flag to cmd NN", "bump the protocol", or whenever a host feature needs the firmware to do something it cannot do today. NOT for a host-only change (no firmware round trip), NOT for the overlay/font-pack bulk transports (those are dispatched independently of the protocol version), and NOT for changing what an existing command already does without a wire change.
+---
+
+# Add a protocol-gated HID command or flag
+
+The host connects across a **range** of firmware protocols and disables features
+individually, so every device-facing command needs a gate. The rules are real and
+enumerated — in `keyboards/polykybd/CLAUDE.md` ("Every new device-facing command
+MUST be version-gated — no exceptions") and in `PolyKybdHost/CLAUDE.md` — but they
+live in prose in two files, and the firmware CLAUDE.md notes the gate "has been
+forgotten twice". This skill is the checklist.
+
+An **ungated** command does not fail cleanly: it connects, then NACKs at runtime on
+an older keyboard, instead of greying out its menu entry.
+
+## 0. Decide the shape first
+
+| You want | Shape | Protocol bump? |
+|---|---|---|
+| A new command the firmware has never had | new `case NN` | **yes**, and a `supports()` gate |
+| A new flag/byte on an existing command | extra payload byte | **yes** — an old firmware IGNORES it, which is the dangerous direction |
+| A new *value* in an already open-ended set (e.g. another glyph script) | none | **no** — see `GlyphScript`, deliberately open |
+| Bulk overlay / font-pack / profiler traffic | dispatched independently | **no** |
+
+⚠️ **Open vs closed ranges are a real design decision, not a default.** An unknown
+`GlyphScript` index is accepted and degrades to the normal legend, which is what
+lets the host offer faces a keyboard lacks. An unknown `GlyphSize` is NACKed,
+because it would otherwise persist as a setting that silently renders small.
+`tests/device/poly_kybd_capabilities_test.py` pins that contrast on purpose.
+
+⚠️ **A new payload byte is backwards-compatible on the wire in ONE direction only.**
+The host zero-pads every report (`hid_helper.send`), so an old *host* sends 0 and
+an old *firmware* reads 0 — fine if you choose 0 to mean the legacy behaviour. But
+an old *firmware* also **ignores** your new byte and does the legacy thing while
+the caller believes otherwise. That asymmetry is why the flag is gated even though
+the wire is compatible. Worked example: cmd 20's VOLATILE flag (protocol 17), where
+an old firmware would have **persisted** a mode the caller explicitly asked not to
+store.
+
+## 1. Firmware (`qmk_firmware`)
+
+```bash
+export QMK_HOME=$PWD && export PATH="/root/.qmk_venv/bin:$PATH"   # container: qmk is off PATH
+```
+
+1. `keyboards/polykybd/hid_com.c` — add the `case NN:` (or read the new byte).
+   Reply with `hid_reply(data, NN, ok)` + `raw_hid_send`; NACK an out-of-range value
+   unless the range is deliberately open.
+2. `keyboards/polykybd/config.h` — `PROTOCOL_VERSION` += 1.
+3. If it needs to reach the **slave**, bridge it and check the ack with
+   `sync_succeeded()` — never bool-test `send_to_bridge()`, every return is non-zero.
+4. If it persists, add the field to `poly_eeconf_t` / `poly_sync_t` and follow the
+   suspend-only dirty-flag model — no direct EEPROM write, and note that
+   `eeprom_update_byte` already skips an unchanged value.
+5. Build **both** variants — `config.h` is shared:
+
+```bash
+qmk compile -kb polykybd/split72 -km default && qmk compile -kb polykybd/split42 -km default
+```
+
+⚠️ Never run two `qmk compile` at once — they share one `.build/` tree and the
+collision presents as a bogus `undefined reference`.
+
+## 2. Host (`PolyKybdHost`)
+
+1. `polyhost/device/command_ids.py` — the `Cmd` entry (and any enum the payload uses).
+2. `polyhost/device/poly_kybd.py` —
+   - a `<FEATURE>_MIN_PROTOCOL = N` constant **with a comment saying what it gates**,
+   - the `FEATURE_MIN_PROTOCOL["<feature>"]` entry,
+   - the getter/setter, guarded by `self.supports("<feature>")` returning a
+     "firmware too old" `(False, msg)` — not an exception.
+3. `polyhost/_version.py` — `__protocol__` = the same N.
+4. `polyhost/device/poly_kybd_mock.py` — mirror the signature, or every mock-backed
+   test breaks on the new keyword.
+5. `polyhost/core/poly_core.py` — the core method (`_device_call` for a read,
+   `worker.submit` for fire-and-forget).
+6. `polyhost/server/protocol.py` + `control_server.py` — the `M_*` method,
+   `polyhost/client/remote_core.py` — the mirror. **A daemon-mode GUI is a client, so
+   anything not mirrored is unreachable out of the box.**
+7. `polyhost/cli/polyctl.py` — the subcommand.
+8. `polyhost/host.py` — the menu entry, gated on `self.supports("<feature>")`.
+
+⚠️ **`keeb.supports()` lazily does device I/O** (`query_version_info()` when
+`protocol_version` is unset). Anywhere off the worker — a background thread, the
+no-I/O status snapshot — use the pure `protocol_supports(self.keeb.protocol_version,
+"<feature>")` instead.
+
+## 3. Tests (both sides, and the wire byte)
+
+```bash
+# host
+.venv/bin/python -m unittest tests.device.poly_kybd_cmd_test \
+    tests.device.poly_kybd_capabilities_test tests.core.<your>_test
+xvfb-run -a .venv/bin/python scripts/run_tests.py --timeout 240   # full suite, 65-90 s
+# firmware, if the logic is pure enough to extract (see base/fw_up_verdict.c)
+make test:<name>
+```
+
+- **Pin the payload BYTES** in `poly_kybd_cmd_test.py` (`self._payload(...)[:4]`),
+  including the flag byte's legacy value — that is the only test that catches the
+  host and firmware disagreeing about the wire.
+- **Pin the GATE** in `poly_kybd_capabilities_test.py`: the threshold, a refusal
+  below it, and that the *unflagged* form still works below it.
+- **Mutation-test** what you added (`mutation-test-suite`). A gate that is never
+  exercised is a gate that does not exist.
+
+## 4. Land it
+
+- `CLAUDE.md` (firmware) — append a `**vN** adds …` paragraph to the HID protocol
+  list, saying what the command does, which direction the compatibility runs, and
+  anything a reader would otherwise re-derive.
+- ⚠️ **Label `bump:minor` (or whatever fits) at OPEN, and NOT `bump:protocol`** when
+  you bumped `PROTOCOL_VERSION` in-source — the label would double-bump it. A label
+  applied later races the merge and loses; `create_pull_request` cannot set labels,
+  so follow it immediately with `issue_write` + `labels:`.
+- **Ship the two repos together**, and say so in both PR bodies. Which order is safe
+  depends on the change; work it out explicitly rather than assuming.
+
+## Verify before you call it done
+
+```bash
+grep -n "PROTOCOL_VERSION" keyboards/polykybd/config.h        # firmware N
+grep -n "__protocol__" ../PolyKybdHost/polyhost/_version.py   # host N — must match
+grep -n "<feature>" ../PolyKybdHost/polyhost/device/poly_kybd.py   # constant + table + guard
+```
+
+## Pitfalls
+
+- **The gate is the easy thing to forget** — it is also the whole point. A command
+  without a `FEATURE_MIN_PROTOCOL` entry connects and then NACKs at runtime.
+- **Forgetting `__protocol__` no longer rejects the keyboard**, which is worse than
+  the old behaviour: it silently leaves the feature disabled and pins the status to
+  "update the host app".
+- **A `RemoteCore` mirror is not optional.** Daemon-by-default means the tray is a
+  client; an un-mirrored method is missing for every normal user and present for you.
+- **Don't bump the protocol for a new value in an open-ended set.** Check whether the
+  firmware already accepts unknown values in that range before adding a version.
+- **Don't add a getter that returns a cached value** where the caller means "what is
+  running right now" — `polyctl fw version` was a cache once, and it lied straight
+  after a flash.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,9 +323,9 @@ For cross-repo context (how this repo relates to `PolyKybdHost/` and `AdafruitGF
 
 ## Mirrored skills (`qmk_firmware` ↔ `PolyKybdHost`)
 
-Four skills exist in **both** repos and are kept **byte-identical**:
-`mutation-test-suite`, `polykybd-github-release`, `session-retro`,
-`update-polykybd-docs`. A skill loads only from the repos a session has attached,
+Five skills exist in **both** repos and are kept **byte-identical**:
+`add-gated-hid-command`, `mutation-test-suite`, `polykybd-github-release`,
+`session-retro`, `update-polykybd-docs`. A skill loads only from the repos a session has attached,
 so one that describes cross-repo work is unreachable from a session opened on the
 other repo alone — which is what happened to `mutation-test-suite`, extended to
 cover Python/unittest suites while living only in the firmware repo.
@@ -341,7 +341,7 @@ because a skill has no build, no test and no reviewer.
 **So the rule is copy, never fork**: edit one, `cp` it to the other, and check with
 
 ```bash
-for s in mutation-test-suite polykybd-github-release session-retro update-polykybd-docs; do
+for s in add-gated-hid-command mutation-test-suite polykybd-github-release session-retro update-polykybd-docs; do
     cmp -s /home/user/qmk_firmware/.claude/skills/$s/SKILL.md \
            /home/user/PolyKybdHost/.claude/skills/$s/SKILL.md \
       && echo "$s: ok" || echo "$s: DRIFTED"
@@ -988,6 +988,26 @@ inherited-upstream noise:
     would analyse the whole upstream QMK tree — the same trap as the
     lint-on-upstream-keyboards problem below. The host repo runs CodeQL instead,
     where Python needs no build and the tree is entirely ours.
+- ⚠️ **A HIL job that never STARTS is a different state from a red one, it alerts
+  nobody, and it blocks the RELEASE gate hours later.** When the self-hosted rig
+  runner is offline, `HIL test (split72)` sits `status: queued` with no
+  `conclusion`, no log, no annotation and no timeout — the PR board shows a
+  spinner, not a failure, so nothing about it looks wrong. Measured 2026-09-08:
+  queued 07:34Z, still queued when the PR merged at 12:10Z, 4.5 hours later.
+  `diagnose-hil-failure` classifies a RED check and has nothing to say about this.
+  Two consequences:
+  - **Read `status` before `conclusion`.** An in-progress or queued run has **no
+    `conclusion` key at all** (the same trap the `actions_list` note below
+    records), so "not failed" is not "passed". A job whose `started_at` is hours
+    old and whose status is still `queued` was never picked up by a runner.
+  - ⚠️ **It silently arms a release refusal.** The FW-APPLY tier runs on every push
+    to `PolyKybd`, so an offline rig means the merge's own apply run hangs too —
+    and `tools/require_fwapply_run.py` refuses to publish a release the apply tier
+    has not covered. The failure surfaces at publish time, on a commit that looked
+    fine when it merged. The recovery is the one that note already prescribes:
+    dispatch *Build and HIL Test* with `tier: fwapply` on the right ref once the
+    rig is back, and remember the ref rules there (the branch tip only works while
+    it IS the release commit; otherwise dispatch on the tag).
 - **A change that cannot alter the firmware does NOT run the build or the rig —
   `qmk-test.yml` path-filters both its `push` and `pull_request` triggers.** Markdown
   since 2026-08-21, then `scripts/` and `.claude/`, then the sibling workflow files
@@ -1659,6 +1679,21 @@ keycode; `process_record_user()` calls it last, before `display_wakeup()`.
   **no upstream patch**. Note the persisting path never needed help: QMK's
   `eeprom_update_byte` already skips a write when the byte matches, so re-asserting
   the SAME mode has always been free; only the transient wrong value is new.
+  ⚠️ **A QMK `*_set_user` hook is a NOTIFICATION, never a setter — and calling one
+  to CHANGE state fails in the quietest possible way: the UI moves and the
+  behaviour does not.** `unicode_input_mode_set_user()` is what QMK fires *from*
+  `set_unicode_input_mode()`, and our override of it (`poly_keymap.c`) does exactly
+  one thing: mirror the value into `local_state->unicode_mode` so the language
+  layer's Mac/Lnx/Win/WinC/BSD keycaps can draw their ON/OFF switch. Cmd 20 called
+  it directly for years, so a host push relabelled those keys while
+  `unicode_config.input_mode` — which decides how codepoints are actually typed —
+  never moved. Field report 2026-09-08: the layer read **Win ON** at startup while
+  emoji still worked (i.e. the keyboard was really in WinCompose mode), and pressing
+  the Win key — the one path through the real setter — made behaviour follow the
+  legend and broke emoji. **The tell is a state whose display and effect disagree**;
+  when you find one, check whether the write went through the setter or the
+  callback. The same shape applies to every `*_set_user` QMK exposes, so grep for
+  one being called rather than implemented.
   **Bump `FW_VERSION` +
   `PROTOCOL_VERSION` (config.h) and `__protocol__` (PolyKybdHost `_version.py`) in
   lockstep.** ⚠️ The old note here said "the host connect gate is exact-match"; it is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -996,10 +996,11 @@ inherited-upstream noise:
   queued 07:34Z, still queued when the PR merged at 12:10Z, 4.5 hours later.
   `diagnose-hil-failure` classifies a RED check and has nothing to say about this.
   Two consequences:
-  - **Read `status` before `conclusion`.** An in-progress or queued run has **no
-    `conclusion` key at all** (the same trap the `actions_list` note below
-    records), so "not failed" is not "passed". A job whose `started_at` is hours
-    old and whose status is still `queued` was never picked up by a runner.
+  - **Read `status` before `conclusion`.** An unfinished run carries no verdict in
+    either shape: the MCP `actions_list` response omits `conclusion` entirely (the
+    trap the note below records), while the REST API returns `"conclusion": null`.
+    So "not failed" is never "passed" — and a job whose `started_at` is hours old
+    while its status is still `queued` was never picked up by a runner at all.
   - ⚠️ **It silently arms a release refusal.** The FW-APPLY tier runs on every push
     to `PolyKybd`, so an offline rig means the merge's own apply run hangs too —
     and `tools/require_fwapply_run.py` refuses to publish a release the apply tier


### PR DESCRIPTION
## Summary

Documentation and tooling only — no firmware change. Three things carried out of the unicode-input-mode session (#278).

**A QMK `*_set_user` hook is a NOTIFICATION, never a setter**, and calling one to change state fails in the quietest way available: the UI moves and the behaviour does not. That was the whole of #278 — cmd 20 relabelled the language layer's Win/WinC/Lnx keycaps while `unicode_config.input_mode` never moved, so the board read **Win ON** at startup while emoji still worked. The tell worth remembering is a state whose *display and effect disagree*; when you see one, check whether the write went through the setter or the callback. It applies to every `*_set_user` QMK exposes, so the note says to grep for one being **called** rather than implemented.

**A HIL job that never STARTS is a different state from a red one.** With the rig runner offline, `HIL test (split72)` sits `status: queued` with no conclusion, no log, no annotation and no timeout — the board shows a spinner, not a failure. Measured on #278: queued 07:34Z, still queued when it merged at 12:10Z, 4.5 hours later. `diagnose-hil-failure` classifies a red check and has nothing to say about this. Two consequences are recorded: read `status` before `conclusion` (a queued run has no `conclusion` key at all), and note that it **silently arms a release refusal** — the FW-APPLY tier runs on every push to `PolyKybd`, so an offline rig means the merge's own apply run hangs too and `require_fwapply_run.py` will refuse to publish until a green apply run covers that commit.

**New skill `add-gated-hid-command`** — the end-to-end checklist for adding a HID command, or a flag byte on an existing one, across firmware and host: the `PROTOCOL_VERSION` bump, the `FEATURE_MIN_PROTOCOL` gate, the device/core/RPC/CLI/GUI wiring (including the `RemoteCore` mirror, without which a daemon-mode tray cannot reach the feature at all), tests that pin both the wire bytes and the gate, both-variant builds, and `bump:minor` rather than `bump:protocol` when the protocol is bumped in-source. It also records the shape table for when a bump is *not* needed, and the one-directional wire compatibility trap that made cmd 20's VOLATILE flag need a gate despite a zero-padded report being harmless.

This file already notes that the version gate "has been forgotten twice", which is the argument for having the checklist somewhere other than prose.

⚠️ Mirrored byte-identically into `PolyKybdHost` (thpoll83/PolyKybdHost#222) and added to the mirrored-skills drift check, four → five. The check passes on all five.

## Version bump label

*(none)* — documentation and a skill; nothing that ships in the image.

## Testing
- [x] Compiled successfully (`qmk compile -kb polykybd/split72 -km default`) — n/a, no source change; the last build on this branch's parent was green for both variants
- [ ] Flashed and tested on hardware — n/a
- [x] If protocol changed: n/a — no protocol change

Verified instead: every note greps back by name after the scripted edit (the trap this file records about `s.replace` silently dropping text between anchors), and the five mirrored skills `cmp` clean across both repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGvdTNMVqudn5m5TFpS1yE

## Summary by Sourcery

Document QMK setter-hook pitfalls and never-started HIL jobs, and add a mirrored checklist for safely extending the HID protocol.

New Features:
- Add an end-to-end skill for introducing protocol-gated HID commands or flags across firmware and host tooling.

Enhancements:
- Document the distinction between QMK *_set_user notification hooks and state-setting APIs.
- Document how queued, never-started HIL jobs differ from failed checks and can block release publication.

Documentation:
- Update the mirrored-skills documentation and drift check to include the new skill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for implementing protocol-gated HID commands and flag bytes across firmware, host tools, testing, and protocol documentation.
  * Expanded contributor documentation with skill synchronization guidance.
  * Documented release-gate risks when hardware-in-the-loop jobs remain queued.
  * Clarified that QMK `*_set_user` hooks provide notifications rather than setters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->