### PR TITLE
docs(session-retro): write mem0 index entries raw

### DIFF
--- a/.claude/skills/session-retro/SKILL.md
+++ b/.claude/skills/session-retro/SKILL.md
@@ -162,15 +162,20 @@ fixed / refuted / skipped. Do not push fixes without approval, per §4.6.
      structure this bullet prescribes. ⚠️ Measured 2026-09-09, the
      fully-qualified PR ref **did** survive that rewrite — so write raw for the
      structure, and do not repeat a claim that the extractor eats the refs.
-     ⚠️ The default is also **asynchronous**: it returns `status: PENDING` plus
-     an `event_id`, where `infer=False` returns `SUCCEEDED` carrying the stored
-     text — so at the call site a written entry and a discarded one look
-     identical until you poll `get_event_status`. ⚠️ And a near-duplicate of an
-     existing entry is dropped **silently**: status `SUCCEEDED`, `results: []`,
-     nothing stored — which is exactly what a retro re-run over an overlapping
-     session produces, i.e. the case the search above exists to catch. **Read
-     `results`, never `status`.** Skip entirely if nothing this session took
-     more than a handful of files to answer.
+     ⚠️ **Read `status` first, then `results` — and note which MODE each
+     observation belongs to.** The two paths differ, and conflating them is how
+     the first version of this note came out wrong. Measured 2026-09-09:
+     `infer=False` returns `SUCCEEDED` **synchronously** with the stored text in
+     `results`, and re-writing identical text is a **no-op that returns the
+     EXISTING memory's id**, leaving its metadata and timestamps untouched. The
+     **default** is asynchronous — `status: PENDING` plus an `event_id`, nothing
+     stored yet — so there a written entry and a discarded one look identical
+     until you poll `get_event_status`, and a near-duplicate resolves
+     `SUCCEEDED` with `results: []` and nothing written. So `status` says
+     whether the call finished and `results` says whether anything landed;
+     neither answers alone, and the empty-`results` dedupe belongs to the
+     default path, NOT to the raw write this bullet prescribes. Skip entirely if
+     nothing this session took more than a handful of files to answer.
    - Offer to commit + push the new/edited files (don't unless asked, per repo
      rules).
 

--- a/.claude/skills/session-retro/SKILL.md
+++ b/.claude/skills/session-retro/SKILL.md
@@ -155,9 +155,22 @@ fixed / refuted / skipped. Do not push fixes without approval, per §4.6.
      itself** — that is the learning above, and two copies of a technical
      conclusion drift with nothing comparing them. ⚠️ **`search_memories` for
      the question BEFORE writing** and skip if it is already indexed: a retro
-     re-run over an overlapping session would otherwise index it twice. Skip
-     entirely if nothing this session took more than a handful of files to
-     answer.
+     re-run over an overlapping session would otherwise index it twice.
+     ⚠️ **Write it raw — `add_memory(..., infer=False)`.** The default runs an
+     LLM extractor that rewrites the entry into third-person narrative prose
+     (*"User explained that …"*), losing the question / verdict / write-up
+     structure this bullet prescribes. ⚠️ Measured 2026-09-09, the
+     fully-qualified PR ref **did** survive that rewrite — so write raw for the
+     structure, and do not repeat a claim that the extractor eats the refs.
+     ⚠️ The default is also **asynchronous**: it returns `status: PENDING` plus
+     an `event_id`, where `infer=False` returns `SUCCEEDED` carrying the stored
+     text — so at the call site a written entry and a discarded one look
+     identical until you poll `get_event_status`. ⚠️ And a near-duplicate of an
+     existing entry is dropped **silently**: status `SUCCEEDED`, `results: []`,
+     nothing stored — which is exactly what a retro re-run over an overlapping
+     session produces, i.e. the case the search above exists to catch. **Read
+     `results`, never `status`.** Skip entirely if nothing this session took
+     more than a handful of files to answer.
    - Offer to commit + push the new/edited files (don't unless asked, per repo
      rules).
 


