### PR TITLE
docs(session-retro): record an investigation index entry in mem0

### DIFF
--- a/.claude/skills/session-retro/SKILL.md
+++ b/.claude/skills/session-retro/SKILL.md
@@ -148,6 +148,12 @@ fixed / refuted / skipped. Do not push fixes without approval, per §4.6.
    - Docs gaps → invoke the **`update-polykybd-docs`** skill for each (it edits
      the `polykybd-docs` site on its own branch + PR). This retro only surfaces
      them; that skill does the writing.
+   - Investigation index → `add_memory`, ONE entry per investigation that cost
+     real effort: the question, the verdict in a sentence, and where the full
+     write-up landed (file + heading, or PR number). ⚠️ **Never the finding
+     itself** — that is the learning above, and two copies of a technical
+     conclusion drift with nothing comparing them. Skip entirely if nothing this
+     session took more than a handful of files to answer.
    - Offer to commit + push the new/edited files (don't unless asked, per repo
      rules).
 
@@ -169,6 +175,10 @@ DOCS GAPS (→ update-polykybd-docs)
   i. <feature added/changed> → <likely polykybd-docs page>
   ii. ...
 
+MEMORY INDEX (→ mem0)
+  •. <question investigated> → <verdict in one line>
+     write-up: <file §heading | PR #N>
+
 ALREADY COVERED (skipped): <item> → <existing doc/skill>
 
 Recommendation: <which to keep, and why>
@@ -182,6 +192,10 @@ Recommendation: <which to keep, and why>
   repo; use for genuinely cross-project meta-skills.
 - **CLAUDE.md** — the most *specific* one wins (a `lang/FUTURE_LANGUAGES.md`-style
   doc over the top-level CLAUDE.md when the learning is narrow).
+- **mem0** — an INDEX of investigations, never a record of findings: one entry
+  pointing at where the real write-up lives, so a later session can find it
+  without re-deriving it. ⚠️ CLAUDE.md wins on any disagreement — a mem0 hit is
+  a lead to verify against the repo, never an authority.
 
 ## Pitfalls
 
@@ -193,6 +207,8 @@ Recommendation: <which to keep, and why>
   is the only thing that decides whether it ever fires.
 - **Cite evidence.** Every proposal should point at what in the session justifies
   it; if you can't, it's probably not worth keeping.
+- **Nothing sensitive in mem0** — no credentials, keys, file contents, or
+  anything you would not put in a public issue.
 - **Approval before writing**, and **don't push** unless asked.
 - This skill is repo-agnostic; if useful beyond this project, copy it to
   `~/.claude/skills/`.

--- a/.claude/skills/session-retro/SKILL.md
+++ b/.claude/skills/session-retro/SKILL.md
@@ -150,10 +150,14 @@ fixed / refuted / skipped. Do not push fixes without approval, per §4.6.
      them; that skill does the writing.
    - Investigation index → `add_memory`, ONE entry per investigation that cost
      real effort: the question, the verdict in a sentence, and where the full
-     write-up landed (file + heading, or PR number). ⚠️ **Never the finding
+     write-up landed (`repo/file §heading`, or `owner/repo#N` — ⚠️ a bare `#N`
+     resolves to the wrong PR across the nine repos). ⚠️ **Never the finding
      itself** — that is the learning above, and two copies of a technical
-     conclusion drift with nothing comparing them. Skip entirely if nothing this
-     session took more than a handful of files to answer.
+     conclusion drift with nothing comparing them. ⚠️ **`search_memories` for
+     the question BEFORE writing** and skip if it is already indexed: a retro
+     re-run over an overlapping session would otherwise index it twice. Skip
+     entirely if nothing this session took more than a handful of files to
+     answer.
    - Offer to commit + push the new/edited files (don't unless asked, per repo
      rules).
 
@@ -177,7 +181,7 @@ DOCS GAPS (→ update-polykybd-docs)
 
 MEMORY INDEX (→ mem0)
   •. <question investigated> → <verdict in one line>
-     write-up: <file §heading | PR #N>
+     write-up: <repo/file §heading | owner/repo#N>
 
 ALREADY COVERED (skipped): <item> → <existing doc/skill>
 

