### PR TITLE
docs: a protocol bump means BOTH releases, checked on the published versions

### DIFF
--- a/.claude/skills/polykybd-github-release/SKILL.md
+++ b/.claude/skills/polykybd-github-release/SKILL.md
@@ -136,7 +136,11 @@ include them in what you show the user at the review gate.
 
 Present to the user, in chat:
 - the **full drafted notes**, and
-- the **proposed metadata**: tag, release title, target branch, latest-flag.
+- the **proposed metadata**: tag, release title, target branch, latest-flag, and
+- **when the range carries a `PROTOCOL_VERSION` bump, the sibling artifact's newest
+  PUBLISHED protocol** — because that decides whether this is one release or two
+  (see the Protocol lockstep pitfall). Draft both sets of notes before the gate
+  rather than after it; a paired release is the default, not an escalation.
 
 Ask them to approve or edit. **Do not** create/push a tag or create/publish the
 release until they explicitly approve. Fold in their edits (and re-show if the change
@@ -316,8 +320,24 @@ note above).
 - **Skipping maintenance versions is about the NOTES only** — the numbers still
   increment through them. Don't renumber or imply they don't exist; fold them into a
   single "plus maintenance releases" line if the user asks.
-- **Protocol lockstep** — when the range includes a `PROTOCOL_VERSION` bump, the notes
-  must tell users to update host + firmware together (exact-match connect gate).
+- **Protocol lockstep — a `PROTOCOL_VERSION` bump in the range means you cut BOTH
+  releases, not just write a sentence in the notes.** Before drafting, read the
+  sibling artifact's newest *published* release (`mcp__github__list_releases`) and
+  check the `__protocol__` / `PROTOCOL_VERSION` at that tag.
+  - ⚠️ **The in-tree versions being in lockstep does NOT mean the releases are**, and
+    that is the check that fails. On 2026-09-09 firmware `PolyKybd` and host `main`
+    both said protocol 17 while the newest published host (v0.14.18) was still 16 —
+    so the existing "bump `__protocol__` in lockstep" note was satisfied and a
+    firmware-only release would still have shipped protocol 17 to users whose host
+    could not drive it.
+  - ⚠️ **Nothing downstream catches it, because the connect gate is NOT exact-match**
+    — this pitfall claimed it was, for a long time. The host connects to any protocol
+    `>= MIN_SUPPORTED_PROTOCOL` and gates each feature through `FEATURE_MIN_PROTOCOL`,
+    so an old host pairs with new firmware and silently leaves the new features off.
+    That is quieter than a refusal, and worse.
+  - **Publish the host first**, then the firmware: the host is the side that has to
+    understand the new protocol, and a user who updates in that order is never
+    holding firmware their app cannot drive.
 - **No git tags in the firmware tree** — releases are the GitHub Releases API; history
   boundaries are the `bump firmware/host version` commits (see `polykybd-release-notes`).
 - **WinCompose: `status.txt` has a wrong value in BOTH directions, and they need

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1357,6 +1357,25 @@ Firmware releases are **GitHub Releases** (tag `PolyKybd-fw-vX.Y.Z`; `FW_VERSION
 `polykybd-github-release` skill to draft the notes and drive the flow. The mechanics
 that cost real debugging to learn (2026-07):
 
+- ⚠️ **A `PROTOCOL_VERSION` bump means BOTH artifacts get released, and the check that
+  catches it is the PUBLISHED versions, not the in-tree ones.** The existing "bump
+  `__protocol__` in lockstep with `PROTOCOL_VERSION`" rule is about the *sources*, and
+  it can be perfectly satisfied while the releases are a protocol apart. Measured
+  2026-09-09: firmware `PolyKybd` and host `main` both read protocol 17, while the
+  newest **published** host (v0.14.18) was still 16 — so a firmware-only release would
+  have shipped protocol 17 to every user's protocol-16 app. Read the sibling's newest
+  release (`list_releases`, then its `__protocol__`/`PROTOCOL_VERSION` at that tag)
+  before drafting.
+  - ⚠️ **Nothing downstream catches it, because the connect gate is NOT exact-match.**
+    The host connects to any protocol `>= MIN_SUPPORTED_PROTOCOL` and gates each
+    feature through `FEATURE_MIN_PROTOCOL`, so an old host pairs with new firmware and
+    silently leaves the new features off — quieter than a refusal, and worse to
+    diagnose. (The release skill's own pitfall claimed exact-match for a long time,
+    which made the pairing read as self-enforcing when it is not.)
+  - **Publish the host first, then the firmware** — the host is the side that has to
+    understand the new protocol, so that order never leaves a user holding firmware
+    their app cannot drive.
+
 - ⚠️ **Publishing is GATED on a green firmware-APPLY run for the commit being
   released** (`tools/require_fwapply_run.py`, the first step of `release.yml`,
   before the build so a refusal changes nothing). The HID-apply brick shipped


### PR DESCRIPTION
## Summary

Records a rule that was not written down anywhere, and that a firmware-only 0.23.0 release would have broken this morning.

**The gap.** `CLAUDE.md` already says to bump `__protocol__` in lockstep with `PROTOCOL_VERSION` — but that is about the **source** versions, and it was fully satisfied while the *releases* were a protocol apart. Measured 2026-09-09: firmware `PolyKybd` and host `main` both read protocol 17, while the newest **published** host (v0.14.18) was still 16. So the existing note passes and a firmware-only release still ships protocol 17 to every user's protocol-16 app. The check that catches it is the published versions, which nothing asked for.

**Why nothing downstream catches it.** The release skill's own pitfall said the connect gate is *exact-match*, which makes the pairing read as self-enforcing. It has not been for a while: the host connects to any protocol `>= MIN_SUPPORTED_PROTOCOL` and gates each feature through `FEATURE_MIN_PROTOCOL`, so an old host pairs with new firmware and silently leaves the new features switched off — quieter than a refusal, and harder to diagnose. Correcting that claim is part of this change.

**Order.** Publish the host first. It is the side that has to understand the new protocol, so a user updating in that order is never holding firmware their app cannot drive.

This complements the PR template's existing line (a protocol change needs a matching `bump:protocol` PR in the sibling repo) — that keeps the *sources* in step; this keeps the *releases* in step.

### Changed

- `CLAUDE.md` § Releases — the rule, the measurement, and the publish order.
- `.claude/skills/polykybd-github-release/SKILL.md` — the *Protocol lockstep* pitfall rewritten from "the notes must tell users" to "you cut both releases", with the exact-match correction; and the review gate now asks for the sibling's published protocol alongside the notes and metadata, so a paired release is the default rather than an escalation.

The skill is one of the four kept **byte-identical** with PolyKybdHost, so the same commit lands in both repos — `cmp` clean between them after this change. (The mirrors were already in step here; `e443b9f7` harmonised them.)

## Version bump label

*(none)* — docs only, patch bump is correct. No protocol change, no firmware change.

## Testing

Documentation only: nothing compiled, nothing flashed, no code path touched.

- Both anchors asserted unique before patching, and each note grepped back by name afterwards (the CLAUDE.md scripted-edit trap this file documents).
- `cmp` confirms the skill mirror is byte-identical to PolyKybdHost's copy.
- The two factual claims are from this session: `list_releases` gave host v0.14.18, and `git show v0.14.18:polyhost/_version.py` gave `__protocol__ = 16` against firmware's `PROTOCOL_VERSION 17`.

Companion PR: thpoll83/PolyKybdHost#228

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNyPVgtQG3iHzMjYntsWTz