### PR DESCRIPTION
## Summary

The `Investigation index` bullet told a retro to call `add_memory` but never said
*how*, so the default call path was left to whoever ran it next. Measured against
the hosted mem0 server on 2026-09-09, that default is the wrong one, for three
reasons that are all invisible at the call site:

- **`infer=True` (the default) rewrites the entry** into third-person narrative
  prose — `"User explained that the split42 status OLED renders…"` — losing the
  question / verdict / write-up structure the bullet prescribes.
- **It is asynchronous.** It returns `status: PENDING` plus an `event_id`, where
  `infer=False` returns `SUCCEEDED` carrying the stored text. So a written entry
  and a discarded one are indistinguishable until you poll `get_event_status`.
- **A near-duplicate is dropped silently** — `status: SUCCEEDED`, `results: []`,
  nothing stored. That is exactly what a retro re-run over an overlapping session
  produces, i.e. the case the pre-write `search_memories` already exists to catch.
  Hence the closing rule: read `results`, never `status`.

⚠️ The note also records a claim it **disproves**. Going in, the expectation was
that the extractor would mangle the `owner/repo#N` refs — which would matter,
since the bullet one line above warns that a bare `#N` resolves to the wrong PR
across the nine repos. It doesn't: the fully-qualified ref survived the rewrite
intact. The note says so explicitly, so the stronger claim isn't repeated later as
though it had been measured.

Method: two probes. The first reused text close to an existing entry and returned
`results: []`; that was **dedupe**, not the extractor, so it proves nothing on its
own. The second used unrelated text to isolate the rewrite. Both were deleted.

Mirrored byte-identically into `PolyKybdHost` per the copy-never-fork rule
(thpoll83/PolyKybdHost#229); the five-skill `cmp` loop from `CLAUDE.md` reports
`ok` for all five.

## Version bump label

*(none)* — patch. Documentation-only change to a skill; no firmware behaviour and
no protocol change.

## Testing

The hardware boxes below don't apply — this PR touches only
`.claude/skills/session-retro/SKILL.md`, and `qmk-test.yml` path-filters
`.claude/**` out of both its triggers, so no build or HIL run fires. What was
actually verified:

- [x] Every added note grepped back out of the file after writing (⚠️ against the
      **unwrapped** text — two patterns span a line wrap and read as `0` under
      line-based grep, which is the false "note lost" scare `CLAUDE.md` warns about)
- [x] Anchor asserted unique before the scripted edit, per the same note
- [x] Five-skill drift check: `add-gated-hid-command`, `mutation-test-suite`,
      `polykybd-github-release`, `session-retro`, `update-polykybd-docs` — all `ok`
- [x] No CRLF, trailing newline present, longest added line 88 cols (the file's
      existing max; line 3 is the pre-existing frontmatter)
- [ ] Compiled successfully — n/a, no firmware sources touched
- [ ] Flashed and tested on hardware — n/a
- [ ] If protocol changed: host updated and tested together — n/a, no protocol change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7fMd1kdJwfF2HxswFE7Vm

## Summary by Sourcery

Document reliable raw mem0 indexing for session retrospectives while distinguishing write completion from whether a memory was stored.

Enhancements:
- Clarify session-retro guidance for writing investigation index entries as raw mem0 memories and interpreting write results correctly.
- Document measured differences between raw and default mem0 writes, including extraction, asynchronous completion, and deduplication behavior.

Documentation:
- Update the session-retro skill with explicit mem0 write and verification guidance, including the confirmed behavior of fully qualified pull-request references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded session retrospective guidance for storing memories, including recommendations for preserving raw entries and avoiding unintended rewrites.
  - Clarified how asynchronous memory indexing reports completion and emphasized checking returned results rather than status alone.
  - Documented that near-duplicate entries may be silently skipped.
  - Retained guidance to skip indexing when the task required only a small number of files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->