### PR TITLE
docs: session-retro learnings from the Workman home-row-mods work, and always-PR on approval

### DIFF
--- a/.claude/skills/session-retro/SKILL.md
+++ b/.claude/skills/session-retro/SKILL.md
@@ -123,7 +123,9 @@ For each finding, in order:
    is the first thing a human reviewer reads.
 
 Report the outcome in the retro proposal as a table: PR → CI state → findings
-fixed / refuted / skipped. Do not push fixes without approval, per §4.6.
+fixed / refuted / skipped. The sweep REPORTS; the approval step (§4.5)
+decides what gets pushed. That gate is separate from §4.6, which is about the
+retro's OWN output.
 
 ## 4. Procedure
 
@@ -176,8 +178,32 @@ fixed / refuted / skipped. Do not push fixes without approval, per §4.6.
      neither answers alone, and the empty-`results` dedupe belongs to the
      default path, NOT to the raw write this bullet prescribes. Skip entirely if
      nothing this session took more than a handful of files to answer.
-   - Offer to commit + push the new/edited files (don't unless asked, per repo
-     rules).
+   - **Commit, push and OPEN A PULL REQUEST — every time, in every repo the
+     retro touched.** The user's approval of the proposal IS the authorization:
+     they asked for this standing behaviour explicitly (2026-09-10), so it
+     overrides the default "do not create a pull request unless asked". Do not
+     stop at a local commit, and do not ask a second time.
+     - **One PR per repo.** A retro routinely writes into two or three
+       `CLAUDE.md`s and maybe a skill; each repo gets its own branch, commit and
+       PR against its own default — `PolyKybd` for the firmware, `master` for
+       `Adafruit-GFX-Library` and `PolyKybd` (hardware), `main` for the rest.
+     - ⚠️ **Cut the branch fresh from the updated default FIRST.** A retro runs
+       at the end of a session, which is exactly when the branch you are
+       standing on has just merged — and a push to a merged branch **succeeds
+       silently and orphans the commit** (see Branching in the repo `CLAUDE.md`).
+       `git fetch origin <default> && git checkout -B <branch> origin/<default>`,
+       then confirm with `git merge-base --is-ancestor origin/<default> HEAD`.
+     - **The PR body carries the EVIDENCE, not a summary** — for each note, what
+       happened in the session that justifies it, so a reviewer can check the
+       claim rather than the prose. That is the same evidence the proposal
+       already cites, so it costs nothing to carry over.
+     - ⚠️ **A mirrored skill is TWO PRs** (`qmk_firmware` ↔ `PolyKybdHost` keep
+       five byte-identical copies — see Mirrored skills in either `CLAUDE.md`).
+       Cross-link them in both bodies, or each reads as half a change; and
+       `cmp` the pair before opening either, since a retro is also when the
+       drift gets noticed.
+     - **Report the PR links when done.** The retro is not finished until they
+       exist.
 
 ## 5. Output format
 
@@ -234,6 +260,8 @@ Recommendation: <which to keep, and why>
   pre-write `search_memories` sends the question text to the same cloud service
   `add_memory` writes to — so a question that cannot leave the machine means
   skipping the index entry altogether, not sanitising it afterwards.
-- **Approval before writing**, and **don't push** unless asked.
+- **Approval before writing — but approval is the ONLY gate.** Once the user
+  picks what to keep, write it, push it and open the PR (§4.6) without asking
+  again. Asking twice is what this instruction exists to stop.
 - This skill is repo-agnostic; if useful beyond this project, copy it to
   `~/.claude/skills/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1645,6 +1645,32 @@ cache at, which is the guard shape this repo keeps getting caught by (`sync_is_l
 the CI suite names, the log-source registry). The invariant is "all keymap mutation goes
 through a `_poly` function", not "these four places also call the invalidator".
 
