### PR TITLE
Settings-layer RGB: gate the irreversible keys, make the effect presets work, rescale the value percent

### DIFF
--- a/keyboards/polykybd/base/disp_array.c
+++ b/keyboards/polykybd/base/disp_array.c
@@ -828,6 +828,17 @@ static void gfx_text_run(const GFXfont *const *fonts, uint8_t num_fonts, int8_t 
                             //   face. See s_mid_font above for why it is a single-font array.
                 mid = true;
                 break;
+            case U'\x17':   // BASE: back to the full-size caller pool for the REST of the
+                            //   string, i.e. the one op that UNDOES \x10 and \x16.
+                            //
+                            //   ⚠️ Both of those latch, and until this existed there was no
+                            //   way out of them: \x10 after \x16 half-scales the mid face
+                            //   rather than returning to the base one, so a small LABEL over
+                            //   a bigger VALUE could not be written at all -- the second line
+                            //   always came out smaller than the first.
+                small = false;
+                mid   = false;
+                break;
             default: {
                 // In a MID run, fall back to the caller's pool for anything the mid
                 // face does not carry. It is ASCII-only, so without this an icon in a

--- a/keyboards/polykybd/base/font_lookup.c
+++ b/keyboards/polykybd/base/font_lookup.c
@@ -131,6 +131,10 @@ static void bbox_walk(const GFXfont *const *fonts, uint8_t num_fonts,
             case U'\x16':                                            // MID: rest of the run is the 19px UI face
                 mid = true;                                          //   (per glyph — see the fallback below)
                 break;
+            case U'\x17':                                            // BASE: undo SMALL/MID for the rest
+                small = false;                                       //   of the run (see disp_array.c)
+                mid   = false;
+                break;
             case U'\x0F':                                            // HALF / THIN composite a glyph at the
             case U'\x11':                                            //   cursor and do not advance
                 if (text[1]) {

--- a/keyboards/polykybd/base/tests/font_bbox_tests.cpp
+++ b/keyboards/polykybd/base/tests/font_bbox_tests.cpp
@@ -368,6 +368,39 @@ TEST_F(FontBboxTest, ANullMidPoolMakesEveryMidGlyphFallBack) {
 }
 
 // ---------------------------------------------------------------------------
+// HINT_BASE (\x17): the one op that UNDOES \x10 and \x16.
+//
+// Both of those latch for the rest of the run and there was no way out of them
+// until this existed — \x10 after \x16 half-scales the mid face rather than
+// returning to the base one — so a small LABEL over a bigger VALUE could not be
+// written at all. That is what the RGB preset keycaps are made of.
+
+TEST_F(FontBboxTest, BaseUndoesSmallForTheRestOfTheRun) {
+    // The glyph AFTER \x17 measures at full size again — derived from a plain 'a'
+    // rather than hardcoded, so the case still means what it says if the synthetic
+    // font's metrics change.
+    EXPECT_EQ(measure({0x10, 'a', 0x17, 'a'}).ymin, measure({'a'}).ymin);
+    // ...and it starts one HALF advance (4 of the font's 8) past the origin, i.e.
+    // the first 'a' was still halved.
+    EXPECT_EQ(measure({0x10, 'a', 0x17, 'a'}).xmax, 4 + measure({'a'}).xmax);
+    // Without the reset the whole run stays halved — the state this op exists to leave.
+    EXPECT_NE(measure({0x10, 'a', 'a'}).ymin, measure({'a'}).ymin);
+}
+
+TEST_F(FontBboxTest, BaseUndoesMid) {
+    EXPECT_EQ(measure_mid({0x16, 'a', 0x17, 'a'}).ymin, measure({'a'}).ymin);
+}
+
+TEST_F(FontBboxTest, BaseAloneChangesNothing) {
+    EXPECT_EQ(measure({0x17, 'a'}), measure({'a'}));
+}
+
+TEST_F(FontBboxTest, SmallAfterMidHalvesTheMidFaceRatherThanReturningToBase) {
+    // ⚠️ The reason HINT_BASE has to exist: this is NOT the base face.
+    EXPECT_FALSE(measure_mid({0x16, 'a', 0x10, 'a'}) == measure_mid({0x16, 'a', 0x17, 'a'}));
+}
+
+// ---------------------------------------------------------------------------
 // The bbox resolves through that same resolver — so a GAP record falls through
 // here too. It did not until 2026-08-29: this function ran its own range scan
 // with no gap check, so a codepoint inside a padded span measured the empty 0x0

--- a/keyboards/polykybd/keycode_helper.c
+++ b/keyboards/polykybd/keycode_helper.c
@@ -70,12 +70,11 @@ static inline const uint32_t* kc_os_gui_icon(void) {
 // RIGHT_*PX live in named_glyphs.h beside HINT_SMALL -- see the note there for
 // why an object-like macro used by a legend cannot live in this file.
 #define RGB_PRESET(right, word)  \
-    HINT_SMALL RIGHT_12PX U"Preset:" U"\r\v" HINT_SMALL right U##word
+    UP_12PX HINT_SMALL RIGHT_12PX U"Preset:" \
+    U"\r\v" DOWN_8PX HINT_BASE HINT_MID right U##word
 
 // The four RGB VALUE keys name their channel with an icon over the spelled-out
-// word, instead of the abbreviation the four-character face forced ("Sat+"). Same
-// two-line shape as the presets: line 1 at the default baseline, line 2 half-scale
-// at +15.
+// word, instead of the abbreviation the four-character face forced ("Sat+").
 //
 // `top` carries the icon and the sign; the sign is the SAME full-size base-font
 // glyph on all four keys, so the row reads as one control family. That is why the
@@ -83,12 +82,26 @@ static inline const uint32_t* kc_os_gui_icon(void) {
 // named_glyphs.h) rather than HINT_SMALL: HINT_SMALL latches for the REST of the
 // run, so it would halve the sign too and give the row two different plus signs.
 //
-// ⚠️ The word is "Bright", not "Brightness": at half scale "Brightness" inks 72px
-// starting at x1, i.e. one column past the 72px panel, and no leading nudge can
-// pull it back (\x08 clamps at the origin). Measured, like every run here, from
-// the rendered ink box rather than from a character count.
-#define RGB_VALUE(top, right, word)  \
-    top U"\r\v" HINT_SMALL right U##word
+// Both legends push their lines to the panel edges — line 1's ink starts at y1
+// and the word's descender lands on row 39 — so the two are as far apart as a
+// 40px keycap allows.
+//
+// ⚠️ `\v` is doing something no other op can here: it is the only one that changes
+// the cursor's PARITY. Every nudge moves 2px, so from an ODD line-1 baseline (19,
+// as high as a full-size '+' can sit) an EVEN line-2 baseline is otherwise
+// unreachable. `\v` steps to the next 15px multiple, i.e. 19 -> 34 exactly.
+//
+// ⚠️ HINT_BASE before HINT_MID is not redundant on the presets: HINT_SMALL is
+// still latched from the label, and HINT_SMALL + HINT_MID is HALF the mid face,
+// not the mid face. Without the reset the second line comes out SMALLER than the
+// first, which is the opposite of the intent.
+//
+// ⚠️ "Sat", not "Saturation": at the mid face "Saturation" measures 97px against a
+// 72px keycap. Even half the keycap face only just fits it (71px of 72), so the
+// full word is exactly as large as it can ever be drawn -- growing the legend and
+// keeping the word were mutually exclusive.
+#define RGB_VALUE(top, down, right, word)  \
+    top U"\r\v" down HINT_BASE HINT_MID right U##word
 
 static const uint32_t* idle_style_legend(void) {
     static const uint32_t* const names[] = { SETTING_LBL("IDLE:", "Pulse"),
@@ -232,18 +245,18 @@ const uint32_t* keycode_to_static_text(uint16_t keycode, led_t state, uint8_t st
         case RM_PREV:                       return U" " ICON_LEFT PRIVATE_LIGHT;
         case KC_RGB_TOG:                    return (state_flags & RGB_ON) == 0 ? U"RGB\r\v" ICON_SWITCH_OFF : U"RGB\r\v" ICON_SWITCH_ON;
         case RM_NEXT:                       return PRIVATE_LIGHT ICON_RIGHT;
-        case RM_HUEU:                       return RGB_VALUE(RIGHT_20PX UP_4PX DEGREE DOWN_4PX U"+", RIGHT_20PX, "Hue");
-        case RM_HUED:                       return RGB_VALUE(RIGHT_24PX UP_4PX DEGREE DOWN_2PX U"-", RIGHT_20PX, "Hue");
-        case RM_SATU:                       return RGB_VALUE(HINT_MOVE(RGB_POS_SAT_ICON) HINT_HALF ICON_RGB_SAT HINT_MOVE(RGB_POS_SAT_PLUS) U"+", U"", "Saturation");
-        case RM_SATD:                       return RGB_VALUE(HINT_MOVE(RGB_POS_SAT_ICON) HINT_HALF ICON_RGB_SAT HINT_MOVE(RGB_POS_SAT_MINS) U"-", U"", "Saturation");
-        case RM_VALU:                       return RGB_VALUE(HINT_MOVE(RGB_POS_VAL_ICON) HINT_HALF ICON_RGB_VAL HINT_MOVE(RGB_POS_VAL_PLUS) U"+", RIGHT_14PX, "Bright");
-        case RM_VALD:                       return RGB_VALUE(HINT_MOVE(RGB_POS_VAL_ICON) HINT_HALF ICON_RGB_VAL HINT_MOVE(RGB_POS_VAL_MINS) U"-", RIGHT_14PX, "Bright");
-        case RM_SPDU:                       return RGB_VALUE(RIGHT_20PX UP_8PX ICON_RGB_SPD DOWN_8PX U"+", RIGHT_16PX, "Speed");
-        case RM_SPDD:                       return RGB_VALUE(RIGHT_24PX UP_8PX ICON_RGB_SPD DOWN_6PX U"-", RIGHT_16PX, "Speed");
-        case RGB_MODE_PLAIN:                return RGB_PRESET(RIGHT_20PX, "Solid");
-        case RGB_MODE_BREATHE:              return RGB_PRESET(RIGHT_12PX, "Breath");
-        case RGB_MODE_SWIRL:                return RGB_PRESET(RIGHT_18PX, "Cycle");
-        case RGB_MODE_RAINBOW:              return RGB_PRESET(RIGHT_6PX,  "Rainbow");
+        case RM_HUEU:                       return RGB_VALUE(UP_4PX RIGHT_20PX UP_2PX DEGREE DOWN_2PX U"+", U"", RIGHT_16PX, "Hue");
+        case RM_HUED:                       return RGB_VALUE(UP_4PX RIGHT_24PX DEGREE U"-", U"", RIGHT_16PX, "Hue");
+        case RM_SATU:                       return RGB_VALUE(HINT_MOVE(RGB_POS_SAT_ICON) HINT_HALF ICON_RGB_SAT HINT_MOVE(RGB_POS_SAT_PLUS) U"+", U"", RIGHT_20PX, "Sat");
+        case RM_SATD:                       return RGB_VALUE(HINT_MOVE(RGB_POS_SATM_ICO) HINT_HALF ICON_RGB_SAT HINT_MOVE(RGB_POS_SAT_MINS) U"-", DOWN_2PX, RIGHT_20PX, "Sat");
+        case RM_VALU:                       return RGB_VALUE(HINT_MOVE(RGB_POS_VAL_ICON) HINT_HALF ICON_RGB_VAL HINT_MOVE(RGB_POS_VAL_PLUS) U"+", U"", RIGHT_6PX, "Bright");
+        case RM_VALD:                       return RGB_VALUE(HINT_MOVE(RGB_POS_VALM_ICO) HINT_HALF ICON_RGB_VAL HINT_MOVE(RGB_POS_VAL_MINS) U"-", DOWN_2PX, RIGHT_6PX, "Bright");
+        case RM_SPDU:                       return RGB_VALUE(UP_4PX RIGHT_20PX UP_10PX ICON_RGB_SPD DOWN_10PX U"+", U"", RIGHT_8PX, "Speed");
+        case RM_SPDD:                       return RGB_VALUE(UP_4PX RIGHT_24PX UP_8PX ICON_RGB_SPD DOWN_8PX U"-", U"", RIGHT_8PX, "Speed");
+        case RGB_MODE_PLAIN:                return RGB_PRESET(RIGHT_12PX, "Solid");
+        case RGB_MODE_BREATHE:              return RGB_PRESET(RIGHT_4PX,  "Breath");
+        case RGB_MODE_SWIRL:                return RGB_PRESET(RIGHT_12PX, "Cycle");
+        case RGB_MODE_RAINBOW:              return RGB_PRESET(RIGHT_2PX,  "Rnbow");
         case KC_MEDIA_NEXT_TRACK:           return ICON_RIGHT ICON_RIGHT;
         case KC_MEDIA_PLAY_PAUSE:           return U"  " ICON_RIGHT;
         case KC_MEDIA_STOP:                 return ICON_MEDIA_STOP;

--- a/keyboards/polykybd/keycode_helper.c
+++ b/keyboards/polykybd/keycode_helper.c
@@ -48,6 +48,27 @@ static inline const uint32_t* kc_os_gui_icon(void) {
 // status-OLED top row.
 #define SETTING_LBL(label, value) MID_TWO_LINE(label, value)
 
+// The four RGB effect presets spell the effect out instead of abbreviating it to
+// four characters ("Plan"/"Brth"/"Swrl"/"Rnbw"), at HALF scale.
+//
+// ⚠️ NOT the 19px mid face the settings labels use: measured, "Rainbow" is 78px
+// there against a 72px keycap and loses its last letters. Half of the 27px keycap
+// face is 11px caps and fits all four -- 58px worst case, 7px of margin each side.
+//
+// There is no centring op, so each legend carries a MEASURED run of \x06 (+2px
+// right) plus one \x05 (+2px down, which puts the ink's centre on the keycap's).
+// The counts come from the rendered ink box (PolyKybdHost tools/oled_preview.py),
+// not from counting characters -- the face is proportional, so "Solid" and "Cycle"
+// need different runs despite both being five letters.
+//
+// ⚠️ The nudge run is its OWN string literal, and has to be: \x06 followed by a hex
+// digit is swallowed into one escape, which the 'B' of "Breath" would do.
+#define RIGHT_6PX   U"\x06\x06\x06"
+#define RIGHT_12PX  U"\x06\x06\x06\x06\x06\x06"
+#define RIGHT_18PX  U"\x06\x06\x06\x06\x06\x06\x06\x06\x06"
+#define RIGHT_20PX  U"\x06\x06\x06\x06\x06\x06\x06\x06\x06\x06"
+#define RGB_PRESET(right, word)  HINT_SMALL right U"\x05" U##word
+
 static const uint32_t* idle_style_legend(void) {
     static const uint32_t* const names[] = { SETTING_LBL("IDLE:", "Pulse"),
                                              SETTING_LBL("IDLE:", "Jittr"),
@@ -198,10 +219,10 @@ const uint32_t* keycode_to_static_text(uint16_t keycode, led_t state, uint8_t st
         case RM_VALD:                       return U"Bri-";
         case RM_SPDU:                       return U"Spd+";
         case RM_SPDD:                       return U"Spd-";
-        case RGB_MODE_PLAIN:                return U"Plan";
-        case RGB_MODE_BREATHE:              return U"Brth";
-        case RGB_MODE_SWIRL:                return U"Swrl";
-        case RGB_MODE_RAINBOW:              return U"Rnbw";
+        case RGB_MODE_PLAIN:                return RGB_PRESET(RIGHT_20PX, "Solid");
+        case RGB_MODE_BREATHE:              return RGB_PRESET(RIGHT_12PX, "Breath");
+        case RGB_MODE_SWIRL:                return RGB_PRESET(RIGHT_18PX, "Cycle");
+        case RGB_MODE_RAINBOW:              return RGB_PRESET(RIGHT_6PX,  "Rainbow");
         case KC_MEDIA_NEXT_TRACK:           return ICON_RIGHT ICON_RIGHT;
         case KC_MEDIA_PLAY_PAUSE:           return U"  " ICON_RIGHT;
         case KC_MEDIA_STOP:                 return ICON_MEDIA_STOP;

--- a/keyboards/polykybd/keycode_helper.c
+++ b/keyboards/polykybd/keycode_helper.c
@@ -63,10 +63,8 @@ static inline const uint32_t* kc_os_gui_icon(void) {
 //
 // ⚠️ The nudge run is its OWN string literal, and has to be: \x06 followed by a hex
 // digit is swallowed into one escape, which the 'B' of "Breath" would do.
-#define RIGHT_6PX   U"\x06\x06\x06"
-#define RIGHT_12PX  U"\x06\x06\x06\x06\x06\x06"
-#define RIGHT_18PX  U"\x06\x06\x06\x06\x06\x06\x06\x06\x06"
-#define RIGHT_20PX  U"\x06\x06\x06\x06\x06\x06\x06\x06\x06\x06"
+// RIGHT_*PX live in named_glyphs.h beside HINT_SMALL -- see the note there for
+// why an object-like macro used by a legend cannot live in this file.
 #define RGB_PRESET(right, word)  HINT_SMALL right U"\x05" U##word
 
 static const uint32_t* idle_style_legend(void) {

--- a/keyboards/polykybd/keycode_helper.c
+++ b/keyboards/polykybd/keycode_helper.c
@@ -247,8 +247,8 @@ const uint32_t* keycode_to_static_text(uint16_t keycode, led_t state, uint8_t st
         case RM_NEXT:                       return PRIVATE_LIGHT ICON_RIGHT;
         case RM_HUEU:                       return RGB_VALUE(UP_4PX RIGHT_20PX UP_2PX DEGREE DOWN_2PX U"+", U"", RIGHT_16PX, "Hue");
         case RM_HUED:                       return RGB_VALUE(UP_4PX RIGHT_24PX DEGREE U"-", U"", RIGHT_16PX, "Hue");
-        case RM_SATU:                       return RGB_VALUE(HINT_MOVE(RGB_POS_SAT_ICON) HINT_HALF ICON_RGB_SAT HINT_MOVE(RGB_POS_SAT_PLUS) U"+", U"", RIGHT_20PX, "Sat");
-        case RM_SATD:                       return RGB_VALUE(HINT_MOVE(RGB_POS_SATM_ICO) HINT_HALF ICON_RGB_SAT HINT_MOVE(RGB_POS_SAT_MINS) U"-", DOWN_2PX, RIGHT_20PX, "Sat");
+        case RM_SATU:                       return RGB_VALUE(HINT_MOVE(RGB_POS_SAT_ICON) HINT_HALF ICON_RGB_SAT HINT_MOVE(RGB_POS_SAT_PLUS) U"+", DOWN_2PX, RIGHT_20PX, "Sat");
+        case RM_SATD:                       return RGB_VALUE(HINT_MOVE(RGB_POS_SATM_ICO) HINT_HALF ICON_RGB_SAT HINT_MOVE(RGB_POS_SAT_MINS) U"-", DOWN_4PX, RIGHT_20PX, "Sat");
         case RM_VALU:                       return RGB_VALUE(HINT_MOVE(RGB_POS_VAL_ICON) HINT_HALF ICON_RGB_VAL HINT_MOVE(RGB_POS_VAL_PLUS) U"+", U"", RIGHT_6PX, "Bright");
         case RM_VALD:                       return RGB_VALUE(HINT_MOVE(RGB_POS_VALM_ICO) HINT_HALF ICON_RGB_VAL HINT_MOVE(RGB_POS_VAL_MINS) U"-", DOWN_2PX, RIGHT_6PX, "Bright");
         case RM_SPDU:                       return RGB_VALUE(UP_4PX RIGHT_20PX UP_10PX ICON_RGB_SPD DOWN_10PX U"+", U"", RIGHT_8PX, "Speed");
@@ -256,7 +256,7 @@ const uint32_t* keycode_to_static_text(uint16_t keycode, led_t state, uint8_t st
         case RGB_MODE_PLAIN:                return RGB_PRESET(RIGHT_12PX, "Solid");
         case RGB_MODE_BREATHE:              return RGB_PRESET(RIGHT_4PX,  "Breath");
         case RGB_MODE_SWIRL:                return RGB_PRESET(RIGHT_12PX, "Cycle");
-        case RGB_MODE_RAINBOW:              return RGB_PRESET(RIGHT_2PX,  "Rnbow");
+        case RGB_MODE_RAINBOW:              return RGB_PRESET(U"",         "Rainbw");
         case KC_MEDIA_NEXT_TRACK:           return ICON_RIGHT ICON_RIGHT;
         case KC_MEDIA_PLAY_PAUSE:           return U"  " ICON_RIGHT;
         case KC_MEDIA_STOP:                 return ICON_MEDIA_STOP;

--- a/keyboards/polykybd/keycode_helper.c
+++ b/keyboards/polykybd/keycode_helper.c
@@ -55,17 +55,40 @@ static inline const uint32_t* kc_os_gui_icon(void) {
 // there against a 72px keycap and loses its last letters. Half of the 27px keycap
 // face is 11px caps and fits all four -- 58px worst case, 7px of margin each side.
 //
-// There is no centring op, so each legend carries a MEASURED run of \x06 (+2px
-// right) plus one \x05 (+2px down, which puts the ink's centre on the keycap's).
-// The counts come from the rendered ink box (PolyKybdHost tools/oled_preview.py),
-// not from counting characters -- the face is proportional, so "Solid" and "Cycle"
-// need different runs despite both being five letters.
+// The effect name sits under a "Preset:" label, so the keycap says what the key
+// selects and not just what it is called -- the same label-over-value shape the
+// settings keys use, one size down.
+//
+// There is no centring op, so each line carries a MEASURED run of \x06 (+2px
+// right). The counts come from the rendered ink box (PolyKybdHost
+// tools/oled_preview.py), not from counting characters -- the face is
+// proportional, so "Solid" and "Cycle" need different runs despite both being
+// five letters.
 //
 // ⚠️ The nudge run is its OWN string literal, and has to be: \x06 followed by a hex
 // digit is swallowed into one escape, which the 'B' of "Breath" would do.
 // RIGHT_*PX live in named_glyphs.h beside HINT_SMALL -- see the note there for
 // why an object-like macro used by a legend cannot live in this file.
-#define RGB_PRESET(right, word)  HINT_SMALL right U"\x05" U##word
+#define RGB_PRESET(right, word)  \
+    HINT_SMALL RIGHT_12PX U"Preset:" U"\r\v" HINT_SMALL right U##word
+
+// The four RGB VALUE keys name their channel with an icon over the spelled-out
+// word, instead of the abbreviation the four-character face forced ("Sat+"). Same
+// two-line shape as the presets: line 1 at the default baseline, line 2 half-scale
+// at +15.
+//
+// `top` carries the icon and the sign; the sign is the SAME full-size base-font
+// glyph on all four keys, so the row reads as one control family. That is why the
+// two oversized PACK icons go through HINT_MOVE + HINT_HALF (see RGB_POS_* in
+// named_glyphs.h) rather than HINT_SMALL: HINT_SMALL latches for the REST of the
+// run, so it would halve the sign too and give the row two different plus signs.
+//
+// ⚠️ The word is "Bright", not "Brightness": at half scale "Brightness" inks 72px
+// starting at x1, i.e. one column past the 72px panel, and no leading nudge can
+// pull it back (\x08 clamps at the origin). Measured, like every run here, from
+// the rendered ink box rather than from a character count.
+#define RGB_VALUE(top, right, word)  \
+    top U"\r\v" HINT_SMALL right U##word
 
 static const uint32_t* idle_style_legend(void) {
     static const uint32_t* const names[] = { SETTING_LBL("IDLE:", "Pulse"),
@@ -209,14 +232,14 @@ const uint32_t* keycode_to_static_text(uint16_t keycode, led_t state, uint8_t st
         case RM_PREV:                       return U" " ICON_LEFT PRIVATE_LIGHT;
         case KC_RGB_TOG:                    return (state_flags & RGB_ON) == 0 ? U"RGB\r\v" ICON_SWITCH_OFF : U"RGB\r\v" ICON_SWITCH_ON;
         case RM_NEXT:                       return PRIVATE_LIGHT ICON_RIGHT;
-        case RM_HUEU:                       return U"Hue+";
-        case RM_HUED:                       return U"Hue-";
-        case RM_SATU:                       return U"Sat+";
-        case RM_SATD:                       return U"Sat-";
-        case RM_VALU:                       return U"Bri+";
-        case RM_VALD:                       return U"Bri-";
-        case RM_SPDU:                       return U"Spd+";
-        case RM_SPDD:                       return U"Spd-";
+        case RM_HUEU:                       return RGB_VALUE(RIGHT_20PX UP_4PX DEGREE DOWN_4PX U"+", RIGHT_20PX, "Hue");
+        case RM_HUED:                       return RGB_VALUE(RIGHT_24PX UP_4PX DEGREE DOWN_2PX U"-", RIGHT_20PX, "Hue");
+        case RM_SATU:                       return RGB_VALUE(HINT_MOVE(RGB_POS_SAT_ICON) HINT_HALF ICON_RGB_SAT HINT_MOVE(RGB_POS_SAT_PLUS) U"+", U"", "Saturation");
+        case RM_SATD:                       return RGB_VALUE(HINT_MOVE(RGB_POS_SAT_ICON) HINT_HALF ICON_RGB_SAT HINT_MOVE(RGB_POS_SAT_MINS) U"-", U"", "Saturation");
+        case RM_VALU:                       return RGB_VALUE(HINT_MOVE(RGB_POS_VAL_ICON) HINT_HALF ICON_RGB_VAL HINT_MOVE(RGB_POS_VAL_PLUS) U"+", RIGHT_14PX, "Bright");
+        case RM_VALD:                       return RGB_VALUE(HINT_MOVE(RGB_POS_VAL_ICON) HINT_HALF ICON_RGB_VAL HINT_MOVE(RGB_POS_VAL_MINS) U"-", RIGHT_14PX, "Bright");
+        case RM_SPDU:                       return RGB_VALUE(RIGHT_20PX UP_8PX ICON_RGB_SPD DOWN_8PX U"+", RIGHT_16PX, "Speed");
+        case RM_SPDD:                       return RGB_VALUE(RIGHT_24PX UP_8PX ICON_RGB_SPD DOWN_6PX U"-", RIGHT_16PX, "Speed");
         case RGB_MODE_PLAIN:                return RGB_PRESET(RIGHT_20PX, "Solid");
         case RGB_MODE_BREATHE:              return RGB_PRESET(RIGHT_12PX, "Breath");
         case RGB_MODE_SWIRL:                return RGB_PRESET(RIGHT_18PX, "Cycle");

--- a/keyboards/polykybd/lang/named_glyphs.h
+++ b/keyboards/polykybd/lang/named_glyphs.h
@@ -1971,6 +1971,22 @@
 #define HINT_SMALL       U"\x10"      // draw the REST of the string half-scale (text, advances)
 #define HINT_MID         U"\x16"      // draw the REST of the string from the standalone 19px UI face
 
+// Centring runs: N x \x06 (+2px right each). There is no centring op, so a run
+// that must sit in the middle of the keycap prepends one of these, with N taken
+// from the rendered ink box rather than counted by eye.
+//
+// ⚠️ They live HERE and not beside their one caller in keycode_helper.c, because
+// the host's preview exporter (PolyKybdHost scripts/export_preview_data.py) reads
+// named glyphs out of THIS file and keycode_helper.h only. Defined in the .c they
+// resolve for the firmware and not for the exporter, which silently DROPS the
+// legend rather than failing -- the four RGB preset keycaps disappeared from the
+// host layout editor's key preview that way (2026-09-08). Function-like macros
+// are parsed from the .c too, so only the object-like ones have this constraint.
+#define RIGHT_6PX        U"\x06\x06\x06"
+#define RIGHT_12PX       U"\x06\x06\x06\x06\x06\x06"
+#define RIGHT_18PX       U"\x06\x06\x06\x06\x06\x06\x06\x06\x06"
+#define RIGHT_20PX       U"\x06\x06\x06\x06\x06\x06\x06\x06\x06\x06"
+
 // Two lines of MID-face text on one 72x40 keycap: a label over the value it names.
 //
 // `\v` advances a fixed 15px while the mid face inks ~14px ABOVE the baseline and

--- a/keyboards/polykybd/lang/named_glyphs.h
+++ b/keyboards/polykybd/lang/named_glyphs.h
@@ -1986,6 +1986,47 @@
 #define RIGHT_12PX       U"\x06\x06\x06\x06\x06\x06"
 #define RIGHT_18PX       U"\x06\x06\x06\x06\x06\x06\x06\x06\x06"
 #define RIGHT_20PX       U"\x06\x06\x06\x06\x06\x06\x06\x06\x06\x06"
+#define RIGHT_14PX       U"\x06\x06\x06\x06\x06\x06\x06"
+#define RIGHT_16PX       U"\x06\x06\x06\x06\x06\x06\x06\x06"
+#define RIGHT_24PX       U"\x06\x06\x06\x06\x06\x06\x06\x06\x06\x06\x06\x06"
+
+// Vertical nudges (\x0C = 2px up, \x05 = 2px down), same story as the runs above:
+// a legend that lifts a glyph has to put it back before drawing the next one, since
+// both ops move the CURSOR rather than the glyph.
+#define UP_4PX           U"\x0C\x0C"
+#define UP_8PX           U"\x0C\x0C\x0C\x0C"
+#define DOWN_2PX         U"\x05"
+#define DOWN_4PX         U"\x05\x05"
+#define DOWN_6PX         U"\x05\x05\x05"
+#define DOWN_8PX         U"\x05\x05\x05\x05"
+
+// RGB value-key icons. The droplet and the sun are the same two symbols the status
+// OLED draws beside the saturation and value percentages (split72/status_oled.c has
+// them as hand-drawn bitmaps; a keycap legend can only reference a FONT glyph, so
+// these are the font originals), and the degree ring stands for the hue wheel that
+// panel already labels in degrees. Speed has no panel icon at all, so it takes the
+// guillemet.
+//
+// ⚠️ DEGREE and ICON_RGB_SPD are RESIDENT; the droplet and the sun are PACK glyphs
+// (EmjEffects / SymBmp1). On a keyboard with no font pack those two simply do not
+// draw -- kdisp_draw_glyph_half_at returns without plotting -- and the keycap keeps
+// its word, which is resident. It is never blank.
+#define ICON_RGB_SAT     U"\x1F4A7"   // droplet
+#define ICON_RGB_VAL     U"\x2600"    // sun
+#define ICON_RGB_SPD     U"\xBB"      // guillemet
+
+// Buffer positions for the two PACK icons above. They ink 26x39 and 31x33 at full
+// size -- taller than the whole 72x40 keycap -- so they are drawn through HINT_HALF,
+// which plots the literal top-left at the cursor and does NOT advance it. That is
+// what makes the sign a separate HINT_MOVE: there is no advanced cursor to draw it
+// from. Measured (tools: PolyKybdHost oled_preview.py) so the icon+sign group
+// centres on the panel and clears the word line, with zero pixels off-panel.
+#define RGB_POS_SAT_ICON U"\x30\x02"   // (48, 2)  halved droplet top-left
+#define RGB_POS_SAT_PLUS U"\x41\x17"   // (65,23)  baseline cursor for '+'
+#define RGB_POS_SAT_MINS U"\x41\x15"   // (65,21)  '-' inks 6px lower than '+' centres
+#define RGB_POS_VAL_ICON U"\x2F\x03"   // (47, 3)  halved sun top-left
+#define RGB_POS_VAL_PLUS U"\x43\x17"   // (67,23)
+#define RGB_POS_VAL_MINS U"\x43\x15"   // (67,21)
 
 // Two lines of MID-face text on one 72x40 keycap: a label over the value it names.
 //

--- a/keyboards/polykybd/lang/named_glyphs.h
+++ b/keyboards/polykybd/lang/named_glyphs.h
@@ -1970,6 +1970,11 @@
 #define HINT_MOVE(pos)   U"\x0E" pos   // move cursor to buffer (x,y) = pos
 #define HINT_SMALL       U"\x10"      // draw the REST of the string half-scale (text, advances)
 #define HINT_MID         U"\x16"      // draw the REST of the string from the standalone 19px UI face
+#define HINT_BASE        U"\x17"      // ...and back to the full-size caller pool: the one op that
+                                    //   UNDOES HINT_SMALL / HINT_MID. Both latch for the rest of
+                                    //   the run and \x10 after \x16 only halves the MID face, so
+                                    //   without this a small LABEL over a bigger VALUE cannot be
+                                    //   written -- the second line always came out the smaller one.
 
 // Centring runs: N x \x06 (+2px right each). There is no centring op, so a run
 // that must sit in the middle of the keycap prepends one of these, with N taken
@@ -1986,6 +1991,9 @@
 #define RIGHT_12PX       U"\x06\x06\x06\x06\x06\x06"
 #define RIGHT_18PX       U"\x06\x06\x06\x06\x06\x06\x06\x06\x06"
 #define RIGHT_20PX       U"\x06\x06\x06\x06\x06\x06\x06\x06\x06\x06"
+#define RIGHT_2PX        U"\x06"
+#define RIGHT_4PX        U"\x06\x06"
+#define RIGHT_8PX        U"\x06\x06\x06\x06"
 #define RIGHT_14PX       U"\x06\x06\x06\x06\x06\x06\x06"
 #define RIGHT_16PX       U"\x06\x06\x06\x06\x06\x06\x06\x06"
 #define RIGHT_24PX       U"\x06\x06\x06\x06\x06\x06\x06\x06\x06\x06\x06\x06"
@@ -1993,12 +2001,16 @@
 // Vertical nudges (\x0C = 2px up, \x05 = 2px down), same story as the runs above:
 // a legend that lifts a glyph has to put it back before drawing the next one, since
 // both ops move the CURSOR rather than the glyph.
+#define UP_2PX           U"\x0C"
 #define UP_4PX           U"\x0C\x0C"
+#define UP_10PX          U"\x0C\x0C\x0C\x0C\x0C"
+#define UP_12PX          U"\x0C\x0C\x0C\x0C\x0C\x0C"
 #define UP_8PX           U"\x0C\x0C\x0C\x0C"
 #define DOWN_2PX         U"\x05"
 #define DOWN_4PX         U"\x05\x05"
 #define DOWN_6PX         U"\x05\x05\x05"
 #define DOWN_8PX         U"\x05\x05\x05\x05"
+#define DOWN_10PX        U"\x05\x05\x05\x05\x05"
 
 // RGB value-key icons. The droplet and the sun are the same two symbols the status
 // OLED draws beside the saturation and value percentages (split72/status_oled.c has
@@ -2021,12 +2033,15 @@
 // what makes the sign a separate HINT_MOVE: there is no advanced cursor to draw it
 // from. Measured (tools: PolyKybdHost oled_preview.py) so the icon+sign group
 // centres on the panel and clears the word line, with zero pixels off-panel.
-#define RGB_POS_SAT_ICON U"\x30\x02"   // (48, 2)  halved droplet top-left
-#define RGB_POS_SAT_PLUS U"\x41\x17"   // (65,23)  baseline cursor for '+'
-#define RGB_POS_SAT_MINS U"\x41\x15"   // (65,21)  '-' inks 6px lower than '+' centres
-#define RGB_POS_VAL_ICON U"\x2F\x03"   // (47, 3)  halved sun top-left
-#define RGB_POS_VAL_PLUS U"\x43\x17"   // (67,23)
-#define RGB_POS_VAL_MINS U"\x43\x15"   // (67,21)
+#define RGB_POS_SAT_ICON U"\x30\x01"   // (48, 1)  halved droplet top-left
+#define RGB_POS_SAT_PLUS U"\x41\x13"   // (65,19)  baseline cursor for '+'
+#define RGB_POS_SATM_ICO U"\x33\x01"   // (51, 1)  ...the '-' group is 6px narrower,
+#define RGB_POS_SAT_MINS U"\x44\x11"   // (68,17)     so it re-centres, and '-' inks
+                                     //             6px lower than '+' centres
+#define RGB_POS_VAL_ICON U"\x2F\x01"   // (47, 1)  halved sun top-left
+#define RGB_POS_VAL_PLUS U"\x43\x13"   // (67,19)
+#define RGB_POS_VALM_ICO U"\x32\x01"   // (50, 1)
+#define RGB_POS_VAL_MINS U"\x46\x11"   // (70,17)
 
 // Two lines of MID-face text on one 72x40 keycap: a label over the value it names.
 //

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -4417,6 +4417,30 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
                 eeconfig_update_rgb_matrix(&rgb_matrix_config);
             }
             return false;
+        // The settings layer's four effect presets. These are the legacy UNDERGLOW
+        // mode keycodes (RGB_MODE_PLAIN/BREATHE/RAINBOW/SWIRL, 0x782B..0x782E), and
+        // QMK does route that range through process_underglow() even on an
+        // RGB-matrix-only board — but its switch only covers toggle / next / prev /
+        // hue / sat / val / speed. The four mode presets have no case there, none in
+        // process_rgb_matrix() (which owns the RM_* range only), and IS_RGB_KEYCODE /
+        // RGB_KEYCODE_RANGE are defined in keycodes.h and dispatched nowhere. So
+        // these keycaps drew a legend (keycode_helper.c: "Plan", "Brth", "Rnbw",
+        // "Swrl") and did nothing at all. Map each onto the closest effect that is
+        // enabled on BOTH variants — CYCLE_SPIRAL is split72-only, so Swirl takes
+        // CYCLE_PINWHEEL. rgb_matrix_mode() persists the pick the way RM_NEXT does
+        // (a deferred eeconfig flag, not a blocking write), and like RM_NEXT it is a
+        // no-op while RGB is off.
+        case RGB_M_P:  case RGB_M_B:
+        case RGB_M_R:  case RGB_M_SW:
+            if (record->event.pressed) {
+                uint8_t mode = RGB_MATRIX_SOLID_COLOR;              // RGB_M_P  "Plan"
+                if      (keycode == RGB_M_B)  mode = RGB_MATRIX_BREATHING;              // "Brth"
+                else if (keycode == RGB_M_R)  mode = RGB_MATRIX_RAINBOW_MOVING_CHEVRON; // "Rnbw"
+                else if (keycode == RGB_M_SW) mode = RGB_MATRIX_CYCLE_PINWHEEL;         // "Swrl"
+                rgb_matrix_mode(mode);
+                request_disp_refresh();
+            }
+            return false;
 #endif
         case KC_CRSEL:
             if (record->event.pressed) { SEND_STRING(SS_TAP(X_HOME) SS_TAP(X_HOME) SS_LSFT(SS_TAP(X_END)) SS_TAP(X_BACKSPACE) SS_TAP(X_BACKSPACE) SS_TAP(X_DOWN)); }

--- a/keyboards/polykybd/poly_keymap.c
+++ b/keyboards/polykybd/poly_keymap.c
@@ -4556,6 +4556,21 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
        (keycode == KC_LEFT_CTRL || keycode == KC_RIGHT_CTRL)) {
         return false;
     }
+    // A gated settings key is BLANK, so it must also be INERT — swallow both edges
+    // before anything can act on it.
+    //
+    // ⚠️ MUST stay above the QK_BOOTLOADER / QK_REBOOT cases below. This file
+    // intercepts both of those and returns true from inside that switch (the
+    // bootloader announce; the reboot's bridged handoff so the slave restarts too),
+    // so a gate placed after them never ran for the only two keys on the row that
+    // cannot be undone — the blank Restart keycap rebooted the board (field
+    // 2026-09-08). QK_DEBUG_TOGGLE really is left to process_action(), which is why
+    // it alone was gated. Every other gated keycode is handled further down in
+    // poly_custom_key_action(), already below this point.
+    if (settings_more_hidden(keycode)) {
+        return false;
+    }
+
     if (record->event.pressed) {
         switch (keycode) {
             case QK_BOOTLOADER: {
@@ -4761,16 +4776,6 @@ bool process_record_user(uint16_t keycode, keyrecord_t* record) {
     // ran. Only a PRESS can be rejected, so every release-edge settings key is
     // unaffected; KC_LANG is the one press-edge case here and would otherwise open _LL
     // / advance the language on the very press that exists only to wake the board.
-    // A gated settings key is BLANK, so it must also be INERT — swallow both edges
-    // before anything can act on it. QK_BOOTLOADER / QK_REBOOT / QK_DEBUG_TOGGLE are
-    // QMK's own keycodes, handled by process_action() rather than by
-    // poly_custom_key_action(), so returning false here is the only thing that stops
-    // them: a gate that only blanked the legend would leave a keycap that reboots the
-    // board with nothing drawn on it.
-    if (settings_more_hidden(keycode)) {
-        return false;
-    }
-
     const bool wake_accepted = display_wakeup(record);
     if (wake_accepted && poly_custom_key_action(keycode, record)) {
         return false;

--- a/keyboards/polykybd/split42/config.h
+++ b/keyboards/polykybd/split42/config.h
@@ -154,6 +154,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGB_MATRIX_KEYPRESSES
 #define RGB_MATRIX_MAXIMUM_BRIGHTNESS 100
 
+// Startup values, written only when the RGB eeconfig is fresh (QMK's
+// eeconfig_update_rgb_matrix_default). Both are expressed as a FRACTION of their
+// own full scale so they keep meaning the same thing if a cap ever moves: the
+// value against RGB_MATRIX_MAXIMUM_BRIGHTNESS (this board's ceiling, and what the
+// status OLED now calls 100%), the speed against the full 0..255 the speed gauge
+// draws. QMK's own defaults are full brightness and half speed.
+#define RGB_MATRIX_DEFAULT_VAL (RGB_MATRIX_MAXIMUM_BRIGHTNESS / 5)   // 20% of full
+#define RGB_MATRIX_DEFAULT_SPD (UINT8_MAX / 10)                      // 10% of full
+
 #define ENABLE_RGB_MATRIX_SOLID_REACTIVE_SIMPLE
 #define ENABLE_RGB_MATRIX_SOLID_REACTIVE
 #define ENABLE_RGB_MATRIX_SOLID_REACTIVE_WIDE

--- a/keyboards/polykybd/split42/config.h
+++ b/keyboards/polykybd/split42/config.h
@@ -155,13 +155,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGB_MATRIX_MAXIMUM_BRIGHTNESS 100
 
 // Startup values, written only when the RGB eeconfig is fresh (QMK's
-// eeconfig_update_rgb_matrix_default). Both are expressed as a FRACTION of their
-// own full scale so they keep meaning the same thing if a cap ever moves: the
-// value against RGB_MATRIX_MAXIMUM_BRIGHTNESS (this board's ceiling, and what the
-// status OLED now calls 100%), the speed against the full 0..255 the speed gauge
-// draws. QMK's own defaults are full brightness and half speed.
-#define RGB_MATRIX_DEFAULT_VAL (RGB_MATRIX_MAXIMUM_BRIGHTNESS / 5)   // 20% of full
-#define RGB_MATRIX_DEFAULT_SPD (UINT8_MAX / 10)                      // 10% of full
+// eeconfig_update_rgb_matrix_default). QMK's own defaults are full brightness and
+// half speed. Each is a fraction of its OWN full scale: the value against
+// RGB_MATRIX_MAXIMUM_BRIGHTNESS above (this board's ceiling, and what the status
+// OLED calls 100%), the speed against the full 0..255 the speed gauge draws.
+//
+// ⚠️ PLAIN INTEGERS, not expressions. `qmk lint --strict` maps both of these into
+// info.json (rgb_matrix.default.val / .speed) and parses the literal with int(),
+// so `(RGB_MATRIX_MAXIMUM_BRIGHTNESS / 5)` fails the lint job with "invalid
+// literal for int()" even though it compiles fine. The arithmetic lives in the
+// comment instead; keep it true if a scale ever moves.
+#define RGB_MATRIX_DEFAULT_VAL 20   // 20% of RGB_MATRIX_MAXIMUM_BRIGHTNESS (100)
+#define RGB_MATRIX_DEFAULT_SPD 25   // 10% of the 0..255 speed range
 
 #define ENABLE_RGB_MATRIX_SOLID_REACTIVE_SIMPLE
 #define ENABLE_RGB_MATRIX_SOLID_REACTIVE

--- a/keyboards/polykybd/split72/config.h
+++ b/keyboards/polykybd/split72/config.h
@@ -138,6 +138,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGB_MATRIX_KEYPRESSES
 #define RGB_MATRIX_MAXIMUM_BRIGHTNESS 100
 
+// Startup values, written only when the RGB eeconfig is fresh (QMK's
+// eeconfig_update_rgb_matrix_default). Both are expressed as a FRACTION of their
+// own full scale so they keep meaning the same thing if a cap ever moves: the
+// value against RGB_MATRIX_MAXIMUM_BRIGHTNESS (this board's ceiling, and what the
+// status OLED now calls 100%), the speed against the full 0..255 the speed gauge
+// draws. QMK's own defaults are full brightness and half speed.
+#define RGB_MATRIX_DEFAULT_VAL (RGB_MATRIX_MAXIMUM_BRIGHTNESS / 5)   // 20% of full
+#define RGB_MATRIX_DEFAULT_SPD (UINT8_MAX / 10)                      // 10% of full
+
 #define ENABLE_RGB_MATRIX_SOLID_REACTIVE_SIMPLE
 #define ENABLE_RGB_MATRIX_SOLID_REACTIVE
 #define ENABLE_RGB_MATRIX_SOLID_REACTIVE_WIDE

--- a/keyboards/polykybd/split72/config.h
+++ b/keyboards/polykybd/split72/config.h
@@ -139,13 +139,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGB_MATRIX_MAXIMUM_BRIGHTNESS 100
 
 // Startup values, written only when the RGB eeconfig is fresh (QMK's
-// eeconfig_update_rgb_matrix_default). Both are expressed as a FRACTION of their
-// own full scale so they keep meaning the same thing if a cap ever moves: the
-// value against RGB_MATRIX_MAXIMUM_BRIGHTNESS (this board's ceiling, and what the
-// status OLED now calls 100%), the speed against the full 0..255 the speed gauge
-// draws. QMK's own defaults are full brightness and half speed.
-#define RGB_MATRIX_DEFAULT_VAL (RGB_MATRIX_MAXIMUM_BRIGHTNESS / 5)   // 20% of full
-#define RGB_MATRIX_DEFAULT_SPD (UINT8_MAX / 10)                      // 10% of full
+// eeconfig_update_rgb_matrix_default). QMK's own defaults are full brightness and
+// half speed. Each is a fraction of its OWN full scale: the value against
+// RGB_MATRIX_MAXIMUM_BRIGHTNESS above (this board's ceiling, and what the status
+// OLED calls 100%), the speed against the full 0..255 the speed gauge draws.
+//
+// ⚠️ PLAIN INTEGERS, not expressions. `qmk lint --strict` maps both of these into
+// info.json (rgb_matrix.default.val / .speed) and parses the literal with int(),
+// so `(RGB_MATRIX_MAXIMUM_BRIGHTNESS / 5)` fails the lint job with "invalid
+// literal for int()" even though it compiles fine. The arithmetic lives in the
+// comment instead; keep it true if a scale ever moves.
+#define RGB_MATRIX_DEFAULT_VAL 20   // 20% of RGB_MATRIX_MAXIMUM_BRIGHTNESS (100)
+#define RGB_MATRIX_DEFAULT_SPD 25   // 10% of the 0..255 speed range
 
 #define ENABLE_RGB_MATRIX_SOLID_REACTIVE_SIMPLE
 #define ENABLE_RGB_MATRIX_SOLID_REACTIVE

--- a/keyboards/polykybd/split72/status_oled.c
+++ b/keyboards/polykybd/split72/status_oled.c
@@ -152,9 +152,21 @@ static const uint8_t val_sun_bitmap[] PROGMEM = {       // 9x9
 #define SUN_SMALL_Y 54
 #define SV_ICON_GAP 2
 
-// v (0..255) as a percentage, rounded to nearest.
+// A 0..255 byte as a percentage, rounded to nearest. SATURATION only — the value
+// has a smaller ceiling and its own helper below.
 static uint8_t byte_to_percent(uint8_t v) {
     return (uint8_t)(((uint16_t)v * 100u + 127u) / 255u);
+}
+
+// The VALUE against ITS OWN full scale. It is capped at RGB_MATRIX_MAXIMUM_BRIGHTNESS
+// (100 here), not 255, so byte_to_percent reported a fully-lit matrix as 39% and the
+// row could never reach 100 — a scale whose top the user cannot see is not a scale.
+// QMK clamps the stored value to the cap, so the clamp below only guards an EEPROM
+// written by a build with a higher ceiling; without it that reads back as "255%".
+static uint8_t val_to_percent(uint8_t v) {
+    if(v > RGB_MATRIX_MAXIMUM_BRIGHTNESS) v = RGB_MATRIX_MAXIMUM_BRIGHTNESS;
+    return (uint8_t)(((uint16_t)v * 100u + (RGB_MATRIX_MAXIMUM_BRIGHTNESS / 2u))
+                     / RGB_MATRIX_MAXIMUM_BRIGHTNESS);
 }
 
 // "<pct>%" as one string, into a uint32_t[] (the kdisp text pipeline is 32-bit).
@@ -429,7 +441,7 @@ void oled_update_buffer(void) {
             kdisp_draw_bitmap(TEXT_X, DROPLET_Y, sat_droplet_bitmap, DROPLET_W, DROPLET_H);
             kdisp_write_gfx_text(smallFont, 1, (int8_t)(TEXT_X + DROPLET_W + SV_ICON_GAP), RGB_ROW_D, buffer);
 
-            pct_to_u32_string(buffer, sizeof(buffer), byte_to_percent(rgb_matrix_get_val()));
+            pct_to_u32_string(buffer, sizeof(buffer), val_to_percent(rgb_matrix_get_val()));
             int8_t val_lo = 0, val_hi = 0;
             kdisp_gfx_text_bounds(smallFont, 1, buffer, &val_lo, &val_hi);
             const int8_t val_x = (int8_t)(TEXT_R - val_hi);

--- a/keyboards/polykybd/tools/status_oled_preview.py
+++ b/keyboards/polykybd/tools/status_oled_preview.py
@@ -374,6 +374,16 @@ GAUGE_SEGMENTS, GAUGE_BAR_W, GAUGE_PITCH, GAUGE_MIN_H = 10, 4, 6, 3
 FULL_BRIGHT = 50
 
 
+MAX_BRIGHT = 100  # RGB_MATRIX_MAXIMUM_BRIGHTNESS (split72/config.h)
+
+
+def val_to_percent(v):
+    """Mirror of status_oled.c val_to_percent() -- the VALUE is capped at
+    RGB_MATRIX_MAXIMUM_BRIGHTNESS, not 255, so it scales against that."""
+    v = min(v, MAX_BRIGHT)
+    return (v * 100 + MAX_BRIGHT // 2) // MAX_BRIGHT
+
+
 def brightness_to_level(contrast):
     contrast = min(contrast, FULL_BRIGHT)
     return min((contrast * GAUGE_SEGMENTS + FULL_BRIGHT // 2) // FULL_BRIGHT, GAUGE_SEGMENTS)
@@ -507,7 +517,7 @@ def build_panel(side, disp, small, icons, tiny, globe, brightness=50, rgb=(128, 
         draw_bitmap(setp, DROPLET_BMP, TEXT_X, DROPLET_Y, DROPLET_W, DROPLET_H)
         draw(setp, small, TEXT_X + DROPLET_W + SV_ICON_GAP, RGB_ROW_D,
              s('%d%%' % byte_to_percent(sat)))
-        vtxt = s('%d%%' % byte_to_percent(val))
+        vtxt = s('%d%%' % val_to_percent(val))
         vx = TEXT_R - measure_width(small, vtxt)
         draw_bitmap(setp, SUN_SMALL_BMP, vx - SV_ICON_GAP - SUN_SMALL_W, SUN_SMALL_Y,
                     SUN_SMALL_W, SUN_SMALL_H)


### PR DESCRIPTION
## Summary

Started from a field report of "two crashes in a row with the multisplash RGB matrix". The log contained no crash: it recorded two presses of the **Restart** key, on a keycap the firmware was drawing **blank**.

**1. `QK_REBOOT` / `QK_BOOTLOADER` were not gated.** The advanced settings row on `_SL` is meant to be blank *and* inert until `KC_SETTINGS_MORE` reveals it. The legend half worked; the action half did not, for the only two keycodes on that row that cannot be undone. `process_record_user()` intercepts both in its pressed-edge switch — the bootloader announce, and the reboot's bridged handoff so the slave restarts too — and returns `true` from there, while the `settings_more_hidden()` check sat ~200 lines further down. So pressing the blank Restart keycap rebooted the board with nothing drawn on it.

The comment beside the gate asserted the premise that made it wrong: that all three of `QK_BOOTLOADER`/`QK_REBOOT`/`QK_DEBUG_TOGGLE` are left to `process_action()`. True of `QK_DEBUG_TOGGLE` alone — which is why it was the one of the three that really was gated. The fix moves the single check above that switch rather than testing inside the two cases, so a third irreversible keycode cannot inherit the same hole.

**2. The four RGB effect presets did nothing at all.** `RGB_M_P` / `RGB_M_B` / `RGB_M_R` / `RGB_M_SW` are the legacy underglow mode keycodes (`0x782B`–`0x782E`). QMK routes that range through `process_underglow()` even on an RGB-matrix-only board, but its switch covers only toggle / next / previous / hue / sat / val / speed; the four mode presets have no case there, none in `process_rgb_matrix()`, and `IS_RGB_KEYCODE` / `RGB_KEYCODE_RANGE` are defined in `keycodes.h` and dispatched nowhere. They drew a legend and were inert. Now mapped to the closest effect enabled on **both** variants:

| Keycap | Effect | Mode |
|---|---|---|
| Solid | `RGB_MATRIX_SOLID_COLOR` | 1 |
| Breath | `RGB_MATRIX_BREATHING` | 5 |
| Cycle | `RGB_MATRIX_CYCLE_PINWHEEL` | 18 |
| Rnbow | `RGB_MATRIX_RAINBOW_MOVING_CHEVRON` | 15 |

`CYCLE_SPIRAL` is the closer match for Swirl but is split72-only, and the handler is in the shared keymap.

**3. The whole RGB row is relegended.** The eight value keys carried a four-character abbreviation (`Sat+`, `Bri-`) because that is all one line of the 27px keycap face fits. They now name the channel with the **same symbol the status OLED puts beside its percentage** — droplet for saturation, sun for value, degree ring for hue — over the word itself. Speed has no panel icon at all, so it takes the guillemet. The four preset keys spell the effect out under a `Preset:` label, so the keycap says what the key *selects* rather than only what it is called.

The words are drawn in the **19px mid face** (14px caps), and both lines are pushed to the panel edges: line 1's ink starts on row 1 and the word's descender lands on row 39, as far apart as a 40px keycap allows. All twelve legends draw with **zero pixels off-panel**.

The sign is **one full-size base-font glyph on all four value keys**, and that is what forces `HINT_MOVE` + `HINT_HALF` for the droplet and the sun: they ink 26x39 and 31x33, taller than the whole keycap, and `HINT_SMALL` cannot halve just the icon — it latches for the rest of the run and would take the sign with it.

> ⚠️ **`Sat`, not `Saturation`.** At the mid face "Saturation" measures 97px against a 72px panel, and even at half the keycap face it was already **71 of 72** — i.e. the full word was as large as it can ever be drawn, so growing the legend and keeping the word were mutually exclusive. "Rainbow" (78px) is `Rnbow` for the same reason.
>
> ⚠️ The droplet and the sun are **pack** glyphs. On a keyboard with no font pack `kdisp_draw_glyph_half_at` returns without plotting, so those two keycaps show their word alone rather than going blank — the word is resident, as are the degree ring and the guillemet.

**3b. That needed a new display-list op: `HINT_BASE` (`\x17`).** `HINT_SMALL` and `HINT_MID` both latch for the rest of the run and neither could be turned off — `HINT_SMALL` *after* `HINT_MID` only halves the mid face — so a small **label** over a bigger **value** was not expressible at all: the second line always came out the smaller one. `\x17` returns to the caller's pool at full size, in the draw walker (`disp_array.c`) and the bbox walker (`font_lookup.c`) alike.

Two constraints that shaped the layout, both recorded beside the macro:

- A `HINT_MOVE` argument of **0 terminates the string**, so an icon cannot be placed on row 0 — the halved droplet sits at row 1.
- Every cursor nudge is 2px, so **`\v` is the only op that changes the cursor's parity**. It is what lets the odd line-1 baseline (19, as high as a full-size `+` reaches) get to the even line-2 baseline (34).

**4. RGB defaults and the value percent.** Defaults were QMK's fallbacks (full brightness, half speed); now 20% and 10%, expressed as fractions of their own full scale. And the status OLED ran the value through the `/255` helper saturation uses — but the value is capped at `RGB_MATRIX_MAXIMUM_BRIGHTNESS` (100), so a fully-lit matrix reported **39%** and the row could never reach 100. `val_to_percent()` scales against the cap; since `RGB_MATRIX_VAL_STEP` is 1, each step is now exactly one percent.

> ⚠️ The new defaults apply only to a **fresh RGB eeconfig** — QMK writes them in `eeconfig_update_rgb_matrix_default()`, so an existing keyboard keeps its stored brightness and speed. The corrected percent is immediate either way. Adopting the defaults on existing boards would need a one-time migration sentinel (the `idle_style_fmt` shape); not done here.

## Version bump label

`bump:minor` — the presets are new working behaviour, and the legends, the new display-list op and the RGB defaults are user-visible. No protocol change.

## Testing
- [x] Compiled successfully — **both** variants (`split72` shipping DOOM_PACK flavour, and `split42`), clean under `-Werror`
- [ ] Flashed and tested on hardware — in progress
- [x] If protocol changed: n/a, `PROTOCOL_VERSION` untouched

Verification beyond the build:
- Effect indices read out of the compiled object (`nm -S` + `objcopy`), not derived by hand.
- `make test:polykybd_font_bbox` **48 → 52 tests**, all green; `polykybd_legend_plan` and `polykybd_os_hints` green. The four new cases pin `HINT_BASE` against SMALL, against MID, as a no-op on its own, and — the one that says why the op has to exist — that `\x10` after `\x16` is *not* the base face. Mutation-checked 3/3 (drop the case, clear only `small`, clear only `mid`), each caught by the intended test.
- Every legend rendered through `PolyKybdHost/tools/oled_preview.py` — the firmware's own display-list interpreter — and pixel-counted outside the 72x40 window: **12 legends, 0 clipped**. That is what caught a transcription slip in this very change (a 5-nudge lift written as `UP_8PX`, which pushed Speed+'s `p` two rows off the panel) while the compiler and every test were green.
- Built the monolithic `POLYKYBD_DOOM=yes` flavour too (the tightest RAM flavour, which PR CI does not build): `.heap` free unchanged at 2256 B.
- `qmk lint --strict` on both keyboards, plus `ci-validate-keyboard-targets` and `ci-validate-aliases` — all clean.
- The status-OLED row measured through `tools/status_oled_preview.py`: worst case (saturation and value both 100%) leaves the 6px gap that row's own comment already predicted, 0 clipped pixels.

Paired with [thpoll83/PolyKybdHost#223](https://github.com/thpoll83/PolyKybdHost/pull/223), which teaches the preview renderer `HINT_HALF` and `HINT_BASE` and reships the keycap-preview export, so the layout editor draws the new legends instead of falling back to keycode text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UattJiMbPb2XUVVXkcjUN7

## Summary by Sourcery

Make the settings-layer RGB controls safe, functional, accurately scaled, and clearer to use.

New Features:
- Make the four RGB effect preset keys select working matrix effects across both keyboard variants.
- Add RGB value and effect legends that clearly identify controls and presets on the settings layer.

Bug Fixes:
- Prevent hidden settings-layer reboot and bootloader keys from acting while their legends are concealed.
- Correct RGB value percentage reporting to use the matrix brightness ceiling so the display reaches 100%.

Enhancements:
- Add a display-list operation for returning from small or mid-sized text to the base font within a legend.
- Set fresh RGB configurations to lower default brightness and speed levels.

Tests:
- Expand font bounding-box coverage for the new base-font display-list operation and its interaction with existing size hints.