--- a/.claude/skills/session-retro/SKILL.md
+++ b/.claude/skills/session-retro/SKILL.md
@@ -211,8 +211,11 @@ Recommendation: <which to keep, and why>
   is the only thing that decides whether it ever fires.
 - **Cite evidence.** Every proposal should point at what in the session justifies
   it; if you can't, it's probably not worth keeping.
-- **Nothing sensitive in mem0** — no credentials, keys, file contents, or
-  anything you would not put in a public issue.
+- **Nothing sensitive in mem0, and that includes the SEARCH.** No credentials,
+  keys, file contents, or anything you would not put in a public issue. ⚠️ The
+  pre-write `search_memories` sends the question text to the same cloud service
+  `add_memory` writes to — so a question that cannot leave the machine means
+  skipping the index entry altogether, not sanitising it afterwards.
 - **Approval before writing**, and **don't push** unless asked.
 - This skill is repo-agnostic; if useful beyond this project, copy it to
   `~/.claude/skills/`.


### PR DESCRIPTION
## Summary

Adds a fourth materialize step to the `session-retro` skill: after an investigation that cost real effort, write **one** mem0 entry carrying the question, the verdict in a sentence, and where the full write-up landed.

Deliberately an **index, not a record**. A durable technical conclusion still goes to `CLAUDE.md`; storing it in both creates two copies that drift with nothing comparing them — the mirrored-file failure this repo already documents for `noto-fonts.yaml` and friends. `CLAUDE.md` wins on any disagreement, so a mem0 hit is a lead to verify against the repo, never an authority.

Four surgical additions (+16 lines), no existing text rewritten:

| § | Change |
|---|---|
| §4 Procedure | the `add_memory` step, with an explicit *never the finding itself* and a skip clause when nothing this session was that big |
| §5 Output format | a `MEMORY INDEX (→ mem0)` block, so entries pass through the existing approval step instead of being written silently |
| §6 Where things go | mem0 described as an index, plus the CLAUDE.md-wins precedence rule |
| Pitfalls | nothing sensitive in a cloud memory service |

Mirrored byte-identically into `PolyKybdHost` per the copy-never-fork rule — companion PR: thpoll83/PolyKybdHost#225.

Context: mem0 is being wired up as an MCP server at the environment level (hosted endpoint, `Authorization: Bearer ${MEM0_API_KEY}`). This PR is only the skill's half of that; the server config lives in the cloud environment's setup script and is not in any repo.

## Version bump label

*(none)* — patch. No firmware source, build input or protocol change; this touches `.claude/skills/` only.

## Testing

The hardware boxes don't apply — no firmware code changed, and `.claude/**` is excluded from `qmk-test.yml`'s path filter, so no build or HIL run is triggered. What was verified instead:

- [x] The repo's own five-skill mirror check passes: `add-gated-hid-command`, `mutation-test-suite`, `polykybd-github-release`, `session-retro`, `update-polykybd-docs` all `ok` against the `PolyKybdHost` copies
- [x] Each new note grepped back by name after the scripted edit, and each anchor's surrounding text re-checked — a `s.replace(anchor, new)` here drops whatever sits between two anchors without erroring
- [ ] Compiled successfully — n/a, no C changed
- [ ] Flashed and tested on hardware — n/a
- [ ] If protocol changed: host updated and tested together — n/a, no protocol change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154GMQUPFgMc7r4jEiqpitb

## Summary by Sourcery

Add a guarded mem0 investigation index to the session-retro workflow while keeping repository documentation authoritative.

New Features:
- Add an approved `mem0` investigation index step to the `session-retro` skill, linking questions and verdicts to their authoritative repository write-ups.

Enhancements:
- Define precedence and deduplication rules so mem0 remains a searchable lead rather than a duplicate source of technical findings.
- Document that sensitive information must not be included in mem0 entries or search queries.

Documentation:
- Update the session-retro skill procedure and output format to support investigation indexing and clarify where durable learnings belong.

Tests:
- Verify that the mirrored session-retro skill remains byte-identical with its companion repository copy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session retrospectives now include a memory index for substantial investigations, capturing the question, a brief verdict, and a link to the full write-up.
  * Added guidance for checking existing memories before recording new entries.

* **Documentation**
  * Clarified that the memory index catalogs investigations and that sensitive information should not be stored there.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->