+⚠️ **The consequence for a KEYMAP EDIT is the one this section does not spell out: on any
+board that has ever stored a keymap, a change to a layer below the write cap is INVISIBLE
+— the EEPROM copy wins.** `poly_keycode_at()` resolves layers under
+`DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT` through `keycode_at_keymap_location()`, i.e. out
+of the dynamic keymap, so the freshly compiled `keymaps[]` is only consulted for a layer
+at or above the cap — or on a board whose EEPROM has never been written. Flash, press the
+key, get the old keycode, and nothing anywhere says why. It is the flip side of this
+section's own correct advice that a CONTENTS change "needs no reset": no reset is needed
+for *correctness*, and none happens, which is exactly what leaves the edit unseen. Two
+recoveries, and they are not equivalent:
+- **Bump `KEYMAP_LAYERS_FL_MERGED`.** Reaches every board automatically at the next boot,
+  and **WIPES THE USER'S MACROS** — `dynamic_keymap_reset_poly()` calls
+  `poly_macro_reset_all()`. Right for a layer add/remove/reorder, far too blunt for a
+  keycode change.
+- **Write the keys over the wire**, which is non-destructive and touches nothing else:
+  `polyctl keymap set <layer> <row> <col> <keycode>` — ⚠️ **POSITIONAL arguments, not
+  flags**, and the keycode goes through `int(x, 0)` so `0x2804` works. One invocation per
+  changed key.
+
+⚠️ **There is NO keymap-reset and no EEPROM-clear anywhere in PolyKybdHost** — not in
+`polyctl`, not on the control socket, not in the tray. `EE_CLR` appears in the host only
+as a preview legend for `QK_CLEAR_EEPROM` in `res/preview/legends.json`, i.e. a label for
+a key the user presses **on the board**. Do not tell anyone to "reset the keymap from the
+host app"; that route does not exist (asserted three times in one session, 2026-09-10,
+and wrong every time).
+
 ### `poly_keycode_at()` is the ONE resolver for both the render and the key-event path
 
 `display_keycode_at()` (legend) and `keymap_key_to_keycode()` (action) both bottom out
@@ -1725,6 +1751,40 @@ VBUS divider on GP24 — is on **both** boards, identically.
 - ⚠️ Minor, unresolved: the **right** sheet references a bare `rp_pico.kicad_sch` with no
   `../../`, and no such file exists beside it. Whether KiCad resolves that from the project
   root or the reference is simply stale was **not** established — don't read it as either.
+
+### ⚠️ Tap-hold settings are `config.h` DEFINES — the `rules.mk` lines were inert for years
+
+`PERMISSIVE_HOLD = yes` and `HOLD_ON_OTHER_KEY_PRESS = yes` sat in **both** variants'
+`rules.mk` and did **nothing**. `quantum/action_tapping.c` tests them with `#ifdef`, and
+nothing in `builddefs/` turns a make variable of that name into a `-D`, so the board ran
+QMK's defaults throughout while the build stayed green and the source read as configured.
+The general shape: a make variable is only a feature switch when some `.mk` file
+translates it: `grep -rn "<NAME>" builddefs/` before believing a line in a `rules.mk`.
+Both were removed and the real defines now live in `split72/config.h` with their
+rationale (2026-09-10, qmk#288).
+
+⚠️ **`CHORDAL_HOLD`'s weak hook is what a SPLIT board wants — do not hand-maintain the
+table.** The default `chordal_hold_handedness()` reads
+`chordal_hold_layout[MATRIX_ROWS][MATRIX_COLS]`, i.e. an 80-entry `PROGMEM` table here
+that must be kept in step with the matrix by hand (and is an undefined symbol at link
+until you write it). The hook is `__attribute__((weak))`, so overriding it answers the
+same question as arithmetic:
+
+```c
+char chordal_hold_handedness(keypos_t key) {
+    return (key.row < MATRIX_ROWS_PER_SIDE) ? 'L' : 'R';
+}
+```
+
+That is the split `LAYOUT_TO_INDEX()` and `is_left_side()` already assume, so it cannot
+drift from the matrix the way a table can. It lives in `poly_keymap.c` under an
+`#ifdef CHORDAL_HOLD`, and the override alone links — the table is never referenced.
+
+⚠️ **`HOLD_ON_OTHER_KEY_PRESS` is deliberately NOT defined**, and the reason survives any
+retuning: it settles a tap-hold as *held* on any other key press, so it fires a mod on
+ordinary fast rolls — precisely what `CHORDAL_HOLD` (opposite-hands only) and
+`FLOW_TAP_TERM` (forces a tap soon after the preceding key) exist to prevent. A home row
+mod that fires while typing is worse than one that is occasionally slow.
 
 ### ⚠️ A release-edge action fires up to THREE times on a ONE-SHOT layer
 


### PR DESCRIPTION
Documentation only — no firmware source touched, so no build/HIL run is expected from the `qmk-test.yml` paths filter.

## 1. The dynamic keymap SHADOWS a compiled keymap edit

Appended to §"The dynamic keymap is indexed BY LAYER NUMBER". That section is where someone would look, and its own correct line — *"never [bump] when a layer's CONTENTS change"* — is exactly what hides the practical consequence.

**Evidence:** #288 added home row mods to `_L4`, the `.bin` was verified to contain them byte-for-byte (`keymaps` table at `0x10079784`, all 8 mod-taps present, `L0[2][1] == 0x0004` as an untouched control), and on a board with a stored keymap they would still not take effect. `poly_keycode_at()` resolves any layer below `DYNAMIC_KEYMAP_UPDATE_MAX_LAYER_COUNT` through `keycode_at_keymap_location()`, i.e. out of EEPROM.

Also records the two recoveries and that they are **not** equivalent — `KEYMAP_LAYERS_FL_MERGED` reaches every board and **wipes the user's macros** (`dynamic_keymap_reset_poly()` calls `poly_macro_reset_all()`), while `polyctl keymap set <layer> <row> <col> <keycode>` is non-destructive and takes **positional** args.

⚠️ And a correction: **PolyKybdHost has no keymap-reset and no EEPROM-clear at all.** I told the user it did, three times. `grep -rn "EE_CLR"` over the host returns two hits, both in `res/preview/legends.json` — it is a preview legend for the on-board `QK_CLEAR_EEPROM` key. The host exposes `keymap.set` plus read-only queries and nothing else.

## 2. The tap-hold lines in `rules.mk` were inert for years

New section beside the one-shot release-edge note.

**Evidence:** `PERMISSIVE_HOLD = yes` and `HOLD_ON_OTHER_KEY_PRESS = yes` sat in **both** variants' `rules.mk`. `quantum/action_tapping.c` tests them with `#ifdef`, and nothing in `builddefs/` turns a make variable of that name into a `-D` — so the board ran QMK's defaults throughout while the build stayed green and the source read as configured. The general check is one command: `grep -rn "<NAME>" builddefs/` before believing a line in a `rules.mk`.

Also covers why `CHORDAL_HOLD`'s **weak** `chordal_hold_handedness()` hook beats the table on a split board (the weak default reads an 80-entry `chordal_hold_layout[MATRIX_ROWS][MATRIX_COLS]` that must be hand-maintained, and is an undefined symbol at link until you write it), and why `HOLD_ON_OTHER_KEY_PRESS` stays out.

## 3. `session-retro`: open a PR once the proposal is approved

The skill stopped at *"offer to commit + push (don't unless asked)"*, so an approved retro left its notes in a local commit and the user had to ask again for each step — which is what happened this session. The approval of the proposal is the authorization.

Records what is easy to get wrong: one PR per repo against that repo's own default; **cut the branch fresh from the updated default first**, because a retro runs at the end of a session — exactly when the branch you are standing on has just merged, and a push to a merged branch succeeds silently and orphans the commit; carry the proposal's evidence into the PR body; and a mirrored skill is two cross-linked PRs.

⚠️ The mirrored copy is thpoll83/PolyKybdHost#232 — the two must land together, and that PR also closes a real drift the skill's own `cmp` check caught (the host's copy was missing the mem0 raw-write / status-vs-results block).

## Verification

- Every anchor asserted to appear exactly once before writing, and every note grepped back by name afterwards. Two of those greps scored 0 on the first pass — both were the documented false scare (a case mismatch and a backticked identifier), not lost text.
- `+60` lines to `CLAUDE.md`, no deletions.
- All five mirrored skills `cmp` clean across the two repos after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yZsenveFq7qh8DLZbBdF8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the session retro workflow, including approval gates, repository updates, pull request requirements, and reporting expectations.
  - Documented EEPROM-backed keymap layer limitations and available ways to apply changed keycodes.
  - Clarified that PolyKybdHost does not reset keymaps or clear EEPROM data.
  - Updated tap-hold configuration guidance for split keyboards, including chordal-hold behavior and supported settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->